### PR TITLE
Adds requestIdleCallback to vdom/component

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -50,17 +50,17 @@ extend(Component.prototype, {
    *
    * @private
    */
-  set renderId (id) {
-    this._id = id;
-  },
+	set renderId (id) {
+		this._id = id;
+	},
 
   /** Gets the stored `requestIdleCallback` id.
    *
    * @private
    */
-  get renderId () {
-    return this._id || null;
-  },
+	get renderId () {
+		return this._id || null;
+	},
 
 	/** Returns a function that sets a state property when called.
 	 *	Calling linkState() repeatedly with the same arguments returns a cached link function.

--- a/src/component.js
+++ b/src/component.js
@@ -44,6 +44,23 @@ extend(Component.prototype, {
 	// 	return true;
 	// },
 
+	/** Sets a `requestIdleCallback` id on the component. If there are
+   * repeated calls to render the component (and the component is set to render
+   * asynchronously), the existing rIC callback will be cancelled using this id.
+   *
+   * @private
+   */
+  set renderId (id) {
+    this._id = id;
+  },
+
+  /** Gets the stored `requestIdleCallback` id.
+   *
+   * @private
+   */
+  get renderId () {
+    return this._id || null;
+  },
 
 	/** Returns a function that sets a state property when called.
 	 *	Calling linkState() repeatedly with the same arguments returns a cached link function.

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -17,39 +17,67 @@ import { removeNode } from '../dom/index';
  *	@param {boolean} [opts.render=true]			If `false`, no render will be triggered.
  */
 export function setComponentProps(component, props, opts, context, mountAll) {
-	if (component._disable) return;
-	component._disable = true;
 
-	if ((component.__ref = props.ref)) delete props.ref;
-	if ((component.__key = props.key)) delete props.key;
+	const requestIdleCallback =
+      typeof window !== 'undefined' &&
+      typeof window.requestIdleCallback !== 'undefined' ?
+         window.requestIdleCallback :
+         null;
 
-	if (!component.base || mountAll) {
-		if (component.componentWillMount) component.componentWillMount();
-	}
-	else if (component.componentWillReceiveProps) {
-		component.componentWillReceiveProps(props, context);
-	}
+	const cancelIdleCallback =
+      requestIdleCallback !== 'null' ?
+      window.cancelIdleCallback :
+      null;
 
-	if (context && context!==component.context) {
-		if (!component.prevContext) component.prevContext = component.context;
-		component.context = context;
-	}
+	let handler = cb => cb();
 
-	if (!component.prevProps) component.prevProps = component.props;
-	component.props = props;
+  // Only support async if rIC is supported and the component requests it.
+	if (requestIdleCallback && component.renderAsync) {
+		handler = requestIdleCallback;
 
-	component._disable = false;
-
-	if (opts!==NO_RENDER) {
-		if (opts===SYNC_RENDER || options.syncComponentUpdates!==false || !component.base) {
-			renderComponent(component, SYNC_RENDER, mountAll);
-		}
-		else {
-			enqueueRender(component);
+    // Remove any pending requests for this component.
+		if (component.renderId) {
+			cancelIdleCallback(component.renderId);
 		}
 	}
 
-	if (component.__ref) component.__ref(component);
+	component.renderId = handler(() => {
+		component.renderId = null;
+
+		if (component._disable) return;
+		component._disable = true;
+
+		if ((component.__ref = props.ref)) delete props.ref;
+		if ((component.__key = props.key)) delete props.key;
+
+		if (!component.base || mountAll) {
+			if (component.componentWillMount) component.componentWillMount();
+		}
+		else if (component.componentWillReceiveProps) {
+			component.componentWillReceiveProps(props, context);
+		}
+
+		if (context && context!==component.context) {
+			if (!component.prevContext) component.prevContext = component.context;
+			component.context = context;
+		}
+
+		if (!component.prevProps) component.prevProps = component.props;
+		component.props = props;
+
+		component._disable = false;
+
+		if (opts!==NO_RENDER) {
+			if (opts===SYNC_RENDER || options.syncComponentUpdates!==false || !component.base) {
+				renderComponent(component, SYNC_RENDER, mountAll);
+			}
+			else {
+				enqueueRender(component);
+			}
+		}
+
+		if (component.__ref) component.__ref(component);
+	});
 }
 
 


### PR DESCRIPTION
So from our offline conversation, I've been working on adding `requestIdleCallback` to `Component`. This is a straw man approach, so I'm not going to be all hurt if you're like "ick, no, don't do THAT!" or anything 😄 

What this does is wraps the `renderComponent` function inners in `requestIdleCallback` if the component in question is set to render as async:

```javascript
class MyComponent extends Component {
  get renderAsync () {
   return true;
  }

  render () {
    // usual gubbins...
  }
}
```

If the component is pending reconciliation and a second call to `renderComponent` is made for it, it cancels the first and replaces it with the most recent.

When faced with a decent number of components to boot from SSR, I'm seeing the main thread blocking time on my Nexus 5X go from ~1 second:

![before](https://cloud.githubusercontent.com/assets/617438/20432930/5e8b62d4-ad99-11e6-914d-e90c306b7602.png)

All the way down to ~160ms:

![after](https://cloud.githubusercontent.com/assets/617438/20432937/68411f94-ad99-11e6-880b-c3b08394b3ef.png)

Obviously this could be a breaking change, though given it's an opt-in behaviour I hope it wouldn't really sting anyone!

I mean, who doesn't enjoy a 6x reduction in blocking main thread time? 🎉 🎉 🎉 🎉 
