### PR TITLE
 fixes the bug to trigger componentWillMount when same component is replaced

### DIFF
--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -107,7 +107,7 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 
 	// If there's no existing element or it's the wrong type, create a new one:
 	vnodeName = String(vnodeName);
-	if (!dom || !isNamedNode(dom, vnodeName)) {
+	if (!dom || !isNamedNode(dom, vnodeName) || (!componentRoot && dom._component)) {
 		out = createNode(vnodeName, isSvgMode);
 
 		if (dom) {

--- a/test/browser/lifecycle.js
+++ b/test/browser/lifecycle.js
@@ -246,6 +246,21 @@ describe('Lifecycle methods', () => {
 			render(<div />, scratch, scratch.lastChild);
 			expect(Bar.prototype.componentWillUnmount, 'when removed').to.have.been.calledOnce;
 		});
+
+		it('should invoke componentWillUnmount for same components', () => {
+			class Foo extends Component {
+				componentDidMount() {}
+				componentWillUnmount() {}
+				render() { return <div>[component]</div>; }
+			}
+			spyAll(Foo.prototype);
+
+			render(<Foo />, scratch, scratch.lastChild);
+			expect(Foo.prototype.componentDidMount, 'initial render').to.have.been.calledOnce;
+
+			render(<div>[div]</div>, scratch, scratch.lastChild);
+			expect(Foo.prototype.componentWillUnmount, 'when replaced').to.have.been.calledOnce;
+		});
 	});
 
 


### PR DESCRIPTION
This fixes this issue #915 where the componentWillMount needs to be triggered when it is replaced with similar component.

I have also added a test case for the same.

Let me know if I need to do any other checks