### PR TITLE
(Relay compatibility) Additional render for PFCs that don't return a VNode

### DIFF
--- a/src/vdom/component-recycler.js
+++ b/src/vdom/component-recycler.js
@@ -45,5 +45,6 @@ export function createComponent(Ctor, props, context) {
 
 /** The `.render()` method for a PFC backing instance. */
 function doRender(props, state, context) {
-	return this.constructor(props, context);
+	let c = this.constructor(props, context);
+	return c && c.render ? c.render() : c;
 }

--- a/test/browser/components.js
+++ b/test/browser/components.js
@@ -80,6 +80,29 @@ describe('Components', () => {
 	});
 
 
+	it('should render functional components that return nested components', () => {
+		const PROPS = { foo:'bar', onBaz:()=>{} };
+
+		class C4 extends Component {
+			render() {
+				return <div>C4</div>;
+			}
+		}
+		sinon.spy(C4.prototype, 'render');
+
+		const C4hoc = sinon.spy( props => <C4 {...props} /> );
+
+		render(<C4hoc {...PROPS} />, scratch);
+
+		expect(C4.prototype.render)
+			.to.have.been.calledOnce
+			.and.to.have.been.calledWithMatch(PROPS)
+			.and.to.have.returned(sinon.match({ nodeName:'div' }));
+
+		expect(scratch.innerHTML).to.equal('<div>C4</div>');
+	});
+
+
 	it('should render components with props', () => {
 		const PROPS = { foo:'bar', onBaz:()=>{} };
 		let constructorProps;


### PR DESCRIPTION
This should help with Relay compatibility (#411)

[`relay`](https://github.com/facebook/relay) adds the concept of Containers to React. A Container defines the data needed to render a React Component with a graphql query. In Relay Modern, Components are wrapped in a Container in 3 ways: [`createFragmentContainer`](https://facebook.github.io/relay/docs/en/fragment-container.html#) (most common), [`createRefetchContainer`](https://facebook.github.io/relay/docs/en/refetch-container.html), and [`createPaginationContainer`](https://facebook.github.io/relay/docs/en/pagination-container.html).

They're all built on [`buildReactRelayContainer`](https://github.com/facebook/relay/blob/bd0b53ff60a41eb415fbd606b8ba4810afe736af/packages/react-relay/modern/buildReactRelayContainer.js#L35-L102) which returns a `Container` ~~constructor, but doesn't instantiate one~~ HOC. This means [when `preact` tries to normalize the component](https://github.com/developit/preact/blob/master/src/vdom/component-recycler.js#L17-L30), it treats the `buildReactRelayContainer` function as a PFC, adding `doRender` as a mock render function. Unfortunately, when `doRender` is called, it returns a `Container` instance instead of a `VNode`, so nothing is rendered.

This solution (courtesy of [an investigation by @adamdickinson](https://github.com/developit/preact/issues/411#issuecomment-373216817)) calls the PFC, then calls `render` if it exists. He notes [there may still be an issue with recycling](https://github.com/developit/preact/issues/411#issuecomment-379134904), but I'm assuming that'll be resolved if/when recycling is removed in #664 or optional in #789.

edit: The skinny is that Preact expects PFCs to return VNodes instead of Components, but React allows PFCs to return Components.