### PR TITLE
Run tests against production bundles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,5 @@ addons:
 script:
   - npm run build
   - COVERAGE=true npm run test
+  - PRODUCTION=true PERFORMANCE=false COVERAGE=false npm run test:karma
   - ./node_modules/coveralls/bin/coveralls.js < ./coverage/lcov.info;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -192,14 +192,6 @@ module.exports = function(config) {
 				}
 			},
 			plugins: [
-				prod && new TerserPlugin({
-					sourceMap: true,
-					exclude: /(dist|node_modules)/,
-					terserOptions: {
-						nameCache,
-						mangle: minifyOptions.mangle
-					}
-				}),
 				new WebpackModules(),
 				new webpack.DefinePlugin({
 					coverage: coverage,
@@ -210,6 +202,18 @@ module.exports = function(config) {
 			].filter(Boolean),
 			performance: {
 				hints: false
+			},
+			optimization: {
+				minimizer: prod
+					? [new TerserPlugin({
+						sourceMap: true,
+						exclude: /(dist|node_modules)/,
+						terserOptions: {
+							nameCache,
+							mangle: minifyOptions.mangle
+						}
+					})]
+					: undefined
 			}
 		},
 

--- a/package.json
+++ b/package.json
@@ -126,8 +126,10 @@
     "npm-run-all": "^4.0.0",
     "sinon": "^6.1.3",
     "sinon-chai": "^3.0.0",
+    "terser-webpack-plugin": "^1.2.3",
     "typescript": "^3.0.1",
-    "webpack": "^4.3.0"
+    "webpack": "^4.3.0",
+    "webpack-modules": "^1.0.0"
   },
   "bundlesize": [
     {


### PR DESCRIPTION
We've had a bit of trouble with mangling properties which shouldn't be mangled at all in our recent alpha releases. This PR runs the tests against the production bundles, hopefully catching these kinds of errors before we do our next release.

- [x] Optionally mangle test files
- [ ] Mangle and run each package's suite individually