### PR TITLE
Remove class attribute when it is null or false

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -76,6 +76,7 @@ export function setAccessor(node, name, old, value, isSvg) {
 	}
 	else if (name==='class' && !isSvg) {
 		node.className = value || '';
+		if (value==null || value===false) node.removeAttribute(name);
 	}
 	else if (name==='style') {
 		if (!value || typeof value==='string' || typeof old==='string') {


### PR DESCRIPTION
```jsx
<div class={null}>text</div>
```

will render

```html
<div class>text</div>
```

This patch will remove it so it becomes:

```html
<div>text</div>
```