### PR TITLE
pass through props on debugger

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -61,14 +61,14 @@ export function initDebug() {
 
 		for (const key in vnode.props) {
 			if (key[0]==='o' && key[1]==='n' && typeof vnode.props[key]!=='function') {
-				throw new Error(
+				console.error(
 					`Component's "${key}" property should be a function, ` +
 					`but got [${typeof vnode.props[key]}] instead\n` +
 					serializeVNode(vnode)
 				);
 			}
 			//return props in case of transient error for ux to continue rendering
-			return vnode.props
+			//return vnode.props
 		}
 
 		// Check prop-types if available

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -67,6 +67,8 @@ export function initDebug() {
 					serializeVNode(vnode)
 				);
 			}
+			//return props in case of transient error for ux to continue rendering
+			return vnode.props
 		}
 
 		// Check prop-types if available


### PR DESCRIPTION
returning the props allows ux to continue rendering if the props are temporarily reset