### PR TITLE
(chore) - tree-shakeable preact/utils

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -259,7 +259,6 @@ export {
 	render,
 	render as hydrate,
 	unmountComponentAtNode,
-	createPortal,
 	createElement,
 	createContext,
 	createFactory,
@@ -269,9 +268,6 @@ export {
 	isValidElement,
 	findDOMNode,
 	Component,
-	PureComponent,
-	memo,
-	forwardRef,
 	// eslint-disable-next-line camelcase
 	unstable_batchedUpdates
 };

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -1,5 +1,5 @@
 import { render as preactRender, cloneElement as preactCloneElement, createRef, h, Component, options, toChildArray, createContext, Fragment } from 'preact';
-import { createPortal, PureComponent, memo, forwardRef } from 'preact/utils';
+import { createPortal, PureComponent, memo } from 'preact/utils';
 import * as hooks from 'preact/hooks';
 export * from 'preact/hooks';
 export * from 'preact/utils';
@@ -253,12 +253,31 @@ function unstable_batchedUpdates(callback, arg) {
 	callback(arg);
 }
 
+/**
+ * Pass ref down to a child. This is mainly used in libraries with HOCs that
+ * wrap components. Using `forwardRef` there is an easy way to get a reference
+ * of the wrapped component instead of one of the wrapper itself.
+ * @param {import('./internal').ForwardFn} fn
+ * @returns {import('./internal').FunctionalComponent}
+ */
+function forwardRef(fn) {
+	function Forwarded(props) {
+		let ref = props.ref;
+		delete props.ref;
+		return fn(props, ref);
+	}
+	Forwarded._forwarded = true;
+	Forwarded.displayName = 'ForwardRef(' + (fn.displayName || fn.name) + ')';
+	return Forwarded;
+}
+
 export {
 	version,
 	Children,
 	render,
 	render as hydrate,
 	unmountComponentAtNode,
+	forwardRef,
 	createElement,
 	createContext,
 	createFactory,

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -45,6 +45,9 @@ function handleElementVNode(vnode, props) {
 	}
 }
 
+// Some libraries like `react-virtualized` explicitely check for this.
+Component.prototype.isReactComponent = {};
+
 /**
  * Proxy render() since React returns a Component reference.
  * @param {import('./internal').VNode} vnode VNode tree to render

--- a/compat/test/browser/memo.test.js
+++ b/compat/test/browser/memo.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from 'preact/test-utils';
+import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { Component, render, createElement as h, memo } from '../../src';
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -139,7 +139,7 @@ module.exports = function(config) {
 										'**/__tests__/**',
 										'**/node_modules/**',
 										// Our custom extension
-										'{debug,hooks,compat,test-utils}/test/**/*'
+										'{debug,hooks,compat,test-utils,}/test/**/*'
 									]
 								}]] : []
 						}
@@ -153,6 +153,7 @@ module.exports = function(config) {
 				alias: {
 					'preact/compat': path.join(__dirname, './compat/src'),
 					'preact/hooks': path.join(__dirname, './hooks/src'),
+					'preact/utils': path.join(__dirname, './utils/src'),
 					'preact/test-utils': path.join(__dirname, './test-utils/src'),
 					preact: path.join(__dirname, './src')
 				}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -100,11 +100,11 @@ module.exports = function(config) {
 
 		files: [
 			{ pattern: 'test/polyfills.js', watched: false },
-			{ pattern: config.grep || '{debug,hooks,compat,test-utils,}/test/{browser,shared}/**.test.js', watched: false }
+			{ pattern: config.grep || '{debug,hooks,compat,test-utils,utils,}/test/{browser,shared}/**.test.js', watched: false }
 		],
 
 		preprocessors: {
-			'{debug,hooks,compat,test-utils,}/test/**/*': ['webpack', 'sourcemap']
+			'{debug,hooks,compat,test-utils,utils,}/test/**/*': ['webpack', 'sourcemap']
 		},
 
 		webpack: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -139,7 +139,7 @@ module.exports = function(config) {
 										'**/__tests__/**',
 										'**/node_modules/**',
 										// Our custom extension
-										'{debug,hooks,compat,test-utils,}/test/**/*'
+										'{debug,hooks,compat,test-utils,utils,}/test/**/*'
 									]
 								}]] : []
 						}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "npm-run-all --parallel build:*",
     "build:core": "microbundle build --raw",
     "build:debug": "microbundle build --raw --cwd debug",
+    "build:utils": "microbundle build --raw --cwd utils",
     "build:hooks": "microbundle build --raw --cwd hooks",
     "build:test-utils": "microbundle build --raw --cwd test-utils",
     "build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks'",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:utils": "microbundle build --raw --cwd utils",
     "build:hooks": "microbundle build --raw --cwd hooks",
     "build:test-utils": "microbundle build --raw --cwd test-utils",
-    "build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks'",
+    "build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks, 'preact/utils=preactUtils",
     "dev": "microbundle watch --raw --format cjs,umd",
     "dev:hooks": "microbundle watch --raw --format cjs --cwd hooks",
     "test": "npm-run-all lint build --parallel test:mocha test:karma test:ts",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "utils",
+  "amdName": "preactUtils",
+  "version": "0.1.0",
+  "private": true,
+  "description": "utils for Preact",
+  "main": "dist/utils.js",
+  "module": "dist/utils.module.js",
+  "umd:main": "dist/utils.umd.js",
+  "source": "src/index.js",
+  "license": "MIT",
+  "types": "src/index.d.ts",
+  "peerDependencies": {
+    "preact": "^10.0.0-alpha.0"
+  },
+  "mangle": {
+    "regex": "^_"
+  }
+}

--- a/utils/src/index.js
+++ b/utils/src/index.js
@@ -1,0 +1,109 @@
+import { render, h, Component } from 'preact';
+import { assign } from '../../src/util';
+
+class ContextProvider {
+	getChildContext() {
+		return this.props.context;
+	}
+	render(props) {
+		return props.children;
+	}
+}
+
+/**
+ * Portal component
+ * @param {object | null | undefined} props
+ */
+function Portal(props) {
+	let wrap = h(ContextProvider, { context: this.context }, props.vnode);
+	render(wrap, props.container);
+	this.componentWillUnmount = () => {
+		render(null, props.container);
+	};
+	return null;
+}
+
+/**
+ * Create a `Portal` to continue rendering the vnode tree at a different DOM node
+ * @param {import('./internal').VNode} vnode The vnode to render
+ * @param {import('./internal').PreactElement} container The DOM node to continue rendering in to.
+ */
+export function createPortal(vnode, container) {
+	return h(Portal, { vnode, container });
+}
+
+/**
+ * Check if two objects have a different shape
+ * @param {object} a
+ * @param {object} b
+ * @returns {boolean}
+ */
+function shallowDiffers(a, b) {
+	for (let i in a) if (!(i in b)) return true;
+	for (let i in b) if (a[i]!==b[i]) return true;
+	return false;
+}
+
+/**
+ * Component class with a predefined `shouldComponentUpdate` implementation
+ */
+export class PureComponent extends Component {
+	constructor(props) {
+		super(props);
+		// Some third-party libraries check if this property is present
+		this.isPureReactComponent = true;
+	}
+
+	shouldComponentUpdate(props, state) {
+		return shallowDiffers(this.props, props) || shallowDiffers(this.state, state);
+	}
+}
+
+// Some libraries like `react-virtualized` explicitely check for this.
+Component.prototype.isReactComponent = {};
+
+/**
+ * Memoize a component, so that it only updates when the props actually have
+ * changed. This was previously known as `React.pure`.
+ * @param {import('./internal').FunctionalComponent} c functional component
+ * @param {(prev: object, next: object) => boolean} [comparer] Custom equality function
+ * @returns {import('./internal').FunctionalComponent}
+ */
+export function memo(c, comparer) {
+	function shouldUpdate(nextProps) {
+		let ref = this.props.ref;
+		let updateRef = ref==nextProps.ref;
+		if (!updateRef) {
+			ref.call ? ref(null) : (ref.current = null);
+		}
+		return (comparer==null
+			? shallowDiffers(this.props, nextProps)
+			: !comparer(this.props, nextProps)) || !updateRef;
+	}
+
+	function Memoed(props) {
+		this.shouldComponentUpdate = shouldUpdate;
+		return h(c, assign({}, props));
+	}
+	Memoed.displayName = 'Memo(' + (c.displayName || c.name) + ')';
+	Memoed._forwarded = true;
+	return Memoed;
+}
+
+/**
+ * Pass ref down to a child. This is mainly used in libraries with HOCs that
+ * wrap components. Using `forwardRef` there is an easy way to get a reference
+ * of the wrapped component instead of one of the wrapper itself.
+ * @param {import('./internal').ForwardFn} fn
+ * @returns {import('./internal').FunctionalComponent}
+ */
+export function forwardRef(fn) {
+	function Forwarded(props) {
+		let ref = props.ref;
+		delete props.ref;
+		return fn(props, ref);
+	}
+	Forwarded._forwarded = true;
+	Forwarded.displayName = 'ForwardRef(' + (fn.displayName || fn.name) + ')';
+	return Forwarded;
+}

--- a/utils/src/index.js
+++ b/utils/src/index.js
@@ -59,9 +59,6 @@ export class PureComponent extends Component {
 	}
 }
 
-// Some libraries like `react-virtualized` explicitely check for this.
-Component.prototype.isReactComponent = {};
-
 /**
  * Memoize a component, so that it only updates when the props actually have
  * changed. This was previously known as `React.pure`.

--- a/utils/src/index.js
+++ b/utils/src/index.js
@@ -89,21 +89,3 @@ export function memo(c, comparer) {
 	Memoed._forwarded = true;
 	return Memoed;
 }
-
-/**
- * Pass ref down to a child. This is mainly used in libraries with HOCs that
- * wrap components. Using `forwardRef` there is an easy way to get a reference
- * of the wrapped component instead of one of the wrapper itself.
- * @param {import('./internal').ForwardFn} fn
- * @returns {import('./internal').FunctionalComponent}
- */
-export function forwardRef(fn) {
-	function Forwarded(props) {
-		let ref = props.ref;
-		delete props.ref;
-		return fn(props, ref);
-	}
-	Forwarded._forwarded = true;
-	Forwarded.displayName = 'ForwardRef(' + (fn.displayName || fn.name) + ')';
-	return Forwarded;
-}

--- a/utils/src/index.js
+++ b/utils/src/index.js
@@ -25,8 +25,8 @@ function Portal(props) {
 
 /**
  * Create a `Portal` to continue rendering the vnode tree at a different DOM node
- * @param {import('./internal').VNode} vnode The vnode to render
- * @param {import('./internal').PreactElement} container The DOM node to continue rendering in to.
+ * @param {import('../../compat/src/internal').VNode} vnode The vnode to render
+ * @param {import('../../compat/src/internal').PreactElement} container The DOM node to continue rendering in to.
  */
 export function createPortal(vnode, container) {
 	return h(Portal, { vnode, container });
@@ -65,9 +65,9 @@ Component.prototype.isReactComponent = {};
 /**
  * Memoize a component, so that it only updates when the props actually have
  * changed. This was previously known as `React.pure`.
- * @param {import('./internal').FunctionalComponent} c functional component
+ * @param {import('../../compat/src/internal').FunctionalComponent} c functional component
  * @param {(prev: object, next: object) => boolean} [comparer] Custom equality function
- * @returns {import('./internal').FunctionalComponent}
+ * @returns {import('../../compat/src/internal').FunctionalComponent}
  */
 export function memo(c, comparer) {
 	function shouldUpdate(nextProps) {

--- a/utils/src/internal.d.ts
+++ b/utils/src/internal.d.ts
@@ -1,0 +1,28 @@
+import { Ref } from '../../src/index';
+import {
+  Component as PreactComponent,
+  VNode as PreactVNode,
+  FunctionalComponent as PreactFunctionalComponent
+} from '../../src/internal';
+
+export { PreactElement } from '../../src/internal';
+
+export interface Component<P = {}, S = {}> extends PreactComponent<P, S> {
+  isReactComponent: object;
+  isPureReactComponent?: true;
+}
+
+export interface FunctionalComponent<P = {}> extends PreactFunctionalComponent<P> {
+  shouldComponentUpdate?(nextProps: Readonly<P>): boolean;
+  _forwarded?: true;
+}
+
+export interface VNode<T = any> extends PreactVNode<T> {
+  $$typeof: symbol | string;
+  preactCompatNormalized: boolean;
+}
+
+export interface ForwardFn<P = {}, T = any> {
+  (props: P, ref: Ref<T>): VNode;
+  displayName?: string;
+}

--- a/utils/src/internal.d.ts
+++ b/utils/src/internal.d.ts
@@ -1,28 +1,7 @@
-import { Ref } from '../../src/index';
-import {
-  Component as PreactComponent,
-  VNode as PreactVNode,
-  FunctionalComponent as PreactFunctionalComponent
-} from '../../src/internal';
+import { FunctionalComponent } from "../../src/internal";
 
-export { PreactElement } from '../../src/internal';
+function EqualityFunction(currentProps: object, nextProps: object): boolean;
 
-export interface Component<P = {}, S = {}> extends PreactComponent<P, S> {
-  isReactComponent: object;
-  isPureReactComponent?: true;
-}
+export function memo(component: FunctionalComponent, isEqual?: EqualityFunction): FunctionalComponent;
 
-export interface FunctionalComponent<P = {}> extends PreactFunctionalComponent<P> {
-  shouldComponentUpdate?(nextProps: Readonly<P>): boolean;
-  _forwarded?: true;
-}
-
-export interface VNode<T = any> extends PreactVNode<T> {
-  $$typeof: symbol | string;
-  preactCompatNormalized: boolean;
-}
-
-export interface ForwardFn<P = {}, T = any> {
-  (props: P, ref: Ref<T>): VNode;
-  displayName?: string;
-}
+// TODO: PureComponent and createPortal

--- a/utils/src/internal.d.ts
+++ b/utils/src/internal.d.ts
@@ -1,7 +1,0 @@
-import { FunctionalComponent } from "../../src/internal";
-
-function EqualityFunction(currentProps: object, nextProps: object): boolean;
-
-export function memo(component: FunctionalComponent, isEqual?: EqualityFunction): FunctionalComponent;
-
-// TODO: PureComponent and createPortal

--- a/utils/test/browser/PureComponent.test.js
+++ b/utils/test/browser/PureComponent.test.js
@@ -1,0 +1,101 @@
+import { setupRerender, teardown } from 'preact/test-utils';
+import { setupScratch } from '../../../test/_util/helpers';
+import { PureComponent } from '../../src';
+import { createElement as h, render } from 'preact';
+
+/** @jsx h */
+
+describe('PureComponent', () => {
+
+	/** @type {HTMLDivElement} */
+	let scratch;
+
+	/** @type {() => void} */
+	let rerender;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+		rerender = setupRerender();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('should pass props in constructor', () => {
+		let spy = sinon.spy();
+		class Foo extends PureComponent {
+			constructor(props) {
+				super(props);
+				spy(this.props, props);
+			}
+		}
+
+		render(<Foo foo="bar" />, scratch);
+
+		let expected = { foo: 'bar' };
+		expect(spy).to.be.calledWithMatch(expected, expected);
+	});
+
+	it('should only re-render when props or state change', () => {
+		let setState;
+		class C extends PureComponent {
+
+			constructor(props) {
+				super(props);
+				setState = this.test = this.test.bind(this);
+			}
+
+			test(x) {
+				this.setState(x);
+			}
+
+			render() {
+				return <div />;
+			}
+		}
+		let spy = sinon.spy(C.prototype, 'render');
+
+		render(<C />, scratch);
+		expect(spy).to.have.been.calledOnce;
+		spy.resetHistory();
+
+		render(<C />, scratch);
+		expect(spy).not.to.have.been.called;
+
+		let b = { foo: 'bar' };
+		render(<C a="a" b={b} />, scratch);
+		expect(spy).to.have.been.calledOnce;
+		spy.resetHistory();
+
+		render(<C a="a" b={b} />, scratch);
+		expect(spy).not.to.have.been.called;
+
+		setState({ });
+		rerender();
+		expect(spy).not.to.have.been.called;
+
+		setState({ a: 'a', b });
+		rerender();
+		expect(spy).to.have.been.calledOnce;
+		spy.resetHistory();
+
+		setState({ a: 'a', b });
+		rerender();
+		expect(spy).not.to.have.been.called;
+	});
+
+	it('should update when props are removed', () => {
+		let spy = sinon.spy();
+		class App extends PureComponent {
+			render() {
+				spy();
+				return <div>foo</div>;
+			}
+		}
+
+		render(<App a="foo" />, scratch);
+		render(<App />, scratch);
+		expect(spy).to.be.calledTwice;
+	});
+});

--- a/utils/test/browser/memo.test.js
+++ b/utils/test/browser/memo.test.js
@@ -1,0 +1,115 @@
+import { setupRerender, teardown } from 'preact/test-utils';
+import { setupScratch } from '../../../test/_util/helpers';
+import { memo } from '../../src';
+import { createElement as h, render, Component } from 'preact';
+
+/** @jsx h */
+
+describe('memo()', () => {
+	let scratch, rerender;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+		rerender = setupRerender();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('should work with function components', () => {
+		let spy = sinon.spy();
+
+		function Foo() {
+			spy();
+			return <h1>Hello World</h1>;
+		}
+
+		let Memoized = memo(Foo);
+
+		let update;
+		class App extends Component {
+			constructor() {
+				super();
+				update = () => this.setState({});
+			}
+			render() {
+				return <Memoized />;
+			}
+		}
+		render(<App />, scratch);
+
+		expect(spy).to.be.calledOnce;
+
+		update();
+		rerender();
+
+		expect(spy).to.be.calledOnce;
+	});
+
+	it('should support custom comparer functions', () => {
+		function Foo() {
+			return <h1>Hello World</h1>;
+		}
+
+		let spy = sinon.spy(() => true);
+		let Memoized = memo(Foo, spy);
+
+		let update;
+		class App extends Component {
+			constructor() {
+				super();
+				update = () => this.setState({});
+			}
+			render() {
+				return <Memoized />;
+			}
+		}
+		render(<App />, scratch);
+
+		update();
+		rerender();
+
+		expect(spy).to.be.calledOnce;
+		expect(spy).to.be.calledWith({}, {});
+	});
+
+	it('should rerender when custom comparer returns false', () => {
+		const spy = sinon.spy();
+		function Foo() {
+			spy();
+			return <h1>Hello World</h1>;
+		}
+
+		const App = memo(Foo, () => false);
+		render(<App />, scratch);
+		expect(spy).to.be.calledOnce;
+
+		render(<App foo="bar" />, scratch);
+		expect(spy).to.be.calledTwice;
+	});
+
+	it('should pass props and nextProps to comparer fn', () => {
+		const spy = sinon.spy(() => false);
+		function Foo() {
+			return <div>foo</div>;
+		}
+
+		const props = { foo: true };
+		const nextProps = { foo: false };
+		const App = memo(Foo, spy);
+		render(h(App, props), scratch);
+		render(h(App, nextProps), scratch);
+
+		expect(spy).to.be.calledWith(props, nextProps);
+	});
+
+	it('should nest without errors', () => {
+		const Foo = () => <div>foo</div>;
+		const App = memo(memo(Foo));
+
+		expect(() => {
+			render(<App />, scratch);
+		}).to.not.throw();
+	});
+});

--- a/utils/test/browser/portals.test.js
+++ b/utils/test/browser/portals.test.js
@@ -1,0 +1,81 @@
+import { createElement as h, render } from 'preact';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { createPortal } from '../../src';
+/* eslint-disable react/jsx-boolean-value, react/display-name, prefer-arrow-callback */
+
+/** @jsx h */
+describe('Portal', () => {
+
+	/** @type {HTMLDivElement} */
+	let scratch;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('should render into a different root node', () => {
+		let root = document.createElement('div');
+		document.body.appendChild(root);
+
+		function Foo(props) {
+			return <div>{createPortal(props.children, root)}</div>;
+		}
+		render(<Foo>foobar</Foo>, scratch);
+
+		expect(root.innerHTML).to.equal('foobar');
+	});
+
+	it('should not render <undefined> for Portal nodes', () => {
+		let root = document.createElement('div');
+		let dialog = document.createElement('div');
+		dialog.id = 'container';
+
+		scratch.appendChild(root);
+		scratch.appendChild(dialog);
+
+		function Dialog() {
+			return <div>Dialog content</div>;
+		}
+
+		function App() {
+			return (
+				<div>
+					{createPortal(<Dialog />, dialog)}
+				</div>
+			);
+		}
+
+		render(<App />, root);
+		expect(scratch.firstChild.firstChild.childNodes.length).to.equal(0);
+	});
+
+	it('should unmount Portal', () => {
+		let root = document.createElement('div');
+		let dialog = document.createElement('div');
+		dialog.id = 'container';
+
+		scratch.appendChild(root);
+		scratch.appendChild(dialog);
+
+		function Dialog() {
+			return <div>Dialog content</div>;
+		}
+
+		function App() {
+			return (
+				<div>
+					{createPortal(<Dialog />, dialog)}
+				</div>
+			);
+		}
+
+		render(<App />, root);
+		expect(dialog.childNodes.length).to.equal(1);
+		render(null, root);
+		expect(dialog.childNodes.length).to.equal(0);
+	});
+});


### PR DESCRIPTION
Provides a solution for: https://github.com/developit/preact/issues/1529

I'm going to make a dedicated test-suite for preact/src then because now we only test if it works in /compat

Another way of going about this could be to make the side-effects in compat part of createElement. I still think that webpack would have issues tree-shaking it though. Not quite sure.