### PR TITLE
(fix) - support react-hot-loader

### DIFF
--- a/mangle.json
+++ b/mangle.json
@@ -33,8 +33,7 @@
       "$_context": "__n",
       "$_defaultValue": "__p",
       "$_id": "__c",
-      "$_parentDom": "__P",
-      "$_self": "_"
+      "$_parentDom": "__P"
     }
   }
 }

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -60,9 +60,9 @@ export function createVNode(type, props, key, ref) {
 		_children: null,
 		_dom: null,
 		_lastDomChild: null,
-		_component: null
+		_component: null,
+		constructor: undefined
 	};
-	vnode._self = vnode;
 
 	if (options.vnode) options.vnode(vnode);
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -35,8 +35,7 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 		newType = newVNode.type, clearProcessingException;
 
 	// When passing through createElement it assigns the object
-	// ref on _self, to prevent JSON Injection we check if this attribute
-	// is equal.
+	// constructor as undefined. This to prevent JSON-injection.
 	if (newVNode.constructor !== undefined) return null;
 
 	if (tmp = options.diff) tmp(newVNode);

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -37,7 +37,7 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 	// When passing through createElement it assigns the object
 	// ref on _self, to prevent JSON Injection we check if this attribute
 	// is equal.
-	if (newVNode._self!==newVNode) return null;
+	if (newVNode.constructor !== undefined) return null;
 
 	if (tmp = options.diff) tmp(newVNode);
 
@@ -382,7 +382,7 @@ function catchErrorInComponent(error, component) {
 						continue;
 					}
 				}
-				else if (component.constructor.getDerivedStateFromError!=null) {
+				else if (component.constructor && component.constructor.getDerivedStateFromError!=null) {
 					component.setState(component.constructor.getDerivedStateFromError(error));
 				}
 				else if (component.componentDidCatch!=null) {

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -25,7 +25,6 @@ export interface PreactElement extends HTMLElement {
 export interface VNode<P = {}> extends preact.VNode<P> {
 	// Redefine type here using our internal ComponentFactory type
 	type: string | ComponentFactory<P> | null;
-	_self: this;
 	_children: Array<VNode> | null;
 	/**
 	 * The [first (for Fragments)] DOM child of a VNode

--- a/test/shared/createElement.test.js
+++ b/test/shared/createElement.test.js
@@ -34,7 +34,6 @@ describe('createElement(jsx)', () => {
 
 	it('should set VNode.constructor property to prevent json injection', () => {
 		const vnode = <span />;
-		// eslint-disable-next-line no-proto
 		expect(vnode.constructor).to.equal(undefined);
 	});
 

--- a/test/shared/createElement.test.js
+++ b/test/shared/createElement.test.js
@@ -32,9 +32,10 @@ describe('createElement(jsx)', () => {
 		expect(<Test />).to.have.property('type', Test);
 	});
 
-	it('should set VNode._self property to prevent json injection', () => {
+	it('should set VNode.constructor property to prevent json injection', () => {
 		const vnode = <span />;
-		expect(vnode._self).to.equal(vnode);
+		// eslint-disable-next-line no-proto
+		expect(vnode.constructor).to.equal(undefined);
 	});
 
 	it('should set VNode#props property', () => {
@@ -68,7 +69,7 @@ describe('createElement(jsx)', () => {
 	});
 
 	it('should have ordered VNode properties', () => {
-		expect(Object.keys(<div />).filter(key => !/^_/.test(key))).to.deep.equal(['type', 'props', 'key', 'ref']);
+		expect(Object.keys(<div />).filter(key => !/^_/.test(key))).to.deep.equal(['type', 'props', 'key', 'ref', 'constructor']);
 	});
 
 	it('should preserve raw props', () => {


### PR DESCRIPTION
__proto__ gave odd issues with devtools, because the objects weren't convertible anymore. Something really odd going on there.

Adds 8B

Fixes: https://github.com/developit/preact/issues/1620