### PR TITLE
Consistently use key check logic (-12 B)

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -61,7 +61,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 			// (holes).
 			oldVNode = oldChildren[i];
 
-			if (oldVNode===null || (oldVNode && (oldVNode.key!=null ? (childVNode.key === oldVNode.key) : (childVNode.key==null && childVNode.type === oldVNode.type)))) {
+			if (oldVNode===null || (oldVNode && childVNode.key == oldVNode.key && childVNode.type === oldVNode.type)) {
 				oldChildren[i] = undefined;
 			}
 			else {


### PR DESCRIPTION
Apply the key check simplification from #1637 to the other place where we looking for matching keys. Reusing the same logic saves us a decent amount of bytes.