### PR TITLE
Fix initially suspended component under sCU

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -3,10 +3,11 @@ import { removeNode } from '../../src/util';
 
 export function catchRender(error, component) {
 	// thrown Promises are meant to suspend...
+	let suspendingComponent = component;
 	if (error.then) {
 		for (; component; component = component._ancestorComponent) {
 			if (component._childDidSuspend) {
-				component._childDidSuspend(error);
+				component._childDidSuspend(error, suspendingComponent);
 				return true;
 			}
 		}
@@ -36,6 +37,7 @@ export function Suspense(props) {
 	// we do not call super here to golf some bytes...
 	this._suspensions = [];
 }
+Suspense.displayName = 'Suspense';
 
 // Things we do here to save some bytes but are not proper JS inheritance:
 // - call `new Component()` as the prototype
@@ -45,7 +47,7 @@ Suspense.prototype = new Component();
 /**
  * @param {Promise} promise The thrown promise
  */
-Suspense.prototype._childDidSuspend = function(promise) {
+Suspense.prototype._childDidSuspend = function(promise, suspendingComponent) {
 	// saves 5B
 	const _this = this;
 
@@ -53,6 +55,14 @@ Suspense.prototype._childDidSuspend = function(promise) {
 	let len = _this._suspensions.length;
 
 	const suspensionsCompleted = () => {
+		// The following would allow us to call forceUpdate() on the comp itself but then
+		// we would need to delay _this forceUpdate() until all suspensions cleared as otherwise
+		// the component might get visible too soon
+		// suspendingComponent._parentDom = suspendingComponent._ancestorComponent.base
+		//                                  || suspendingComponent._ancestorComponent._parentDom;
+
+		suspendingComponent._ancestorComponent.forceUpdate();
+
 		// make sure we did not add any more suspensions
 		if (len === _this._suspensions.length) {
 			// clear old suspensions
@@ -119,8 +129,7 @@ export function lazy(loader) {
 
 	function Lazy(props) {
 		if (!prom) {
-			prom = loader();
-			prom.then(
+			prom = loader().then(
 				(exports) => { component = exports.default; },
 				(e) => { error = e; },
 			);


### PR DESCRIPTION
So the parking approach to suspense has an issue when the suspending component suspends on the first render (as lazy() does) and is under a component with an sCU that returns false. This is represented by the newly added `should work throughout sCU when initially being suspended` test.

My first approach was to patch the `_parentDom` attribute and then call `forceUpdate()` on the component that suspended. The problem with this is, that when this component is directly under `Suspense` that it will show up (modify the DOM) too soon.

The second approach (this PR) is to not patch the `_parentDom` but call `forceUpdate()` on the `_ancestorComponent` of the suspending component. This seems to work but feels wrong. It also breaks other tests since it will result in some render methods being called too often.

Other thoughts I will explore:
- ~~Patch `_parentDom` and call `forceUpdate` on all suspending components once all of them finished.~~ This seems wrong as a suspending component might suspend again.