### PR TITLE
Add preact-charts to Component Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Preact supports modern browsers and IE9+:
 - [**preact-photon**](https://git.io/preact-photon): build beautiful desktop UI with [photon](http://photonkit.com)
 - [**preact-mdl**](https://git.io/preact-mdl): [Material Design Lite](https://getmdl.io) for Preact
 - [**preact-weui**](https://github.com/afeiship/preact-weui): [Weui](https://github.com/afeiship/preact-weui) for Preact
+- [**preact-charts**](https://github.com/pmkroeker/preact-charts): Charts for Preact
 
 
 ---


### PR DESCRIPTION
With preact-X now in beta.2, I have moved preact-charts up to version 1! With support for both preact 8.4.2 and X! It would be great to be included in the README.