### PR TITLE
Retype style to error on strings

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -601,7 +601,7 @@ export namespace JSXInternal {
 		srcSet?: string;
 		start?: number;
 		step?: number | string;
-		style?: any;
+		style?: {[key: string]: string | number};
 		summary?: string;
 		tabIndex?: number;
 		target?: string;


### PR DESCRIPTION
In #1606, support for string styles was removed. This change to the typings enforces that you must pass an object to `style`. This change will help improved typescript users transition to non-string stylings, with an error being thrown.

Could also possible add in something like [csstype](https://www.npmjs.com/package/csstype) to fill out the possibilities more fully, but I think that it would add extra stuff people would need to download with the package.

**EDIT**: Not sure why coverage decreased.