### PR TITLE
Add toEqualNode chai assertion

### DIFF
--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -21,7 +21,7 @@ describe('forwardRef', () => {
 		let ref = createRef();
 		render(<App ref={ref} />, scratch);
 
-		expect(ref.current).to.equal(scratch.firstChild);
+		expect(ref.current).to.equalNode(scratch.firstChild);
 	});
 
 	it('should share the same ref reference', () => {
@@ -42,7 +42,7 @@ describe('forwardRef', () => {
 		let ref;
 		render(<App ref={x => (ref = x)} />, scratch);
 
-		expect(ref).to.equal(scratch.firstChild.firstChild);
+		expect(ref).to.equalNode(scratch.firstChild.firstChild);
 	});
 
 	it('should forward props', () => {

--- a/compat/test/browser/index.test.js
+++ b/compat/test/browser/index.test.js
@@ -270,7 +270,7 @@ describe('preact-compat', () => {
 
 		it('should return a regular DOM Element if given a regular DOM Element', () => {
 			let scratch = document.createElement('div');
-			expect(findDOMNode(scratch)).to.equal(scratch);
+			expect(findDOMNode(scratch)).to.equalNode(scratch);
 		}),
 
 		// NOTE: React.render() returning false or null has the component pointing

--- a/debug/test/browser/devtools.test.js
+++ b/debug/test/browser/devtools.test.js
@@ -534,7 +534,7 @@ describe('devtools', () => {
 			let vnode = scratch._prevVNode;
 			let rid = Object.keys(hook._renderers)[0];
 			let renderer = hook._renderers[rid];
-			expect(renderer.findHostInstanceByFiber(vnode)).to.equal(vnode._dom);
+			expect(renderer.findHostInstanceByFiber(vnode)).to.equalNode(vnode._dom);
 		});
 
 		it('should find vnode by dom node', () => {
@@ -551,7 +551,7 @@ describe('devtools', () => {
 			let vnode = scratch._prevVNode;
 			let rid = Object.keys(hook._renderers)[0];
 			let helpers = hook.helpers[rid];
-			expect(helpers.getNativeFromReactElement(vnode)).to.equal(vnode._dom);
+			expect(helpers.getNativeFromReactElement(vnode)).to.equalNode(vnode._dom);
 		});
 
 		it('should getReactElementFromNative', () => {

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -1392,24 +1392,24 @@ describe('Components', () => {
 		}
 
 		render(<App />, scratch);
-		expect(child._vnode._dom).to.equal(child.base);
+		expect(child._vnode._dom).to.equalNode(child.base);
 
 		app.forceUpdate();
-		expect(child._vnode._dom).to.equal(child.base);
+		expect(child._vnode._dom).to.equalNode(child.base);
 
 		parent.setState({});
 		condition = true;
 		child.forceUpdate();
-		expect(child._vnode._dom).to.equal(child.base);
+		expect(child._vnode._dom).to.equalNode(child.base);
 		rerender();
 
-		expect(child._vnode._dom).to.equal(child.base);
+		expect(child._vnode._dom).to.equalNode(child.base);
 
 		condition = false;
 		app.setState({});
 		child.forceUpdate();
 		rerender();
-		expect(child._vnode._dom).to.equal(child.base);
+		expect(child._vnode._dom).to.equalNode(child.base);
 	});
 
 	it('should update old dom on forceUpdate in a lifecycle', () => {

--- a/test/browser/focus.test.js
+++ b/test/browser/focus.test.js
@@ -26,7 +26,7 @@ describe('focus', () => {
 		input.focus();
 		input.setSelectionRange(2, 5);
 
-		expect(document.activeElement).to.equal(input);
+		expect(document.activeElement).to.equalNode(input);
 
 		return input;
 	}
@@ -39,7 +39,7 @@ describe('focus', () => {
 		input.focus();
 		input.setSelectionRange(2, 5);
 
-		expect(document.activeElement).to.equal(input);
+		expect(document.activeElement).to.equalNode(input);
 
 		return input;
 	}
@@ -51,9 +51,7 @@ describe('focus', () => {
 	 * eqaul to the `input` parameter
 	 */
 	function validateFocus(input, message) {
-		// Check `nodeName` first to make cli output less spammy
-		expect(document.activeElement.nodeName).to.equal(input.nodeName, message);
-		expect(document.activeElement).to.equal(input, message);
+		expect(document.activeElement).to.equalNode(input, message);
 		expect(input.selectionStart).to.equal(2);
 		expect(input.selectionEnd).to.equal(5);
 
@@ -442,7 +440,7 @@ describe('focus', () => {
 		input.focus();
 		updateState();
 
-		expect(document.activeElement).to.equal(input, 'Before rerender');
+		expect(document.activeElement).to.equalNode(input, 'Before rerender');
 		rerender();
 
 		expect(scratch.innerHTML).to.equal(div([
@@ -452,7 +450,7 @@ describe('focus', () => {
 			'foobar',
 			inputStr()
 		].join('')));
-		expect(document.activeElement).to.equal(input, 'After rerender');
+		expect(document.activeElement).to.equalNode(input, 'After rerender');
 	});
 
 	it('should keep text selection', () => {
@@ -504,7 +502,7 @@ describe('focus', () => {
 		input.setSelectionRange(2, 5);
 		updateState();
 
-		expect(document.activeElement).to.equal(input, 'Before rerender');
+		expect(document.activeElement).to.equalNode(input, 'Before rerender');
 		rerender();
 
 		expect(scratch.innerHTML).to.equal(div([
@@ -516,6 +514,6 @@ describe('focus', () => {
 		].join('')));
 		expect(input.selectionStart).to.equal(2);
 		expect(input.selectionEnd).to.equal(5);
-		expect(document.activeElement).to.equal(input, 'After rerender');
+		expect(document.activeElement).to.equalNode(input, 'After rerender');
 	});
 });

--- a/test/browser/lifecycle.test.js
+++ b/test/browser/lifecycle.test.js
@@ -876,7 +876,7 @@ describe('Lifecycle methods', () => {
 
 					// Verify that the component is actually mounted when this
 					// callback is invoked.
-					expect(scratch.querySelector('#inner')).to.equal(this.base);
+					expect(scratch.querySelector('#inner')).to.equalNode(this.base);
 				}
 
 				render() {

--- a/test/browser/refs.test.js
+++ b/test/browser/refs.test.js
@@ -35,7 +35,7 @@ describe('refs', () => {
 		expect(r.current).to.equal(undefined);
 
 		render(<div ref={r} />, scratch);
-		expect(r.current).to.equal(scratch.firstChild);
+		expect(r.current).to.equalNode(scratch.firstChild);
 	});
 
 	it('should invoke refs in Component.render()', () => {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -646,7 +646,7 @@ describe('render()', () => {
 			// Re-render
 			thing.forceUpdate();
 
-			expect(firstInnerHTMLChild).to.equal(scratch.firstChild.firstChild);
+			expect(firstInnerHTMLChild).to.equalNode(scratch.firstChild.firstChild);
 		});
 	});
 
@@ -689,10 +689,8 @@ describe('render()', () => {
 			</div>
 		), scratch);
 
-		expect(scratch.firstChild.firstChild).to.have.property('nodeName', 'B');
-		expect(scratch.firstChild.lastChild).to.have.property('nodeName', 'A');
-		expect(scratch.firstChild.firstChild).to.equal(b);
-		expect(scratch.firstChild.lastChild).to.equal(a);
+		expect(scratch.firstChild.firstChild).to.equalNode(b);
+		expect(scratch.firstChild.lastChild).to.equalNode(a);
 	});
 
 	it('should not merge attributes with node created by the DOM', () => {
@@ -792,12 +790,12 @@ describe('render()', () => {
 		});
 
 		// Before Preact rerenders, focus should be on the input
-		expect(document.activeElement).to.equal(input);
+		expect(document.activeElement).to.equalNode(input);
 
 		rerender();
 
 		// After Preact rerenders, focus should remain on the input
-		expect(document.activeElement).to.equal(input);
+		expect(document.activeElement).to.equalNode(input);
 		expect(scratch.innerHTML).to.contain(`<span>${todoText}</span>`);
 	});
 
@@ -986,7 +984,7 @@ describe('render()', () => {
 		it('should use replaceNode as render root and not inject into it', () => {
 			const childA = scratch.querySelector('#a');
 			render(<div id="a">contents</div>, scratch, childA);
-			expect(scratch.querySelector('#a')).to.equal(childA);
+			expect(scratch.querySelector('#a')).to.equalNode(childA);
 			expect(childA.innerHTML).to.equal('contents');
 		});
 

--- a/test/extensions.d.ts
+++ b/test/extensions.d.ts
@@ -1,0 +1,5 @@
+declare module Chai {
+	export interface Assertion {
+		equalNode(node: Node | null, message?: string): void;
+	}
+}

--- a/test/polyfills.js
+++ b/test/polyfills.js
@@ -21,3 +21,34 @@ if (!(function f() {}).name) {
 		}
 	});
 }
+
+/* global chai */
+chai.use((chai, util) => {
+	const Assertion = chai.Assertion;
+
+	Assertion.addMethod('equalNode', function (expectedNode, message) {
+		const obj = this._obj;
+
+		if (expectedNode == null) {
+			new Assertion(obj).to.equal(expectedNode);
+		}
+		else {
+			new Assertion(obj).to.be.instanceof(Node);
+			// new Assertion(obj).to.have.property('tagName', expectedNode.tagName);
+			this.assert(
+				obj.tagName === expectedNode.tagName,
+				`${message}: expected node to have tagName #{exp} but got #{act} instead.`,
+				`${message}: expected node to not have tagName #{act} instead.`,
+				expectedNode.tagName,
+				obj.tagName
+			);
+			this.assert(
+				obj === expectedNode,
+				`${message}: expected #{this} to be #{exp} but got #{act}`,
+				`${message}: expected #{this} not to be #{exp}`,
+				expectedNode,
+				obj
+			);
+		}
+	});
+});


### PR DESCRIPTION
Add a new chai assertion to check if two DOM Nodes are equal. This helper improves the error output if the assertion is incorrect by first checking if the tagNames of the two Nodes are equal before checking their referential equality.

Makes it unlikely that Karma will dump the entire DOM contents of a Node if a test is failing.