### PR TITLE
Bypass props during hydration

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -232,9 +232,9 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
 					dom.innerHTML = newHtml && newHtml.__html || '';
 				}
 			}
-
-			diffProps(dom, newProps, oldProps, isSvg);
 		}
+
+		diffProps(dom, newProps, oldProps, isSvg, excessDomChildren!=null);
 
 		// If the new vnode didn't have dangerouslySetInnerHTML, diff its children
 		if (!newHtml) {

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -222,18 +222,30 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
 
 		let oldHtml = oldProps.dangerouslySetInnerHTML;
 		let newHtml = newProps.dangerouslySetInnerHTML;
-		if ((newHtml || oldHtml) && excessDomChildren==null) {
-			// Avoid re-applying the same '__html' if it did not changed between re-render
-			if (!newHtml || !oldHtml || newHtml.__html!=oldHtml.__html) {
-				dom.innerHTML = newHtml && newHtml.__html || '';
+
+		// During hydration, props are not diffed at all (including dangerouslySetInnerHTML)
+		// @TODO we should warn in debug mode when props don't match here.
+		if (excessDomChildren == null) {
+			if (newHtml || oldHtml) {
+				// Avoid re-applying the same '__html' if it did not changed between re-render
+				if (!newHtml || !oldHtml || newHtml.__html!=oldHtml.__html) {
+					dom.innerHTML = newHtml && newHtml.__html || '';
+				}
 			}
-		}
-		if (newProps.multiple) {
-			dom.multiple = newProps.multiple;
+
+			diffProps(dom, newProps, oldProps, isSvg);
 		}
 
-		diffChildren(dom, newVNode, oldVNode, context, newVNode.type==='foreignObject' ? false : isSvg, excessDomChildren, mounts, EMPTY_OBJ);
-		diffProps(dom, newProps, oldProps, isSvg);
+		// If the new vnode didn't have dangerouslySetInnerHTML, diff its children
+		if (!newHtml) {
+			diffChildren(dom, newVNode, oldVNode, context, newVNode.type==='foreignObject' ? false : isSvg, excessDomChildren, mounts, EMPTY_OBJ);
+		}
+
+		// (as above, don't diff props during hydration)
+		if (excessDomChildren == null) {
+			if (('value' in newProps) && newProps.value!==undefined && newProps.value !== dom.value) dom.value = newProps.value==null ? '' : newProps.value;
+			if (('checked' in newProps) && newProps.checked!==undefined && newProps.checked !== dom.checked) dom.checked = newProps.checked;
+		}
 	}
 
 	return dom;

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -8,8 +8,9 @@ import options from '../options';
  * @param {object} newProps The new props
  * @param {object} oldProps The old props
  * @param {boolean} isSvg Whether or not this node is an SVG node
+ * @param {boolean} hydrate Whether or not we are in hydration mode
  */
-export function diffProps(dom, newProps, oldProps, isSvg) {
+export function diffProps(dom, newProps, oldProps, isSvg, hydrate) {
 	let i;
 
 	for (i in oldProps) {
@@ -19,7 +20,7 @@ export function diffProps(dom, newProps, oldProps, isSvg) {
 	}
 
 	for (i in newProps) {
-		if (i!=='value' && i!=='checked' && oldProps[i]!==newProps[i]) {
+		if ((!hydrate || typeof newProps[i]=='function') && i!=='value' && i!=='checked' && oldProps[i]!==newProps[i]) {
 			setProperty(dom, i, newProps[i], oldProps[i], isSvg);
 		}
 	}

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -1,6 +1,5 @@
-import { IS_NON_DIMENSIONAL, EMPTY_OBJ } from '../constants';
+import { IS_NON_DIMENSIONAL } from '../constants';
 import options from '../options';
-import { assign } from '../util';
 
 /**
  * Diff the old and new properties of a VNode and apply changes to the DOM node
@@ -13,29 +12,27 @@ import { assign } from '../util';
 export function diffProps(dom, newProps, oldProps, isSvg) {
 	let i;
 
-	const keys = Object.keys(newProps).sort();
-	for (i = 0; i < keys.length; i++) {
-		const k = keys[i];
-		if (
-			k!=='children' &&
-			k!=='key' &&
-			// We check for value and checked to diff it against the DOM #1324
-			// However value can't be undefined since this would indicate us dealing with an uncontrolled node.
-			(!oldProps || (((k==='value' || k==='checked') && newProps[k]!==undefined) ? dom : oldProps)[k]!==newProps[k])
-		) {
-			setProperty(dom, k, newProps[k], oldProps[k], isSvg);
+	for (i in oldProps) {
+		if (!(i in newProps)) {
+			setProperty(dom, i, null, oldProps[i], isSvg);
 		}
 	}
 
-	for (i in oldProps) {
-		if (i!=='children' && i!=='key' && !(i in newProps)) {
-			setProperty(dom, i, null, oldProps[i], isSvg);
+	for (i in newProps) {
+		if (i!=='value' && i!=='checked' && oldProps[i]!==newProps[i]) {
+			setProperty(dom, i, newProps[i], oldProps[i], isSvg);
 		}
 	}
 }
 
-const CAMEL_REG = /[A-Z]/g;
-const XLINK_NS = 'http://www.w3.org/1999/xlink';
+function setStyle(style, key, value) {
+	if (key[0] === '-') {
+		style.setProperty(key, value);
+	}
+	else {
+		style[key] = typeof value==='number' && IS_NON_DIMENSIONAL.test(key)===false ? value+'px' : value;
+	}
+}
 
 /**
  * Set a property value on a DOM node
@@ -48,8 +45,9 @@ const XLINK_NS = 'http://www.w3.org/1999/xlink';
 function setProperty(dom, name, value, oldValue, isSvg) {
 	name = isSvg ? (name==='className' ? 'class' : name) : (name==='class' ? 'className' : name);
 
-	if (name==='style') {
-		let s = dom.style;
+	if (name==='key' || name === 'children') {}
+	else if (name==='style') {
+		const s = dom.style;
 
 		if (typeof value==='string') {
 			s.cssText = value;
@@ -57,22 +55,19 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 		else {
 			if (typeof oldValue==='string') {
 				s.cssText = '';
-				oldValue = EMPTY_OBJ;
+				oldValue = null;
 			}
 
-			const set = assign(assign({}, oldValue), value);
-			for (let i in set) {
-				if ((value || EMPTY_OBJ)[i] === (oldValue || EMPTY_OBJ)[i]) {
-					continue;
+			if (oldValue) for (let i in oldValue) {
+				if (!(value && i in value)) {
+					setStyle(s, i, '');
 				}
-				s.setProperty(
-					(i[0] === '-' && i[1] === '-') ? i : i.replace(CAMEL_REG, '-$&'),
-					(value && (i in value))
-						? (typeof set[i]==='number' && IS_NON_DIMENSIONAL.test(i)===false)
-							? set[i] + 'px'
-							: set[i]
-						: ''
-				);
+			}
+
+			if (value) for (let i in value) {
+				if (!oldValue || value[i] !== oldValue[i]) {
+					setStyle(s, i, value[i]);
+				}
 			}
 		}
 
@@ -106,10 +101,10 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 	else if (typeof value!=='function' && name!=='dangerouslySetInnerHTML') {
 		if (name!==(name = name.replace(/^xlink:?/, ''))) {
 			if (value==null || value===false) {
-				dom.removeAttributeNS(XLINK_NS, name.toLowerCase());
+				dom.removeAttributeNS('http://www.w3.org/1999/xlink', name.toLowerCase());
 			}
 			else {
-				dom.setAttributeNS(XLINK_NS, name.toLowerCase(), value);
+				dom.setAttributeNS('http://www.w3.org/1999/xlink', name.toLowerCase(), value);
 			}
 		}
 		else if (value==null || value===false) {

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -138,12 +138,8 @@ describe('hydrate()', () => {
 		clearLog();
 		hydrate(vnode, scratch);
 
-		expect(serializeHtml(scratch)).to.equal(sortAttributes('<div><span before-hydrate="test" same-value="foo" different-value="b" new-value="c">Test</span></div>'));
-		expect(getLog()).to.deep.equal([
-			'<span>Test.setAttribute(different-value, b)',
-			'<span>Test.setAttribute(new-value, c)',
-			'<span>Test.setAttribute(same-value, foo)'
-		]);
+		expect(serializeHtml(scratch)).to.equal(sortAttributes('<div><span before-hydrate="test" different-value="a" same-value="foo">Test</span></div>'));
+		expect(getLog()).to.deep.equal([]);
 	});
 
 	it('should update class attribute via className prop', () => {

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -257,4 +257,15 @@ describe('hydrate()', () => {
 		// TODO: Fill in with proper log once this test is passing
 		expect(getLog()).to.deep.equal([]);
 	});
+
+	it('should attach event handlers', () => {
+		let spy = sinon.spy();
+		scratch.innerHTML = '<span>Test</span>';
+		let vnode = <span onClick={spy}>Test</span>;
+
+		hydrate(vnode, scratch);
+
+		scratch.firstChild.click();
+		expect(spy).to.be.calledOnce;
+	});
 });

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -674,8 +674,8 @@ describe('render()', () => {
 			// eslint-disable-next-line react/no-danger
 			render(<div dangerouslySetInnerHTML={{ __html: html }} />, scratch);
 
-			expect(scratch.firstChild).to.have.property('innerHTML', '');
-			expect(scratch.innerHTML).to.equal(`<div></div>`);
+			expect(scratch.firstChild).to.have.property('innerHTML', html);
+			expect(scratch.innerHTML).to.equal(`<div>${html}</div>`);
 		});
 
 		it('should avoid reapplying innerHTML when __html property of dangerouslySetInnerHTML attr remains unchanged', () => {


### PR DESCRIPTION
This fixes a couple things that end up being best done together:

- instead of special-casing the `multiple` prop by applying it before diffing other props, it leverages the fact that preact already special-cases the `value` and `checked` props. Pulling these out into `diffElementNodes()` ensures they are applied last.

- during hydration (`excessDomChildren==null`), never call `diffProps()`. This makes it so that Preact no longer diffs attributes and props at all during hydration - previously only unknown attributes were ignored, but for performance reasons and to match other VDOM libraries it's worth also not diffing known attributes

- don't diff children when a node has dangerouslySetInnerHTML applied. This avoids the case where you have a node with both dangerouslySetInnerHTML and children specified, which previously would continually remove children. The solution in this PR probably doesn't correctly unmount children when transitioning from JSX children to dangerouslySetInnerHTML. This could perhaps be fixed by having the existence of dangerouslySetInnerHTML for a VNode assign `vnode._children=[]`.

- **styles:** this should be a bit of a performance optimization for styles. It's hard to verify, but I think I'm seeing some relatively consistent numbers in the perf tests showing this to be the case. I'd originally made the change in order to fix the style issue someone reported this week (can't find an open issue about it for some reason)