### PR TITLE
Disable Safari in Saucelabs tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,12 +20,16 @@ var sauceLabsLaunchers = {
 		browserName: 'firefox',
 		platform: 'Windows 10'
 	},
-	sl_safari: {
-		base: 'SauceLabs',
-		browserName: 'Safari',
-		version: '11',
-		platform: 'OS X 10.13'
-	},
+	// TODO: Safari always fails and disconnects before any tests are executed.
+	// This seems to be an issue with Saucelabs and they're actively investigating
+	// that (see: https://mobile.twitter.com/bromann/status/1136323458328084482).
+	// We'll disable Safari for now until that's resolved.
+	// sl_safari: {
+	// 	base: 'SauceLabs',
+	// 	browserName: 'Safari',
+	// 	version: '11',
+	// 	platform: 'OS X 10.13'
+	// },
 	sl_edge: {
 		base: 'SauceLabs',
 		browserName: 'MicrosoftEdge',


### PR DESCRIPTION
This PR disables test execution on Safari. We tried various combinations of MacOS and Safari versions and can't get it to work. It always times out with an exception before any test is run.

At this years JSConfEU (2019) we got in touch with the Saucelabs team and they are [investigating](https://mobile.twitter.com/bromann/status/1136323458328084482) this issue. In the meantime it's best to disable that browser for now as discussed on slack :tada: