### PR TITLE
Fix cross browser assertions

### DIFF
--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -83,7 +83,7 @@ describe('Portal', () => {
 		let set;
 
 		function Foo(props) {
-			const [additionalProps, setProps] = useState({ style: { background: 'red' } });
+			const [additionalProps, setProps] = useState({ style: { backgroundColor: 'red' } });
 			set = (c) => setProps(c);
 			return (
 				<div>
@@ -94,11 +94,11 @@ describe('Portal', () => {
 		}
 
 		render(<Foo />, scratch);
-		expect(scratch.firstChild.style.background).to.equal('red');
+		expect(scratch.firstChild.style.backgroundColor).to.equal('red');
 
 		set({});
 		rerender();
-		expect(scratch.firstChild.style.background).to.equal('');
+		expect(scratch.firstChild.style.backgroundColor).to.equal('');
 	});
 
 	it('should not unmount the portal component', () => {

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -171,21 +171,15 @@ describe('debug', () => {
 		expect(fn).to.throw(/createElement/);
 	});
 
-	it('Should throw errors when accessing certain attributes', () => {
-		let Foo = () => <div />;
-		const oldOptionsVnode = options.vnode;
-		options.vnode = (vnode) => {
-			oldOptionsVnode(vnode);
-			expect(() => vnode).to.not.throw();
-			expect(() => vnode.attributes).to.throw(/use vnode.props/);
-			expect(() => vnode.nodeName).to.throw(/use vnode.type/);
-			expect(() => vnode.children).to.throw(/use vnode.props.children/);
-			expect(() => vnode.attributes = {}).to.throw(/use vnode.props/);
-			expect(() => vnode.nodeName = 'test').to.throw(/use vnode.type/);
-			expect(() => vnode.children = [<div />]).to.throw(/use vnode.props.children/);
-		};
-		render(<Foo />, scratch);
-		options.vnode = oldOptionsVnode;
+	it('should throw errors when accessing certain attributes', () => {
+		const vnode = h('div', null);
+		expect(() => vnode).to.not.throw();
+		expect(() => vnode.attributes).to.throw(/use vnode.props/);
+		expect(() => vnode.nodeName).to.throw(/use vnode.type/);
+		expect(() => vnode.children).to.throw(/use vnode.props.children/);
+		expect(() => vnode.attributes = {}).to.throw(/use vnode.props/);
+		expect(() => vnode.nodeName = 'test').to.throw(/use vnode.type/);
+		expect(() => vnode.children = [<div />]).to.throw(/use vnode.props.children/);
 	});
 
 	it('should print an error when component is an array', () => {

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -77,9 +77,7 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 		// Only `<select>` elements have the length property
 		if (dom.length && name=='value') {
 			for (name = dom.length; name--;) {
-				if (dom.options[name].value==value) {
-					dom.selectedIndex = name;
-				}
+				dom.options[name].selected = dom.options[name].value==value;
 			}
 		}
 		else {

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -12,7 +12,7 @@ import { assign } from '../util';
  */
 export function diffProps(dom, newProps, oldProps, isSvg) {
 	let i;
-	
+
 	const keys = Object.keys(newProps).sort();
 	for (i = 0; i < keys.length; i++) {
 		const k = keys[i];
@@ -73,7 +73,18 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 		}
 	}
 	else if (name!=='list' && name!=='tagName' && !isSvg && (name in dom)) {
-		dom[name] = value==null ? '' : value;
+		// Setting `select.value` doesn't work in IE11.
+		// Only `<select>` elements have the length property
+		if (dom.length && name=='value') {
+			for (name = dom.length; name--;) {
+				if (dom.options[name].value==value) {
+					dom.selectedIndex = name;
+				}
+			}
+		}
+		else {
+			dom[name] = value==null ? '' : value;
+		}
 	}
 	else if (typeof value!=='function' && name!=='dangerouslySetInnerHTML') {
 		if (name!==(name = name.replace(/^xlink:?/, ''))) {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -402,9 +402,9 @@ describe('render()', () => {
 
 		it('should remove old styles', () => {
 			render(<div style={{ color: 'red' }} />, scratch);
-			render(<div style={{ background: 'blue' }} />, scratch);
-			expect(scratch.firstChild.style).to.have.property('color').that.equals('');
-			expect(scratch.firstChild.style).to.have.property('background').that.equals('blue');
+			render(<div style={{ backgroundColor: 'blue' }} />, scratch);
+			expect(scratch.firstChild.style.color).to.equal('');
+			expect(scratch.firstChild.style.backgroundColor).to.equal('blue');
 		});
 
 		// Skip test if the currently running browser doesn't support CSS Custom Properties

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -318,11 +318,17 @@ describe('render()', () => {
 		let div = scratch.childNodes[0];
 		expect(div.attributes.length).to.equal(2);
 
-		expect(div.attributes[0].name).equal('bar');
-		expect(div.attributes[0].value).equal('abc');
+		// Normalize attribute order because it's different in various browsers
+		let normalized = {};
+		for (let i = 0; i < div.attributes.length; i++) {
+			let attr = div.attributes[i];
+			normalized[attr.name] = attr.value;
+		}
 
-		expect(div.attributes[1].name).equal('foo');
-		expect(div.attributes[1].value).equal('[object Object]');
+		expect(normalized).to.deep.equal({
+			bar: 'abc',
+			foo: '[object Object]'
+		});
 	});
 
 	it('should apply class as String', () => {


### PR DESCRIPTION
This PR attempts to fix all cross-browser issues and attempts to make the CI green again. Size increase is mainly due to the IE11 workaround for `select.value`.

~~Adds `+41 B`~~ 😐
Adds `+35 B` 🙂 
