### PR TITLE
Minify names of externally exposed private functions

### DIFF
--- a/compat/mangle.json
+++ b/compat/mangle.json
@@ -23,7 +23,8 @@
       "$_render": "__r",
       "$_hook": "__h",
       "$_catchError": "__e",
-      "$_catchRender": "__E"
+      "$_catchRender": "__E",
+      "$_unmount": "_e"
     }
   }
 }

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -1,4 +1,4 @@
-import { Component, createElement, unmount } from 'preact';
+import { Component, createElement, _unmount as unmount } from 'preact';
 import { removeNode } from '../../src/util';
 
 /**

--- a/debug/mangle.json
+++ b/debug/mangle.json
@@ -35,7 +35,8 @@
       "$_render": "__r",
       "$_hook": "__h",
       "$_catchError": "__e",
-      "$_catchRender": "__E"
+      "$_catchRender": "__E",
+      "$_unmount": "_e"
     }
   }
 }

--- a/hooks/mangle.json
+++ b/hooks/mangle.json
@@ -17,7 +17,8 @@
       "$_render": "__r",
       "$_hook": "__h",
       "$_catchError": "__e",
-      "$_catchRender": "__E"
+      "$_catchRender": "__E",
+      "$_unmount": "_e"
     }
   }
 }

--- a/mangle.json
+++ b/mangle.json
@@ -39,7 +39,8 @@
       "$_render": "__r",
       "$_hook": "__h",
       "$_catchError": "__e",
-      "$_catchRender": "__E"
+      "$_catchRender": "__E",
+      "$_unmount": "_e"
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,5 +4,5 @@ export { Component } from './component';
 export { cloneElement } from './clone-element';
 export { createContext } from './create-context';
 export { toChildArray } from './diff/children';
-export { unmount } from './diff';
+export { unmount as _unmount } from './diff';
 export { default as options } from './options';


### PR DESCRIPTION
We externally expose the `unmount` function for Suspense. Since this function is only intended for internal use, this PR minifies the name.

Total change: +0 B