### PR TITLE
(bug) Fix the falsy event values beeing added

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -66,11 +66,11 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 
 		if (value) {
 			if (!oldValue) dom.addEventListener(name, eventProxy, useCapture);
+			(dom._listeners || (dom._listeners = {}))[name] = value;
 		}
 		else {
 			dom.removeEventListener(name, eventProxy, useCapture);
 		}
-		(dom._listeners || (dom._listeners = {}))[name] = value;
 	}
 	else if (name!=='list' && name!=='tagName' && !isSvg && (name in dom)) {
 		dom[name] = value==null ? '' : value;

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -462,7 +462,7 @@ describe('render()', () => {
 		});
 
 		it('should only register truthy values as handlers', () => {
-			function fooHandler() {};
+			function fooHandler() {}
 			const falsyHandler = false;
 
 			render(<div onClick={falsyHandler} onOtherClick={fooHandler} />, scratch);

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -461,6 +461,17 @@ describe('render()', () => {
 				.and.to.have.been.calledWithExactly('click', sinon.match.func, false);
 		});
 
+		it('should only register truthy values as handlers', () => {
+			function fooHandler() {};
+			const falsyHandler = false;
+
+			render(<div onClick={falsyHandler} onOtherClick={fooHandler} />, scratch);
+
+			expect(scratch.childNodes[0]._listeners).to.deep.equal({
+				OtherClick: fooHandler
+			});
+		});
+
 		it('should support native event names', () => {
 			let click = sinon.spy(),
 				mousedown = sinon.spy();


### PR DESCRIPTION
Based on this migration gist https://gist.github.com/pl12133/4a3978bd11eb3e4c7a81aa52fdbd0eb4 from @pl12133 - awesome stuff btw!, falsy events are added to the dom. We're already listen to events only if `value` is truthy, but we do keep a `_listeners` entry.

Adds `+1B` 🤔 