### PR TITLE
Add functions to `debug` for inspecting the rendered VNode tree

### DIFF
--- a/debug/src/index.js
+++ b/debug/src/index.js
@@ -1,5 +1,6 @@
 import { initDebug } from './debug';
 import { initDevTools } from './devtools';
+export { getVNodeFromContainer, getLastRenderOutput, getDOMNode, getComponent } from './inspect';
 
 if (process.env.NODE_ENV==='development') {
 	initDebug();

--- a/debug/src/inspect.js
+++ b/debug/src/inspect.js
@@ -1,0 +1,58 @@
+/**
+ * Functions for inspecting a rendered VNode tree.
+ */
+
+/**
+ * Return the VNode that was most recently rendered into a DOM container using
+ * `render`.
+ *
+ * The rendered children of the returned VNode can be inspected using
+ * `getLastRenderOutput`.
+ *
+ * @return {VNode|null}
+ */
+export function getVNodeFromContainer(container) {
+	return container._children || null;
+}
+
+/**
+ * Return the most recent rendered output from a component or vnode.
+ *
+ * Returns `null` if the component or vnode has not been rendered.
+ *
+ * @param {Component|VNode} component
+ * @return {VNode[]|null}
+ */
+export function getLastRenderOutput(componentOrVNode) {
+	const vnode = componentOrVNode._vnode || componentOrVNode;
+	return vnode._children || null;
+}
+
+/**
+ * Return the DOM node produced by rendering a VNode.
+ *
+ * Returns `null` if the vnode did not produce a DOM node or if it has not
+ * been rendered.
+ *
+ * @param {VNode}
+ * @return {Node|null}
+ */
+export function getDOMNode(vnode) {
+	if (typeof vnode.type === 'function' || vnode.type == null) {
+		return null;
+	}
+	return vnode._dom || null;
+}
+
+/**
+ * Return the `Component` instance produced by rendering a VNode.
+ *
+ * Returns `null` if the vnode did not produce a Component instance or has
+ * not been rendered.
+ *
+ * @param {VNode}
+ * @return {Component|null}
+ */
+export function getComponent(vnode) {
+	return vnode._component || null;
+}

--- a/debug/test/inspect.test.js
+++ b/debug/test/inspect.test.js
@@ -1,0 +1,90 @@
+import { createElement as h, render } from 'preact';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+import {
+	getVNodeFromContainer,
+	getLastRenderOutput,
+	getDOMNode,
+	getComponent,
+} from '../../src/inspect';
+
+/** @jsx h */
+
+describe('inspect', () => {
+	let scratch;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	describe('getVNodeFromContainer', () => {
+		it('returns `null` if no element is not a container for a rendered tree', () => {
+			expect(h('div')).to.equal(null);
+		});
+
+		it('returns root VNode if one has been rendered into container', () => {
+			render(<div someProp="someValue" />, scratch);
+			const vnode = getVNodeFromContainer(scratch);
+			expect(vnode).to.be.ok;
+			expect(vnode.props).to.deep.equal({ someProp: 'someValue' });
+		});
+	});
+
+	describe('getLastRenderOutput', () => {
+		it('returns `null` if vnode has not been rendered', () => {
+			const vnode = getLastRenderOutput(h('div'));
+			expect(vnode).to.equal(null);
+		});
+
+		it('returns rendered vnode array for a rendered vnode', () => {
+			function Comp() {
+				return <div someProp="someValue" />;
+			}
+			render(<Comp />, scratch);
+			const vnode = getVNodeFromContainer(scratch);
+			const rendered = getLastRenderOutput(vnode);
+			expect(rendered).to.be.ok;
+			expect(rendered.length).to.equal(1);
+			expect(rendered[0].type).to.equal('div');
+			expect(rendered[0].props).to.deep.equal({ someProp: 'someValue' });
+		});
+
+		it('returns rendered vnode array for a component instance', () => {
+			let instance;
+			class Component {
+				render() {
+					instance = this;
+					return <div />;
+				}
+			}
+			render(<Component />, scratch);
+			const rendered = getLastRenderOutput(instance);
+			expect(rendered).to.be.ok;
+			expect(rendered.length).to.equal(1);
+			expect(rendered.type).to.equal('div');
+		});
+	});
+
+	describe('getDOMNode', () => {
+		it('returns `null` if vnode has not been rendered', () => {
+			expect(h('div')).to.equal(null);
+		});
+
+		it('returns `null` if vnode is not a DOM element', () => {});
+
+		it('returns DOM element', () => {});
+	});
+
+	describe('getComponent', () => {
+		it('returns `null` if vnode has not been rendered', () => {
+			expect(h('div')).to.equal(null);
+		});
+
+		it('returns `null` if vnode is not a component node', () => {});
+
+		it('returns component instance if vnode is a component node', () => {});
+	});
+});


### PR DESCRIPTION
This adds a set of functions to `preact/debug` that can be used by development/testing tools to inspect the rendered component tree:

```ts
// Get the root vnode that was rendered into a DOM element.
getVNodeFromContainer(dom): VNode|null

// Get the output that were produced when a VNode or Component instance was last rendered.
getLastRenderOutput(containerOrVNode): VNode[]|null

// For rendered vnodes with a string `type` or text nodes, get the corresponding DOM node.
getDOMNode(vnode): Node|null

// For rendered vnodes with a function `type`, get the `Component` instance.
getComponent(vnode): Component|null
```

The initial use case is for the Enzyme adapter, which currently relies on [its own version of this](https://github.com/preactjs/enzyme-adapter-preact-pure/blob/master/src/preact10-internals.ts) and is vulnerable to breaking if Preact's internals change (eg. the `_prevNode` => `_children` change).

The API only exposes the minimal amount of information that the Enzyme
adpater needs, with the hope of not getting in the way of future changes
to Preact's internals.

At this stage what I'd like feedback on is whether other devs are happy with
exposing this information via APIs in the debug package, as well as any feedback
on the function names etc. If/when folks are happy with the APIs being added, I'll finish up the tests.

----

- [ ] Get approval on the new APIs being added
- [ ] Finish up the tests