### PR TITLE
use object.is instead of === to check the same state in hooks

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -9,6 +9,15 @@ let currentComponent;
 /** @type {Array<import('./internal').Component>} */
 let afterPaintEffects = [];
 
+
+/**
+ * Object.is polyfill
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+ */
+function is(x, y) {
+	return (x === y && (x !== 0 || 1 / x === 1 / y)) || (x !== x && y !== y);
+}
+
 let oldBeforeRender = options._render;
 options._render = vnode => {
 	if (oldBeforeRender) oldBeforeRender(vnode);
@@ -84,7 +93,7 @@ export function useReducer(reducer, initialState, init) {
 
 			action => {
 				const nextValue = reducer(hookState._value[0], action);
-				if (hookState._value[0]!==nextValue) {
+				if (!is(hookState._value[0], nextValue)) {
 					hookState._value[0] = nextValue;
 					hookState._component.setState({});
 				}

--- a/hooks/test/browser/useState.test.js
+++ b/hooks/test/browser/useState.test.js
@@ -80,6 +80,32 @@ describe('useState', () => {
 		expect(Comp).to.be.calledOnce;
 	});
 
+	it('does not rerender on same value', () => {
+		let lastState;
+		let doSetState;
+
+		const Comp = sinon.spy(() => {
+			const [state, setState] = useState(NaN);
+			lastState = state;
+			doSetState = setState;
+			return null;
+		});
+
+		render(<Comp />, scratch);
+		expect(lastState).to.be.NaN;
+		expect(Comp).to.be.calledOnce;
+
+		doSetState(NaN);
+		rerender();
+		expect(lastState).to.be.NaN;
+		expect(Comp).to.be.calledOnce;
+
+		doSetState(() => NaN);
+		rerender();
+		expect(lastState).to.be.NaN;
+		expect(Comp).to.be.calledOnce;
+	});
+
 	it('rerenders when setting the state', () => {
 		let lastState;
 		let doSetState;


### PR DESCRIPTION
use object.is can check NaN for hook state change, and can follow react : [https://reactjs.org/docs/hooks-reference.html#bailing-out-of-a-state-update](https://reactjs.org/docs/hooks-reference.html#bailing-out-of-a-state-update)