### PR TITLE
(fix) - replaceNode should unmount when diffing twice with replaceNode

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -13,13 +13,16 @@ import options from './options';
  */
 export function render(vnode, parentDom, replaceNode) {
 	if (options._root) options._root(vnode, parentDom);
-	let oldVNode = parentDom._children;
+	let oldVNode = replaceNode ?
+		replaceNode._children || parentDom._children :
+		parentDom._children;
+
 	vnode = createElement(Fragment, null, [vnode]);
 
 	let mounts = [];
 	diff(
 		parentDom,
-		replaceNode ? vnode : (parentDom._children = vnode),
+		replaceNode ? (replaceNode._children = vnode) : (parentDom._children = vnode),
 		oldVNode || EMPTY_OBJ,
 		EMPTY_OBJ,
 		parentDom.ownerSVGElement !== undefined,

--- a/src/render.js
+++ b/src/render.js
@@ -13,9 +13,7 @@ import options from './options';
  */
 export function render(vnode, parentDom, replaceNode) {
 	if (options._root) options._root(vnode, parentDom);
-	let oldVNode = replaceNode ?
-		replaceNode._children || parentDom._children :
-		parentDom._children;
+	let oldVNode = replaceNode && replaceNode._children || parentDom._children;
 
 	vnode = createElement(Fragment, null, [vnode]);
 

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -963,6 +963,30 @@ describe('render()', () => {
 		expect(scratch.textContent).to.equal('01');
 	});
 
+	it('should call unmount when working with replaceNode', () => {
+		const mountSpy = sinon.spy();
+		const unmountSpy = sinon.spy();
+		class MyComponent extends Component {
+			componentDidMount() {
+				mountSpy();
+			}
+			componentWillUnmount() {
+				unmountSpy();
+			}
+			render() {
+				return <div>My Component</div>;
+			}
+		}
+
+		const container = document.createElement('div');
+		scratch.appendChild(container);
+		render(<MyComponent />, scratch, container);
+		expect(mountSpy).to.be.calledOnce;
+
+		render(<div>Not my component</div>, document.body, container);
+		expect(unmountSpy).to.be.calledOnce;
+	});
+
 	it('should not cause infinite loop with referentially equal props', () => {
 		let i = 0;
 		let prevDiff = options._diff;


### PR DESCRIPTION
Fixes: https://github.com/preactjs/preact/issues/1722

Adds 7Bytes