### PR TITLE
Update suspense so tests only rely on public API

### DIFF
--- a/compat/src/internal.d.ts
+++ b/compat/src/internal.d.ts
@@ -1,7 +1,7 @@
 import { Ref } from '../..';
 import {
-  Component as PreactComponent,
-  VNode as PreactVNode,
+	Component as PreactComponent,
+	VNode as PreactVNode,
 	FunctionalComponent as PreactFunctionalComponent
 } from '../../src/internal';
 import { SuspenseProps } from './suspense';
@@ -11,25 +11,25 @@ export { ComponentChildren } from '../..';
 export { PreactElement } from '../../src/internal';
 
 export interface Component<P = {}, S = {}> extends PreactComponent<P, S> {
-  isReactComponent?: object;
+	isReactComponent?: object;
 	isPureReactComponent?: true;
 
 	_childDidSuspend?(error: Promise<void>);
 }
 
 export interface FunctionalComponent<P = {}> extends PreactFunctionalComponent<P> {
-  shouldComponentUpdate?(nextProps: Readonly<P>): boolean;
-  _forwarded?: true;
+	shouldComponentUpdate?(nextProps: Readonly<P>): boolean;
+	_forwarded?: true;
 }
 
 export interface VNode<T = any> extends PreactVNode<T> {
-  $$typeof?: symbol | string;
-  preactCompatNormalized?: boolean;
+	$$typeof?: symbol | string;
+	preactCompatNormalized?: boolean;
 }
 
 export interface ForwardFn<P = {}, T = any> {
-  (props: P, ref: Ref<T>): VNode;
-  displayName?: string;
+	(props: P, ref: Ref<T>): VNode;
+	displayName?: string;
 }
 
 export interface SuspenseState {

--- a/compat/src/internal.d.ts
+++ b/compat/src/internal.d.ts
@@ -2,8 +2,9 @@ import { Ref } from '../..';
 import {
   Component as PreactComponent,
   VNode as PreactVNode,
-  FunctionalComponent as PreactFunctionalComponent
+	FunctionalComponent as PreactFunctionalComponent
 } from '../../src/internal';
+import { SuspenseProps } from './suspense';
 
 export { ComponentChildren } from '../..';
 
@@ -11,7 +12,9 @@ export { PreactElement } from '../../src/internal';
 
 export interface Component<P = {}, S = {}> extends PreactComponent<P, S> {
   isReactComponent: object;
-  isPureReactComponent?: true;
+	isPureReactComponent?: true;
+
+	_childDidSuspend?(error: Promise<void>);
 }
 
 export interface FunctionalComponent<P = {}> extends PreactFunctionalComponent<P> {
@@ -27,4 +30,12 @@ export interface VNode<T = any> extends PreactVNode<T> {
 export interface ForwardFn<P = {}, T = any> {
   (props: P, ref: Ref<T>): VNode;
   displayName?: string;
+}
+
+export interface SuspenseComponent extends PreactComponent<SuspenseProps & { maxDuration: number; }> {
+	_suspensions: Array<Promise<any>>;
+	_parkedChildren: PreactVNode<{}>[];
+	_timeout: Promise<void>;
+	_timeoutCompleted: boolean;
+	__test__suspensions_timeout_race: Promise<void>
 }

--- a/compat/src/internal.d.ts
+++ b/compat/src/internal.d.ts
@@ -11,7 +11,7 @@ export { ComponentChildren } from '../..';
 export { PreactElement } from '../../src/internal';
 
 export interface Component<P = {}, S = {}> extends PreactComponent<P, S> {
-  isReactComponent: object;
+  isReactComponent?: object;
 	isPureReactComponent?: true;
 
 	_childDidSuspend?(error: Promise<void>);
@@ -23,8 +23,8 @@ export interface FunctionalComponent<P = {}> extends PreactFunctionalComponent<P
 }
 
 export interface VNode<T = any> extends PreactVNode<T> {
-  $$typeof: symbol | string;
-  preactCompatNormalized: boolean;
+  $$typeof?: symbol | string;
+  preactCompatNormalized?: boolean;
 }
 
 export interface ForwardFn<P = {}, T = any> {
@@ -32,10 +32,10 @@ export interface ForwardFn<P = {}, T = any> {
   displayName?: string;
 }
 
-export interface SuspenseComponent extends PreactComponent<SuspenseProps & { maxDuration: number; }> {
+export interface SuspenseState {
+	_parkedChildren: VNode<any>[];
+}
+
+export interface SuspenseComponent extends PreactComponent<SuspenseProps, SuspenseState> {
 	_suspensions: Array<Promise<any>>;
-	_parkedChildren: PreactVNode<{}>[];
-	_timeout: Promise<void>;
-	_timeoutCompleted: boolean;
-	__test__suspensions_timeout_race: Promise<void>
 }

--- a/compat/src/suspense.d.ts
+++ b/compat/src/suspense.d.ts
@@ -5,7 +5,7 @@ import { Component } from '../../src';
 // -----------------------------------
 export function lazy<T>(loader: () => Promise<{default: T}>): T;
 
-interface SuspenseProps {
+export interface SuspenseProps {
   children?: preact.ComponentChildren;
   fallback: preact.ComponentChildren;
 }

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -71,6 +71,8 @@ Suspense.prototype._childDidSuspend = function(promise) {
 
 		if (c._suspensions.length == 0) {
 			unmount(c.props.fallback);
+			c._vnode._dom = null;
+
 			c._vnode._children = c.state._parkedChildren;
 			c.setState({ _parkedChildren: null });
 		}

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -60,6 +60,7 @@ Suspense.prototype = new Component();
  */
 Suspense.prototype._childDidSuspend = function(promise) {
 	// saves 5B
+	/** @type {import('./internal').SuspenseComponent} */
 	const _this = this;
 
 	_this._suspensions.push(promise);

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -30,7 +30,7 @@ export function catchRender(error, newVNode, oldVNode) {
 	return false;
 }
 
-function removeDom(children) {
+function detachDom(children) {
 	for (let i = 0; i < children.length; i++) {
 		let child = children[i];
 		if (child != null) {
@@ -38,7 +38,7 @@ function removeDom(children) {
 				removeNode(child._dom);
 			}
 			else if (child._children) {
-				removeDom(child._children);
+				detachDom(child._children);
 			}
 		}
 	}
@@ -59,71 +59,34 @@ Suspense.prototype = new Component();
  * @param {Promise} promise The thrown promise
  */
 Suspense.prototype._childDidSuspend = function(promise) {
-	// saves 5B
+
 	/** @type {import('./internal').SuspenseComponent} */
-	const _this = this;
+	const c = this;
+	c._suspensions.push(promise);
 
-	_this._suspensions.push(promise);
-	let len = _this._suspensions.length;
+	const onSuspensionComplete = () => {
+		// From https://twitter.com/Rich_Harris/status/1125850391155965952
+		c._suspensions[c._suspensions.indexOf(promise)] = c._suspensions[c._suspensions.length - 1];
+		c._suspensions.pop();
 
-	const suspensionsCompleted = () => {
-		// make sure we did not add any more suspensions
-		if (len === _this._suspensions.length) {
-			// clear old suspensions
-			_this._suspensions = [];
-
-			// remove fallback
-			unmount(_this.props.fallback);
-
-			// make preact think we had mounted the _parkedChildren previously...
-			_this._vnode._children = _this._parkedChildren;
-			// reset the timeout & clear the now no longer parked vnode
-			_this._timeout = _this._parkedChildren = null;
-
-			_this.forceUpdate();
+		if (c._suspensions.length == 0) {
+			unmount(c.props.fallback);
+			c._vnode._children = c.state._parkedChildren;
+			c.setState({ _parkedChildren: null });
 		}
 	};
 
-	const timeoutOrSuspensionsCompleted = () => {
-		if (_this._timeoutCompleted && _this._suspensions.length && !_this._parkedChildren) {
-			// park old vnode & remove dom
-			removeDom(_this._parkedChildren = _this._vnode._children);
-			_this._vnode._children = [];
-
-			// render and mount fallback
-			_this.forceUpdate();
-		}
-	};
-
-	if (!_this._timeout) {
-		_this._timeoutCompleted = false;
-
-		_this._timeout = (
-			_this.props.maxDuration
-				? new Promise((res) => {
-					setTimeout(res, _this.props.maxDuration);
-				})
-				// even tough there is not maxDuration configured we will defer the suspension
-				// as we want the rendering/diffing to finish as it might yield other suspensions
-				: Promise.resolve()
-		)
-			.then(() => {
-				_this._timeoutCompleted = true;
-			});
+	if (c.state._parkedChildren == null) {
+		c.setState({ _parkedChildren: c._vnode._children });
+		detachDom(c._vnode._children);
+		c._vnode._children = [];
 	}
 
-	// __test__suspensions_timeout_race is assigned here to let tests await _this...
-	_this.__test__suspensions_timeout_race = Promise.race([
-		_this._timeout,
-		// Suspense ignores errors thrown in Promises as _this should be handled by user land code
-		Promise.all(_this._suspensions).then(suspensionsCompleted, suspensionsCompleted)
-	])
-		.then(timeoutOrSuspensionsCompleted);
+	promise.then(onSuspensionComplete, onSuspensionComplete);
 };
 
 Suspense.prototype.render = function(props, state) {
-	// When _parkedChildren is set, we are in suspension state
-	return this._parkedChildren ? props.fallback : props.children;
+	return state._parkedChildren ? props.fallback : props.children;
 };
 
 export function lazy(loader) {

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -5,12 +5,6 @@ import { createElement as h, render, Component, Suspense, lazy, Fragment } from 
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { enqueueRender } from '../../../src/component';
 
-class LazyComp extends Component {
-	render() {
-		return <div>Hello from LazyComp</div>;
-	}
-}
-
 /**
  * @param {h.JSX.Element} defaultResult
  * @typedef {[(c: h.JSX.Element) => void, (error: Error) => void]} Resolvers
@@ -147,8 +141,9 @@ describe('suspense', () => {
 	});
 
 	it('should support lazy', () => {
-		let resolve;
+		const LazyComp = () => <div>Hello from LazyComp</div>;
 
+		let resolve;
 		const Lazy = lazy(() => {
 			const p = new Promise((res) => {
 				resolve = () => {

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -4,9 +4,6 @@ import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render, Component, Suspense, lazy, Fragment } from '../../src/index';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
-// TODO:
-// * Have different initial component and resolved component in all tests
-
 /**
  * @typedef {import('../../../src').ComponentType} ComponentType
  * @typedef {[(c: ComponentType) => Promise<void>, (error: Error) => Promise<void>]} Resolvers
@@ -224,10 +221,10 @@ describe('suspense', () => {
 		expect(componentDidMount).to.have.been.calledOnce;
 		expect(componentWillUnmount).to.not.have.been.called;
 
-		return resolve(() => <div>Suspense</div>).then(() => {
+		return resolve(() => <div>Suspense 2</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
-				`<div>Suspense</div><div>Lifecycle</div>`
+				`<div>Suspense 2</div><div>Lifecycle</div>`
 			);
 
 			expect(componentWillMount).to.have.been.calledOnce;
@@ -278,10 +275,10 @@ describe('suspense', () => {
 		expect(componentDidMount).to.have.been.calledOnce;
 		expect(componentWillUnmount).to.not.have.been.called;
 
-		return resolve(() => <div>Suspense</div>).then(() => {
+		return resolve(() => <div>Suspense 2</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
-				`<div>Suspense</div>`
+				`<div>Suspense 2</div>`
 			);
 
 			expect(componentWillMount).to.have.been.calledOnce;
@@ -335,10 +332,10 @@ describe('suspense', () => {
 			`<div>Suspended...</div>`
 		);
 
-		return resolve(() => <div>Suspense</div>).then(() => {
+		return resolve(() => <div>Suspense 2</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
-				`<div>Suspense</div><div>Stateful: first</div>`
+				`<div>Suspense 2</div><div>Stateful: first</div>`
 			);
 		});
 	});
@@ -395,10 +392,10 @@ describe('suspense', () => {
 			`<div>Suspended...</div>`
 		);
 
-		return resolve(() => <div>Suspense</div>).then(() => {
+		return resolve(() => <div>Suspense 2</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
-				`<div>Suspense</div><div>Stateful: second</div>`
+				`<div>Suspense 2</div><div>Stateful: second</div>`
 			);
 		});
 	});
@@ -459,10 +456,10 @@ describe('suspense', () => {
 			`<div>Suspended...</div><div>Stateful: second</div>`
 		);
 
-		return resolve(() => <div>Suspense</div>).then(() => {
+		return resolve(() => <div>Suspense 2</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
-				`<div>Suspense</div><div>Stateful: second</div>`
+				`<div>Suspense 2</div><div>Stateful: second</div>`
 			);
 		});
 	});
@@ -491,10 +488,10 @@ describe('suspense', () => {
 			`<div>Suspended...</div>`
 		);
 
-		return resolve(() => <div>within error boundary</div>).then(() => {
+		return resolve(() => <div>within error boundary 2</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
-				`<div>within error boundary</div>`
+				`<div>within error boundary 2</div>`
 			);
 		});
 	});
@@ -531,7 +528,7 @@ describe('suspense', () => {
 		expect(Suspender1.prototype.render).to.have.been.calledTwice;
 		expect(Suspender2.prototype.render).to.have.been.calledTwice;
 
-		return resolve1(() => <div>Hello first</div>).then(() => {
+		return resolve1(() => <div>Hello first 2</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
 				`<div>Suspended...</div>`
@@ -539,10 +536,10 @@ describe('suspense', () => {
 			expect(Suspender1.prototype.render).to.have.been.calledTwice;
 			expect(Suspender2.prototype.render).to.have.been.calledTwice;
 
-			return resolve2(() => <div>Hello second</div>).then(() => {
+			return resolve2(() => <div>Hello second 2</div>).then(() => {
 				rerender();
 				expect(scratch.innerHTML).to.eql(
-					`<div>Hello first</div><div>Hello second</div>`
+					`<div>Hello first 2</div><div>Hello second 2</div>`
 				);
 				expect(Suspender1.prototype.render).to.have.been.calledThrice;
 				expect(Suspender2.prototype.render).to.have.been.calledThrice;
@@ -585,7 +582,7 @@ describe('suspense', () => {
 		expect(Suspender1.prototype.render).to.have.been.calledTwice;
 		expect(Suspender2.prototype.render).to.have.been.calledTwice;
 
-		return resolve1(() => <div>Hello first</div>).then(() => {
+		return resolve1(() => <div>Hello first 2</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
 				`<div>Suspended...</div>`
@@ -593,10 +590,10 @@ describe('suspense', () => {
 			expect(Suspender1.prototype.render).to.have.been.calledTwice;
 			expect(Suspender2.prototype.render).to.have.been.calledTwice;
 
-			return resolve2(() => <div>Hello second</div>).then(() => {
+			return resolve2(() => <div>Hello second 2</div>).then(() => {
 				rerender();
 				expect(scratch.innerHTML).to.eql(
-					`<div>Hello first</div><div><div>Hello second</div></div>`
+					`<div>Hello first 2</div><div><div>Hello second 2</div></div>`
 				);
 				expect(Suspender1.prototype.render).to.have.been.calledThrice;
 				expect(Suspender2.prototype.render).to.have.been.calledThrice;
@@ -627,10 +624,10 @@ describe('suspense', () => {
 			`<div>Suspended...</div>`
 		);
 
-		return resolve(() => <div>Hello</div>).then(() => {
+		return resolve(() => <div>Hello 2</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
-				`Text<div>Hello</div>`
+				`Text<div>Hello 2</div>`
 			);
 		});
 	});
@@ -677,10 +674,10 @@ describe('suspense', () => {
 
 		setState({ tag: 'article' });
 
-		return resolve(() => <div>Hello</div>).then(() => {
+		return resolve(() => <div>Hello 2</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
-				`<article>Stateful</article><div>Hello</div>`
+				`<article>Stateful</article><div>Hello 2</div>`
 			);
 		});
 	});
@@ -714,10 +711,10 @@ describe('suspense', () => {
 			`Not suspended...<div>Suspended... 2</div>`
 		);
 
-		return resolve(() => <div>Hello</div>).then(() => {
+		return resolve(() => <div>Hello 2</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
-				`Not suspended...<div>Hello</div>`
+				`Not suspended...<div>Hello 2</div>`
 			);
 		});
 	});

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -118,7 +118,7 @@ describe('suspense', () => {
 				<Lazy />
 			</Suspense>
 		);
-		
+
 		render(suspense, scratch);
 
 		return suspense._component.__test__suspensions_timeout_race.then(() => {
@@ -149,7 +149,7 @@ describe('suspense', () => {
 				</ClassWrapper>
 			</Suspense>
 		);
-		
+
 		render(suspense, scratch);
 
 		expect(scratch.innerHTML).to.eql(
@@ -198,7 +198,7 @@ describe('suspense', () => {
 				<LifecycleLogger />
 			</Suspense>
 		);
-		
+
 		render(suspense, scratch);
 
 		expect(scratch.innerHTML).to.eql(
@@ -211,7 +211,7 @@ describe('suspense', () => {
 		s._component.suspend();
 
 		rerender();
-	
+
 		return suspense._component.__test__suspensions_timeout_race.then(() => {
 			expect(scratch.innerHTML).to.eql(
 				`<div>Suspended...</div>`
@@ -227,7 +227,7 @@ describe('suspense', () => {
 					expect(scratch.innerHTML).to.eql(
 						`<div>Suspense</div><div>Lifecycle</div>`
 					);
-			
+
 					expect(componentWillMount).to.have.been.calledOnce;
 					expect(componentDidMount).to.have.been.calledOnce;
 					expect(componentWillUnmount).to.not.have.been.called;
@@ -256,7 +256,7 @@ describe('suspense', () => {
 				{s}
 			</Suspense>
 		);
-		
+
 		render(suspense, scratch);
 
 		expect(scratch.innerHTML).to.eql(
@@ -269,7 +269,7 @@ describe('suspense', () => {
 		s._component.suspend();
 
 		rerender();
-	
+
 		return suspense._component.__test__suspensions_timeout_race.then(() => {
 			expect(scratch.innerHTML).to.eql(
 				`<div>Lifecycle</div>`
@@ -285,7 +285,7 @@ describe('suspense', () => {
 					expect(scratch.innerHTML).to.eql(
 						`<div>Suspense</div>`
 					);
-			
+
 					expect(componentWillMount).to.have.been.calledOnce;
 					expect(componentDidMount).to.have.been.calledOnce;
 					expect(componentWillUnmount).to.have.been.calledOnce;
@@ -315,7 +315,7 @@ describe('suspense', () => {
 				<Stateful />
 			</Suspense>
 		);
-		
+
 		render(suspense, scratch);
 
 		expect(scratch.innerHTML).to.eql(
@@ -586,7 +586,7 @@ describe('suspense', () => {
 			expect(s1._component.spies.render).to.have.been.calledTwice;
 			expect(s1._component.spies.render).to.have.been.calledTwice;
 			expect(suspense._component._suspensions.length).to.eql(2);
-	
+
 			return s1._component.resolve()
 				.then(() => {
 					rerender();
@@ -721,12 +721,12 @@ describe('suspense', () => {
 
 		s._component.suspend();
 		rerender();
-		
+
 		return suspense._component.__test__suspensions_timeout_race.then(() => {
 			expect(scratch.innerHTML).to.eql(
 				`Not suspended...<div>Suspended... 2</div>`
 			);
-			
+
 			return s._component.resolve()
 				.then(() => Promise.all(suspense._component._suspensions))
 				.then(() => {

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -107,13 +107,11 @@ describe('suspense', () => {
 			return p;
 		});
 
-		const suspense = (
+		render((
 			<Suspense fallback={<div>Suspended...</div>}>
 				<Lazy />
 			</Suspense>
-		);
-
-		render(suspense, scratch); // Render initial state
+		), scratch); // Render initial state
 		rerender(); // Re-render with fallback cuz lazy threw
 
 		expect(scratch.innerHTML).to.eql(
@@ -147,7 +145,7 @@ describe('suspense', () => {
 
 		const [Suspender, suspend] = createSuspender(() => <div>Hello</div>);
 
-		const suspense = (
+		render((
 			<Suspense fallback={<div>Suspended...</div>}>
 				<ClassWrapper>
 					<FuncWrapper>
@@ -155,9 +153,7 @@ describe('suspense', () => {
 					</FuncWrapper>
 				</ClassWrapper>
 			</Suspense>
-		);
-
-		render(suspense, scratch);
+		), scratch);
 
 		expect(scratch.innerHTML).to.eql(
 			`<div id="class-wrapper"><div id="func-wrapper"><div>Hello</div></div></div>`
@@ -194,14 +190,12 @@ describe('suspense', () => {
 
 		const [Suspender, suspend] = createSuspender(() => <div>Suspense</div>);
 
-		const suspense = (
+		render((
 			<Suspense fallback={<div>Suspended...</div>}>
 				<Suspender />
 				<LifecycleLogger />
 			</Suspense>
-		);
-
-		render(suspense, scratch);
+		), scratch);
 
 		expect(scratch.innerHTML).to.eql(
 			`<div>Suspense</div><div>Lifecycle</div>`
@@ -249,13 +243,11 @@ describe('suspense', () => {
 
 		const [Suspender, suspend] = createSuspender(() => <div>Suspense</div>);
 
-		const suspense = (
+		render((
 			<Suspense fallback={<LifecycleLogger />}>
 				<Suspender />
 			</Suspense>
-		);
-
-		render(suspense, scratch);
+		), scratch);
 
 		expect(scratch.innerHTML).to.eql(
 			`<div>Suspense</div>`
@@ -304,14 +296,12 @@ describe('suspense', () => {
 
 		const [Suspender, suspend] = createSuspender(() => <div>Suspense</div>);
 
-		const suspense = (
+		render((
 			<Suspense fallback={<div>Suspended...</div>}>
 				<Suspender />
 				<Stateful />
 			</Suspense>
-		);
-
-		render(suspense, scratch);
+		), scratch);
 
 		expect(scratch.innerHTML).to.eql(
 			`<div>Suspense</div><div>Stateful: initial</div>`
@@ -358,14 +348,12 @@ describe('suspense', () => {
 
 		const [Suspender, suspend] = createSuspender(() => <div>Suspense</div>);
 
-		const suspense = (
+		render((
 			<Suspense fallback={<div>Suspended...</div>}>
 				<Suspender />
 				<Stateful />
 			</Suspense>
-		);
-
-		render(suspense, scratch);
+		), scratch);
 
 		expect(scratch.innerHTML).to.eql(
 			`<div>Suspense</div><div>Stateful: initial</div>`
@@ -417,14 +405,11 @@ describe('suspense', () => {
 
 		const [Suspender, suspend] = createSuspender(() => <div>Suspense</div>);
 
-		const suspense = (
-			<Suspense fallback={<div>Suspended...</div>}>
-				<Suspender />
-			</Suspense>
-		);
 		render(
 			<Fragment>
-				{suspense}
+				<Suspense fallback={<div>Suspended...</div>}>
+					<Suspender />
+				</Suspense>
 				<Stateful />
 			</Fragment>,
 			scratch
@@ -467,15 +452,13 @@ describe('suspense', () => {
 	it('should suspend with custom error boundary', () => {
 		const [Suspender, suspend] = createSuspender(() => <div>within error boundary</div>);
 
-		const suspense = (
+		render((
 			<Suspense fallback={<div>Suspended...</div>}>
 				<Catcher>
 					<Suspender />
 				</Catcher>
 			</Suspense>
-		);
-
-		render(suspense, scratch);
+		), scratch);
 
 		expect(scratch.innerHTML).to.eql(
 			`<div>within error boundary</div>`
@@ -500,15 +483,15 @@ describe('suspense', () => {
 		const [Suspender1, suspend1] = createSuspender(() => <div>Hello first</div>);
 		const [Suspender2, suspend2] = createSuspender(() => <div>Hello second</div>);
 
-		const suspense = (
+		render((
 			<Suspense fallback={<div>Suspended...</div>}>
 				<Catcher>
 					<Suspender1 />
 					<Suspender2 />
 				</Catcher>
 			</Suspense>
-		);
-		render(suspense, scratch);
+		), scratch);
+
 		expect(scratch.innerHTML).to.eql(
 			`<div>Hello first</div><div>Hello second</div>`
 		);
@@ -551,7 +534,7 @@ describe('suspense', () => {
 		const [Suspender1, suspend1] = createSuspender(() => <div>Hello first</div>);
 		const [Suspender2, suspend2] = createSuspender(() => <div>Hello second</div>);
 
-		const suspense = (
+		render((
 			<Suspense fallback={<div>Suspended...</div>}>
 				<Catcher>
 					<Suspender1 />
@@ -560,8 +543,7 @@ describe('suspense', () => {
 					</div>
 				</Catcher>
 			</Suspense>
-		);
-		render(suspense, scratch);
+		), scratch);
 
 		expect(scratch.innerHTML).to.eql(
 			`<div>Hello first</div><div><div>Hello second</div></div>`
@@ -604,14 +586,13 @@ describe('suspense', () => {
 	it('should support text directly under Suspense', () => {
 		const [Suspender, suspend] = createSuspender(() => <div>Hello</div>);
 
-		const suspense = (
+		render((
 			<Suspense fallback={<div>Suspended...</div>}>
 				Text
 				{/* Adding a <div> here will make things work... */}
 				<Suspender />
 			</Suspense>
-		);
-		render(suspense, scratch);
+		), scratch);
 
 		expect(scratch.innerHTML).to.eql(
 			`Text<div>Hello</div>`
@@ -653,13 +634,12 @@ describe('suspense', () => {
 
 		const [Suspender, suspend] = createSuspender(() => <div>Hello</div>);
 
-		const suspense = (
+		render((
 			<Suspense fallback={<div>Suspended...</div>}>
 				<StatefulComp defaultTag="div" />
 				<Suspender />
 			</Suspense>
-		);
-		render(suspense, scratch);
+		), scratch);
 
 		expect(scratch.innerHTML).to.eql(
 			`<div>Stateful</div><div>Hello</div>`
@@ -685,17 +665,14 @@ describe('suspense', () => {
 	it('should only suspend the most inner Suspend', () => {
 		const [Suspender, suspend] = createSuspender(() => <div>Hello</div>);
 
-		const suspense = (
-			<Suspense fallback={<div>Suspended... 2</div>}>
-				<Catcher>
-					<Suspender />
-				</Catcher>
-			</Suspense>
-		);
 		render(
 			<Suspense fallback={<div>Suspended... 1</div>}>
 				Not suspended...
-				{suspense}
+				<Suspense fallback={<div>Suspended... 2</div>}>
+					<Catcher>
+						<Suspender />
+					</Catcher>
+				</Suspense>
 			</Suspense>,
 			scratch
 		);
@@ -755,14 +732,13 @@ describe('suspense', () => {
 			return prom;
 		});
 
-		const suspense = (
+		render((
 			<Suspense fallback={<div>Suspended...</div>}>
 				<Catcher>
 					<ThrowingLazy />
 				</Catcher>
 			</Suspense>
-		);
-		render(suspense, scratch);
+		), scratch);
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -1,4 +1,4 @@
-/*eslint-env browser, mocha */
+/* eslint-env browser, mocha */
 /** @jsx h */
 import { setupRerender } from 'preact/test-utils';
 import { createElement as h, render, Component, Suspense, lazy, Fragment } from '../../src/index';
@@ -11,10 +11,6 @@ import { setupScratch, teardown } from '../../../test/_util/helpers';
  * @returns {[typeof Component, () => Resolvers]}
  */
 function createSuspender(DefaultComponent) {
-	// Test public api
-	// Prefer not relying on internal VNode shape
-	// Prefer not refs so refs can change and break without affecting unrelated tests
-	// Prefer not using forceUpdate since it doesn't match what our user's will do/experience
 
 	/** @type {(lazy: h.JSX.Element) => void} */
 	let renderLazy;

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -5,12 +5,10 @@ import { createElement as h, render, Component, Suspense, lazy, Fragment } from 
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
 // TODO:
-// Add tests for
-// * Fix TODO about improperly unmounting fallback and updating _dom pointers
 // * Specify sibling to what (Suspense) in existing tests
-// * maintaining state of sibling to suspender and suspense
-// * updating state of sibling to suspender and suspense
-// * Have different initial component and resolved component
+// * Add test for maintaining state of sibling to suspender and suspense
+// * Add test for updating state of sibling to suspender and suspense
+// * Have different initial component and resolved component in all tests
 
 /**
  * @typedef {import('../../../src').ComponentType} ComponentType
@@ -372,28 +370,21 @@ describe('suspense', () => {
 		);
 		render(
 			<Fragment>
-				{/*
-					TODO: Update Suspense to use this.state to manage it's children so that it can
-					take advantage of the _dom pointer tracking that happens in `forceUpdate` to
-					unmount fallback and properly mount the new content
-			 	*/}
-				<div>
-					{suspense}
-				</div>
+				{suspense}
 				<Stateful />
 			</Fragment>,
 			scratch
 		);
 
 		expect(scratch.innerHTML).to.eql(
-			`<div><div>Suspense</div></div><div>Stateful: initial</div>`
+			`<div>Suspense</div><div>Stateful: initial</div>`
 		);
 
 		setState({ s: 'first' });
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(
-			`<div><div>Suspense</div></div><div>Stateful: first</div>`
+			`<div>Suspense</div><div>Stateful: first</div>`
 		);
 
 		const [resolve] = suspend();
@@ -401,20 +392,20 @@ describe('suspense', () => {
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(
-			`<div><div>Suspended...</div></div><div>Stateful: first</div>`
+			`<div>Suspended...</div><div>Stateful: first</div>`
 		);
 
 		setState({ s: 'second' });
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(
-			`<div><div>Suspended...</div></div><div>Stateful: second</div>`
+			`<div>Suspended...</div><div>Stateful: second</div>`
 		);
 
 		return resolve(() => <div>Suspense</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
-				`<div><div>Suspense</div></div><div>Stateful: second</div>`
+				`<div>Suspense</div><div>Stateful: second</div>`
 			);
 		});
 	});
@@ -511,7 +502,6 @@ describe('suspense', () => {
 				<Catcher>
 					<Suspender1 />
 					<div>
-						{/* TODO: Try to update such that this div is not needed */}
 						<Suspender2 />
 					</div>
 				</Catcher>

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks'",
     "dev": "microbundle watch --raw --format cjs",
     "dev:hooks": "microbundle watch --raw --format cjs --cwd hooks",
+    "dev:compat": "microbundle watch --raw --format cjs --cwd compat --globals 'preact/hooks=preactHooks'",
     "test": "npm-run-all lint build --parallel test:mocha test:karma test:ts",
     "test:flow": "flow check",
     "test:ts": "tsc -p test/ts/ && mocha --require babel-register test/ts/**/*-test.js",

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -109,6 +109,8 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 			if (tmp = options._render) tmp(newVNode);
 
 			c._dirty = false;
+			c._vnode = newVNode;
+			c._parentDom = parentDom;
 
 			try {
 				tmp = c.render(c.props, c.state, c.context);
@@ -130,10 +132,7 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 
 			diffChildren(parentDom, newVNode, oldVNode, context, isSvg, excessDomChildren, mounts, oldDom);
 
-			// Only change the fields on the component once they represent the new state of the DOM
 			c.base = newVNode._dom;
-			c._vnode = newVNode;
-			c._parentDom = parentDom;
 
 			while (tmp=c._renderCallbacks.pop()) tmp.call(c);
 

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -51,7 +51,7 @@ export interface PreactElement extends HTMLElement {
 export interface VNode<P = {}> extends preact.VNode<P> {
 	// Redefine type here using our internal ComponentFactory type
 	type: string | ComponentFactory<P> | null;
-	_children: Array<VNode> | null;
+	_children: Array<VNode<any>> | null;
 	_parent: VNode | null;
 	_depth: number | null;
 	/**


### PR DESCRIPTION
The goal of this PR is to abstract the suspense tests away from the implementation to enable experimentation. Ideally, our tests should use the public api as much as possible to match how our users will use features. This makes our tests a good validation that our code is meeting our user's expectations.

With that in mind, I tried to avoid using internal properties on VNode - they may change over time, and ideally we can change them without having rewrite these tests each time. I also try to avoid using `forceUpdate` directly and instead rely on our `rerender` method helper to simulate our rerender queue flushing.

While working on this I also rewrote `_childDidSuspend` to reduce it's size a bit. I removed the `maxDuration` feature since we don't have any tests for it yet and it's not yet released in React. If we preemptively ship `maxDuration` before React, we may accidentally introduce some compat problems that aren't fixable without a major version bump. So personally I'd prefer to wait for them first.

Total change in compat:
-63 B :smile: