### PR TITLE
Add return type to _childDidSuspend

### DIFF
--- a/compat/src/internal.d.ts
+++ b/compat/src/internal.d.ts
@@ -14,7 +14,7 @@ export interface Component<P = {}, S = {}> extends PreactComponent<P, S> {
 	isReactComponent?: object;
 	isPureReactComponent?: true;
 
-	_childDidSuspend?(error: Promise<void>);
+	_childDidSuspend?(error: Promise<void>): void;
 }
 
 export interface FunctionalComponent<P = {}> extends PreactFunctionalComponent<P> {


### PR DESCRIPTION
Having strict ts settings throws if function does not specify a return type. Adding `: void` fixes the issue.