### PR TITLE
Golf sibling DOM handling

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -107,10 +107,11 @@ export function getDomSibling(vnode, childIndex) {
 	for (; childIndex < vnode._children.length; childIndex++) {
 		sibling = vnode._children[childIndex];
 
-		if (sibling != null) {
-			return typeof sibling.type !== 'function'
-				? sibling._dom
-				: getDomSibling(sibling, 0);
+		if (sibling != null && sibling._dom != null) {
+			// Since updateParentDomPointers keeps _dom pointer correct,
+			// we can rely on _dom to tell us if this subtree contains a
+			// rendered DOM node, and what the first rendered DOM node is
+			return sibling._dom;
 		}
 	}
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -2,6 +2,7 @@ import { diff, unmount, applyRef } from './index';
 import { coerceToVNode } from '../create-element';
 import { EMPTY_OBJ, EMPTY_ARR } from '../constants';
 import { removeNode } from '../util';
+import { getDomSibling } from '../component';
 
 /**
  * Diff the children of a virtual node
@@ -36,14 +37,14 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 	// for this purpose, because `null` is a valid value for `oldDom` which can mean to skip to this logic
 	// (e.g. if mounting a new tree in which the old DOM should be ignored (usually for Fragments).
 	if (oldDom == EMPTY_OBJ) {
-		oldDom = null;
-		if (excessDomChildren!=null) {
+		if (excessDomChildren != null) {
 			oldDom = excessDomChildren[0];
 		}
+		else if (oldChildrenLength) {
+			oldDom = getDomSibling(oldParentVNode, 0);
+		}
 		else {
-			for (i = 0; !oldDom && i < oldChildrenLength; i++) {
-				oldDom = oldChildren[i] && oldChildren[i]._dom;
-			}
+			oldDom = null;
 		}
 	}
 


### PR DESCRIPTION
* acbebbc Simplify getDomSibling (-12 B)
  
  With #1700 complete, we can now rely on the `sibling._dom` pointer to tell us if that subtree contains a rendered DOM node and what the first dom is.

* 89a0df5 Reuse getDomSibling in diffChildren oldDom initialization (-7 B)
  
  Reuse the sibling children loop in getDomSibling to get the first dom sibling of the parent vnode being diffed
