### PR TITLE
Replace catchRender with catchError

### DIFF
--- a/compat/mangle.json
+++ b/compat/mangle.json
@@ -23,7 +23,6 @@
       "$_render": "__r",
       "$_hook": "__h",
       "$_catchError": "__e",
-      "$_catchRender": "__E",
       "$_unmount": "_e"
     }
   }

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -1,7 +1,7 @@
 import { hydrate, render as preactRender, cloneElement as preactCloneElement, createRef, h, Component, options, toChildArray, createContext, Fragment } from 'preact';
 import * as hooks from 'preact/hooks';
 export * from 'preact/hooks';
-import { Suspense as _Suspense, lazy as _lazy, catchRender } from './suspense';
+import { Suspense as _Suspense, lazy as _lazy } from './suspense';
 import { assign, removeNode } from '../../src/util';
 
 const version = '16.8.0'; // trick libraries to think we are react
@@ -17,13 +17,6 @@ options.event = e => {
 	if (oldEventHook) e = oldEventHook(e);
 	e.persist = () => {};
 	return e.nativeEvent = e;
-};
-
-const oldCatchError = options._catchError;
-options._catchError = function (error, newVNode, oldVNode) {
-	if (!error.then || !oldVNode || !catchRender(error, newVNode, oldVNode)) {
-		oldCatchError(error, newVNode, oldVNode);
-	}
 };
 
 /**

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -19,10 +19,12 @@ options.event = e => {
 	return e.nativeEvent = e;
 };
 
-let oldCatchRender = options._catchRender;
-options._catchRender = (error, newVNode, oldVNode) => (
-	oldCatchRender && oldCatchRender(error, newVNode, oldVNode) || catchRender(error, newVNode, oldVNode)
-);
+const oldCatchError = options._catchError;
+options._catchError = function (error, newVNode, oldVNode) {
+	if (!error.then || !oldVNode || !catchRender(error, newVNode, oldVNode)) {
+		oldCatchError(error, newVNode, oldVNode);
+	}
+};
 
 /**
  * Legacy version of createElement.

--- a/debug/mangle.json
+++ b/debug/mangle.json
@@ -35,7 +35,6 @@
       "$_render": "__r",
       "$_hook": "__h",
       "$_catchError": "__e",
-      "$_catchRender": "__E",
       "$_unmount": "_e"
     }
   }

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -8,14 +8,17 @@ export function initDebug() {
 	let oldBeforeDiff = options._diff;
 	let oldDiffed = options.diffed;
 	let oldVnode = options.vnode;
+	let oldCatchError = options._catchError;
 	const warnedComponents = { useEffect: {}, useLayoutEffect: {}, lazyPropTypes: {} };
 
-	// options._catchError = (error, vnode) => {
-	// 	let component = vnode && vnode._component;
-	// 	if (component && typeof error.then === 'function') {
-	// 		error = new Error('Missing Suspense. The throwing component was: ' + (component.displayName || component.name));
-	// 	}
-	// };
+	options._catchError = (error, vnode) => {
+		let component = vnode && vnode._component;
+		if (component && typeof error.then === 'function') {
+			error = new Error('Missing Suspense. The throwing component was: ' + (component.displayName || component.name));
+		}
+
+		oldCatchError(error, vnode);
+	};
 
 	options._root = (vnode, parentNode) => {
 		if (!parentNode) {

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -10,12 +10,12 @@ export function initDebug() {
 	let oldVnode = options.vnode;
 	const warnedComponents = { useEffect: {}, useLayoutEffect: {}, lazyPropTypes: {} };
 
-	options._catchError = (error, vnode) => {
-		let component = vnode && vnode._component;
-		if (component && typeof error.then === 'function') {
-			error = new Error('Missing Suspense. The throwing component was: ' + (component.displayName || component.name));
-		}
-	};
+	// options._catchError = (error, vnode) => {
+	// 	let component = vnode && vnode._component;
+	// 	if (component && typeof error.then === 'function') {
+	// 		error = new Error('Missing Suspense. The throwing component was: ' + (component.displayName || component.name));
+	// 	}
+	// };
 
 	options._root = (vnode, parentNode) => {
 		if (!parentNode) {

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -268,6 +268,20 @@ describe('debug', () => {
 		expect(console.error).to.not.be.called;
 	});
 
+	it('should throw an error when missing Suspense', () => {
+		const Foo = () => <div>Foo</div>;
+		const LazyComp = lazy(() => new Promise(resolve => resolve({ default: Foo })));
+		const fn = () => {
+			render((
+				<Fragment>
+					<LazyComp />
+				</Fragment>
+			), scratch);
+		};
+
+		expect(fn).to.throw(/Missing Suspense/gi);
+	});
+
 	describe('duplicate keys', () => {
 		const List = props => <ul>{props.children}</ul>;
 		const ListItem = props => <li>{props.children}</li>;

--- a/hooks/mangle.json
+++ b/hooks/mangle.json
@@ -17,7 +17,6 @@
       "$_render": "__r",
       "$_hook": "__h",
       "$_catchError": "__e",
-      "$_catchRender": "__E",
       "$_unmount": "_e"
     }
   }

--- a/mangle.json
+++ b/mangle.json
@@ -39,7 +39,6 @@
       "$_render": "__r",
       "$_hook": "__h",
       "$_catchError": "__e",
-      "$_catchRender": "__E",
       "$_unmount": "_e"
     }
   }

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -142,12 +142,12 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 	if (excessDomChildren!=null && typeof newParentVNode.type !== 'function') for (i=excessDomChildren.length; i--; ) if (excessDomChildren[i]!=null) removeNode(excessDomChildren[i]);
 
 	// Remove remaining oldChildren if there are any.
-	for (i=oldChildrenLength; i--; ) if (oldChildren[i]!=null) unmount(oldChildren[i]);
+	for (i=oldChildrenLength; i--; ) if (oldChildren[i]!=null) unmount(oldChildren[i], newParentVNode);
 
 	// Set refs only after unmount
 	if (refs) {
 		for (i = 0; i < refs.length; i++) {
-			applyRef(refs[i], refs[++i]);
+			applyRef(refs[i], refs[++i], newParentVNode);
 		}
 	}
 }

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -84,7 +84,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 			newDom = diff(parentDom, childVNode, oldVNode, context, isSvg, excessDomChildren, mounts, null, oldDom);
 
 			if ((j = childVNode.ref) && oldVNode.ref != j) {
-				(refs || (refs=[])).push(j, childVNode._component || newDom);
+				(refs || (refs=[])).push(j, childVNode._component || newDom, childVNode);
 			}
 
 			// Only proceed if the vnode has not been unmounted by `diff()` above.
@@ -142,12 +142,12 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 	if (excessDomChildren!=null && typeof newParentVNode.type !== 'function') for (i=excessDomChildren.length; i--; ) if (excessDomChildren[i]!=null) removeNode(excessDomChildren[i]);
 
 	// Remove remaining oldChildren if there are any.
-	for (i=oldChildrenLength; i--; ) if (oldChildren[i]!=null) unmount(oldChildren[i], newParentVNode);
+	for (i=oldChildrenLength; i--; ) if (oldChildren[i]!=null) unmount(oldChildren[i], oldChildren[i]);
 
 	// Set refs only after unmount
 	if (refs) {
 		for (i = 0; i < refs.length; i++) {
-			applyRef(refs[i], refs[++i], newParentVNode);
+			applyRef(refs[i], refs[++i], refs[++i]);
 		}
 	}
 }

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -142,12 +142,12 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 	if (excessDomChildren!=null && typeof newParentVNode.type !== 'function') for (i=excessDomChildren.length; i--; ) if (excessDomChildren[i]!=null) removeNode(excessDomChildren[i]);
 
 	// Remove remaining oldChildren if there are any.
-	for (i=oldChildrenLength; i--; ) if (oldChildren[i]!=null) unmount(oldChildren[i], newParentVNode);
+	for (i=oldChildrenLength; i--; ) if (oldChildren[i]!=null) unmount(oldChildren[i]);
 
 	// Set refs only after unmount
 	if (refs) {
 		for (i = 0; i < refs.length; i++) {
-			applyRef(refs[i], refs[++i], newParentVNode);
+			applyRef(refs[i], refs[++i]);
 		}
 	}
 }

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -112,15 +112,9 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 			c._vnode = newVNode;
 			c._parentDom = parentDom;
 
-			try {
-				tmp = c.render(c.props, c.state, c.context);
-				let isTopLevelFragment = tmp != null && tmp.type == Fragment && tmp.key == null;
-				toChildArray(isTopLevelFragment ? tmp.props.children : tmp, newVNode._children=[], coerceToVNode, true);
-			}
-			catch (e) {
-				if ((tmp = options._catchRender) && tmp(e, newVNode, oldVNode)) break outer;
-				throw e;
-			}
+			tmp = c.render(c.props, c.state, c.context);
+			let isTopLevelFragment = tmp != null && tmp.type == Fragment && tmp.key == null;
+			toChildArray(isTopLevelFragment ? tmp.props.children : tmp, newVNode._children=[], coerceToVNode, true);
 
 			if (c.getChildContext!=null) {
 				context = assign(assign({}, context), c.getChildContext());
@@ -153,7 +147,7 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 		if (tmp = options.diffed) tmp(newVNode);
 	}
 	catch (e) {
-		options._catchError(e, newVNode);
+		options._catchError(e, newVNode, oldVNode);
 	}
 
 	return newVNode._dom;
@@ -317,8 +311,10 @@ function doRender(props, state, context) {
  * @param {import('../internal').VNode} vnode The vnode that threw
  * the error that was caught (except for unmounting when this parameter
  * is the highest parent that was being unmounted)
+ * @param {import('../internal').VNode} oldVNode The oldVNode of the vnode
+ * that threw, if this VNode threw while diffing
  */
-(options)._catchError = function (error, vnode) {
+(options)._catchError = function (error, vnode, oldVNode) {
 
 	/** @type {import('../internal').Component} */
 	let component;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -153,7 +153,7 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 		if (tmp = options.diffed) tmp(newVNode);
 	}
 	catch (e) {
-		catchErrorInComponent(e, newVNode._parent);
+		options._catchError(e, newVNode._parent);
 	}
 
 	return newVNode._dom;
@@ -166,7 +166,7 @@ export function commitRoot(mounts, root) {
 			c.componentDidMount();
 		}
 		catch (e) {
-			catchErrorInComponent(e, c._vnode._parent);
+			options._catchError(e, c._vnode._parent);
 		}
 	}
 
@@ -257,7 +257,7 @@ export function applyRef(ref, value, parentVNode) {
 		else ref.current = value;
 	}
 	catch (e) {
-		catchErrorInComponent(e, parentVNode);
+		options._catchError(e, parentVNode);
 	}
 }
 
@@ -290,7 +290,7 @@ export function unmount(vnode, parentVNode, skipRemove) {
 				r.componentWillUnmount();
 			}
 			catch (e) {
-				catchErrorInComponent(e, parentVNode);
+				options._catchError(e, parentVNode);
 			}
 		}
 
@@ -317,8 +317,7 @@ function doRender(props, state, context) {
  * @param {import('../internal').VNode} vnode The first ancestor
  * VNode check for error boundary behaviors
  */
-function catchErrorInComponent(error, vnode) {
-	if (options._catchError) { options._catchError(error, vnode); }
+(options)._catchError = function (error, vnode) {
 
 	/** @type {import('../internal').Component} */
 	let component;
@@ -344,4 +343,4 @@ function catchErrorInComponent(error, vnode) {
 	}
 
 	throw error;
-}
+};

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -153,7 +153,7 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 		if (tmp = options.diffed) tmp(newVNode);
 	}
 	catch (e) {
-		options._catchError(e, newVNode._parent);
+		options._catchError(e, newVNode);
 	}
 
 	return newVNode._dom;
@@ -166,7 +166,7 @@ export function commitRoot(mounts, root) {
 			c.componentDidMount();
 		}
 		catch (e) {
-			options._catchError(e, c._vnode._parent);
+			options._catchError(e, c._vnode);
 		}
 	}
 
@@ -249,15 +249,15 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
  * Invoke or update a ref, depending on whether it is a function or object ref.
  * @param {object|function} ref
  * @param {any} value
- * @param {import('../internal').VNode} parentVNode
+ * @param {import('../internal').VNode} vnode
  */
-export function applyRef(ref, value, parentVNode) {
+export function applyRef(ref, value, vnode) {
 	try {
 		if (typeof ref=='function') ref(value);
 		else ref.current = value;
 	}
 	catch (e) {
-		options._catchError(e, parentVNode);
+		options._catchError(e, vnode);
 	}
 }
 
@@ -314,15 +314,16 @@ function doRender(props, state, context) {
 /**
  * Find the closest error boundary to a thrown error and call it
  * @param {object} error The thrown value
- * @param {import('../internal').VNode} vnode The first ancestor
- * VNode check for error boundary behaviors
+ * @param {import('../internal').VNode} vnode The vnode that threw
+ * the error that was caught (except for unmounting when this parameter
+ * is the highest parent that was being unmounted)
  */
 (options)._catchError = function (error, vnode) {
 
 	/** @type {import('../internal').Component} */
 	let component;
 
-	for (; vnode; vnode = vnode._parent) {
+	for (; vnode = vnode._parent;) {
 		if ((component = vnode._component) && !component._processingException) {
 			try {
 				if (component.constructor && component.constructor.getDerivedStateFromError!=null) {

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -252,13 +252,8 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
  * @param {import('../internal').VNode} parentVNode
  */
 export function applyRef(ref, value, parentVNode) {
-	try {
-		if (typeof ref=='function') ref(value);
-		else ref.current = value;
-	}
-	catch (e) {
-		options._catchError(e, parentVNode);
-	}
+	if (typeof ref=='function') ref(value);
+	else ref.current = value;
 }
 
 /**
@@ -286,12 +281,7 @@ export function unmount(vnode, parentVNode, skipRemove) {
 
 	if ((r = vnode._component)!=null) {
 		if (r.componentWillUnmount) {
-			try {
-				r.componentWillUnmount();
-			}
-			catch (e) {
-				options._catchError(e, parentVNode);
-			}
+			r.componentWillUnmount();
 		}
 
 		r.base = r._parentDom = null;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -249,9 +249,8 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
  * Invoke or update a ref, depending on whether it is a function or object ref.
  * @param {object|function} ref
  * @param {any} value
- * @param {import('../internal').VNode} parentVNode
  */
-export function applyRef(ref, value, parentVNode) {
+export function applyRef(ref, value) {
 	if (typeof ref=='function') ref(value);
 	else ref.current = value;
 }
@@ -259,17 +258,15 @@ export function applyRef(ref, value, parentVNode) {
 /**
  * Unmount a virtual node from the tree and apply DOM changes
  * @param {import('../internal').VNode} vnode The virtual node to unmount
- * @param {import('../internal').VNode} parentVNode The parent of the VNode that
- * initiated the unmount
  * @param {boolean} [skipRemove] Flag that indicates that a parent node of the
  * current element is already detached from the DOM.
  */
-export function unmount(vnode, parentVNode, skipRemove) {
+export function unmount(vnode, skipRemove) {
 	let r;
 	if (options.unmount) options.unmount(vnode);
 
 	if (r = vnode.ref) {
-		applyRef(r, null, parentVNode);
+		applyRef(r, null);
 	}
 
 	let dom;
@@ -289,7 +286,7 @@ export function unmount(vnode, parentVNode, skipRemove) {
 
 	if (r = vnode._children) {
 		for (let i = 0; i < r.length; i++) {
-			if (r[i]) unmount(r[i], parentVNode, skipRemove);
+			if (r[i]) unmount(r[i], skipRemove);
 		}
 	}
 

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -12,18 +12,7 @@ export interface Options extends preact.Options {
 	/** Attach a hook that is invoked before a hook's state is queried. */
 	_hook?(component: Component): void;
 	/** Attach a hook that is invoked after an error is caught in a component but before calling lifecycle hooks */
-	_catchError(error: any, vnode: VNode): void;
-	/**
-	 * Attach a hook that is invoked after an error is caught while executing render.
-	 *
-	 * When this hook returns true, the diffing on the affected vnode will be stopped.
-	 * When this hook returns false, the error will be thrown (and thus passed to catchError or lifecycle hooks)
-	 *
-	 * @param error The error caught
-	 * @param vnode The VNode whose component's render method threw an error
-	 * @return Return a boolean indicating whether the error was handled by the hook or not
-	 */
-	_catchRender?(error: any, newVNode: VNode, oldVNode: VNode): boolean;
+	_catchError(error: any, vnode: VNode, oldVNode: VNode | undefined): void;
 }
 
 export interface FunctionalComponent<P = {}> extends preact.FunctionComponent<P> {

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -12,7 +12,7 @@ export interface Options extends preact.Options {
 	/** Attach a hook that is invoked before a hook's state is queried. */
 	_hook?(component: Component): void;
 	/** Attach a hook that is invoked after an error is caught in a component but before calling lifecycle hooks */
-	_catchError?(error: any, vnode: VNode): void;
+	_catchError(error: any, vnode: VNode): void;
 	/**
 	 * Attach a hook that is invoked after an error is caught while executing render.
 	 *

--- a/test/browser/lifecycles/componentDidCatch.test.js
+++ b/test/browser/lifecycles/componentDidCatch.test.js
@@ -43,7 +43,7 @@ describe('Lifecycle methods', () => {
 				this.setState({ error });
 			}
 			render() {
-				return <div>{this.state.error ? String(this.state.error) : this.props.children}</div>;
+				return this.state.error ? String(this.state.error) : this.props.children;
 			}
 		}
 
@@ -91,6 +91,24 @@ describe('Lifecycle methods', () => {
 			rerender();
 
 			expect(Receiver.prototype.componentDidCatch).to.have.been.calledWith(expectedError);
+		});
+
+		// https://github.com/preactjs/preact/issues/1570
+		it('should handle double child throws', () => {
+			const Child = ({ i }) => {
+				throw new Error(`error! ${i}`);
+			};
+
+			const fn = () => render(
+				<Receiver>
+					{[1, 2].map(i => <Child key={i} i={i} />)}
+				</Receiver>,
+				scratch
+			);
+			expect(fn).to.not.throw();
+
+			rerender();
+			expect(scratch.innerHTML).to.equal('Error: error! 2');
 		});
 
 		it('should be called when child fails in componentWillMount', () => {
@@ -165,7 +183,7 @@ describe('Lifecycle methods', () => {
 					this.setState({ error });
 				}
 				render() {
-					return <div>{this.state.error ? String(this.state.error) : <ThrowErr foo={this.state.foo} />}</div>;
+					return this.state.error ? String(this.state.error) : <ThrowErr foo={this.state.foo} />;
 				}
 			}
 
@@ -192,7 +210,7 @@ describe('Lifecycle methods', () => {
 					this.setState({ error });
 				}
 				render() {
-					return <div>{this.state.error ? String(this.state.error) : <ThrowErr foo={this.state.foo} />}</div>;
+					return this.state.error ? String(this.state.error) : <ThrowErr foo={this.state.foo} />;
 				}
 			}
 
@@ -229,11 +247,7 @@ describe('Lifecycle methods', () => {
 					this.setState({ error });
 				}
 				render() {
-					return (
-						<div>
-							{this.state.error ? String(this.state.error) : <Foo ref={ref} />}
-						</div>
-					);
+					return this.state.error ? String(this.state.error) : <Foo ref={ref} />;
 				}
 			}
 
@@ -256,11 +270,7 @@ describe('Lifecycle methods', () => {
 					this.setState({ error });
 				}
 				render() {
-					return (
-						<div>
-							{this.state.error ? String(this.state.error) : <div ref={ref} />}
-						</div>
-					);
+					return this.state.error ? String(this.state.error) : <div ref={ref} />;
 				}
 			}
 

--- a/test/browser/lifecycles/getDerivedStateFromError.test.js
+++ b/test/browser/lifecycles/getDerivedStateFromError.test.js
@@ -43,7 +43,7 @@ describe('Lifecycle methods', () => {
 				return { error };
 			}
 			render() {
-				return <div>{this.state.error ? String(this.state.error) : this.props.children}</div>;
+				return this.state.error ? String(this.state.error) : this.props.children;
 			}
 		}
 
@@ -112,7 +112,7 @@ describe('Lifecycle methods', () => {
 			expect(fn).to.not.throw();
 
 			rerender();
-			expect(scratch.innerHTML).to.equal('<div>Error: error! 2</div>');
+			expect(scratch.innerHTML).to.equal('Error: error! 2');
 		});
 
 		it('should be called when child fails in componentWillMount', () => {
@@ -187,7 +187,7 @@ describe('Lifecycle methods', () => {
 					return { error };
 				}
 				render() {
-					return <div>{this.state.error ? String(this.state.error) : <ThrowErr foo={this.state.foo} />}</div>;
+					return this.state.error ? String(this.state.error) : <ThrowErr foo={this.state.foo} />;
 				}
 			}
 
@@ -213,7 +213,7 @@ describe('Lifecycle methods', () => {
 					return { error };
 				}
 				render() {
-					return <div>{this.state.error ? String(this.state.error) : <ThrowErr foo={this.state.foo} />}</div>;
+					return this.state.error ? String(this.state.error) : <ThrowErr foo={this.state.foo} />;
 				}
 			}
 
@@ -250,11 +250,7 @@ describe('Lifecycle methods', () => {
 					return { error };
 				}
 				render() {
-					return (
-						<div>
-							{this.state.error ? String(this.state.error) : <Foo ref={ref} />}
-						</div>
-					);
+					return this.state.error ? String(this.state.error) : <Foo ref={ref} />;
 				}
 			}
 
@@ -277,11 +273,7 @@ describe('Lifecycle methods', () => {
 					return { error };
 				}
 				render() {
-					return (
-						<div>
-							{this.state.error ? String(this.state.error) : <div ref={ref} />}
-						</div>
-					);
+					return this.state.error ? String(this.state.error) : <div ref={ref} />;
 				}
 			}
 


### PR DESCRIPTION
This PR changes the behavior of the `catchError` option to enable composing of catchError option hooks (similar to middleware). The initial value of `options.catchError` is set to `catchErrorInComponent`. Any code that overrides `options.catchError` should store the previous value of `options.catchError` and invoke it if they want to rely on the default implementation of `catchError`. This pattern allows code to skip the default implementation of if an option hook chooses not to invoke the previous catchError behavior. It also gives options the ability to change what the default implementation is invoked with.

Two new features this pattern enables:
1. Using catchError to replace catchRender (to implement Suspense)
2. Adding debug error for "Missing Suspense"

In order to enable using `catchError` for Suspense, I had to change the behavior the of `catchError` to take in the VNode that threw error, instead of the first parent. An initial implementation caused some problems in how errors were caught that our tests didn't catch so I modified some tests to cover this scenario. Namely, if a direct child of an error boundary throws, the error boundary should catch that error. The initial implementation was skipping the first parent if a child threw in unmount and refs.

Change:
preact.js: -18 B
compat.js: -10 B