### PR TITLE
(fix) - portals

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -80,8 +80,8 @@ class ContextProvider {
  * @param {object | null | undefined} props
  */
 function Portal(props) {
-	let wrap = h(ContextProvider, { context: this.context }, props.vnode);
 	let container = props.container;
+	let wrap = h(ContextProvider, { context: this.context }, props.vnode);
 
 	// When we change container we should clear our old container and
 	// indicate a new mount.
@@ -100,12 +100,7 @@ function Portal(props) {
 			// wrap into the container.
 			hydrate('', container);
 			// If it has child nodes we need to insert before the first child.
-			if (container.hasChildNodes()) {
-				container.insertBefore(temp, container.firstChild);
-			}
-			else {
-				container.appendChild(temp);
-			}
+			container.insertBefore(temp, container.firstChild);
 			this.hasMounted = true;
 			this.container = container;
 			// Render our wrapping element into temp.

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -96,21 +96,22 @@ function Portal(props) {
 	if (props.vnode) {
 		if (!this.hasMounted) {
 			// Create a placeholder that we can use to insert into.
-			let temp = document.createTextNode('');
+			this.temp = document.createTextNode('');
 			// Hydrate existing nodes to keep the dom intact, when rendering
 			// wrap into the container.
 			hydrate('', container);
 			// Insert before first child (will just append if firstChild is null).
-			container.insertBefore(temp, container.firstChild);
+			container.insertBefore(this.temp, container.firstChild);
+			// At this point we have mounted and should set our container.
 			this.hasMounted = true;
 			this.container = container;
-			this.wrap = wrap;
-			this.temp = temp;
 			// Render our wrapping element into temp.
-			preactRender(wrap, container, temp);
+			preactRender(wrap, container, this.temp);
 		}
 		else {
-			this.wrap = wrap;
+			// When we have mounted and the vnode is present it means the
+			// props have changed or a parent is triggering a rerender.
+			// This implies we only need to call render.
 			render(wrap, container);
 		}
 	}
@@ -119,6 +120,8 @@ function Portal(props) {
 	else if (this.hasMounted) {
 		render(null, container);
 	}
+	// Set the wrapping element for future unmounting.
+	this.wrap = wrap;
 
 	this.componentWillUnmount = () => {
 		if (this.temp.parentNode) this.container.removeChild(this.temp);

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -90,6 +90,8 @@ function Portal(props) {
 		this.hasMounted = false;
 	}
 
+	// When props.vnode is undefined/false/null we are dealing with some kind of
+	// conditional vnode. This should not trigger a render.
 	if (props.vnode) {
 		if (!this.hasMounted) {
 			// Create a placeholder that we can use to insert into.
@@ -113,7 +115,9 @@ function Portal(props) {
 			render(wrap, container);
 		}
 	}
-	else if (!props.vnode && this.hasMounted) {
+	// When we come from a conditional render, on a mounted
+	// portal we should clear the DOM.
+	else if (this.hasMounted) {
 		render(null, container);
 	}
 

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -86,28 +86,28 @@ function Portal(props) {
 
 	// When we change container we should clear our old container and
 	// indicate a new mount.
-	if (_this.container && _this.container !== container) {
-		if (_this.temp.parentNode) _this.container.removeChild(_this.temp);
-		_unmount(_this.wrap);
-		_this.hasMounted = false;
+	if (_this._container && _this._container !== container) {
+		if (_this._temp.parentNode) _this._container.removeChild(_this._temp);
+		_unmount(_this._wrap);
+		_this._hasMounted = false;
 	}
 
 	// When props.vnode is undefined/false/null we are dealing with some kind of
 	// conditional vnode. This should not trigger a render.
 	if (props.vnode) {
-		if (!_this.hasMounted) {
+		if (!_this._hasMounted) {
 			// Create a placeholder that we can use to insert into.
-			_this.temp = document.createTextNode('');
+			_this._temp = document.createTextNode('');
 			// Hydrate existing nodes to keep the dom intact, when rendering
 			// wrap into the container.
 			hydrate('', container);
 			// Insert before first child (will just append if firstChild is null).
-			container.insertBefore(_this.temp, container.firstChild);
+			container.insertBefore(_this._temp, container.firstChild);
 			// At this point we have mounted and should set our container.
-			_this.hasMounted = true;
-			_this.container = container;
+			_this._hasMounted = true;
+			_this._container = container;
 			// Render our wrapping element into temp.
-			preactRender(wrap, container, _this.temp);
+			preactRender(wrap, container, _this._temp);
 		}
 		else {
 			// When we have mounted and the vnode is present it means the
@@ -118,16 +118,16 @@ function Portal(props) {
 	}
 	// When we come from a conditional render, on a mounted
 	// portal we should clear the DOM.
-	else if (_this.hasMounted) {
-		if (_this.temp.parentNode) _this.container.removeChild(_this.temp);
-		_unmount(_this.wrap);
+	else if (_this._hasMounted) {
+		if (_this._temp.parentNode) _this._container.removeChild(_this._temp);
+		_unmount(_this._wrap);
 	}
 	// Set the wrapping element for future unmounting.
-	_this.wrap = wrap;
+	_this._wrap = wrap;
 
 	_this.componentWillUnmount = () => {
-		if (_this.temp.parentNode) _this.container.removeChild(_this.temp);
-		_unmount(_this.wrap);
+		if (_this._temp.parentNode) _this._container.removeChild(_this._temp);
+		_unmount(_this._wrap);
 	};
 
 	return null;

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -118,7 +118,8 @@ function Portal(props) {
 	// When we come from a conditional render, on a mounted
 	// portal we should clear the DOM.
 	else if (this.hasMounted) {
-		render(null, container);
+		if (this.temp.parentNode) this.container.removeChild(this.temp);
+		_unmount(this.wrap);
 	}
 	// Set the wrapping element for future unmounting.
 	this.wrap = wrap;

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -90,26 +90,31 @@ function Portal(props) {
 		this.hasMounted = false;
 	}
 
-	if (!this.hasMounted) {
-		// Create a placeholder that we can use to insert into.
-		let temp = document.createTextNode('');
-		// Hydrate existing nodes to keep the dom intact, when rendering
-		// wrap into the container.
-		hydrate('', container);
-		// If it has child nodes we need to insert before the first child.
-		if (container.hasChildNodes()) {
-			container.insertBefore(temp, container.firstChild);
+	if (props.vnode) {
+		if (!this.hasMounted) {
+			// Create a placeholder that we can use to insert into.
+			let temp = document.createTextNode('');
+			// Hydrate existing nodes to keep the dom intact, when rendering
+			// wrap into the container.
+			hydrate('', container);
+			// If it has child nodes we need to insert before the first child.
+			if (container.hasChildNodes()) {
+				container.insertBefore(temp, container.firstChild);
+			}
+			else {
+				container.appendChild(temp);
+			}
+			this.hasMounted = true;
+			this.container = container;
+			// Render our wrapping element into temp.
+			preactRender(wrap, container, temp);
 		}
 		else {
-			container.appendChild(temp);
+			render(wrap, container);
 		}
-		this.hasMounted = true;
-		this.container = container;
-		// Render our wrapping element into temp.
-		preactRender(wrap, container, temp);
 	}
-	else {
-		render(wrap, container);
+	else if (!props.vnode && this.hasMounted) {
+		render(null, container);
 	}
 
 	this.componentWillUnmount = () => {

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -83,12 +83,29 @@ function Portal(props) {
 	let wrap = h(ContextProvider, { context: this.context }, props.vnode);
 	let container = props.container;
 
-	if (props.container !== this.container) {
-		hydrate('', container);
-		this.container = container;
+	if (this.container && this.container !== container) {
+		render(null, this.container);
+		this.hasMounted = false;
 	}
 
-	render(wrap, container);
+	if (!this.hasMounted) {
+		hydrate('', container);
+		let temp = document.createTextNode('');
+		if (container.hasChildNodes()) {
+			container.insertBefore(temp, container.firstChild);
+		}
+		else {
+			container.appendChild(temp);
+		}
+		this.hasMounted = true;
+		this.temp = temp;
+		this.container = container;
+		preactRender(wrap, container, temp);
+	}
+	else {
+		render(wrap, container);
+	}
+
 	this.componentWillUnmount = () => {
 		render(null, container);
 	};

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -80,33 +80,34 @@ class ContextProvider {
  * @param {object | null | undefined} props
  */
 function Portal(props) {
+	let _this = this;
 	let container = props.container;
-	let wrap = h(ContextProvider, { context: this.context }, props.vnode);
+	let wrap = h(ContextProvider, { context: _this.context }, props.vnode);
 
 	// When we change container we should clear our old container and
 	// indicate a new mount.
-	if (this.container && this.container !== container) {
-		if (this.temp.parentNode) this.container.removeChild(this.temp);
-		_unmount(this.wrap);
-		this.hasMounted = false;
+	if (_this.container && _this.container !== container) {
+		if (_this.temp.parentNode) _this.container.removeChild(_this.temp);
+		_unmount(_this.wrap);
+		_this.hasMounted = false;
 	}
 
 	// When props.vnode is undefined/false/null we are dealing with some kind of
 	// conditional vnode. This should not trigger a render.
 	if (props.vnode) {
-		if (!this.hasMounted) {
+		if (!_this.hasMounted) {
 			// Create a placeholder that we can use to insert into.
-			this.temp = document.createTextNode('');
+			_this.temp = document.createTextNode('');
 			// Hydrate existing nodes to keep the dom intact, when rendering
 			// wrap into the container.
 			hydrate('', container);
 			// Insert before first child (will just append if firstChild is null).
-			container.insertBefore(this.temp, container.firstChild);
+			container.insertBefore(_this.temp, container.firstChild);
 			// At this point we have mounted and should set our container.
-			this.hasMounted = true;
-			this.container = container;
+			_this.hasMounted = true;
+			_this.container = container;
 			// Render our wrapping element into temp.
-			preactRender(wrap, container, this.temp);
+			preactRender(wrap, container, _this.temp);
 		}
 		else {
 			// When we have mounted and the vnode is present it means the
@@ -117,16 +118,16 @@ function Portal(props) {
 	}
 	// When we come from a conditional render, on a mounted
 	// portal we should clear the DOM.
-	else if (this.hasMounted) {
-		if (this.temp.parentNode) this.container.removeChild(this.temp);
-		_unmount(this.wrap);
+	else if (_this.hasMounted) {
+		if (_this.temp.parentNode) _this.container.removeChild(_this.temp);
+		_unmount(_this.wrap);
 	}
 	// Set the wrapping element for future unmounting.
-	this.wrap = wrap;
+	_this.wrap = wrap;
 
-	this.componentWillUnmount = () => {
-		if (this.temp.parentNode) this.container.removeChild(this.temp);
-		_unmount(this.wrap);
+	_this.componentWillUnmount = () => {
+		if (_this.temp.parentNode) _this.container.removeChild(_this.temp);
+		_unmount(_this.wrap);
 	};
 
 	return null;

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -83,14 +83,20 @@ function Portal(props) {
 	let wrap = h(ContextProvider, { context: this.context }, props.vnode);
 	let container = props.container;
 
+	// When we change container we should clear our old container and
+	// indicate a new mount.
 	if (this.container && this.container !== container) {
 		render(null, this.container);
 		this.hasMounted = false;
 	}
 
 	if (!this.hasMounted) {
-		hydrate('', container);
+		// Create a placeholder that we can use to insert into.
 		let temp = document.createTextNode('');
+		// Hydrate existing nodes to keep the dom intact, when rendering
+		// wrap into the container.
+		hydrate('', container);
+		// If it has child nodes we need to insert before the first child.
 		if (container.hasChildNodes()) {
 			container.insertBefore(temp, container.firstChild);
 		}
@@ -98,8 +104,8 @@ function Portal(props) {
 			container.appendChild(temp);
 		}
 		this.hasMounted = true;
-		this.temp = temp;
 		this.container = container;
+		// Render our wrapping element into temp.
 		preactRender(wrap, container, temp);
 	}
 	else {
@@ -107,6 +113,8 @@ function Portal(props) {
 	}
 
 	this.componentWillUnmount = () => {
+		// Since our old dom was hydrated this will result in
+		// our inserted element being rendered away.
 		render(null, container);
 	};
 	return null;

--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -4,7 +4,7 @@ import { setupRerender } from 'preact/test-utils';
 /* eslint-disable react/jsx-boolean-value, react/display-name, prefer-arrow-callback */
 
 /** @jsx h */
-describe('Portal', () => {
+describe.only('Portal', () => {
 
 	/** @type {HTMLDivElement} */
 	let scratch;

--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -319,4 +319,6 @@ describe('Portal', () => {
 		rerender();
 		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
 	});
+
+	// TODO: change container with multiple insertions in one root.
 });

--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -4,7 +4,7 @@ import { setupRerender } from 'preact/test-utils';
 /* eslint-disable react/jsx-boolean-value, react/display-name, prefer-arrow-callback */
 
 /** @jsx h */
-describe.only('Portal', () => {
+describe('Portal', () => {
 
 	/** @type {HTMLDivElement} */
 	let scratch;

--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -320,5 +320,26 @@ describe('Portal', () => {
 		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
 	});
 
-	// TODO: change container with multiple insertions in one root.
+	it('should work with removing an element from stacked container to new one', () => {
+		let toggle, root2;
+
+		function Foo(props) {
+			const [root, setRoot] = useState(scratch);
+			toggle = () => setRoot(() => root2);
+			return (
+				<div ref={r => { root2 = r; }}>
+					<p>Hello</p>
+					{createPortal(props.children, scratch)}
+					{createPortal(props.children, root)}
+				</div>
+			);
+		}
+
+		render(<Foo><div>foobar</div></Foo>, scratch);
+		expect(scratch.innerHTML).to.equal('<div>foobar</div><div>foobar</div><div><p>Hello</p></div>');
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div>foobar</div><div><div>foobar</div><p>Hello</p></div>');
+	});
 });

--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -342,4 +342,46 @@ describe('Portal', () => {
 		rerender();
 		expect(scratch.innerHTML).to.equal('<div>foobar</div><div><div>foobar</div><p>Hello</p></div>');
 	});
+
+	it('should support nested portals', () => {
+		let toggle, toggle2, inner;
+
+		function Bar() {
+			const [mounted, setMounted] = useState(false);
+			toggle2 = () => setMounted(s => !s);
+			return (
+				<div ref={r => { inner = r; }}>
+					<p>Inner</p>
+					{mounted && createPortal(<p>hiFromBar</p>, scratch)}
+					{mounted && createPortal(<p>innerPortal</p>, inner)}
+				</div>
+			);
+		}
+
+		function Foo(props) {
+			const [mounted, setMounted] = useState(false);
+			toggle = () => setMounted(s => !s);
+			return (
+				<div>
+					<p>Hello</p>
+					{mounted && createPortal(<Bar />, scratch)}
+				</div>
+			);
+		}
+
+		render(<Foo />, scratch);
+		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div><p>Inner</p></div><div><p>Hello</p></div>');
+
+		toggle2();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<p>hiFromBar</p><div><p>innerPortal</p><p>Inner</p></div><div><p>Hello</p></div>');
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
+	});
 });


### PR DESCRIPTION
Adds ~~101~~ ~~81~~  ~~123~~ ~~114~~ ~~103~~ 88B to the compat package 👎 

- [x] support switching container
- [x] avoid irrelevant children from rerendering
- [x] support placeholder vnodes
- [x] support multiple portals in one root
- [x] support nested portals

This is a remake of: https://github.com/preactjs/preact/pull/1713
I needed to clear my head a bit and start over I felt like I was stuck in a rut.

I have almost gotten to the fix the only remaining issue is that when we insert another portal in the same container and unmount one of them we lose both. I don't know if this is an issue or not.... Let's assume it is, working on a fix for it but it can possibly get quite complicated.

One of the options would be to check the _children of the array for an existing portal and if there is one remove from the array.... I’m not sure about this
 