### PR TITLE
Minor debug enhancements.

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -32,6 +32,12 @@ export function initDebug() {
 					break;
 				}
 			}
+
+			// We haven't recovered and we know at this point that there is no
+			// Suspense component higher up in the tree
+			if (error instanceof Error) {
+				throw error;
+			}
 		}
 
 		oldCatchError(error, vnode, oldVNode);

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -81,7 +81,7 @@ export function initDebug() {
 			throw new Error('Invalid type passed to createElement(): '+(Array.isArray(type) ? 'array' : type));
 		}
 
-		if ((type==='thead' || type==='tfoot' || type==='thead') && parentVNode.type!=='table') {
+		if ((type==='thead' || type==='tfoot' || type==='tbody') && parentVNode.type!=='table') {
 			console.error(
 				'Improper nesting of table.' +
 				'Your <thead/tbody/tfoot> should have a <table> parent.'

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -270,22 +270,20 @@ export function serializeVNode(vnode) {
 	let name = getDisplayName(vnode);
 
 	let attrs = '';
-	if (props) {
-		for (let prop in props) {
-			if (props.hasOwnProperty(prop) && prop!=='children') {
-				let value = props[prop];
+	for (let prop in props) {
+		if (props.hasOwnProperty(prop) && prop!=='children') {
+			let value = props[prop];
 
-				// If it is an object but doesn't have toString(), use Object.toString
-				if (typeof value==='function') {
-					value = `function ${value.displayName || value.name}() {}`;
-				}
-
-				value = Object(value) === value && !value.toString
-					? Object.prototype.toString.call(value)
-					: value + '';
-
-				attrs += ` ${prop}=${JSON.stringify(value)}`;
+			// If it is an object but doesn't have toString(), use Object.toString
+			if (typeof value==='function') {
+				value = `function ${value.displayName || value.name}() {}`;
 			}
+
+			value = Object(value) === value && !value.toString
+				? Object.prototype.toString.call(value)
+				: value + '';
+
+			attrs += ` ${prop}=${JSON.stringify(value)}`;
 		}
 	}
 

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -55,8 +55,6 @@ export function initDebug() {
 	};
 
 	options._diff = vnode => {
-		if (vnode == null) { return; }
-
 		let { type, _parent: parent } = vnode;
 		let parentVNode = getClosestDomNodeParent(parent);
 
@@ -194,8 +192,6 @@ export function initDebug() {
 	};
 
 	options.diffed = (vnode) => {
-		if (vnode == null) { return; }
-
 		if (vnode._component && vnode._component.__hooks) {
 			let hooks = vnode._component.__hooks;
 			hooks._list.forEach(hook => {

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -406,6 +406,30 @@ describe('debug', () => {
 			expect(console.error).to.be.calledOnce;
 		});
 
+		it('missing <table> #1', () => {
+			const Table = () => (
+				<thead><tr><td>hi</td></tr></thead>
+			);
+			render(<Table />, scratch);
+			expect(console.error).to.be.calledOnce;
+		});
+
+		it('missing <table> #2', () => {
+			const Table = () => (
+				<tbody><tr><td>hi</td></tr></tbody>
+			);
+			render(<Table />, scratch);
+			expect(console.error).to.be.calledOnce;
+		});
+
+		it('missing <table> #3', () => {
+			const Table = () => (
+				<tfoot><tr><td>hi</td></tr></tfoot>
+			);
+			render(<Table />, scratch);
+			expect(console.error).to.be.calledOnce;
+		});
+
 		it('missing <tr>', () => {
 			const Table = () => (
 				<table>
@@ -420,6 +444,19 @@ describe('debug', () => {
 
 		it('missing <tr> with td component', () => {
 			const Cell = ({ children }) => <td>{children}</td>;
+			const Table = () => (
+				<table>
+					<tbody>
+						<Cell>Hi</Cell>
+					</tbody>
+				</table>
+			);
+			render(<Table />, scratch);
+			expect(console.error).to.be.calledOnce;
+		});
+
+		it('missing <tr> with th component', () => {
+			const Cell = ({ children }) => <th>{children}</th>;
 			const Table = () => (
 				<table>
 					<tbody>

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -406,7 +406,7 @@ describe('debug', () => {
 			expect(console.error).to.be.calledOnce;
 		});
 
-		it('missing <table> #1', () => {
+		it('missing <table> with <thead>', () => {
 			const Table = () => (
 				<thead><tr><td>hi</td></tr></thead>
 			);
@@ -414,7 +414,7 @@ describe('debug', () => {
 			expect(console.error).to.be.calledOnce;
 		});
 
-		it('missing <table> #2', () => {
+		it('missing <table> with <tbody>', () => {
 			const Table = () => (
 				<tbody><tr><td>hi</td></tr></tbody>
 			);
@@ -422,7 +422,7 @@ describe('debug', () => {
 			expect(console.error).to.be.calledOnce;
 		});
 
-		it('missing <table> #3', () => {
+		it('missing <table> with <tfoot>', () => {
 			const Table = () => (
 				<tfoot><tr><td>hi</td></tr></tfoot>
 			);

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -627,6 +627,14 @@ describe('debug', () => {
 				});
 		});
 
+		it('should throw on missing <Suspense>', () => {
+			function Foo() {
+				throw Promise.resolve();
+			}
+
+			expect(() => render(<Foo />, scratch)).to.throw;
+		});
+
 		describe('warn for PropTypes on lazy()', () => {
 			it('should log the function name', () => {
 				const loader = Promise.resolve({ default: function MyLazyLoadedComponent() { return <div>Hi there</div>; } });

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -9,8 +9,8 @@ import options from '../options';
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
  * @param {import('../internal').PreactElement} parentDom The parent of the DOM element
- * @param {import('../internal').VNode | null} newVNode The new virtual node
- * @param {import('../internal').VNode | null} oldVNode The old virtual node
+ * @param {import('../internal').VNode} newVNode The new virtual node
+ * @param {import('../internal').VNode} oldVNode The old virtual node
  * @param {object} context The current context object
  * @param {boolean} isSvg Whether or not this element is an SVG node
  * @param {Array<import('../internal').PreactElement>} excessDomChildren


### PR DESCRIPTION
This PR improves code coverage in `preact/debug` and fixes some debug errors not being thrown.

- `diff()` will never receive a `null` vnode. `diffChildren` will skip `diff` if encounters a null-vnode
- `props` can never be `null` either
- Fix "Missing Suspense"-error never being thrown
- Improve overall code-coverage of `preact/debug`