### PR TITLE
Add Partial to setState

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -121,7 +121,6 @@ declare namespace preact {
 		// From https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e836acc75a78cf0655b5dfdbe81d69fdd4d8a252/types/react/index.d.ts#L402
 		// // We MUST keep setState() as a unified signature because it allows proper checking of the method return type.
 		// // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
-		// // Also, the ` | S` allows intellisense to not be dumbisense
 		setState<K extends keyof S>(
 			state: ((prevState: Readonly<S>, props: Readonly<P>) => (Pick<S, K> | Partial<S> | null)) | (Pick<S, K> | Partial<S> | null),
 			callback?: () => void

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -123,7 +123,7 @@ declare namespace preact {
 		// // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
 		// // Also, the ` | S` allows intellisense to not be dumbisense
 		setState<K extends keyof S>(
-			state: ((prevState: Readonly<S>, props: Readonly<P>) => (Pick<S, K> | S | null)) | (Pick<S, K> | S | null),
+			state: ((prevState: Readonly<S>, props: Readonly<P>) => (Pick<S, K> | Partial<S> | null)) | (Pick<S, K> | Partial<S> | null),
 			callback?: () => void
 		): void;
 

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -204,3 +204,19 @@ class ComponentWithDefaultProps extends Component<{ value: string }> {
 }
 
 const withDefaultProps = <ComponentWithDefaultProps />;
+
+interface PartialState {
+	foo: string;
+	bar: number;
+}
+
+class ComponentWithPartialSetState extends Component<{}, PartialState> {
+	render({}, {foo, bar}: PartialState) {
+		return <button onClick={ () => this.handleClick('foo')}>{foo}-{bar}</button>;
+	}
+	handleClick = (value: keyof PartialState) => {
+		this.setState({ [value]: 'updated' });
+	}
+}
+
+const withPartialSetState = <ComponentWithPartialSetState />


### PR DESCRIPTION
Fixes some typing issues when using `keyof State` as a key in setState. Fixes #1778.

Allows for this:
```typescript
interface IState {
  username: string;
  password: string;
}

function onInputChange(e: Event, field: keyof IState) {
  const target = e.target as HTMLInputElement;
  setState({ [field]: target.value });
}
```

Without throwing errors of missing fields.