### PR TITLE
Fix Portal children always being mounted

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -103,6 +103,7 @@ function Portal(props) {
 			_this._container = container;
 			// Render our wrapping element into temp.
 			preactRender(wrap, container, _this._temp);
+			_this._children = this._temp._children;
 		}
 		else {
 			// When we have mounted and the vnode is present it means the
@@ -110,11 +111,9 @@ function Portal(props) {
 			// This implies we only need to call render. But we need to keep
 			// the old tree around, otherwise will treat the vnodes as new and
 			// will wrongly call `componentDidMount` on them
-			if (!_this._lastWasUpdate) {
-				container._children = _this._temp._children;
-				_this._lastWasUpdate = true;
-			}
+			container._children = _this._children;
 			preactRender(wrap, container);
+			_this._children = container._children;
 		}
 	}
 	// When we come from a conditional render, on a mounted

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -107,8 +107,14 @@ function Portal(props) {
 		else {
 			// When we have mounted and the vnode is present it means the
 			// props have changed or a parent is triggering a rerender.
-			// This implies we only need to call render.
-			render(wrap, container);
+			// This implies we only need to call render. But we need to keep
+			// the old tree around, otherwise will treat the vnodes as new and
+			// will wrongly call `componentDidMount` on them
+			if (!_this._lastWasUpdate) {
+				container._children = _this._temp._children;
+				_this._lastWasUpdate = true;
+			}
+			preactRender(wrap, container);
 		}
 	}
 	// When we come from a conditional render, on a mounted

--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -223,7 +223,7 @@ describe('Portal', () => {
 		expect(scratch.innerHTML).to.equal('<div></div>');
 	});
 
-	it('should work with stacking portals', () => {
+	it.skip('should work with stacking portals', () => {
 		let toggle, toggle2;
 
 		function Foo(props) {
@@ -383,5 +383,49 @@ describe('Portal', () => {
 		toggle();
 		rerender();
 		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
+	});
+
+	it('should not unmount when parent renders', () => {
+		let root = document.createElement('div');
+		let dialog = document.createElement('div');
+		dialog.id = 'container';
+
+		scratch.appendChild(root);
+		scratch.appendChild(dialog);
+
+		let spy = sinon.spy();
+		class Child extends Component {
+			componentDidMount() {
+				spy();
+			}
+
+			render() {
+				return <div id="child">child</div>;
+			}
+		}
+
+		let spyParent = sinon.spy();
+		class App extends Component {
+			componentDidMount() {
+				spyParent();
+			}
+			render() {
+				return <div>{createPortal(<Child />, dialog)}</div>;
+			}
+		}
+
+		render(<App />, root);
+		let dom = document.getElementById('child');
+		expect(spyParent).to.be.calledOnce;
+		expect(spy).to.be.calledOnce;
+
+		// Render twice to trigger update scenario
+		render(<App />, root);
+		render(<App />, root);
+
+		let domNew = document.getElementById('child');
+		expect(dom).to.equal(domNew);
+		expect(spyParent).to.be.calledOnce;
+		expect(spy).to.be.calledOnce;
 	});
 });

--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -223,7 +223,7 @@ describe('Portal', () => {
 		expect(scratch.innerHTML).to.equal('<div></div>');
 	});
 
-	it.skip('should work with stacking portals', () => {
+	it('should work with stacking portals', () => {
 		let toggle, toggle2;
 
 		function Foo(props) {


### PR DESCRIPTION
This PR fixes an issue where the children of a `Portal` component would always be treated as new children, leading to incorrect `componentDidMount` calls. By switching to the raw preact `render` function we skip the `dom` from being destroyed in an update scenario.

~~The downside of this is that this definitely breaks the stacking scenario where multiple trees are rendered into the same `dom` node. I'm wondering if we should reject that case in general and push rethinking root handling after the X release.~~

Nevermind the stacking bit. Found a way to fix that too :tada: 

Fixes #1780