### PR TITLE
typings fix for Suspense and PureComponent

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -57,7 +57,7 @@ declare namespace React {
 	export function isValidElement(element: any): boolean;
 	export function findDOMNode(component: preact.Component): Element | null;
 
-	export class PureComponent<P = {}, S = {}> extends preact.Component {
+	export abstract class PureComponent<P = {}, S = {}> extends preact.Component {
 		isPureReactComponent: boolean;
 	}
 

--- a/compat/src/suspense.d.ts
+++ b/compat/src/suspense.d.ts
@@ -1,4 +1,4 @@
-import { Component } from '../../src';
+import { Component, RenderableProps, ComponentChild } from '../../src';
 
 //
 // Suspense/lazy
@@ -10,4 +10,6 @@ export interface SuspenseProps {
   fallback: preact.ComponentChildren;
 }
 
-export class Suspense extends Component<SuspenseProps> {}
+export class Suspense extends Component<SuspenseProps> {
+    render(props?: RenderableProps<SuspenseProps>, state?: Readonly<{}>, context?: any): ComponentChild;
+}


### PR DESCRIPTION
Typescript types in sub-package `preact/compat` for `Suspense` and `PureComponent` were invalid. 

Importing of `preact/compat` resulted in errors:
```
TypeScript error: node_modules/preact/compat/src/index.d.ts(60,15): Error TS2515: Non-abstract class 'PureComponent<P, S>' does not implement inherited abstract member 'render' from class 'Component<{}, {}>'.
TypeScript error: node_modules/preact/compat/src/suspense.d.ts(13,14): Error TS2515: Non-abstract class 'Suspense' does not implement inherited abstract member 'render' from class 'Component<SuspenseProps, {}>'.
```

`Suspense` has implementation of `render()` in `suspense.js`, just type was missing. `PureComponent` has no implementation of `render()`, thus is still abstract class.