### PR TITLE
Fix typos across preact repository

### DIFF
--- a/debug/src/devtools/renderer.js
+++ b/debug/src/devtools/renderer.js
@@ -50,7 +50,7 @@ export class Renderer {
 	}
 
 	/**
-	 * Recursively mount a vnode tree. Note that the devtools expectes the tree to
+	 * Recursively mount a vnode tree. Note that the devtools expects the tree to
 	 * be mounted from the bottom up, otherwise the order will be messed up.
 	 * Therefore we mount children prior to mounting the vnode itself.
 	 * @param {import('../internal').VNode} vnode
@@ -171,7 +171,7 @@ export class Renderer {
 		if (this.inst2vnode.has(inst)) this.update(vnode);
 		else this.mount(vnode);
 
-		// The devtools checks via the existance of this property if the devtools
+		// The devtools checks via the existence of this property if the devtools
 		// profiler should be enabled or not. If it is missing from the first root
 		// node the "Profiler" tab won't show up.
 		/** @type {import('../internal').VNode} */

--- a/debug/test/browser/devtools.test.js
+++ b/debug/test/browser/devtools.test.js
@@ -95,7 +95,7 @@ function checkEventReferences(events) {
 		if (i > 0 && event.type!=='unmount' && Array.isArray(event.data.children)) {
 			event.data.children.forEach(child => {
 				if (!checkPreceding(child, seen) && event.type!=='rootCommitted') {
-					throw new Error(`Event at index ${i} has a child that could not be found in a preceeding event for component "${getDisplayName(child)}"`);
+					throw new Error(`Event at index ${i} has a child that could not be found in a preceding event for component "${getDisplayName(child)}"`);
 				}
 			});
 		}

--- a/src/component.js
+++ b/src/component.js
@@ -58,12 +58,12 @@ Component.prototype.setState = function(update, callback) {
 /**
  * Immediately perform a synchronous re-render of the component
  * @param {() => void} [callback] A function to be called after component is
- * re-renderd
+ * re-rendered
  */
 Component.prototype.forceUpdate = function(callback) {
 	let vnode = this._vnode, oldDom = this._vnode._dom, parentDom = this._parentDom;
 	if (parentDom) {
-		// Set render mode so that we can differantiate where the render request
+		// Set render mode so that we can differentiate where the render request
 		// is coming from. We need this because forceUpdate should never call
 		// shouldComponentUpdate
 		const force = callback!==false;
@@ -155,7 +155,7 @@ const defer = typeof Promise=='function' ? Promise.prototype.then.bind(Promise.r
 
 /*
  * The value of `Component.debounce` must asynchronously invoke the passed in callback. It is
- * important that contributors to Preact can consistenly reason about what calls to `setState`, etc.
+ * important that contributors to Preact can consistently reason about what calls to `setState`, etc.
  * do, and when their effects will be applied. See the links below for some further reading on designing
  * asynchronous APIs.
  * * [Designing APIs for Asynchrony](https://blog.izs.me/2013/08/designing-apis-for-asynchrony)

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -41,7 +41,7 @@ export function createElement(type, props, children) {
  * Create a VNode (used internally by Preact)
  * @param {import('./internal').VNode["type"]} type The node name or Component
  * Constructor for this virtual node
- * @param {object | string | number | null} props The properites of this virtual node.
+ * @param {object | string | number | null} props The properties of this virtual node.
  * If this virtual node represents a text node, this is the text of the node (string or number).
  * @param {string | number | null} key The key for this virtual node, used when
  * diffing it against its children

--- a/test/browser/toChildArray.test.js
+++ b/test/browser/toChildArray.test.js
@@ -43,7 +43,7 @@ describe('props.children', () => {
 		expect(scratch.innerHTML).to.equal('<div></div>');
 	});
 
-	it('returns an emtpy array with false as a child', () => {
+	it('returns an empty array with false as a child', () => {
 		render(<Foo>{false}</Foo>, scratch);
 
 		expect(children).to.be.an('array');

--- a/test/ts/VNode-test.tsx
+++ b/test/ts/VNode-test.tsx
@@ -41,7 +41,7 @@ describe("VNode", () => {
 		expect(constructor.name).to.eq("SimpleFunctionalComponent");
 	});
 
-	it("has a nodeName equal to the constructor of a componet", () => {
+	it("has a nodeName equal to the constructor of a component", () => {
 		const sfc = <SimpleComponent />;
 		expect(sfc.type).to.be.instanceOf(Function);
 		const constructor = sfc.type as ComponentConstructor<any>;

--- a/test/ts/hoc-test.tsx
+++ b/test/ts/hoc-test.tsx
@@ -41,7 +41,7 @@ const HighlightedSimpleComponent = highlighted<SimpleComponentProps>(SimpleCompo
 describe("hoc", () => {
 	it("wraps the given component", () => {
 		const highlight = new HighlightedSimpleComponent({
-			initialName: "inital name",
+			initialName: "initial name",
 			isHighlighted: true
 		});
 


### PR DESCRIPTION
:blue_heart: Fix typos across **preact repository**

### Fixed files :wrench: 

<details><summary>See all fixed files</summary>
<p>

```
preact/debug/src/devtools/renderer.js:53:59: "expectes" is a misspelling of "expects"
preact/debug/src/devtools/renderer.js:174:33: "existance" is a misspelling of "existence"
preact/debug/test/browser/devtools.test.js:98:83: "preceeding" is a misspelling of "preceding"
preact/src/component.js:61:6: "renderd" is a misspelling of "rendered"
preact/src/component.js:66:36: "differantiate" is a misspelling of "differentiate"
preact/src/component.js:158:45: "consistenly" is a misspelling of "consistently"
preact/src/create-element.js:44:54: "properites" is a misspelling of "properties"
preact/test/browser/toChildArray.test.js:46:16: "emtpy" is a misspelling of "empty"
preact/test/ts/VNode-test.tsx:44:50: "componet" is a misspelling of "components"
preact/test/ts/hoc-test.tsx:44:17: "inital" is a misspelling of "initial"
```

</p>
</details>

**FYI:** I used [**Go Spellchecker**](https://github.com/liamzdenek/go-spellcheck) :smile_cat: