### PR TITLE
TS: improve typing of "style" attribute using CSSType

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage
 *.log
 package/
 preact-*.tgz
+jsx-csstype.d.ts

--- a/config/copy-csstype.js
+++ b/config/copy-csstype.js
@@ -1,0 +1,6 @@
+const fs = require('fs');
+const path = require('path');
+
+const src = path.join(__dirname, '..', 'node_modules', 'csstype', 'index.d.ts');
+const dest = path.join(__dirname, '..', 'src', 'jsx-csstype.d.ts');
+fs.copyFileSync(src, dest);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3547,6 +3547,12 @@
 				"css-tree": "1.0.0-alpha.37"
 			}
 		},
+		"csstype": {
+			"version": "2.6.13",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
+			"integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==",
+			"dev": true
+		},
 		"currently-unhandled": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "build:test-utils": "microbundle build --raw --cwd test-utils",
     "build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks'",
     "build:jsx": "microbundle build --raw --cwd jsx-runtime",
-    "postbuild": "node ./config/node-13-exports.js",
+    "postbuild": "node ./config/node-13-exports.js && node ./config/copy-csstype.js",
     "dev": "microbundle watch --raw --format cjs",
     "dev:hooks": "microbundle watch --raw --format cjs --cwd hooks",
     "dev:compat": "microbundle watch --raw --format cjs --cwd compat --globals 'preact/hooks=preactHooks'",
@@ -222,6 +222,7 @@
     "check-export-map": "^1.0.1",
     "coveralls": "^3.0.0",
     "cross-env": "^5.2.0",
+    "csstype": "^2.6.6",
     "diff": "^3.5.0",
     "eslint": "5.15.1",
     "eslint-config-developit": "^1.1.1",
@@ -250,8 +251,5 @@
     "sinon-chai": "^3.0.0",
     "typescript": "3.5.3",
     "webpack": "^4.3.0"
-  },
-  "dependencies": {
-    "csstype": "^2.6.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -250,5 +250,8 @@
     "sinon-chai": "^3.0.0",
     "typescript": "3.5.3",
     "webpack": "^4.3.0"
+  },
+  "dependencies": {
+    "csstype": "^2.6.6"
   }
 }

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1,5 +1,6 @@
 // Users who only use Preact for SSR might not specify "dom" in their lib in tsconfig.json
 /// <reference lib="dom" />
+import * as CSS from 'csstype';
 
 type Defaultize<Props, Defaults> =
 	// Distribute over unions
@@ -30,6 +31,17 @@ export namespace JSXInternal {
 
 	interface ElementChildrenAttribute {
 		children: any;
+	}
+
+	interface CSSProperties extends CSS.Properties<string | number> {
+		/**
+		 * The index signature was removed to enable closed typing for style
+		 * using CSSType. You're able to use type assertion or module augmentation
+		 * to add properties or an index signature of your own.
+		 *
+		 * For examples and more information, visit:
+		 * https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors
+		 */
 	}
 
 	interface SVGAttributes<Target extends EventTarget = SVGElement>
@@ -719,7 +731,7 @@ export namespace JSXInternal {
 		srcSet?: string;
 		start?: number;
 		step?: number | string;
-		style?: string | { [key: string]: string | number };
+		style?: string | CSSProperties;
 		summary?: string;
 		tabIndex?: number;
 		target?: string;

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1,6 +1,6 @@
 // Users who only use Preact for SSR might not specify "dom" in their lib in tsconfig.json
 /// <reference lib="dom" />
-import * as CSS from 'csstype';
+import * as CSS from './jsx-csstype';
 
 type Defaultize<Props, Defaults> =
 	// Distribute over unions

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -291,3 +291,7 @@ let classProps: ComponentProps<typeof DummyComponent> = {
 let elementProps: ComponentProps<'button'> = {
 	type: 'button'
 };
+
+// Typing of style property
+const acceptsNumberAsLength = <div style={{ marginTop: 20 }} />;
+const acceptsStringAsLength = <div style={{ marginTop: '20px' }} />;


### PR DESCRIPTION
This commit adds the [CSSType library](https://www.npmjs.com/package/csstype), which provides TypeScript and Flow definitions for CSS, generated by data from MDN. It provides autocompletion and type checking for CSS properties and values.

The library is used by [most other popular css-in-js frameworks](https://www.npmjs.com/browse/depended/csstype) for TS typechecking, including:
- [@types/react](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/2ccc2ff364f965e7407387f9045c8b7496d734a3/types/react/index.d.ts#L1656)
- [@material-ui/styles](https://github.com/mui-org/material-ui/blob/4d8206d3d44580345141405e5f78cd02fbb7ef99/packages/material-ui-styles/src/withStyles/withStyles.d.ts#L14)
- [@types/styled-components](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/4e23957ab6ef42ced4ac67048b33df9567474d9c/types/styled-components/index.d.ts#L25)
- glamorous
- csx
- @types/jss