### PR TITLE
Use internal reference for hydration flag

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -3,6 +3,8 @@ import { commitRoot, diff } from './diff/index';
 import { createElement, Fragment } from './create-element';
 import options from './options';
 
+const IS_HYDRATE = EMPTY_OBJ;
+
 /**
  * Render a Preact virtual node into a DOM element
  * @param {import('./index').ComponentChild} vnode The virtual node to render
@@ -14,8 +16,8 @@ import options from './options';
 export function render(vnode, parentDom, replaceNode) {
 	if (options._root) options._root(vnode, parentDom);
 
-	let oldVNode = replaceNode && replaceNode._children || parentDom._children;
-	let isHydrating = replaceNode === null;
+	let isHydrating = replaceNode === IS_HYDRATE;
+	let oldVNode = replaceNode && replaceNode._children || !isHydrating && parentDom._children;
 	vnode = createElement(Fragment, null, [vnode]);
 
 	let mounts = [];
@@ -25,7 +27,7 @@ export function render(vnode, parentDom, replaceNode) {
 		oldVNode || EMPTY_OBJ,
 		EMPTY_OBJ,
 		parentDom.ownerSVGElement !== undefined,
-		replaceNode
+		replaceNode && !isHydrating
 			? [replaceNode]
 			: oldVNode
 				? null
@@ -45,6 +47,5 @@ export function render(vnode, parentDom, replaceNode) {
  * update
  */
 export function hydrate(vnode, parentDom) {
-	parentDom._children = null;
-	render(vnode, parentDom, null);
+	render(vnode, parentDom, IS_HYDRATE);
 }

--- a/src/render.js
+++ b/src/render.js
@@ -17,13 +17,13 @@ export function render(vnode, parentDom, replaceNode) {
 	if (options._root) options._root(vnode, parentDom);
 
 	let isHydrating = replaceNode === IS_HYDRATE;
-	let oldVNode = replaceNode && replaceNode._children || !isHydrating && parentDom._children;
+	let oldVNode = isHydrating ? null : replaceNode && replaceNode._children || parentDom._children;
 	vnode = createElement(Fragment, null, [vnode]);
 
 	let mounts = [];
 	diff(
 		parentDom,
-		(replaceNode || parentDom)._children = vnode,
+		isHydrating ? parentDom._children = vnode : (replaceNode || parentDom)._children = vnode,
 		oldVNode || EMPTY_OBJ,
 		EMPTY_OBJ,
 		parentDom.ownerSVGElement !== undefined,

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1077,7 +1077,7 @@ describe('render()', () => {
 		it('should not remove siblings of replaceNode', () => {
 			const childA = scratch.querySelector('#a');
 			render(<div id="a" />, scratch, childA);
-			expect(scratch.innerHTML).to.equal('<div id="a">b</div><div id="b"></div><div id="c"></div>');
+			expect(scratch.innerHTML).to.equal('<div id="a"></div><div id="b"></div><div id="c"></div>');
 		});
 
 		it('should notice prop changes on replaceNode', () => {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1077,7 +1077,13 @@ describe('render()', () => {
 		it('should not remove siblings of replaceNode', () => {
 			const childA = scratch.querySelector('#a');
 			render(<div id="a" />, scratch, childA);
-			expect(scratch.innerHTML).to.equal('<div id="a"></div><div id="b"></div><div id="c"></div>');
+			expect(scratch.innerHTML).to.equal('<div id="a">b</div><div id="b"></div><div id="c"></div>');
+		});
+
+		it('should notice prop changes on replaceNode', () => {
+			const childA = scratch.querySelector('#a');
+			render(<div id="a" className="b" />, scratch, childA);
+			expect(scratch.innerHTML).to.equal('<div id="a" class="b"></div><div id="b"></div><div id="c"></div>');
 		});
 
 		it('should unmount existing components', () => {


### PR DESCRIPTION
This avoids users accidentally passing `null` as the third argument to render:

```js
const root = document.createElement('div');
document.body.appendChild(root);

render(<App />, root, root.firstElementChild);
                      //   ^^^^^^^^^^^^^^^^^ this will be `null`
```