### PR TITLE
Add VNode.constructor to src/internal.d.ts

### DIFF
--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -52,6 +52,7 @@ export interface VNode<P = {}> extends preact.VNode<P> {
 	 */
 	_lastDomChild: PreactElement | Text | null;
 	_component: Component | null;
+	constructor: undefined;
 }
 
 export interface Component<P = {}, S = {}> extends preact.Component<P, S> {


### PR DESCRIPTION
This adds `VNode.constructor` to type definition.