### PR TITLE
Remove a duplicate test in render tests

### DIFF
--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -44,12 +44,6 @@ describe('render()', () => {
 		logCall(Element.prototype, 'remove');
 	});
 
-	it('should render nothing node given null', () => {
-		render(null, scratch);
-		let c = scratch.childNodes;
-		expect(c).to.have.length(0);
-	});
-
 	it('should render an empty text node given an empty string', () => {
 		render('', scratch);
 		let c = scratch.childNodes;


### PR DESCRIPTION
It looks like `should render nothing node given null` and `should not render null` are testing the same thing. Perhaps it's worth removing one of them. It might be that `scratch.childNodes` and `scratch.innerHTML` checks are not equivalent though, but they look the same to me. 