### PR TITLE
Compat: Only destroy DOM on first render

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -51,8 +51,11 @@ function handleElementVNode(vnode, props) {
  */
 function render(vnode, parent, callback) {
 	// React destroys any existing DOM nodes, see #1727
-	while (parent.firstChild) {
-		removeNode(parent.firstChild);
+	// ...but only on the first render, see #1828
+	if (parent._children==null) {
+		while (parent.firstChild) {
+			removeNode(parent.firstChild);
+		}
 	}
 
 	preactRender(vnode, parent);

--- a/compat/test/browser/index.test.js
+++ b/compat/test/browser/index.test.js
@@ -149,6 +149,18 @@ describe('preact-compat', () => {
 			render(<span>foo</span>, scratch);
 			expect(scratch.innerHTML).to.equal('<span>foo</span>');
 		});
+
+		it('should only destroy existing DOM nodes on first render', () => {
+			scratch.appendChild(document.createElement('div'));
+			scratch.appendChild(document.createElement('div'));
+
+			render(<input />, scratch);
+
+			let child = scratch.firstChild;
+			child.focus();
+			render(<input />, scratch);
+			expect(document.activeElement.nodeName).to.equal('INPUT');
+		});
 	});
 
 	describe('createFactory', () => {


### PR DESCRIPTION
Fixes #1828.
Adds `+6 B` to compat.