### PR TITLE
Avoid accessing fn.prototype where possible

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -49,7 +49,7 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 			}
 			else {
 				// Instantiate the new component
-				if (newType.prototype && newType.prototype.render) {
+				if ('prototype' in newType && newType.prototype.render) {
 					newVNode._component = c = new newType(newProps, cctx); // eslint-disable-line new-cap
 				}
 				else {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/105127/62429401-45b41180-b6dc-11e9-9333-80c9fb1147ff.png)

Hoping this has minimal byte size impact. Perhaps there are other places where we do this? 