### PR TITLE
Fix IE11 not setting initial select value

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -123,6 +123,20 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 						}
 						parentDom.insertBefore(newDom, oldDom);
 					}
+
+					// Browsers will infer an option's `value` from `textContent` when
+					// no value is present. This essentially bypasses our code to set it
+					// later in `diff()`. It works fine in all browsers except for IE11
+					// where it breaks setting `select.value`. There it will be always set
+					// to an empty string. Re-applying an options value will fix that, so
+					// there are probably some internal data structures that aren't
+					// updated properly.
+					//
+					// To fix it we make sure to reset the inferred value, so that our own
+					// value check in `diff()` won't be skipped.
+					if (newParentVNode.type == 'option') {
+						parentDom.value = '';
+					}
 				}
 
 				oldDom = newDom.nextSibling;

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -88,16 +88,7 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 		}
 	}
 	else if (name!=='list' && name!=='tagName' && !isSvg && (name in dom)) {
-		// Setting `select.value` doesn't work in IE11.
-		// Only `<select>` elements have the length property
-		if (dom.length && name=='value') {
-			for (name = dom.length; name--;) {
-				dom.options[name].selected = dom.options[name].value==value;
-			}
-		}
-		else {
-			dom[name] = value==null ? '' : value;
-		}
+		dom[name] = value==null ? '' : value;
 	}
 	else if (typeof value!=='function' && name!=='dangerouslySetInnerHTML') {
 		if (name!==(name = name.replace(/^xlink:?/, ''))) {


### PR DESCRIPTION
Oh boy, it took me all day to figure this one out. Basically all browsers will infer the option `value` from `textContent` when it isn't present. It's probably done for backwards compatibility.

```js
const option = document.createElement("option");
option.textContent = "A";
console.log(option.value); // Logs: "A"
```

At this point `option.value` is set and that will skip our own check later:

https://github.com/preactjs/preact/blob/c2909d09fa34e8ba0c594bf1dd35fbf6f155b54b/src/diff/index.js#L248

This works fine in all browsers except IE11. When the option value isn't explicitly set, it leads to subtle bugs like `select.value` not working anymore. In this case it will always reset it to an empty string :man_shrugging: 

@andrewiggins this is basically a continuation from #1708 and it turns out that my fix wasn't correct. This PR gets those bytes back :wink: 

Here is a simple test case to verify the behavior in IE11:

```js
// IE11 Bug: <select> value won't be set correctly
var select = document.createElement("select");
var data = ["A", "B", "C"];
for (var i = 0; i < data.length; i++) {
	var option = document.createElement("option");
	option.textContent = data[i];
	// Uncomment this line to make `select.value` work
	// option.value = data[i];
	select.appendChild(option);
}

document.body.appendChild(select);
select.value = "C";
console.log("actual:", select.value, "expected: C");
// Logs: actual: "" expected: C
```

Removes `-24 B` :tada: 