### PR TITLE
Exclude Edge from running devtool tests

### DIFF
--- a/debug/test/browser/devtools.test.js
+++ b/debug/test/browser/devtools.test.js
@@ -137,7 +137,9 @@ function getRoot(element) {
 	return element._children;
 }
 
-const supported = /(Chrome)|(Firefox)[^(Edge)]/i.test(navigator.userAgent);
+const supported = /Chrome|Firefox/i.test(navigator.userAgent) &&
+	!/Edge/i.test(navigator.userAgent);
+
 describe('devtools', () => {
 	if (!supported) return;
 


### PR DESCRIPTION
The UserAgent for Edge has the word `Chrome` in it, so the regex would fail.