### PR TITLE
Fix `act` not flushing effects/updates if global effect/update queues are non-empty before `act` call

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -231,8 +231,12 @@ function safeRaf(callback) {
 
 /* istanbul ignore else */
 if (typeof window !== 'undefined') {
+	let prevRaf = options.requestAnimationFrame;
 	afterPaint = (component) => {
-		if (!component._afterPaintQueued && (component._afterPaintQueued = true) && afterPaintEffects.push(component) === 1) {
+		if ((!component._afterPaintQueued && (component._afterPaintQueued = true) && afterPaintEffects.push(component) === 1) ||
+		    prevRaf !== options.requestAnimationFrame) {
+			prevRaf = options.requestAnimationFrame;
+
 			/* istanbul ignore next */
 			(options.requestAnimationFrame || safeRaf)(flushAfterPaintEffects);
 		}

--- a/src/component.js
+++ b/src/component.js
@@ -162,12 +162,16 @@ const defer = typeof Promise=='function' ? Promise.prototype.then.bind(Promise.r
  * * [Callbacks synchronous and asynchronous](https://blog.ometer.com/2011/07/24/callbacks-synchronous-and-asynchronous/)
  */
 
+let prevDebounce = options.debounceRendering;
+
 /**
  * Enqueue a rerender of a component
  * @param {import('./internal').Component} c The component to rerender
  */
 export function enqueueRender(c) {
-	if (!c._dirty && (c._dirty = true) && q.push(c) === 1) {
+	if ((!c._dirty && (c._dirty = true) && q.push(c) === 1) ||
+	    (prevDebounce !== options.debounceRendering)) {
+		prevDebounce = options.debounceRendering;
 		(options.debounceRendering || defer)(process);
 	}
 }


### PR DESCRIPTION
When scheduling a state update or effect, check whether the
`options.{debounceRendering, requestAnimationFrame}` hooks changed since
an update/effect queue flush was last scheduled and schedule a flush
using the new hooks if so.

This fixes an issue where a call to `act` would fail to synchronously flush
state updates and effects if a flush was already scheduled but not yet executed
before `act` was called. This happened because when a state update or effect was
queued during the `act` callback, if the global update/effect queues were
non-empty then the temporary hooks installed by `act` to facilitate
synchronously flushing the queue would not be called.

More generally, this fixes an issue where any changes to the scheduling hooks
do not take effect until any already-scheduled flushes have happened.

Fixes #1794