### PR TITLE
Fix IE11 regressions

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -31,7 +31,7 @@ function setStyle(style, key, value) {
 		style.setProperty(key, value);
 	}
 	else {
-		style[key] = typeof value==='number' && IS_NON_DIMENSIONAL.test(key)===false ? value+'px' : value || null;
+		style[key] = typeof value==='number' && IS_NON_DIMENSIONAL.test(key)===false ? value+'px' : value || '';
 	}
 }
 

--- a/test-utils/test/shared/act.test.js
+++ b/test-utils/test/shared/act.test.js
@@ -4,6 +4,15 @@ import { useEffect, useState } from 'preact/hooks';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { act } from '../../src';
 
+// IE11 doesn't support `new Event()`
+function createEvent(name) {
+	if (typeof Event === 'function') return new Event(name);
+
+	const event = document.createEvent('Event');
+	event.initEvent(name, true, true);
+	return event;
+}
+
 /** @jsx h */
 describe('act', () => {
 
@@ -156,13 +165,13 @@ describe('act', () => {
 
 		// Click button. This will schedule an update which is deferred, as is
 		// normal for Preact, since it happens outside an `act` call.
-		button.dispatchEvent(new Event('click'));
+		button.dispatchEvent(createEvent('click'));
 
 		expect(button.textContent).to.equal('0');
 
 		act(() => {
 			// Click button a second time. This will schedule a second update.
-			button.dispatchEvent(new Event('click'));
+			button.dispatchEvent(createEvent('click'));
 		});
 		// All state updates should be applied synchronously after the `act`
 		// callback has run but before `act` returns.


### PR DESCRIPTION
This PR fixes some regressions with IE11 introduced by the last 2 PRs (#1854 and #1853 ) 🙈 
Adds `+1 B`.

Build passes with SauceLabs: https://travis-ci.org/preactjs/preact/builds/570482228