### PR TITLE
Disable coveralls until their outage is resolved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
 
 script:
   - COVERAGE=true npm run test
-  - ./node_modules/coveralls/bin/coveralls.js < ./coverage/lcov.info;
+  # Disable coveralls until their outage is over: https://status.coveralls.io
+  #- ./node_modules/coveralls/bin/coveralls.js < ./coverage/lcov.info;
 
 after_success: sizereport --config


### PR DESCRIPTION
This PR disables reporting the collected code coverage stats to `coveralls`. They've been experiencing various outages since more than a day ago and it will probably at least another day until their back up again: https://status.coveralls.io . This unblocks merging of PRs as the CI currently always fails as soon as the report is sent to coveralls.