### PR TITLE
Skip form attribute test on IE11

### DIFF
--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -108,8 +108,12 @@ describe('render()', () => {
 		const form = div.childNodes[0];
 		const button = div.childNodes[1];
 		const input = div.childNodes[2];
-		expect(button).to.have.property('form', form);
-		expect(input).to.have.property('form', form);
+
+		// IE11 doesn't support the form attribute
+		if (!/(Trident)/.test(navigator.userAgent)) {
+			expect(button).to.have.property('form', form);
+			expect(input).to.have.property('form', form);
+		}
 	});
 
 	it('should allow VNode reuse', () => {


### PR DESCRIPTION
This PR skips the test for setting the `form` attribute in IE11 because it doesn't support that. This feature was introduced in #1863 .

Build to prove that CI is green on IE11: https://travis-ci.org/preactjs/preact/builds/571655511