### PR TITLE
Restructure devtools code in preparation for V4

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -1,5 +1,5 @@
 import { checkPropTypes } from './check-props';
-import { getDisplayName } from './devtools/custom';
+import { getDisplayName } from './devtools/vnode';
 import { options, Component } from 'preact';
 import { ELEMENT_NODE, DOCUMENT_NODE, DOCUMENT_FRAGMENT_NODE } from './constants';
 

--- a/debug/src/devtools/legacy/connect.js
+++ b/debug/src/devtools/legacy/connect.js
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import { Fragment } from 'preact';
 import { assign } from '../../../../src/util';
 import { Renderer } from './renderer';

--- a/debug/src/devtools/legacy/connect.js
+++ b/debug/src/devtools/legacy/connect.js
@@ -1,0 +1,71 @@
+import { Fragment } from 'preact';
+import { assign } from '../../../../src/util';
+import { Renderer } from './renderer';
+import { catchErrors } from '../util';
+
+/**
+ * Create an adapter instance for the legacy devtools
+ * @param {import('../../internal').RendererConfigBase} config
+ * @param {import('.').LegacyDevtoolsHook} hook
+ */
+export function createLegacyAdapter(config, hook) {
+	// The renderer id is just a random string
+	let rendererId = Math.random().toString(16).slice(2);
+
+	let adapter = new Renderer(hook, rendererId);
+
+	let renderer = assign(assign({}, config), {
+		findHostInstanceByFiber: adapter.getNativeFromReactElement.bind(adapter),
+		findFiberByHostInstance: adapter.getReactElementFromNative.bind(adapter)
+	});
+
+	hook._renderers[rendererId] = renderer;
+	let shouldConnect = false;
+	let connectManually = false;
+
+	// We can't bring our own `attachRenderer` function therefore we simply
+	// prevent the devtools from overwriting our custom renderer by creating
+	// a noop setter.
+	Object.defineProperty(hook.helpers, rendererId, {
+		get: () => adapter,
+		set: () => {
+			if (shouldConnect && !adapter.connected) {
+				helpers.markConnected();
+			}
+			else {
+				connectManually = true;
+			}
+		}
+	});
+
+	let helpers = hook.helpers[rendererId];
+
+	return {
+		renderer,
+		connect() {
+			shouldConnect = true;
+
+			if (connectManually) {
+				helpers.markConnected();
+			}
+
+			// Tell the devtools that we are ready to start
+			hook.emit('renderer-attached', {
+				id: rendererId,
+				renderer,
+				helpers
+			});
+		},
+		onCommitRoot: catchErrors(root => {
+			// Empty root
+			if (root.type===Fragment && root._children.length==0) return;
+
+			let roots = hook.getFiberRoots(rendererId);
+			root = helpers.handleCommitFiberRoot(root);
+			if (!roots.has(root)) roots.add(root);
+		}),
+		onCommitUnmount: catchErrors(vnode => {
+			hook.onCommitFiberUnmount(rendererId, vnode);
+		})
+	};
+}

--- a/debug/src/devtools/legacy/data.js
+++ b/debug/src/devtools/legacy/data.js
@@ -1,10 +1,12 @@
 /* istanbul ignore file */
 import { Component, Fragment } from 'preact';
+import { getDisplayName, getInstance } from '../vnode';
+import { setIn } from '../util';
 
 /**
  * Get the type/category of a vnode
- * @param {import('../internal').VNode} vnode
- * @returns {import('../internal').NodeType}
+ * @param {import('.').VNode} vnode
+ * @returns {import('.').NodeType}
  */
 export function getNodeType(vnode) {
 	if (vnode.type===Fragment) return 'Wrapper';
@@ -14,40 +16,14 @@ export function getNodeType(vnode) {
 }
 
 /**
- * Get human readable name of the component/dom element
- * @param {import('../internal').VNode} vnode
- * @returns {string}
- */
-export function getDisplayName(vnode) {
-	if (vnode.type===Fragment) return 'Fragment';
-	else if (typeof vnode.type==='function') return vnode.type.displayName || vnode.type.name;
-	else if (typeof vnode.type==='string') return vnode.type;
-	return '#text';
-}
-
-/**
- * Deeply mutate a property by walking down an array of property keys
- * @param {object} obj
- * @param {Array<string | number>} path
- * @param {any} value
- */
-export function setIn(obj, path, value) {
-	let last = path.pop();
-	let parent = path.reduce((acc, attr) => acc ? acc[attr] : null, obj);
-	if (parent) {
-		parent[last] = value;
-	}
-}
-
-/**
  * Get devtools compatible data from vnode
- * @param {import('../internal').VNode} vnode
- * @returns {import('../internal').DevtoolData}
+ * @param {import('.').VNode} vnode
+ * @returns {import('.').LegacyDevtoolData}
  */
 export function getData(vnode) {
 	let c = vnode._component;
 
-	/** @type {import('../internal').DevtoolsUpdater | null} */
+	/** @type {import('../../internal').DevtoolsUpdater | null} */
 	let updater = null;
 
 	if (c!=null && c instanceof Component) {
@@ -105,8 +81,8 @@ export function getData(vnode) {
 /**
  * Get all rendered vnode children as an array. Moreover we need to filter
  * out `null` or other falsy children.
- * @param {import('../internal').VNode} vnode
- * @returns {import('../internal').VNode[]}
+ * @param {import('.').VNode} vnode
+ * @returns {import('.').VNode[]}
  */
 export function getChildren(vnode) {
 	if (vnode._component==null) {
@@ -114,42 +90,6 @@ export function getChildren(vnode) {
 	}
 
 	return vnode._children != null ? vnode._children.filter(Boolean) : null;
-}
-
-/**
- * Check if a vnode is a root node
- * @param {import('../internal').VNode} vnode
- * @returns {boolean}
- */
-export function isRoot(vnode) {
-	// Timings of root vnodes will never be set
-	return vnode.type===Fragment && vnode._parent === null;
-}
-
-/**
- * Cache a vnode by its instance and retrieve previous vnodes by the next
- * instance.
- *
- * We need this to be able to identify the previous vnode of a given instance.
- * For components we want to check if we already rendered it and use the class
- * instance as key. For html elements we use the dom node as key.
- *
- * @param {import('../internal').VNode} vnode
- * @returns {import('../internal').Component | import('../internal').PreactElement | Text | null}
- */
-export function getInstance(vnode) {
-	// Use the parent element as instance for root nodes
-	if (isRoot(vnode)) {
-		// Edge case: When the tree only consists of components that have not rendered
-		// anything into the DOM we revert to using the vnode as instance.
-		return vnode._children.length > 0 && vnode._children[0]!=null && vnode._children[0]._dom!=null
-			? /** @type {import('../internal').PreactElement | null} */
-			(vnode._children[0]._dom.parentNode)
-			: vnode;
-	}
-	if (vnode._component!=null) return vnode._component;
-	if (vnode.type===Fragment) return vnode.props;
-	return vnode._dom;
 }
 
 /**
@@ -173,8 +113,8 @@ export function shallowEqual(a, b, isProps) {
 
 /**
  * Check if a vnode was actually updated
- * @param {import('../internal').VNode} next
- * @param {import('../internal').VNode} prev
+ * @param {import('../../internal').VNode} next
+ * @param {import('../../internal').VNode} prev
  * @returns {boolean}
  */
 export function hasDataChanged(prev, next) {

--- a/debug/src/devtools/legacy/index.d.ts
+++ b/debug/src/devtools/legacy/index.d.ts
@@ -1,0 +1,66 @@
+import { RendererConfigBase } from '../../internal';
+
+export { VNode, Component, PreactElement } from '../../internal';
+
+//
+// Legacy devtools version (v3)
+//
+export type NodeType = "Composite" | "Native" | "Wrapper" | "Text";
+
+export interface LegacyRendererConfig  extends RendererConfigBase {
+	/** Find the root dom node of a vnode */
+	findHostInstanceByFiber(vnode: VNode): HTMLElement | null;
+	/** Find the closest vnode given a dom node */
+	findFiberByHostInstance(instance: HTMLElement): VNode | null;
+}
+
+export interface LegacyDevtoolsHook {
+	_renderers: Record<string, any>;
+	_roots: Set<VNode>;
+	isDisabled?: boolean;
+	helpers: Record<string, any>;
+	on(ev: string, listener: () => void): void;
+	emit(ev: string, data?: object): void;
+	getFiberRoots(rendererId: string): Set<any>;
+	inject(config: DevtoolsInjectOptions): string;
+	onCommitFiberRoot(rendererId: string, root: VNode): void;
+	onCommitFiberUnmount(rendererId: string, vnode: VNode): void;
+}
+
+export interface LegacyRendererConfig  extends RendererConfigBase {
+	/** Find the root dom node of a vnode */
+	findHostInstanceByFiber(vnode: VNode): HTMLElement | null;
+	/** Find the closest vnode given a dom node */
+	findFiberByHostInstance(instance: HTMLElement): VNode | null;
+}
+
+export interface LegacyDevtoolData {
+	nodeType: NodeType;
+	// Component type
+	type: any;
+	name: string;
+	ref: any;
+	key: string | number;
+	updater: DevtoolsUpdater | null;
+	text: string | number | null;
+	state: any;
+	props: any;
+	children: VNode[] | string | number | null;
+	publicInstance: PreactElement | Text | Component;
+	memoizedInteractions: any[];
+
+	actualDuration: number,
+	actualStartTime: number,
+	treeBaseDuration: number,
+}
+
+export type EventType = 'unmount' | 'rootCommitted' | 'root' | 'mount' | 'update' | 'updateProfileTimes';
+
+export interface DevtoolsEvent {
+	data?: LegacyDevtoolData;
+	internalInstance: VNode;
+	renderer: string;
+	type: EventType;
+}
+
+export type InstanceCache = WeakMap<Component, PreactElement | VNode | HTMLElement | Text>;

--- a/debug/src/devtools/util.js
+++ b/debug/src/devtools/util.js
@@ -1,0 +1,43 @@
+/**
+ * Get current timestamp in ms. Used for profiling.
+ * @returns {number}
+ */
+export let now = Date.now;
+
+try {
+	/* istanbul ignore else */
+	now = performance.now.bind(performance);
+}
+catch (e) {}
+
+/**
+ * Wrap function with generic error logging
+ * @param {*} fn
+ */
+export function catchErrors(fn) {
+	return arg => {
+		try {
+			return fn(arg);
+		}
+		catch (e) {
+			/* istanbul ignore next */
+			console.error('The react devtools encountered an error');
+			/* istanbul ignore next */
+			console.error(e); // eslint-disable-line no-console
+		}
+	};
+}
+
+/**
+ * Deeply mutate a property by walking down an array of property keys
+ * @param {object} obj
+ * @param {Array<string | number>} path
+ * @param {any} value
+ */
+export function setIn(obj, path, value) {
+	let last = path.pop();
+	let parent = path.reduce((acc, attr) => acc ? acc[attr] : null, obj);
+	if (parent) {
+		parent[last] = value;
+	}
+}

--- a/debug/src/devtools/vnode.js
+++ b/debug/src/devtools/vnode.js
@@ -1,0 +1,64 @@
+import { Fragment } from 'preact';
+
+/**
+ * Get human readable name of the component/dom element
+ * @param {import('../internal').VNode} vnode
+ * @returns {string}
+ */
+export function getDisplayName(vnode) {
+	if (vnode.type===Fragment) return 'Fragment';
+	else if (typeof vnode.type==='function') return vnode.type.displayName || vnode.type.name;
+	else if (typeof vnode.type==='string') return vnode.type;
+	return '#text';
+}
+
+/**
+ * Get the root of a vnode
+ * @param {import('../internal').VNode} vnode
+ * @returns {import('../internal').VNode}
+ */
+export function getRoot(vnode) {
+	let next = vnode;
+	while (next = next._parent) {
+		if (isRoot(next)) {
+			return next;
+		}
+	}
+
+	return vnode;
+}
+
+/**
+ * Get the ancestor component that rendered the current vnode
+ * @param {import('../internal').VNode} vnode
+ * @returns {boolean}
+ */
+export function isRoot(vnode) {
+	return vnode.type===Fragment && vnode._parent==null;
+}
+
+/**
+ * Cache a vnode by its instance and retrieve previous vnodes by the next
+ * instance.
+ *
+ * We need this to be able to identify the previous vnode of a given instance.
+ * For components we want to check if we already rendered it and use the class
+ * instance as key. For html elements we use the dom node as key.
+ *
+ * @param {import('../internal').VNode} vnode
+ * @returns {import('../internal').VNode | import('../internal').Component | import('../internal').PreactElement | Text | null}
+ */
+export function getInstance(vnode) {
+	// Use the parent element as instance for root nodes
+	if (isRoot(vnode)) {
+		// Edge case: When the tree only consists of components that have not rendered
+		// anything into the DOM we revert to using the vnode as instance.
+		return vnode._children.length > 0 && vnode._children[0]!=null && vnode._children[0]._dom!=null
+			? /** @type {import('../internal').PreactElement | null} */
+			(vnode._children[0]._dom.parentNode)
+			: vnode;
+	}
+	if (vnode._component!=null) return vnode._component;
+	if (vnode.type===Fragment) return vnode.props;
+	return vnode._dom;
+}

--- a/debug/src/internal.d.ts
+++ b/debug/src/internal.d.ts
@@ -2,17 +2,13 @@ import { Component, PreactElement, VNode } from "../../src/internal";
 
 export { Component, PreactElement, VNode };
 
-export interface DevtoolsInjectOptions {
+export interface RendererConfigBase {
 	/** 1 = DEV, 0 = production */
 	bundleType: 1 | 0;
 	/** The devtools enable different features for different versions of react */
 	version: string;
 	/** Informative string, currently unused in the devtools  */
 	rendererPackageName: string;
-	/** Find the root dom node of a vnode */
-	findHostInstanceByFiber(vnode: VNode): HTMLElement | null;
-	/** Find the closest vnode given a dom node */
-	findFiberByHostInstance(instance: HTMLElement): VNode | null;
 }
 
 export interface DevtoolsUpdater {
@@ -21,49 +17,6 @@ export interface DevtoolsUpdater {
 	setInState(path: Array<string | number>, value: any): void;
 	setInProps(path: Array<string | number>, value: any): void;
 	setInContext(): void;
-}
-
-export type NodeType = "Composite" | "Native" | "Wrapper" | "Text";
-
-export interface DevtoolData {
-	nodeType: NodeType;
-	// Component type
-	type: any;
-	name: string;
-	ref: any;
-	key: string | number;
-	updater: DevtoolsUpdater | null;
-	text: string | number | null;
-	state: any;
-	props: any;
-	children: VNode[] | string | number | null;
-	publicInstance: PreactElement | Text | Component;
-	memoizedInteractions: any[];
-
-	actualDuration: number,
-	actualStartTime: number,
-	treeBaseDuration: number,
-}
-
-export type EventType = 'unmount' | 'rootCommitted' | 'root' | 'mount' | 'update' | 'updateProfileTimes';
-
-export interface DevtoolsEvent {
-	data?: DevtoolData;
-	internalInstance: VNode;
-	renderer: string;
-	type: EventType;
-}
-
-export interface DevtoolsHook {
-	_renderers: Record<string, any>;
-	_roots: Set<VNode>;
-	on(ev: string, listener: () => void): void;
-	emit(ev: string, data?: object): void;
-	helpers: Record<string, any>;
-	getFiberRoots(rendererId: string): Set<any>;
-	inject(config: DevtoolsInjectOptions): string;
-	onCommitFiberRoot(rendererId: string, root: VNode): void;
-	onCommitFiberUnmount(rendererId: string, vnode: VNode): void;
 }
 
 export interface DevtoolsWindow extends Window {


### PR DESCRIPTION
This PR prepares the current devtools code for V4. I decided to split #1549 to make reviews easier. The changes here are only cosmetic and introduce no new features. They mainly shuffle the code around so that we can easily switch between multiple devtool versions.

The goal is that we can smooth out the transition period. Our code will (with #1549 ) be able to pick the right adapter depending on the devtools extension the user has installed.