### PR TITLE
Fix type definitions for getDerivedStateFromProps() and getDerivedStateFromError()

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -76,8 +76,8 @@ declare namespace preact {
 		new (props: P, context?: any): Component<P, S>;
 		displayName?: string;
 		defaultProps?: Partial<P>;
-		getDerivedStateFromProps?(props: Readonly<P>, state: Readonly<S>): Partial<S>;
-		getDerivedStateFromError?(error: any): Partial<S>;
+		getDerivedStateFromProps?(props: Readonly<P>, state: Readonly<S>): Partial<S> | null;
+		getDerivedStateFromError?(error: any): Partial<S> | null;
 	}
 	interface ComponentConstructor<P = {}, S = {}> extends ComponentClass<P, S> {}
 
@@ -110,8 +110,8 @@ declare namespace preact {
 		// constraint under no circumstances, see #1356.In general type arguments
 		// seem to be a bit buggy and not supported well at the time of this
 		// writing with TS 3.3.3333.
-		static getDerivedStateFromProps?(props: Readonly<object>, state: Readonly<object>): object;
-		static getDerivedStateFromError?(error: any): object;
+		static getDerivedStateFromProps?(props: Readonly<object>, state: Readonly<object>): object | null;
+		static getDerivedStateFromError?(error: any): object | null;
 
 		state: Readonly<S>;
 		props: RenderableProps<P>;


### PR DESCRIPTION
This type definitions for `getDerivedStateFromProps()` and `getDerivedStateFromError()`.

https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops

https://github.com/preactjs/preact/blob/4618891cbc72bf528ee0613e8ae8ae52a4897cc1/src/diff/index.js#L75

https://github.com/preactjs/preact/blob/4618891cbc72bf528ee0613e8ae8ae52a4897cc1/src/diff/index.js#L340