### PR TITLE
V8 devtools attempt 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/node_modules
+node_modules/
 /npm-debug.log
 .DS_Store
 /dist

--- a/demo/package.json
+++ b/demo/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --inline"
+    "start": "webpack-dev-server --inline --port 3000"
   },
   "author": "",
   "license": "ISC",

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "demo",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "webpack-dev-server --inline"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@babel/core": "^7.5.5",
+    "@babel/plugin-proposal-class-properties": "^7.5.5",
+    "@babel/plugin-transform-react-constant-elements": "^7.5.0",
+    "@babel/plugin-transform-react-jsx": "^7.3.0",
+    "@babel/preset-env": "^7.5.5",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^8.0.6",
+    "html-webpack-plugin": "^3.2.0",
+    "webpack": "^4.39.2",
+    "webpack-cli": "^3.3.6",
+    "webpack-dev-server": "^3.8.0"
+  },
+  "dependencies": {
+    "preact-compat": "^3.19.0"
+  }
+}

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -1,8 +1,26 @@
 import "preact/debug";
 import { createElement, render, Component } from 'preact';
 
-function App() {
-	return <div>Hello World</div>;
+class Bar extends Component {
+	constructor(props) {
+		super(props);
+		this.state = { foo: 123 }
+	}
+	render() {
+		return <div>bar {this.state.foo}</div>
+	}
 }
 
-render(<App />, document.body);
+function Bob() {
+	return <Baz />;
+}
+
+function Baz() {
+	return <div>blah</div>;
+}
+
+function App() {
+	return <div>Hello World <Bar/> <Bob /></div>;
+}
+
+render(<App><Bar /></App>, document.body);

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -1,0 +1,8 @@
+import "preact/debug";
+import { createElement, render, Component } from 'preact';
+
+function App() {
+	return <div>Hello World</div>;
+}
+
+render(<App />, document.body);

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -1,0 +1,68 @@
+/* eslint-disable */
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+const preact = path.join(__dirname, '..', 'src', 'preact.js');
+
+module.exports = {
+	context: __dirname,
+	entry: './src/index',
+	output: {
+		publicPath: '/'
+	},
+	resolve: {
+		alias: {
+			["preact/debug"]: path.join(__dirname, '..', 'debug'),
+			["preact/devtools"]: path.join(__dirname, '..', 'devtools'),
+			preact: preact,
+			react: 'preact-compat',
+			'react-dom': 'preact-compat'
+		},
+		extensions: [ '.tsx', '.ts', '.js' ]
+	},
+	module: {
+		rules: [
+			{
+				test: /\.jsx?$/,
+				loader: 'babel-loader',
+				options: {
+					sourceMap: true,
+					presets: [
+						[require.resolve('@babel/preset-env'), {
+							targets: {
+								browsers: ['last 2 versions', 'IE >= 9']
+							},
+							modules: false,
+							loose: true
+						}],
+						[require.resolve('@babel/preset-react')],
+					],
+					plugins: [
+						[require.resolve('@babel/plugin-transform-react-jsx'), { pragma: 'createElement', pragmaFrag: 'Fragment' }],
+						[require.resolve('@babel/plugin-proposal-class-properties')],
+						[require.resolve('@babel/plugin-transform-react-constant-elements')],
+					]
+				}
+			},
+			{
+				test: /\.css$/,
+				use: [
+					'style-loader',
+					'css-loader',
+				]
+			}
+		]
+	},
+	devtool: 'inline-source-map',
+	node: {
+		process: 'mock',
+		Buffer: false,
+		setImmediate: false
+	},
+	devServer: {
+		historyApiFallback: true
+	},
+	plugins: [
+		new HtmlWebpackPlugin()
+	]
+};

--- a/devtools/devtools.js
+++ b/devtools/devtools.js
@@ -86,6 +86,10 @@ function createReactCompositeComponent(component) {
 	const node = component.base;
 
 	let instance = {
+		getPublicInstance() {
+			// Can be anything other than null
+			return true;
+		},
 		// --- ReactDOMComponent properties
 		getName() {
 			return typeName(_currentElement);
@@ -258,13 +262,18 @@ function createDevToolsBridge() {
 
 		Reconciler.receiveComponent(instance);
 		visitNonCompositeChildren(instance, childInst => {
+			const info = {
+				// Must be defined otherwise state updates won't work
+				_topLevelWrapper: instance
+			};
+
 			if (!childInst._inDevTools) {
 				// New DOM child component
 				childInst._inDevTools = true;
-				Reconciler.mountComponent(childInst);
+				Reconciler.mountComponent(childInst, null, null, info);
 			} else {
 				// Updated DOM child component
-				Reconciler.receiveComponent(childInst);
+				Reconciler.receiveComponent(childInst, null, null, info);
 			}
 		});
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "strip:esm": "jscodeshift --run-in-band -s -t config/codemod-strip-tdz.js dist/preact.mjs && jscodeshift --run-in-band -s -t config/codemod-const.js dist/preact.mjs && jscodeshift --run-in-band -s -t config/codemod-let-name.js dist/preact.mjs",
     "strip": "npm-run-all strip:main strip:esm",
     "size": "node -e \"process.stdout.write('gzip size: ')\" && gzip-size --raw dist/preact.min.js",
-    "test": "npm-run-all lint --parallel test:mocha test:karma test:ts test:flow test:size",
+    "test": "npm-run-all lint --parallel test:mocha test:karma test:ts test:flow",
     "test:flow": "flow check",
     "test:ts": "tsc -p test/ts/ && mocha --require babel-register test/ts/**/*-test.js",
     "test:mocha": "mocha --recursive --require babel-register test/shared test/node",


### PR DESCRIPTION
Add support for the new react devtools to Preact 8.x. Seems to work pretty well so far. The only downside is that the root component node (if there is any) is not displayed, and instead the `dom` instance will be shown. Can't find a way around that, but it's a good compromise between broken devtools and a minor inconvenience :+1: 

This PR also adds a demo app to make testing devtools code easier.

Fixes #1877 , fixes #1873 .