### PR TITLE
TS: Add key to all jsx elements

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -14,6 +14,10 @@ export namespace JSXInternal {
 		? Defaultize<Props, Defaults>
 		: Props;
 
+	interface IntrinsicAttributes {
+		key?: any;
+	}
+
 	interface Element extends preact.VNode<any> {
 	}
 

--- a/test/ts/Component-test.tsx
+++ b/test/ts/Component-test.tsx
@@ -116,6 +116,14 @@ class StaticComponent extends Component<SimpleComponentProps, SimpleState> {
 	}
 }
 
+function MapperItem(props: { foo: number }) {
+	return <div />;
+}
+
+function Mapper() {
+	return [1, 2, 3].map(x => <MapperItem foo={x} key={x}/>)
+}
+
 describe("Component", () => {
 	const component = new SimpleComponent({ initialName: "da name" });
 


### PR DESCRIPTION
This allows every `JSX` element to have an optional `key` prop (see the test snippet).

cc @pmkroeker 