### PR TITLE
(fix) - register the handles after rendering

### DIFF
--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -1,15 +1,17 @@
-import { createElement as h, render, createRef, forwardRef, hydrate, memo } from '../../src';
+import { createElement as h, render, createRef, forwardRef, hydrate, memo, useState, useImperativeHandle } from '../../src';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { setupRerender } from 'preact/test-utils';
 /* eslint-disable react/jsx-boolean-value, react/display-name, prefer-arrow-callback */
 
 /** @jsx h */
 describe('forwardRef', () => {
 
 	/** @type {HTMLDivElement} */
-	let scratch;
+	let scratch, rerender;
 
 	beforeEach(() => {
 		scratch = setupScratch();
+		rerender = setupRerender();
 	});
 
 	afterEach(() => {
@@ -151,6 +153,34 @@ describe('forwardRef', () => {
 			scratch
 		);
 		expect(ref.current==null).to.equal(true);
+	});
+
+	it('should support useImperativeHandle', () => {
+		let setValue;
+		const Foo = forwardRef((props, ref) => {
+			const result = useState('');
+			setValue = result[1];
+
+			useImperativeHandle(ref, () => ({
+				getValue: () => result[0]
+			}), [result[0]]);
+
+			return (
+				<input ref={ref} value={result[0]}  />
+			);
+		});
+
+		const ref = createRef();
+		render(<Foo ref={ref} />, scratch);
+
+		expect(typeof ref.current.getValue).to.equal('function');
+		expect(ref.current.getValue()).to.equal('');
+
+		setValue('x');
+		rerender();
+		expect(typeof ref.current.getValue).to.equal('function');
+		expect(ref.current.getValue()).to.equal('x');
+
 	});
 
 	it('should not bailout if forwardRef is not wrapped in memo', () => {

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -30,8 +30,8 @@ options.diffed = vnode => {
 
 	const hooks = c.__hooks;
 	if (hooks) {
+		hooks._handles = bindHandles(hooks._handles);
 		hooks._pendingLayoutEffects = handleEffects(hooks._pendingLayoutEffects);
-		hooks._handles = handleHandles(hooks._handles);
 	}
 };
 
@@ -140,7 +140,7 @@ export function useImperativeHandle(ref, createHandle, args) {
 	}
 }
 
-function handleHandles(handles) {
+function bindHandles(handles) {
 	handles.some(handle => {
 		if (handle.ref) handle.ref.current = handle.createHandle();
 	});

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -31,6 +31,7 @@ options.diffed = vnode => {
 	const hooks = c.__hooks;
 	if (hooks) {
 		hooks._pendingLayoutEffects = handleEffects(hooks._pendingLayoutEffects);
+		hooks._handles = handleHandles(hooks._handles);
 	}
 };
 
@@ -60,7 +61,7 @@ function getHookState(index) {
 	// * https://github.com/michael-klein/funcy.js/blob/650beaa58c43c33a74820a3c98b3c7079cf2e333/src/renderer.mjs
 	// Other implementations to look at:
 	// * https://codesandbox.io/s/mnox05qp8
-	const hooks = currentComponent.__hooks || (currentComponent.__hooks = { _list: [], _pendingEffects: [], _pendingLayoutEffects: [] });
+	const hooks = currentComponent.__hooks || (currentComponent.__hooks = { _list: [], _pendingEffects: [], _pendingLayoutEffects: [], _handles: [] });
 
 	if (index >= hooks._list.length) {
 		hooks._list.push({});
@@ -135,10 +136,15 @@ export function useImperativeHandle(ref, createHandle, args) {
 	const state = getHookState(currentIndex++);
 	if (argsChanged(state._args, args)) {
 		state._args = args;
-		if (ref) {
-			ref.current = createHandle();
-		}
+		currentComponent.__hooks._handles.push({ ref, createHandle });
 	}
+}
+
+function handleHandles(handles) {
+	handles.some(handle => {
+		if (handle.ref) handle.ref.current = handle.createHandle();
+	});
+	return [];
 }
 
 /**


### PR DESCRIPTION
Fixes: https://github.com/preactjs/preact/issues/1903

When we put a ref on a html-node this will effectively remove the handle, that's why we have to register these after our render occurs