### PR TITLE
(fix) vnode._children should keep their type as array when diffing

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -1,7 +1,7 @@
 import { EMPTY_OBJ, EMPTY_ARR } from '../constants';
 import { Component, enqueueRender } from '../component';
 import { Fragment } from '../create-element';
-import { diffChildren } from './children';
+import { diffChildren, toChildArray } from './children';
 import { diffProps } from './props';
 import { assign, removeNode } from '../util';
 import options from '../options';
@@ -118,7 +118,7 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 
 			tmp = c.render(c.props, c.state, c.context);
 			let isTopLevelFragment = tmp != null && tmp.type == Fragment && tmp.key == null;
-			newVNode._children = isTopLevelFragment ? tmp.props.children : tmp;
+			newVNode._children = toChildArray(isTopLevelFragment ? tmp.props.children : tmp);
 
 			if (c.getChildContext!=null) {
 				context = assign(assign({}, context), c.getChildContext());


### PR DESCRIPTION
When trying to pave the way for `preact-redux` with the latest rc, seems that the `_children` is loosing it's array type whenever `react-redux` is trying to `.forceUpdate()`.
This is the relevant error and log https://travis-ci.org/developit/preact-redux/builds/583356189#L390

Adds `+2B`