### PR TITLE
Change .forceUpdate() to participate in the update queue

### DIFF
--- a/compat/test/browser/component.test.js
+++ b/compat/test/browser/component.test.js
@@ -68,6 +68,7 @@ describe('components', () => {
 
 		let a = React.render(<Parent />, scratch);
 		a.forceUpdate();
+		rerender();
 
 		expect(props).to.exist.and.deep.equal({
 			children: 'second'

--- a/src/component.js
+++ b/src/component.js
@@ -50,6 +50,7 @@ Component.prototype.setState = function(update, callback) {
 	if (update==null) return;
 
 	if (this._vnode) {
+		this._force = false;
 		if (callback) this._renderCallbacks.push(callback);
 		enqueueRender(this);
 	}

--- a/src/component.js
+++ b/src/component.js
@@ -202,6 +202,5 @@ function process() {
 	while ((p=q.pop())) {
 		// forceUpdate's callback argument is reused here to indicate a non-forced update.
 		if (p._dirty) renderComponent(p);
-		// p.forceUpdate(false);
 	}
 }

--- a/src/component.js
+++ b/src/component.js
@@ -61,22 +61,20 @@ Component.prototype.setState = function(update, callback) {
  * re-rendered
  */
 Component.prototype.forceUpdate = function(callback) {
-	let vnode = this._vnode, oldDom = this._vnode._dom, parentDom = this._parentDom;
-	if (parentDom) {
+	if (this._vnode) {
 		// Set render mode so that we can differentiate where the render request
 		// is coming from. We need this because forceUpdate should never call
 		// shouldComponentUpdate
-		const force = callback!==false;
+		if (callback) this._renderCallbacks.push(callback);
+		this._force = true;
+		enqueueRender(this);
 
-		let mounts = [];
-		let newDom = diff(parentDom, vnode, assign({}, vnode), this._context, parentDom.ownerSVGElement!==undefined, null, mounts, force, oldDom == null ? getDomSibling(vnode) : oldDom);
-		commitRoot(mounts, vnode);
-
-		if (newDom != oldDom) {
-			updateParentDomPointers(vnode);
-		}
+		// A thought: if there's nothing queued up for rendering, we could immediately flush or render.
+		// This reduces the number of failing tests from 17 to 4, but has the effect of allowing
+		// sequential forceUpdate() calls to produce multiple top-level renders.
+		//if (q.length) enqueueRender(this);
+		//else renderComponent(this);
 	}
-	if (callback) callback();
 };
 
 /**
@@ -121,6 +119,27 @@ export function getDomSibling(vnode, childIndex) {
 	// VNode (meaning we reached the DOM parent of the original vnode that began
 	// the search)
 	return typeof vnode.type === 'function' ? getDomSibling(vnode) : null;
+}
+
+/**
+ * Trigger in-place re-rendering of a component.
+ * @param {import('./internal').Component} c The component to rerender
+ */
+function renderComponent(component) {
+	let vnode = component._vnode,
+		oldDom = vnode._dom,
+		parentDom = component._parentDom,
+		force = component._force;
+	component._force = false;
+	if (parentDom) {
+		let mounts = [];
+		let newDom = diff(parentDom, vnode, assign({}, vnode), component._context, parentDom.ownerSVGElement!==undefined, null, mounts, force, oldDom == null ? getDomSibling(vnode) : oldDom);
+		commitRoot(mounts, vnode);
+
+		if (newDom != oldDom) {
+			updateParentDomPointers(vnode);
+		}
+	}
 }
 
 /**
@@ -182,6 +201,7 @@ function process() {
 	q.sort((a, b) => b._vnode._depth - a._vnode._depth);
 	while ((p=q.pop())) {
 		// forceUpdate's callback argument is reused here to indicate a non-forced update.
-		if (p._dirty) p.forceUpdate(false);
+		if (p._dirty) renderComponent(p);
+		// p.forceUpdate(false);
 	}
 }

--- a/src/component.js
+++ b/src/component.js
@@ -68,12 +68,6 @@ Component.prototype.forceUpdate = function(callback) {
 		if (callback) this._renderCallbacks.push(callback);
 		this._force = true;
 		enqueueRender(this);
-
-		// A thought: if there's nothing queued up for rendering, we could immediately flush or render.
-		// This reduces the number of failing tests from 17 to 4, but has the effect of allowing
-		// sequential forceUpdate() calls to produce multiple top-level renders.
-		//if (q.length) enqueueRender(this);
-		//else renderComponent(this);
 	}
 };
 

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -533,14 +533,17 @@ describe('Components', () => {
 
 		comp.setState({ alt: true });
 		comp.forceUpdate();
+		rerender();
 		expect(scratch.innerHTML, 'switching to textnode').to.equal('asdf');
 
 		comp.setState({ alt: false });
 		comp.forceUpdate();
+		rerender();
 		expect(scratch.innerHTML, 'switching to element').to.equal('<div>test</div>');
 
 		comp.setState({ alt: true });
 		comp.forceUpdate();
+		rerender();
 		expect(scratch.innerHTML, 'switching to textnode 2').to.equal('asdf');
 	});
 
@@ -1264,6 +1267,7 @@ describe('Components', () => {
 
 			outer.setState({ child: Inner2 });
 			outer.forceUpdate();
+			rerender();
 
 			expect(Inner2.prototype.render).to.have.been.calledOnce;
 
@@ -1278,6 +1282,7 @@ describe('Components', () => {
 			expect(Inner2.prototype.componentWillUnmount, 'inner2 swap').not.to.have.been.called;
 
 			inner2.forceUpdate();
+			rerender();
 
 			expect(Inner2.prototype.render, 'inner2 update').to.have.been.calledTwice;
 			expect(Inner2.prototype.componentWillMount, 'inner2 update').to.have.been.calledOnce;

--- a/test/browser/lifecycles/componentDidCatch.test.js
+++ b/test/browser/lifecycles/componentDidCatch.test.js
@@ -147,6 +147,7 @@ describe('Lifecycle methods', () => {
 
 			render(<Receiver><ThrowErr /></Receiver>, scratch);
 			receiver.forceUpdate();
+			rerender();
 
 			expect(Receiver.prototype.componentDidCatch).to.have.been.calledWith(expectedError);
 		});
@@ -157,6 +158,7 @@ describe('Lifecycle methods', () => {
 			render(<Receiver><ThrowErr /></Receiver>, scratch);
 
 			receiver.forceUpdate();
+			rerender();
 			expect(Receiver.prototype.componentDidCatch).to.have.been.calledWith(expectedError);
 		});
 
@@ -166,6 +168,7 @@ describe('Lifecycle methods', () => {
 			render(<Receiver><ThrowErr /></Receiver>, scratch);
 
 			receiver.forceUpdate();
+			rerender();
 			expect(Receiver.prototype.componentDidCatch).to.have.been.calledWith(expectedError);
 		});
 

--- a/test/browser/lifecycles/componentWillReceiveProps.test.js
+++ b/test/browser/lifecycles/componentWillReceiveProps.test.js
@@ -136,6 +136,7 @@ describe('Lifecycle methods', () => {
 			spyInner.resetHistory();
 
 			c.forceUpdate();
+			rerender();
 			expect(spy).to.not.be.called;
 			expect(spyInner).to.be.calledOnce;
 		});

--- a/test/browser/lifecycles/getDerivedStateFromError.test.js
+++ b/test/browser/lifecycles/getDerivedStateFromError.test.js
@@ -151,6 +151,7 @@ describe('Lifecycle methods', () => {
 
 			render(<Receiver><ThrowErr /></Receiver>, scratch);
 			receiver.forceUpdate();
+			rerender();
 
 			expect(Receiver.getDerivedStateFromError).to.have.been.calledWith(expectedError);
 		});
@@ -161,6 +162,7 @@ describe('Lifecycle methods', () => {
 			render(<Receiver><ThrowErr /></Receiver>, scratch);
 
 			receiver.forceUpdate();
+			rerender();
 			expect(Receiver.getDerivedStateFromError).to.have.been.calledWith(expectedError);
 		});
 
@@ -170,6 +172,7 @@ describe('Lifecycle methods', () => {
 			render(<Receiver><ThrowErr /></Receiver>, scratch);
 
 			receiver.forceUpdate();
+			rerender();
 			expect(Receiver.getDerivedStateFromError).to.have.been.calledWith(expectedError);
 		});
 

--- a/test/browser/lifecycles/lifecycle.test.js
+++ b/test/browser/lifecycles/lifecycle.test.js
@@ -513,11 +513,13 @@ describe('Lifecycle methods', () => {
 
 			reset();
 			setState({ show: false });
+			rerender();
 
 			expect(proto.componentWillUnmount).to.have.been.called;
 
 			reset();
 			setState({ show: true });
+			rerender();
 
 			expect(proto.componentWillMount).to.have.been.called;
 			expect(proto.componentWillMount).to.have.been.calledBefore(proto.componentDidMount);

--- a/test/browser/lifecycles/shouldComponentUpdate.test.js
+++ b/test/browser/lifecycles/shouldComponentUpdate.test.js
@@ -148,6 +148,7 @@ describe('Lifecycle methods', () => {
 
 			render(<Foo />, scratch);
 			Comp.forceUpdate();
+			rerender();
 
 			expect(Foo.prototype.shouldComponentUpdate).to.not.have.been.called;
 			expect(Foo.prototype.render).to.have.been.calledTwice;

--- a/test/browser/refs.test.js
+++ b/test/browser/refs.test.js
@@ -126,6 +126,7 @@ describe('refs', () => {
 		outer.resetHistory();
 		inner.resetHistory();
 		update();
+		rerender();
 
 		expect(outer, 're-render').not.to.have.been.called;
 		expect(inner, 're-render').not.to.have.been.called;
@@ -133,6 +134,7 @@ describe('refs', () => {
 		inner.resetHistory();
 		InnermostComponent = 'x-span';
 		update();
+		rerender();
 
 		expect(inner, 're-render swap');
 		expect(inner.firstCall, 're-render swap').to.have.been.calledWith(null);

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -929,6 +929,7 @@ describe('render()', () => {
 		checkbox.checked = false;
 
 		inputs.forceUpdate();
+		rerender();
 
 		expect(text.value).to.equal('Hello');
 		expect(checkbox.checked).to.equal(true);
@@ -988,8 +989,11 @@ describe('render()', () => {
 		render(<App />, scratch);
 
 		updateApp();
+		rerender();
 		updateParent();
+		rerender();
 		updateApp();
+		rerender();
 
 		// Without a fix it would render: `<div>foo</div><div></div>`
 		expect(scratch.innerHTML).to.equal('<div>foo</div>');

--- a/test/browser/spec.test.js
+++ b/test/browser/spec.test.js
@@ -108,6 +108,7 @@ describe('Component spec', () => {
 			expect(ForceUpdateComponent.prototype.componentWillUpdate).not.to.have.been.called;
 
 			forceUpdate();
+			rerender();
 
 			expect(ForceUpdateComponent.prototype.componentWillUpdate).to.have.been.called;
 			expect(ForceUpdateComponent.prototype.forceUpdate).to.have.been.called;
@@ -128,6 +129,7 @@ describe('Component spec', () => {
 			render(<ForceUpdateComponent />, scratch);
 
 			forceUpdate();
+			rerender();
 
 			expect(ForceUpdateComponent.prototype.forceUpdate).to.have.been.called;
 			expect(ForceUpdateComponent.prototype.forceUpdate).to.have.been.calledWith(callback);


### PR DESCRIPTION
This changes forceUpdate so that it's no longer inherently synchronous, instead pushing updates into the same queue currently used for state.

This means the following produces a single render pass:

```js
class Demo extends Component {
  componentDidMount() {
    this.setState({ a:'b' });
    this.forceUpdate(() => console.log('updated'));
    this.setState({ a: 'c' });
  }
  shouldComponentUpdate() {
    return false;
  }
}

// A single render is triggered, bypassing shouldComponentUpdate, with `{a:'c'}` as state.
```

I left a commented-out possible tweak that would still allow standalone forceUpdate() to be synchronous when nothing else is in the queue, but I'm not sure that's desirable.