### PR TITLE
Fix UNSAFE_* lifecycles being overwritten

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -384,9 +384,9 @@ function forwardRef(fn) {
 }
 
 // Patch in `UNSAFE_*` lifecycle hooks
-function setSafeDescriptor(obj, key) {
-	if (obj.prototype['UNSAFE_'+key] && !obj.prototype[key]) {
-		Object.defineProperty(obj.prototype, key, {
+function setSafeDescriptor(proto, key) {
+	if (proto['UNSAFE_'+key] && !proto[key]) {
+		Object.defineProperty(proto, key, {
 			configurable: false,
 			get() { return this['UNSAFE_' + key]; },
 			set(v) { this['UNSAFE_' + key] = v; }
@@ -409,9 +409,9 @@ options.vnode = vnode => {
 	// inheritance and are transpiled down to ES5 will overwrite our patched
 	// getters and setters. See #1941
 	if (typeof type === 'function' && !type._patchedLifecycles && type.prototype) {
-		setSafeDescriptor(type, 'componentWillMount');
-		setSafeDescriptor(type, 'componentWillReceiveProps');
-		setSafeDescriptor(type, 'componentWillUpdate');
+		setSafeDescriptor(type.prototype, 'componentWillMount');
+		setSafeDescriptor(type.prototype, 'componentWillReceiveProps');
+		setSafeDescriptor(type.prototype, 'componentWillUpdate');
 		type._patchedLifecycles = true;
 	}
 	/* istanbul ignore next */

--- a/compat/test/browser/component.test.js
+++ b/compat/test/browser/component.test.js
@@ -195,6 +195,23 @@ describe('components', () => {
 			expect(spy).to.be.calledOnce;
 		});
 
+		it('should support UNSAFE_componentWillMount #2', () => {
+			let spy = sinon.spy();
+
+			class Foo extends React.Component {
+				render() {
+					return <h1>foo</h1>;
+				}
+			}
+
+			Object.defineProperty(Foo.prototype, 'UNSAFE_componentWillMount', {
+				value: spy
+			});
+
+			React.render(<Foo />, scratch);
+			expect(spy).to.be.calledOnce;
+		});
+
 		it('should support UNSAFE_componentWillReceiveProps', () => {
 			let spy = sinon.spy();
 
@@ -215,6 +232,25 @@ describe('components', () => {
 			expect(spy).to.be.calledOnce;
 		});
 
+		it('should support UNSAFE_componentWillReceiveProps #2', () => {
+			let spy = sinon.spy();
+
+			class Foo extends React.Component {
+				render() {
+					return <h1>foo</h1>;
+				}
+			}
+
+			Object.defineProperty(Foo.prototype, 'UNSAFE_componentWillReceiveProps', {
+				value: spy
+			});
+
+			React.render(<Foo />, scratch);
+			// Trigger an update
+			React.render(<Foo />, scratch);
+			expect(spy).to.be.calledOnce;
+		});
+
 		it('should support UNSAFE_componentWillUpdate', () => {
 			let spy = sinon.spy();
 
@@ -228,6 +264,26 @@ describe('components', () => {
 					return <h1>foo</h1>;
 				}
 			}
+
+			React.render(<Foo />, scratch);
+			// Trigger an update
+			React.render(<Foo />, scratch);
+			expect(spy).to.be.calledOnce;
+		});
+
+		it('should support UNSAFE_componentWillUpdate #2', () => {
+			let spy = sinon.spy();
+
+			class Foo extends React.Component {
+				render() {
+					return <h1>foo</h1>;
+				}
+			}
+
+
+			Object.defineProperty(Foo.prototype, 'UNSAFE_componentWillUpdate', {
+				value: spy
+			});
 
 			React.render(<Foo />, scratch);
 			// Trigger an update

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -201,18 +201,17 @@ describe('suspense', () => {
 	});
 
 	it('should not call lifecycle methods when suspending', () => {
+		let componentWillMount = sinon.spy();
+		let componentDidMount = sinon.spy();
+		let componentWillUnmount = sinon.spy();
 		class LifecycleLogger extends Component {
 			render() {
 				return <div>Lifecycle</div>;
 			}
-			componentWillMount() {}
-			componentDidMount() {}
-			componentWillUnmount() {}
+			componentWillMount() { componentWillMount(); }
+			componentDidMount() { componentDidMount(); }
+			componentWillUnmount() { componentWillUnmount(); }
 		}
-
-		const componentWillMount = sinon.spy(LifecycleLogger.prototype, 'componentWillMount');
-		const componentDidMount = sinon.spy(LifecycleLogger.prototype, 'componentDidMount');
-		const componentWillUnmount = sinon.spy(LifecycleLogger.prototype, 'componentWillUnmount');
 
 		const [Suspender, suspend] = createSuspender(() => <div>Suspense</div>);
 


### PR DESCRIPTION
This was caused by transpilers overwriting our patched property when inheritance was in play. It's based on the assumption that having both the prefixed `UNSAFE_*` and the unprefixed lifecycle hook is invalid.

Fixes #1941
Adds `+29 B` to compat.