### PR TITLE
Change Preact v8 "browser" field to "umd:main"

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "minified:main": "dist/preact.min.js",
   "unpkg": "dist/preact.min.js",
   "types": "dist/preact.d.ts",
+  "umd:main": "dist/preact.umd.js",
   "scripts": {
     "clean": "rimraf dist/ devtools.js devtools.js.map debug.js debug.js.map test/ts/**/*.js",
     "copy-flow-definition": "copyfiles -f src/preact.js.flow dist",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "minified:main": "dist/preact.min.js",
   "unpkg": "dist/preact.min.js",
   "types": "dist/preact.d.ts",
-  "browser": "dist/preact.umd.js",
   "scripts": {
     "clean": "rimraf dist/ devtools.js devtools.js.map debug.js debug.js.map test/ts/**/*.js",
     "copy-flow-definition": "copyfiles -f src/preact.js.flow dist",


### PR DESCRIPTION
**tl;dr**: Rollup configured to use the "browser" field doesn't work if that field points to a UMD module, so I propose we don't provide a "browser" field.

## The concept

My understanding of the "browser" field in package.json (mostly informed by [Nolan Lawson's blog on it](https://nolanlawson.com/2017/01/09/how-to-write-a-javascript-package-for-both-node-and-the-browser/)) is that the intention of the browser field is to give a module written for Node's runtime a way to specify an alternate file when someone bundles your module for use in a browser environment.

Two things to call out:
1. The "browser" field is intended to be used by bundlers that read package.json, not by the browser itself
2. The "browser" field useful for modules that have different entry points when targeting a Node environment vs a browser environment.

If the browser field is intended to be used by bundlers, then the file it points to should probably be written in a module format you want bundlers to read. Since most bundlers now read CommonJS or ES6 modules, this file should probably be written in one of those module formats. While UMD works for a CommonJS bundler, it doesn't perform well in all bundlers (specifically Rollup, more detail below).

Also, since Preact only targets a browser environment and doesn't target a Node environment (though it could work if you provide a DOM like jsdom lol), the browser field doesn't add any value. Preact doesn't have different entries for Node vs Browser - there is one entry, intended for browser. So I don't think Preact has much use for the browser field. If anything, it should likely point to the same file as the main field.

The [base64-encode-string](https://www.npmjs.com/package/base64-encode-string) package mentioned in Nolan's blog linked above is an example of a package that benefits from the "browser" field for different entry points per environment.

Given that understanding above, I propose we don't supply a "browser" field in our package.json. I've replaced it with a "umd:main" field to match what Preact X's package.json uses.

## The actual problem

See my [preact-v8-browser-field repo](https://github.com/andrewiggins/preact-v8-browser-field) for reproductions of the error.

If a user tries to use ES6 named imports in a file (e.g. [`import { h } from "preact"`](https://github.com/andrewiggins/preact-v8-browser-field/blob/041000cedd05d033d9d031421a79370eeb5649db/src/index.js#L1)) (which I understand to be common practice in the Preact community), and tries to bundle this code with [Rollup configured to read the "browser" field](https://github.com/andrewiggins/preact-v8-browser-field/blob/041000cedd05d033d9d031421a79370eeb5649db/rollup.config.js#L12) in order to use packages such as "base64-encode-string", Rollup fails with the following error:

![image](https://user-images.githubusercontent.com/459878/66004541-efeeb200-e45d-11e9-9716-36ec3af57b7f.png)

A workaround is to [manually specify the named exports of Preact](https://github.com/andrewiggins/preact-v8-browser-field/blob/041000cedd05d033d9d031421a79370eeb5649db/rollup.config.js#L17), but I think we should avoid requiring users to do this. Configuring bundlers is complicated enough lol 😅.

Other bundlers I tried (Webpack, Parcel, Browserify) all bundle correctly if Preact removes the "browser" field. I tested this by installing the repo above and manually removing the "browser" field from the package.json of the installed Preact package.

Thoughts?
