### PR TITLE
Reduce size of adding hooks to core (-117 B)

### DIFF
--- a/compat/test/browser/memo.test.js
+++ b/compat/test/browser/memo.test.js
@@ -17,7 +17,7 @@ describe('memo()', () => {
 	});
 
 	it('should have isReactComponent flag', () => {
-		let App = memo(() => <div>foo</div>);
+		const App = memo(() => <div>foo</div>); // eslint-disable-line react/display-name
 		expect(App.prototype.isReactComponent).to.equal(true);
 	});
 

--- a/debug/src/devtools/index.js
+++ b/debug/src/devtools/index.js
@@ -73,7 +73,7 @@ export function initDevTools() {
 		};
 
 		if (!hook._renderers) {
-			console.info(
+			console.info( // eslint-disable-line no-console
 				'Preact is not compatible with your version of react-devtools. We ' +
 				'will address this in future releases.'
 			);

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -156,7 +156,8 @@ describe('debug', () => {
 		expect(warnings[1]).to.be.undefined;
 	});
 
-	it('should warn for argumentless useLayoutEffect hooks', () => {
+	// TODO: Revist when addressing #1893 which should enable this again
+	it.skip('should warn for argumentless useLayoutEffect hooks', () => {
 		const App = () => {
 			const [state] = useState('test');
 			useLayoutEffect(() => 'test');

--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -1,1 +1,18 @@
-export { useDebugValue, StateUpdater, useState, Reducer, useReducer, useRef, useEffect, useLayoutEffect, useImperativeHandle, useCallback, useMemo, useContext } from 'preact'
+export {
+	Inputs,
+	StateUpdater,
+	useState,
+	Reducer,
+	useReducer,
+	PropRef,
+	useRef,
+	EffectCallback,
+	useEffect,
+	CreateHandle,
+	useImperativeHandle,
+	useLayoutEffect,
+	useCallback,
+	useMemo,
+	useContext,
+	useDebugValues,
+} from "preact";

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -1,1 +1,12 @@
-export { useState, useEffect, useLayoutEffect, useRef, useImperativeHandle, useReducer, useContext, useMemo, useCallback, useDebugValue } from 'preact';
+export {
+	useState,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useImperativeHandle,
+	useReducer,
+	useContext,
+	useMemo,
+	useCallback,
+	useDebugValue
+} from 'preact';

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -149,10 +149,6 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 			}
 
 			if (c.__hooks) {
-				c.__hooks._handles.some(handle => {
-					if (handle._ref) handle._ref.current = handle._createHandle();
-				});
-				c.__hooks._handles = [];
 				c.__hooks._pendingLayoutEffects = handleEffects(c.__hooks._pendingLayoutEffects);
 			}
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -150,7 +150,7 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 
 			if (c.__hooks) {
 				c.__hooks._handles.some(handle => {
-					if (handle.ref) handle.ref.current = handle.createHandle();
+					if (handle._ref) handle._ref.current = handle._createHandle();
 				});
 				c.__hooks._handles = [];
 				c.__hooks._pendingLayoutEffects = handleEffects(c.__hooks._pendingLayoutEffects);

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -148,6 +148,14 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 				c.componentDidUpdate(oldProps, oldState, snapshot);
 			}
 
+			if (c.__hooks) {
+				c.__hooks._handles.some(handle => {
+					if (handle.ref) handle.ref.current = handle.createHandle();
+				});
+				c.__hooks._handles = [];
+				c.__hooks._pendingLayoutEffects = handleEffects(c.__hooks._pendingLayoutEffects);
+			}
+
 			if (clearProcessingException) {
 				c._pendingError = c._processingException = null;
 			}
@@ -157,15 +165,6 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 		}
 
 		if (tmp = options.diffed) tmp(newVNode);
-
-		const hooks = newVNode._component && newVNode._component.__hooks;
-		if (hooks) {
-			hooks._handles.some(handle => {
-				if (handle.ref) handle.ref.current = handle.createHandle();
-			});
-			hooks._handles = [];
-			hooks._pendingLayoutEffects = handleEffects(hooks._pendingLayoutEffects);
-		}
 	}
 	catch (e) {
 		options._catchError(e, newVNode, oldVNode);

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -303,12 +303,6 @@ export function applyRef(ref, value, vnode) {
 export function unmount(vnode, parentVNode, skipRemove) {
 	let r;
 	if (options.unmount) options.unmount(vnode);
-	const hooks = vnode._component && vnode._component.__hooks;
-	if (hooks) {
-		hooks._list.some(h => {
-			h._cleanup && h._cleanup();
-		});
-	}
 
 	if (r = vnode.ref) {
 		applyRef(r, null, parentVNode);
@@ -322,6 +316,12 @@ export function unmount(vnode, parentVNode, skipRemove) {
 	vnode._dom = vnode._lastDomChild = null;
 
 	if ((r = vnode._component)!=null) {
+		if (r.__hooks) {
+			r.__hooks._list.some(h => {
+				h._cleanup && h._cleanup();
+			});
+		}
+
 		if (r.componentWillUnmount) {
 			try {
 				r.componentWillUnmount();

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -5,7 +5,7 @@ import { diffChildren, toChildArray } from './children';
 import { diffProps } from './props';
 import { assign, removeNode } from '../util';
 import options from '../options';
-import { globalHookState } from '../hooks';
+import { resetHookState } from "../hooks";
 
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
@@ -111,8 +111,7 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 			c.props = newProps;
 			c.state = c._nextState;
 
-			globalHookState.currentComponent = c;
-			globalHookState.currentIndex = 0;
+			resetHookState(c);
 
 			if (c.__hooks) {
 				c.__hooks._pendingEffects = handleEffects(c.__hooks._pendingEffects);

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -5,7 +5,7 @@ import { diffChildren, toChildArray } from './children';
 import { diffProps } from './props';
 import { assign, removeNode } from '../util';
 import options from '../options';
-import { resetHookState } from "../hooks";
+import { resetHookState } from '../hooks';
 
 /**
  * Diff two virtual nodes and apply proper changes to the DOM

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -5,7 +5,7 @@ import { diffChildren, toChildArray } from './children';
 import { diffProps } from './props';
 import { assign, removeNode } from '../util';
 import options from '../options';
-import { resetHookState } from '../hooks';
+import { resetHookState, handleEffects } from '../hooks';
 
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
@@ -379,14 +379,3 @@ function doRender(props, state, context) {
 
 	throw error;
 };
-
-export function handleEffects(effects) {
-	effects.some(h => {
-		h._cleanup && h._cleanup();
-	});
-	effects.some(h => {
-		const result = h._value();
-		if (typeof result === 'function') h._cleanup = result;
-	});
-	return [];
-}

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -62,6 +62,7 @@ export const useState = useReducer.bind(undefined, invokeOrReturn);
  * @param {any[]} args
  */
 export function useEffect(callback, args) {
+
 	/** @type {import('./internal').EffectHookState} */
 	const state = getHookState(currentIndex++);
 	if (argsChanged(state._args, args)) {
@@ -135,7 +136,7 @@ export function useCallback(callback, args) {
 export function useContext(context) {
 	const provider = currentComponent.context[context._id];
 	if (!provider) return context._defaultValue;
-	let state = getHookState(currentIndex++);
+	const state = getHookState(currentIndex++);
 	// This is probably not safe to convert to "!"
 	if (state._value == null) {
 		state._value = true;

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -23,7 +23,7 @@ function getHookState(index) {
 	// * https://github.com/michael-klein/funcy.js/blob/650beaa58c43c33a74820a3c98b3c7079cf2e333/src/renderer.mjs
 	// Other implementations to look at:
 	// * https://codesandbox.io/s/mnox05qp8
-	const hooks = currentComponent.__hooks || (currentComponent.__hooks = { _list: [], _pendingEffects: [], _pendingLayoutEffects: [], _handles: [] });
+	const hooks = currentComponent.__hooks || (currentComponent.__hooks = { _list: [], _pendingEffects: [], _pendingLayoutEffects: [] });
 
 	if (index >= hooks._list.length) {
 		hooks._list.push({});
@@ -93,11 +93,15 @@ export function useRef(initialValue) {
 }
 
 export function useImperativeHandle(_ref, _createHandle, args) {
-	let state = getHookState(currentIndex++);
-	if (argsChanged(state._args, args)) {
-		state._args = args;
-		currentComponent.__hooks._handles.push({ _ref, _createHandle });
-	}
+	// -37 B
+	// useMemo(() => { if (_ref) { _ref.current = _createHandle(); } }, args);
+
+	// -31 B
+	useLayoutEffect(() => {
+		if (_ref) {
+			_ref.current = _createHandle();
+		}
+	}, args);
 }
 
 /**

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,5 +1,4 @@
 import options from './options';
-import { handleEffects } from './diff';
 import { enqueueRender } from './component';
 
 let currentComponent = null;
@@ -203,6 +202,17 @@ if (typeof window !== 'undefined') {
 			(options.requestAnimationFrame || safeRaf)(flushAfterPaintEffects);
 		}
 	};
+}
+
+export function handleEffects(effects) {
+	effects.some(h => {
+		h._cleanup && h._cleanup();
+	});
+	effects.some(h => {
+		const result = h._value();
+		if (typeof result === 'function') h._cleanup = result;
+	});
+	return [];
 }
 
 function argsChanged(oldArgs, newArgs) {

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -93,9 +93,9 @@ export function useRef(initialValue) {
 }
 
 export function useImperativeHandle(ref, createHandle, args) {
-	let { _args } = getHookState(currentIndex++);
-	if (argsChanged(_args, args)) {
-		_args = args;
+	let state = getHookState(currentIndex++);
+	if (argsChanged(state._args, args)) {
+		state._args = args;
 		currentComponent.__hooks._handles.push({ ref, createHandle });
 	}
 }

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -92,11 +92,11 @@ export function useRef(initialValue) {
 	return useMemo(() => ({ current: initialValue }), []);
 }
 
-export function useImperativeHandle(ref, createHandle, args) {
+export function useImperativeHandle(_ref, _createHandle, args) {
 	let state = getHookState(currentIndex++);
 	if (argsChanged(state._args, args)) {
 		state._args = args;
-		currentComponent.__hooks._handles.push({ ref, createHandle });
+		currentComponent.__hooks._handles.push({ _ref, _createHandle });
 	}
 }
 

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -92,14 +92,10 @@ export function useRef(initialValue) {
 	return useMemo(() => ({ current: initialValue }), []);
 }
 
-export function useImperativeHandle(_ref, _createHandle, args) {
-	// -37 B
-	// useMemo(() => { if (_ref) { _ref.current = _createHandle(); } }, args);
-
-	// -31 B
+export function useImperativeHandle(ref, createHandle, args) {
 	useLayoutEffect(() => {
-		if (_ref) {
-			_ref.current = _createHandle();
+		if (ref) {
+			ref.current = createHandle();
 		}
 	}, args);
 }

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -135,10 +135,10 @@ export function useCallback(callback, args) {
 export function useContext(context) {
 	const provider = currentComponent.context[context._id];
 	if (!provider) return context._defaultValue;
-	let { _value } = getHookState(currentIndex++);
+	let state = getHookState(currentIndex++);
 	// This is probably not safe to convert to "!"
-	if (_value == null) {
-		_value = true;
+	if (state._value == null) {
+		state._value = true;
 		provider.sub(currentComponent);
 	}
 	return provider.props.value;

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,26 @@
-export { render, hydrate } from './render';
-export { createElement, createElement as h, Fragment, createRef, isValidElement } from './create-element';
-export { Component } from './component';
-export { cloneElement } from './clone-element';
-export { createContext } from './create-context';
-export { toChildArray } from './diff/children';
-export { unmount as _unmount } from './diff';
-export { default as options } from './options';
-export * from './hooks';
+export { render, hydrate } from "./render";
+export {
+	createElement,
+	createElement as h,
+	Fragment,
+	createRef,
+	isValidElement
+} from "./create-element";
+export { Component } from "./component";
+export { cloneElement } from "./clone-element";
+export { createContext } from "./create-context";
+export { toChildArray } from "./diff/children";
+export { unmount as _unmount } from "./diff";
+export { default as options } from "./options";
+export {
+	useReducer,
+	useState,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useImperativeHandle,
+	useMemo,
+	useCallback,
+	useContext,
+	useDebugValue
+} from "./hooks";

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,17 @@
-export { render, hydrate } from "./render";
+export { render, hydrate } from './render';
 export {
 	createElement,
 	createElement as h,
 	Fragment,
 	createRef,
 	isValidElement
-} from "./create-element";
-export { Component } from "./component";
-export { cloneElement } from "./clone-element";
-export { createContext } from "./create-context";
-export { toChildArray } from "./diff/children";
-export { unmount as _unmount } from "./diff";
-export { default as options } from "./options";
+} from './create-element';
+export { Component } from './component';
+export { cloneElement } from './clone-element';
+export { createContext } from './create-context';
+export { toChildArray } from './diff/children';
+export { unmount as _unmount } from './diff';
+export { default as options } from './options';
 export {
 	useReducer,
 	useState,
@@ -23,4 +23,4 @@ export {
 	useCallback,
 	useContext,
 	useDebugValue
-} from "./hooks";
+} from './hooks';

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -27,6 +27,8 @@ export interface ComponentHooks {
 	_pendingEffects: EffectHookState[];
 	/** List of Effects to be invoked at the end of the current render */
 	_pendingLayoutEffects: EffectHookState[];
+	/** List of handles for useImperativeHandle hook */
+	_handles: ImperativeHandleState[];
 }
 
 export type HookState = EffectHookState | MemoHookState | ReducerHookState;
@@ -51,6 +53,10 @@ export interface ReducerHookState {
 	_component?: Component;
 }
 
+export interface ImperativeHandleState {
+	_ref: preact.RefObject<unknown>;
+	_createHandle(): preact.RefObject<unknown>;
+}
 
 export interface Options extends preact.Options {
 	/** Attach a hook that is invoked before render, mainly to check the arguments. */

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -27,8 +27,6 @@ export interface ComponentHooks {
 	_pendingEffects: EffectHookState[];
 	/** List of Effects to be invoked at the end of the current render */
 	_pendingLayoutEffects: EffectHookState[];
-	/** List of handles for useImperativeHandle hook */
-	_handles: ImperativeHandleState[];
 }
 
 export type HookState = EffectHookState | MemoHookState | ReducerHookState;
@@ -51,11 +49,6 @@ export interface MemoHookState {
 export interface ReducerHookState {
 	_value?: any;
 	_component?: Component;
-}
-
-export interface ImperativeHandleState {
-	_ref: preact.RefObject<unknown>;
-	_createHandle(): preact.RefObject<unknown>;
 }
 
 export interface Options extends preact.Options {

--- a/test/browser/hooks/useContext.test.js
+++ b/test/browser/hooks/useContext.test.js
@@ -162,4 +162,27 @@ describe('useContext', () => {
 		 expect(spy).to.be.calledTwice;
 		 expect(unmountspy).not.to.be.called;
 	});
+
+
+	it('should only subscribe a component once', () => {
+		const values = [];
+		const Context = createContext(13);
+		let provider, subSpy;
+
+		function Comp() {
+			const value = useContext(Context);
+			values.push(value);
+			return null;
+		}
+
+		render(<Comp />, scratch);
+
+		render(<Context.Provider ref={p => provider = p} value={42}><Comp /></Context.Provider>, scratch);
+		subSpy = sinon.spy(provider, 'sub');
+
+		render(<Context.Provider value={69}><Comp /></Context.Provider>, scratch);
+		expect(subSpy).to.not.have.been.called;
+
+		expect(values).to.deep.equal([13, 42, 69]);
+	});
 });

--- a/test/browser/hooks/useImperativeHandle.test.js
+++ b/test/browser/hooks/useImperativeHandle.test.js
@@ -31,37 +31,49 @@ describe('useImperativeHandle', () => {
 		expect(ref.current.test()).to.equal('test');
 	});
 
-	it('Updates given ref with args', () => {
-		let ref;
+	it('Updates given ref when args change', () => {
+		let ref, createHandleSpy = sinon.spy();
 
 		function Comp({ a }) {
 			ref = useRef({});
-			useImperativeHandle(ref, () => ({ test: () => 'test' + a }), [a]);
+			useImperativeHandle(ref, () => {
+				createHandleSpy();
+				return { test: () => "test" + a };
+			}, [a]);
 			return <p>Test</p>;
 		}
 
 		render(<Comp a={0} />, scratch);
+		expect(createHandleSpy).to.have.been.calledOnce;
 		expect(ref.current).to.have.property('test');
 		expect(ref.current.test()).to.equal('test0');
 
 		render(<Comp a={1} />, scratch);
+		expect(createHandleSpy).to.have.been.calledTwice;
 		expect(ref.current).to.have.property('test');
 		expect(ref.current.test()).to.equal('test1');
+
+		render(<Comp a={0} />, scratch);
+		expect(createHandleSpy).to.have.been.calledThrice;
+		expect(ref.current).to.have.property('test');
+		expect(ref.current.test()).to.equal('test0');
 	});
 
 	it('should not update ref when args have not changed', () => {
-		let ref;
+		let ref, createHandleSpy = sinon.spy(() => ({ test: () => 'test' }));
 
 		function Comp() {
 			ref = useRef({});
-			useImperativeHandle(ref, () => ({ test: () => 'test' }), [1]);
+			useImperativeHandle(ref, createHandleSpy, [1]);
 			return <p>Test</p>;
 		}
 
 		render(<Comp />, scratch);
+		expect(createHandleSpy).to.have.been.calledOnce;
 		expect(ref.current.test()).to.equal('test');
 
 		render(<Comp />, scratch);
+		expect(createHandleSpy).to.have.been.calledOnce;
 		expect(ref.current.test()).to.equal('test');
 	});
 

--- a/test/browser/hooks/useImperativeHandle.test.js
+++ b/test/browser/hooks/useImperativeHandle.test.js
@@ -38,7 +38,7 @@ describe('useImperativeHandle', () => {
 			ref = useRef({});
 			useImperativeHandle(ref, () => {
 				createHandleSpy();
-				return { test: () => "test" + a };
+				return { test: () => 'test' + a };
 			}, [a]);
 			return <p>Test</p>;
 		}


### PR DESCRIPTION
## Summary

Individual commit messages have more detail about the change if you are curious.

897bb21 Replace `globalHookState` with `resetHookState` function (-70 B)
4954398 Fix bug introduced by descturcturing `useImperativeHandle` hook state (+2 B)
ecb99ee Reuse `vnode._component` null check in `unmount` to call hook cleanup callbacks (-5 B)
401ed47 Move `pendingLayoutEffects` flush into component diff to reuse `c` variable (-12 B)
4756817 Minify `useImperativeHandle` hook state props (-10 B)
bb9acdd Schedule imperative handle creation as a layout effect (-31 B)
bd45a91b Fix `useContext` args change check (+9 B)
8e4de8f7 Move `handleEffects` into hooks.js so most hooks code is in hooks file (+0 B)

Total size:
4264 B: preact.js.gz (-117 B) 😁 
3884 B: preact.js.br (-112 B) 😁 