### PR TITLE
(fix) - should reorder memoized children

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -90,7 +90,7 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 					c.state = c._nextState;
 					c._dirty = false;
 					c._vnode = newVNode;
-					newVNode._dom = oldDom!=null ? oldDom!==oldVNode._dom ? oldDom : oldVNode._dom : null;
+					newVNode._dom = oldVNode._dom;
 					newVNode._children = oldVNode._children;
 					for (tmp = 0; tmp < newVNode._children.length; tmp++) {
 						if (newVNode._children[tmp]) newVNode._children[tmp]._parent = newVNode;

--- a/test/browser/lifecycles/shouldComponentUpdate.test.js
+++ b/test/browser/lifecycles/shouldComponentUpdate.test.js
@@ -63,6 +63,42 @@ describe('Lifecycle methods', () => {
 			expect(ShouldNot.prototype.render).to.have.been.calledOnce;
 		});
 
+		it('should reorder non-updating children', () => {
+			const rows = [
+				{ id: '1', a: 5, b: 100 },
+				{ id: '2', a: 50, b: 10 },
+				{ id: '3', a: 25, b: 1000 }
+			];
+
+			class Row extends Component {
+				shouldComponentUpdate(nextProps) {
+					return nextProps.id !== this.props.id;
+				}
+
+				render() {
+					return this.props.id;
+				}
+			}
+
+			const App = ({ sortBy }) => (
+				<div>
+					<table>
+						{rows
+							.sort((a, b) => (a[sortBy] > b[sortBy] ? -1 : 1))
+							.map(row => (
+								<Row id={row.id} key={row.id} />
+							))}
+					</table>
+				</div>
+			);
+
+			render(<App sortBy="a" />, scratch);
+			expect(scratch.innerHTML).to.equal('<div><table>231</table></div>');
+
+			render(<App sortBy="b" />, scratch);
+			expect(scratch.innerHTML).to.equal('<div><table>312</table></div>');
+		});
+
 		it('should rerender when sCU returned false before', () => {
 			let c;
 			let spy = sinon.spy();


### PR DESCRIPTION
So apparently the fix introduced in the other PR where we make children point to their parents make this line irrelevant.

Save bytes + fix code 🎉 

-15B