### PR TITLE
Always pull force flag from component

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -123,13 +123,13 @@ export function getDomSibling(vnode, childIndex) {
 function renderComponent(component) {
 	let vnode = component._vnode,
 		oldDom = vnode._dom,
-		parentDom = component._parentDom,
-		force = component._force;
-	component._force = false;
+		parentDom = component._parentDom;
+
 	if (parentDom) {
 		let mounts = [];
-		let newDom = diff(parentDom, vnode, assign({}, vnode), component._context, parentDom.ownerSVGElement!==undefined, null, mounts, force, oldDom == null ? getDomSibling(vnode) : oldDom);
+		let newDom = diff(parentDom, vnode, assign({}, vnode), component._context, parentDom.ownerSVGElement!==undefined, null, mounts, oldDom == null ? getDomSibling(vnode) : oldDom);
 		commitRoot(mounts, vnode);
+		component._force = false;
 
 		if (newDom != oldDom) {
 			updateParentDomPointers(vnode);

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -82,7 +82,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 			oldVNode = oldVNode || EMPTY_OBJ;
 
 			// Morph the old element into the new one, but don't append it to the dom yet
-			newDom = diff(parentDom, childVNode, oldVNode, context, isSvg, excessDomChildren, mounts, null, oldDom, isHydrating);
+			newDom = diff(parentDom, childVNode, oldVNode, context, isSvg, excessDomChildren, mounts, oldDom, isHydrating);
 
 			if ((j = childVNode.ref) && oldVNode.ref != j) {
 				(refs || (refs=[])).push(j, childVNode._component || newDom, childVNode);

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -22,7 +22,7 @@ import options from '../options';
  * Fragments that have siblings. In most cases, it starts out as `oldChildren[0]._dom`.
  * @param {boolean} isHydrating Whether or not we are in hydration
  */
-export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChildren, mounts, force, oldDom, isHydrating) {
+export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChildren, mounts, oldDom, isHydrating) {
 	let tmp, newType = newVNode.type;
 
 	// When passing through createElement it assigns the object
@@ -81,11 +81,11 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 				if (c.componentDidMount!=null) mounts.push(c);
 			}
 			else {
-				if (newType.getDerivedStateFromProps==null && force==null && c.componentWillReceiveProps!=null) {
+				if (newType.getDerivedStateFromProps==null && c._force==null && c.componentWillReceiveProps!=null) {
 					c.componentWillReceiveProps(newProps, cctx);
 				}
 
-				if (!force && c.shouldComponentUpdate!=null && c.shouldComponentUpdate(newProps, c._nextState, cctx)===false) {
+				if (!c._force && c.shouldComponentUpdate!=null && c.shouldComponentUpdate(newProps, c._nextState, cctx)===false) {
 					c.props = newProps;
 					c.state = c._nextState;
 					c._dirty = false;

--- a/src/render.js
+++ b/src/render.js
@@ -33,7 +33,6 @@ export function render(vnode, parentDom, replaceNode) {
 				? null
 				: EMPTY_ARR.slice.call(parentDom.childNodes),
 		mounts,
-		false,
 		replaceNode || EMPTY_OBJ,
 		isHydrating,
 	);

--- a/test/browser/lifecycles/shouldComponentUpdate.test.js
+++ b/test/browser/lifecycles/shouldComponentUpdate.test.js
@@ -154,6 +154,45 @@ describe('Lifecycle methods', () => {
 			expect(Foo.prototype.render).to.have.been.calledTwice;
 		});
 
+		it('should not block queued child forceUpdate', () => {
+			let i = 0;
+			let updateInner;
+			class Inner extends Component {
+				shouldComponentUpdate() {
+					return i===0;
+				}
+				render() {
+					updateInner = () => this.forceUpdate();
+					return <div>{++i}</div>;
+				}
+			}
+
+			let updateOuter;
+			class Outer extends Component {
+				shouldComponentUpdate() {
+					return i===0;
+				}
+				render() {
+					updateOuter = () => this.forceUpdate();
+					return <Inner />;
+				}
+			}
+
+			class App extends Component {
+				render() {
+					return <Outer />;
+				}
+			}
+
+			render(<App />, scratch);
+
+			updateOuter();
+			updateInner();
+			rerender();
+
+			expect(scratch.textContent).to.equal('2');
+		});
+
 		it('should be passed next props and state', () => {
 
 			/** @type {() => void} */


### PR DESCRIPTION
The way MobX works is that every observed component returns `false` from `shouldComponentUpdate` unless `props` have changed. They than trigger the child renders themselves via direct `forceUpdate` calls.

Our issue was that we only set the `force` flag sort-of globally during a render and would ignore any children that have been enqueued via `forceUpdate` in the same render cycle. This PR addresses that by ensuring that the `force` flag is always the one from the current component.

**Tasks:**
- [x] Add a test case

Fixes #1983
Size `-24 B` :100: 