### PR TITLE
Reset force flag on a component basis

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -129,7 +129,6 @@ function renderComponent(component) {
 		let mounts = [];
 		let newDom = diff(parentDom, vnode, assign({}, vnode), component._context, parentDom.ownerSVGElement!==undefined, null, mounts, oldDom == null ? getDomSibling(vnode) : oldDom);
 		commitRoot(mounts, vnode);
-		component._force = false;
 
 		if (newDom != oldDom) {
 			updateParentDomPointers(vnode);

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -146,6 +146,8 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 			if (clearProcessingException) {
 				c._pendingError = c._processingException = null;
 			}
+
+			c._force = null;
 		}
 		else {
 			newVNode._dom = diffElementNodes(oldVNode._dom, newVNode, oldVNode, context, isSvg, excessDomChildren, mounts, isHydrating);

--- a/test/browser/lifecycles/shouldComponentUpdate.test.js
+++ b/test/browser/lifecycles/shouldComponentUpdate.test.js
@@ -227,6 +227,12 @@ describe('Lifecycle methods', () => {
 			rerender();
 
 			expect(scratch.textContent).to.equal('2');
+
+			// The inner sCU should return false on second render because
+			// it was not enqueued via forceUpdate
+			updateOuter();
+			rerender();
+			expect(scratch.textContent).to.equal('2');
 		});
 
 		it('should be passed next props and state', () => {


### PR DESCRIPTION
Ensure that the `_force` flag is reset on a component basis. This is essentially a follow-up to #1984 .

Adds `0 B` :tada: :grin: 