### PR TITLE
(fix) - layout timing

### DIFF
--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -1,17 +1,16 @@
 import { createElement as h, render, createRef, forwardRef, hydrate, memo, useState, useImperativeHandle } from '../../src';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { setupRerender } from 'preact/test-utils';
+import { act } from 'preact/test-utils';
 /* eslint-disable react/jsx-boolean-value, react/display-name, prefer-arrow-callback */
 
 /** @jsx h */
 describe('forwardRef', () => {
 
 	/** @type {HTMLDivElement} */
-	let scratch, rerender;
+	let scratch;
 
 	beforeEach(() => {
 		scratch = setupScratch();
-		rerender = setupRerender();
 	});
 
 	afterEach(() => {
@@ -171,13 +170,11 @@ describe('forwardRef', () => {
 		});
 
 		const ref = createRef();
-		render(<Foo ref={ref} />, scratch);
-
+		act(() => render(<Foo ref={ref} />, scratch));
 		expect(typeof ref.current.getValue).to.equal('function');
 		expect(ref.current.getValue()).to.equal('');
 
-		setValue('x');
-		rerender();
+		act(() => setValue('x'));
 		expect(typeof ref.current.getValue).to.equal('function');
 		expect(ref.current.getValue()).to.equal('x');
 

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -19,7 +19,9 @@ options._render = vnode => {
 	currentIndex = 0;
 
 	if (currentComponent.__hooks) {
-		currentComponent.__hooks._pendingEffects = handleEffects(currentComponent.__hooks._pendingEffects);
+		currentComponent.__hooks._pendingEffects.forEach(invokeCleanup);
+		currentComponent.__hooks._pendingEffects.forEach(invokeEffect);
+		currentComponent.__hooks._pendingEffects = [];
 	}
 };
 
@@ -199,13 +201,15 @@ let afterPaint = () => {};
  */
 function flushAfterPaintEffects() {
 	let c;
-	let tempLayoutEffects = [...layoutEffects];
+
+	let tempLayoutEffects = [].concat(layoutEffects);
 	while (c = layoutEffects.pop()) {
 		const hooks = c.__hooks;
 		if (hooks) {
 			hooks._pendingLayoutEffects.forEach(invokeCleanup);
 		}
 	}
+
 	while (c = tempLayoutEffects.pop()) {
 		const hooks = c.__hooks;
 		if (hooks) {
@@ -214,7 +218,7 @@ function flushAfterPaintEffects() {
 		}
 	}
 
-	let tempAfterPaintEffects = [...afterPaintEffects];
+	let tempAfterPaintEffects = [].concat(afterPaintEffects);
 	while (c = afterPaintEffects.pop()) {
 		c._afterPaintQueued = false;
 		if (c._parentDom) {
@@ -255,12 +259,6 @@ if (typeof window !== 'undefined') {
 			prevRaf = options.requestAnimationFrame;
 		}
 	};
-}
-
-function handleEffects(effects) {
-	effects.forEach(invokeCleanup);
-	effects.forEach(invokeEffect);
-	return [];
 }
 
 function invokeCleanup(hook) {

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -27,13 +27,7 @@ let oldCommit = options._commit;
 options._commit = root => {
 	if (oldCommit) oldCommit(root);
 
-	layoutEffects.some(c => {
-		const hooks = c.__hooks;
-		if (hooks) {
-			hooks._pendingLayoutEffects = handleEffects(hooks._pendingLayoutEffects);
-		}
-	});
-	layoutEffects = [];
+	(options.requestAnimationFrame || safeRaf)(flushAfterPaintEffects);
 };
 
 
@@ -204,6 +198,13 @@ let afterPaint = () => {};
  * After paint effects consumer.
  */
 function flushAfterPaintEffects() {
+	layoutEffects.some(c => {
+		const hooks = c.__hooks;
+		if (hooks) {
+			hooks._pendingLayoutEffects = handleEffects(hooks._pendingLayoutEffects);
+		}
+	});
+	layoutEffects = [];
 	afterPaintEffects.some(component => {
 		component._afterPaintQueued = false;
 		if (component._parentDom) {
@@ -237,7 +238,7 @@ if (typeof window !== 'undefined') {
 			prevRaf = options.requestAnimationFrame;
 
 			/* istanbul ignore next */
-			(options.requestAnimationFrame || safeRaf)(flushAfterPaintEffects);
+			// (options.requestAnimationFrame || safeRaf)(flushAfterPaintEffects);
 		}
 	};
 }

--- a/hooks/test/browser/combinations.test.js
+++ b/hooks/test/browser/combinations.test.js
@@ -214,4 +214,64 @@ describe('combinations', () => {
 
 		expect(scratch.textContent).to.equal('01');
 	});
+
+	it('should have a right call order with correct dom ref', () => {
+		let i = 0, set;
+		const calls = [];
+
+		function Inner() {
+			useLayoutEffect(() => {
+				calls.push('layout inner call ' + scratch.firstChild.innerHTML);
+				return () => calls.push('layout inner dispose ' + scratch.firstChild.innerHTML);
+			});
+			useEffect(() => {
+				calls.push('effect inner call ' + scratch.firstChild.innerHTML);
+				return () => calls.push('effect inner dispose ' + scratch.firstChild.innerHTML);
+			});
+			return <span>hello {i}</span>;
+		}
+
+		function Outer() {
+			i++;
+			const [state, setState] = useState(false);
+			set = () => setState(!state);
+			useLayoutEffect(() => {
+				calls.push('layout outer call ' + scratch.firstChild.innerHTML);
+				return () => calls.push('layout outer dispose ' + scratch.firstChild.innerHTML);
+			});
+			useEffect(() => {
+				calls.push('effect outer call ' + scratch.firstChild.innerHTML);
+				return () => calls.push('effect outer dispose ' + scratch.firstChild.innerHTML);
+			});
+			return (
+				<div>
+					<Inner />
+				</div>
+			);
+		}
+
+		act(() => render(<Outer />, scratch));
+		expect(calls).to.deep.equal([
+			'layout inner call <span>hello 1</span>',
+			'layout outer call <span>hello 1</span>',
+			'effect inner call <span>hello 1</span>',
+			'effect outer call <span>hello 1</span>'
+		]);
+
+		act(() => set());
+		expect(calls).to.deep.equal([
+			'layout inner call <span>hello 1</span>',
+			'layout outer call <span>hello 1</span>',
+			'effect inner call <span>hello 1</span>',
+			'effect outer call <span>hello 1</span>',
+			'layout inner dispose <span>hello 2</span>',
+			'layout outer dispose <span>hello 2</span>',
+			'layout inner call <span>hello 2</span>',
+			'layout outer call <span>hello 2</span>',
+			'effect inner dispose <span>hello 2</span>',
+			'effect outer dispose <span>hello 2</span>',
+			'effect inner call <span>hello 2</span>',
+			'effect outer call <span>hello 2</span>'
+		]);
+	});
 });

--- a/hooks/test/browser/combinations.test.js
+++ b/hooks/test/browser/combinations.test.js
@@ -70,7 +70,7 @@ describe('combinations', () => {
 			return null;
 		}
 
-		render(<Comp />, scratch);
+		act(() => render(<Comp />, scratch));
 
 		return scheduleEffectAssert(() => {
 			rerender();
@@ -90,7 +90,7 @@ describe('combinations', () => {
 			return null;
 		}
 
-		render(<Comp />, scratch);
+		act(() => render(<Comp />, scratch));
 		rerender();
 
 		expect(didRender).to.have.been.calledTwice.and.calledWith(1);
@@ -109,7 +109,7 @@ describe('combinations', () => {
 			return <input ref={input} value="hello" />;
 		}
 
-		render(<Comp />, scratch);
+		act(() => render(<Comp />, scratch));
 
 		expect(refAtLayoutTime.value).to.equal('hello');
 	});

--- a/hooks/test/browser/useEffectAssertions.test.js
+++ b/hooks/test/browser/useEffectAssertions.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from 'preact/test-utils';
+import { act, setupRerender } from 'preact/test-utils';
 import { createElement as h, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
@@ -32,11 +32,11 @@ export function useEffectAssertions(useEffect, scheduleEffectAssert) {
 			return null;
 		}
 
-		render(<Comp />, scratch);
+		act(() => render(<Comp />, scratch));
 
 		return scheduleEffectAssert(() => expect(callback).to.be.calledOnce)
 			.then(() => scheduleEffectAssert(() => expect(callback).to.be.calledOnce))
-			.then(() => render(<Comp />, scratch))
+			.then(() => act(() => render(<Comp />, scratch)))
 			.then(() => scheduleEffectAssert(() => expect(callback).to.be.calledTwice));
 	});
 
@@ -48,14 +48,14 @@ export function useEffectAssertions(useEffect, scheduleEffectAssert) {
 			return null;
 		}
 
-		render(<Comp a={1} b={2} />, scratch);
+		act(() => render(<Comp a={1} b={2} />, scratch));
 
 		return scheduleEffectAssert(() => expect(callback).to.be.calledOnce)
-			.then(() => render(<Comp a={1} b={2} />, scratch))
+			.then(() => act(() => render(<Comp a={1} b={2} />, scratch)))
 			.then(() => scheduleEffectAssert(() => expect(callback).to.be.calledOnce))
-			.then(() => render(<Comp a={2} b={2} />, scratch))
+			.then(() => act(() => render(<Comp a={2} b={2} />, scratch)))
 			.then(() => scheduleEffectAssert(() => expect(callback).to.be.calledTwice))
-			.then(() => render(<Comp a={2} b={2} />, scratch))
+			.then(() => act(() => render(<Comp a={2} b={2} />, scratch)))
 			.then(() => scheduleEffectAssert(() => expect(callback).to.be.calledTwice));
 	});
 
@@ -67,13 +67,13 @@ export function useEffectAssertions(useEffect, scheduleEffectAssert) {
 			return null;
 		}
 
-		render(<Comp />, scratch);
-		render(<Comp />, scratch);
+		act(() => render(<Comp />, scratch));
+		act(() => render(<Comp />, scratch));
 
 		expect(callback).to.be.calledOnce;
 
 		return scheduleEffectAssert(() => expect(callback).to.be.calledOnce)
-			.then(() => render(<Comp />, scratch))
+			.then(() => act(() => render(<Comp />, scratch)))
 			.then(() => scheduleEffectAssert(() => expect(callback).to.be.calledOnce));
 	});
 
@@ -86,14 +86,14 @@ export function useEffectAssertions(useEffect, scheduleEffectAssert) {
 			return null;
 		}
 
-		render(<Comp />, scratch);
+		act(() => render(<Comp />, scratch));
 
 		return scheduleEffectAssert(() => {
 			expect(cleanupFunction).to.be.not.called;
 			expect(callback).to.be.calledOnce;
 		})
 			.then(() => scheduleEffectAssert(() => expect(callback).to.be.calledOnce))
-			.then(() => render(<Comp />, scratch))
+			.then(() => act(() => render(<Comp />, scratch)))
 			.then(() => scheduleEffectAssert(() => {
 				expect(cleanupFunction).to.be.calledOnce;
 				expect(callback).to.be.calledTwice;
@@ -110,10 +110,10 @@ export function useEffectAssertions(useEffect, scheduleEffectAssert) {
 			return null;
 		}
 
-		render(<Comp />, scratch);
+		act(() => render(<Comp />, scratch));
 
 		return scheduleEffectAssert(() => {
-			render(null, scratch);
+			act(() => render(null, scratch));
 			rerender();
 			expect(cleanupFunction).to.be.calledOnce;
 		});
@@ -127,8 +127,8 @@ export function useEffectAssertions(useEffect, scheduleEffectAssert) {
 			return null;
 		}
 
-		render(<Comp value={1} />, scratch);
-		render(<Comp value={2} />, scratch);
+		act(() => render(<Comp value={1} />, scratch));
+		act(() => render(<Comp value={2} />, scratch));
 
 		return scheduleEffectAssert(() => expect(values).to.deep.equal([1, 2]));
 	});

--- a/hooks/test/browser/useImperativeHandle.test.js
+++ b/hooks/test/browser/useImperativeHandle.test.js
@@ -1,4 +1,5 @@
 import { createElement as h, render } from 'preact';
+import { act } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useImperativeHandle, useRef } from '../../src';
 
@@ -27,7 +28,7 @@ describe('useImperativeHandle', () => {
 			return <p>Test</p>;
 		}
 
-		render(<Comp />, scratch);
+		act(() => render(<Comp />, scratch));
 		expect(ref.current).to.have.property('test');
 		expect(ref.current.test()).to.equal('test');
 	});
@@ -41,11 +42,11 @@ describe('useImperativeHandle', () => {
 			return <p>Test</p>;
 		}
 
-		render(<Comp a={0} />, scratch);
+		act(() => render(<Comp a={0} />, scratch));
 		expect(ref.current).to.have.property('test');
 		expect(ref.current.test()).to.equal('test0');
 
-		render(<Comp a={1} />, scratch);
+		act(() => render(<Comp a={1} />, scratch));
 		expect(ref.current).to.have.property('test');
 		expect(ref.current.test()).to.equal('test1');
 	});
@@ -59,11 +60,11 @@ describe('useImperativeHandle', () => {
 			return <p>Test</p>;
 		}
 
-		render(<Comp />, scratch);
+		act(() => render(<Comp />, scratch));
 		expect(ref.current.test()).to.equal('test');
 
 		render(<Comp />, scratch);
-		expect(ref.current.test()).to.equal('test');
+		act(() => expect(ref.current.test()).to.equal('test'));
 	});
 
 	it('should not throw with nullish ref', () => {
@@ -72,6 +73,6 @@ describe('useImperativeHandle', () => {
 			return <p>Test</p>;
 		}
 
-		expect(() => render(<Comp />, scratch)).to.not.throw();
+		expect(() => act(() => render(<Comp />, scratch))).to.not.throw();
 	});
 });

--- a/hooks/test/browser/useLayoutEffect.test.js
+++ b/hooks/test/browser/useLayoutEffect.test.js
@@ -1,8 +1,8 @@
 import { act } from 'preact/test-utils';
-import { createElement as h, render } from 'preact';
+import { createElement as h, render, Fragment } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useEffectAssertions } from './useEffectAssertions.test';
-import { useLayoutEffect } from '../../src';
+import { useLayoutEffect, useRef } from '../../src';
 
 /** @jsx h */
 
@@ -87,5 +87,62 @@ describe('useLayoutEffect', () => {
 		act(() => render(<App i={0} />, scratch));
 		act(() => render(<App i={2} />, scratch));
 		expect(executionOrder).to.deep.equal(['cleanup1', 'cleanup2', 'action1', 'action2']);
+	});
+
+	it('should correctly display DOM', () => {
+		function AutoResizeTextareaLayoutEffect(props) {
+			const ref = useRef(null);
+			useLayoutEffect(() => {
+				expect(scratch.innerHTML).to.equal(`<div><p>${props.value}</p><textarea></textarea></div>`);
+				expect(ref.current.isConnected).to.equal(true);
+			});
+			return (
+				<Fragment>
+					<p>{props.value}</p>
+					<textarea ref={ref} value={props.value} onChange={props.onChange} />
+				</Fragment>
+			);
+		}
+
+		function App(props) {
+			return (
+				<div class={props.value}>
+					<AutoResizeTextareaLayoutEffect {...props} />>
+				</div>
+			);
+		}
+
+		render(<App value="hi" />, scratch);
+		render(<App value="hii" />, scratch);
+	});
+
+	it('should invoke layout effects after subtree is fully connected', done => {
+		let ref;
+		let layoutEffect = sinon.spy(() => {
+			expect(ref.current.parentNode).to.not.be.undefined;
+			expect(ref.current.parentNode.isConnected).to.equal(true);
+		});
+
+		function Inner() {
+			ref = useRef(null);
+			useLayoutEffect(layoutEffect);
+			return (
+				<Fragment>
+					<textarea ref={ref} />
+					<span>hello</span>;
+				</Fragment>
+			);
+		}
+
+		function Outer() {
+			return <div><Inner /></div>;
+		}
+
+		render(<Outer />, scratch);
+
+		setTimeout(() => {
+			expect(layoutEffect).to.have.been.calledOnce;
+			done();
+		}, 50);
 	});
 });

--- a/hooks/test/browser/useLayoutEffect.test.js
+++ b/hooks/test/browser/useLayoutEffect.test.js
@@ -37,13 +37,13 @@ describe('useLayoutEffect', () => {
 			return null;
 		}
 
-		render(<Comp />, scratch);
-		render(<Comp />, scratch);
+		act(() => render(<Comp />, scratch));
+		act(() => render(<Comp />, scratch));
 
 		expect(cleanupFunction).to.be.calledOnce;
 		expect(callback).to.be.calledTwice;
 
-		render(<Comp />, scratch);
+		act(() => render(<Comp />, scratch));
 
 		expect(cleanupFunction).to.be.calledTwice;
 		expect(callback).to.be.calledThrice;
@@ -65,7 +65,7 @@ describe('useLayoutEffect', () => {
 			return null;
 		}
 
-		render(<Parent />, scratch);
+		act(() => render(<Parent />, scratch));
 
 		expect(callback).to.be.calledOnce;
 	});
@@ -93,7 +93,7 @@ describe('useLayoutEffect', () => {
 		function AutoResizeTextareaLayoutEffect(props) {
 			const ref = useRef(null);
 			useLayoutEffect(() => {
-				expect(scratch.innerHTML).to.equal(`<div><p>${props.value}</p><textarea></textarea></div>`);
+				expect(scratch.innerHTML).to.equal(`<div class="${props.value}"><p>${props.value}</p><textarea></textarea></div>`);
 				expect(ref.current.isConnected).to.equal(true);
 			});
 			return (
@@ -107,16 +107,16 @@ describe('useLayoutEffect', () => {
 		function App(props) {
 			return (
 				<div class={props.value}>
-					<AutoResizeTextareaLayoutEffect {...props} />>
+					<AutoResizeTextareaLayoutEffect {...props} />
 				</div>
 			);
 		}
 
-		render(<App value="hi" />, scratch);
-		render(<App value="hii" />, scratch);
+		act(() => render(<App value="hi" />, scratch));
+		act(() => render(<App value="hii" />, scratch));
 	});
 
-	it('should invoke layout effects after subtree is fully connected', done => {
+	it('should invoke layout effects after subtree is fully connected', () => {
 		let ref;
 		let layoutEffect = sinon.spy(() => {
 			expect(ref.current.parentNode).to.not.be.undefined;
@@ -138,11 +138,7 @@ describe('useLayoutEffect', () => {
 			return <div><Inner /></div>;
 		}
 
-		render(<Outer />, scratch);
-
-		setTimeout(() => {
-			expect(layoutEffect).to.have.been.calledOnce;
-			done();
-		}, 50);
+		act(() => render(<Outer />, scratch));
+		expect(layoutEffect).to.have.been.calledOnce;
 	});
 });


### PR DESCRIPTION
Fixes: https://github.com/preactjs/preact/issues/1893

Will add these as a test as well
https://codesandbox.io/s/dawn-waterfall-gc5vr
https://codesandbox.io/embed/nostalgic-taussig-m09gx

This is a solution inside our hooks implementation

The problem I'm mainly facing is now our effects have no discrepancy in time (both happen after paint) afaik. I think the only feasible solution to make these incrementally before and after is with 2 phase

Adds 40B :(