### PR TITLE
Remove null from VNode.type TS definition and add some TS tests

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,7 +11,7 @@ declare namespace preact {
 	// -----------------------------------
 
 	interface VNode<P = {}> {
-		type: ComponentType<P> | string | null;
+		type: ComponentType<P> | string;
 		props: P & { children: ComponentChildren };
 		key: Key;
 		ref: Ref<any> | null;

--- a/test/ts/VNode-test.tsx
+++ b/test/ts/VNode-test.tsx
@@ -3,10 +3,25 @@ import { expect } from "chai";
 import {
 	createElement,
 	Component,
+	toChildArray,
 	FunctionalComponent,
 	ComponentConstructor,
-	ComponentFactory
+	ComponentFactory,
+	VNode,
+	ComponentChildren
 } from "../../src";
+
+function getDisplayType(vnode: VNode | string | number) {
+	if (typeof vnode === 'string' || typeof vnode == 'number') {
+		return vnode.toString();
+	}
+	else if (typeof vnode.type == 'string') {
+		return vnode.type;
+	}
+	else {
+		return vnode.type.displayName;
+	}
+}
 
 class SimpleComponent extends Component<{}, {}> {
 	render() {
@@ -21,7 +36,7 @@ const SimpleFunctionalComponent = () => <div />;
 const a: ComponentFactory = SimpleComponent;
 const b: ComponentFactory = SimpleFunctionalComponent;
 
-describe("VNode", () => {
+describe("VNode TS types", () => {
 	it("is returned by h", () => {
 		const actual = <div className="wow"/>;
 		expect(actual).to.include.all.keys(
@@ -59,6 +74,58 @@ describe("VNode", () => {
 		expect(comp.props.children).to.be.instanceOf(Array);
 		expect(comp.props.children[1]).to.be.a("string");
 	});
+
+	it("children type should work with toChildArray", () => {
+		const comp: VNode = (
+			<SimpleComponent>
+				child1 {1}
+			</SimpleComponent>
+		);
+
+		const children = toChildArray(comp.props.children);
+		expect(children).to.have.lengthOf(2);
+	});
+
+	it("toChildArray should filter out some types", () => {
+		const compChild = <SimpleComponent />;
+		const comp: VNode = (
+			<SimpleComponent>
+				a{null}
+				{true}
+				{false}
+				{2}
+				{undefined}
+				{["b", "c"]}
+				{compChild}
+			</SimpleComponent>
+		);
+
+		const children = toChildArray(comp.props.children);
+		expect(children).to.deep.equal(["a", 2, "b", "c", compChild]);
+	});
+
+	it("functions like getDisplayType should work", () => {
+		function TestComp(props: { children?: ComponentChildren }) {
+			return <div>{props.children}</div>;
+		}
+		TestComp.displayName = "TestComp";
+
+		const compChild = <TestComp />;
+		const comp: VNode = (
+			<SimpleComponent>
+				a{null}
+				{true}
+				{false}
+				{2}
+				{undefined}
+				{["b", "c"]}
+				{compChild}
+			</SimpleComponent>
+		);
+
+		const types = toChildArray(comp.props.children).map(getDisplayType);
+		expect(types).to.deep.equal(["a", "2", "b", "c", "TestComp"]);
+	})
 });
 
 class ComponentWithFunctionChild extends Component<{ children: (num: number) => string; }> {


### PR DESCRIPTION
* Add some tests for the fixes in #1979 
* Remove null from `VNode.type` since we don't expose our string VNodes (the only vnodes with `v.type == null`)
* Add a test to verify that previous assertion (I think it does at least)