### PR TITLE
Properly flush nested setState callbacks (-6 B) 

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -52,8 +52,8 @@ Component.prototype.forceUpdate = function(callback) {
 		// Set render mode so that we can differentiate where the render request
 		// is coming from. We need this because forceUpdate should never call
 		// shouldComponentUpdate
-		if (callback) this._renderCallbacks.push(callback);
 		this._force = true;
+		if (callback) this._renderCallbacks.push(callback);
 		enqueueRender(this);
 	}
 };

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -132,10 +132,8 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 
 			c.base = newVNode._dom;
 
-			while (tmp=c._renderCallbacks.pop()) {
-				if (c._nextState) { c.state = c._nextState; }
-				tmp.call(c);
-			}
+			tmp = c._renderCallbacks; c._renderCallbacks=[];
+			tmp.some(cb => cb.call(c));
 
 			// Don't call componentDidUpdate on mount or when we bailed out via
 			// `shouldComponentUpdate`

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -132,8 +132,9 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 
 			c.base = newVNode._dom;
 
-			tmp = c._renderCallbacks; c._renderCallbacks=[];
-			tmp.some(cb => cb.call(c));
+			tmp = c._renderCallbacks;
+			c._renderCallbacks=[];
+			tmp.some(cb => { cb.call(c); });
 
 			// Don't call componentDidUpdate on mount or when we bailed out via
 			// `shouldComponentUpdate`

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -143,10 +143,15 @@ describe('Components', () => {
 
 				componentDidMount() {
 					states.push(this.state);
+					expect(scratch.innerHTML).to.equal('<p>b</p>');
+
 					// eslint-disable-next-line
 					this.setState({ a: 'a' }, () => {
 						states.push(this.state);
+						expect(scratch.innerHTML).to.equal('<p>a</p>');
+
 						this.setState({ a: 'c' }, () => {
+							expect(scratch.innerHTML).to.equal('<p>c</p>');
 							states.push(this.state);
 						});
 					});
@@ -154,7 +159,7 @@ describe('Components', () => {
 
 				render() {
 					finalState = this.state;
-					return <p>Test</p>;
+					return <p>{this.state.a}</p>;
 				}
 			}
 


### PR DESCRIPTION
Previously, we would synchronously flush nested renderCallbacks (i.e. setState and forceUpdate callbacks). This behavior meant that nested setState calls would flush before the state was properly applied in diff, meaning DOM, props, etc. wouldn't have been updated for that setState call when the callback was run (though the state would be correct due to a shortcut we took).

This PR fixes this behavior by only invoking the renderCallbacks for the current setState call synchronously. Nested setState callbacks are queued and executed when those setState calls are applied.

Also includes a small change to make `setState` and `forceUpdate` a little more similar which I assume helps gzip.