### PR TITLE
Remove internal import from compat types

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -1,7 +1,6 @@
 import * as _hooks from '../../hooks';
 import * as preact from '../../src';
 import { JSXInternal } from '../../src/jsx'
-import * as _internal from './internal';
 import * as _Suspense from './suspense';
 
 // export default React;
@@ -43,7 +42,6 @@ declare namespace React {
 	export import lazy = _Suspense.lazy;
 
 	// Compat
-	export import ForwardFn = _internal.ForwardFn;
 	export const version: string;
 
 	export function createPortal(vnode: preact.VNode, container: Element): preact.VNode<any>;
@@ -64,7 +62,12 @@ declare namespace React {
 
 	export function memo<P = {}>(component: preact.FunctionalComponent<P>, comparer?: (prev: P, next: P) => boolean): preact.FunctionComponent<P>;
 
-	export function forwardRef<R, P = {}>(fn: _internal.ForwardFn<P, R>): preact.FunctionalComponent<P>;
+	export interface ForwardFn<P = {}, T = any> {
+		(props: P, ref: Ref<T>): preact.ComponentChild;
+		displayName?: string;
+	}
+
+	export function forwardRef<R, P = {}>(fn: ForwardFn<P, R>): preact.FunctionalComponent<P>;
 
 	export function unstable_batchedUpdates(callback: (arg?: any) => void, arg?: any): void;
 

--- a/compat/src/internal.d.ts
+++ b/compat/src/internal.d.ts
@@ -1,4 +1,3 @@
-import { Ref, ComponentChild } from '../..';
 import {
 	Component as PreactComponent,
 	VNode as PreactVNode,
@@ -25,11 +24,6 @@ export interface FunctionalComponent<P = {}> extends PreactFunctionalComponent<P
 export interface VNode<T = any> extends PreactVNode<T> {
 	$$typeof?: symbol | string;
 	preactCompatNormalized?: boolean;
-}
-
-export interface ForwardFn<P = {}, T = any> {
-	(props: P, ref: Ref<T>): ComponentChild;
-	displayName?: string;
 }
 
 export interface SuspenseState {

--- a/compat/test/ts/forward-ref.tsx
+++ b/compat/test/ts/forward-ref.tsx
@@ -1,4 +1,4 @@
-import * as React from '../../src';
+import React from '../../src';
 
 const MyInput: React.ForwardFn<{ id: string }, { focus(): void }> = (props, ref) => {
   const inputRef = React.useRef<HTMLInputElement>()


### PR DESCRIPTION
Public types should not expose internal types to consumers. If the type is mean to be used by consumers, let's put it in the public types file, `index.d.ts`.

Follow up to #2015 