### PR TITLE
Add _force and _lastDomChild to mangle.json

### DIFF
--- a/mangle.json
+++ b/mangle.json
@@ -18,6 +18,7 @@
     "cname": 6,
     "props": {
       "$_depth": "__b",
+      "$_lastDomChild": "__d",
       "$_dirty": "__d",
       "$_force": "__e",
       "$_nextState": "__s",

--- a/mangle.json
+++ b/mangle.json
@@ -19,6 +19,7 @@
     "props": {
       "$_depth": "__b",
       "$_dirty": "__d",
+      "$_force": "__e",
       "$_nextState": "__s",
       "$_renderCallbacks": "__h",
       "$_vnode": "__v",


### PR DESCRIPTION
`__e` doesn't seem to be used on Component yet (please correct me if I'm wrong!)

Update: also noticed `_lastDomChild` wasn't mapped (it was showing up as `vnode.l`)

See [codepen test](https://codepen.io/developit/pen/jOOMoev?editors=0010)