### PR TITLE
Add nonce to JSX HTMLAttributes types for better Content Security Policy support.

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -572,6 +572,7 @@ export namespace JSXInternal {
 		multiple?: boolean;
 		muted?: boolean;
 		name?: string;
+		nonce?: string;
 		noValidate?: boolean;
 		open?: boolean;
 		optimum?: number;


### PR DESCRIPTION
With [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP), you can set a `nonce` that certain elements on the page must use to be allowed.  As such, it's necessary to have Preact's JSX implementation support `nonce` as part of its HTMLAttributes types.

* https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/nonce

For comparison, React does have `nonce` in its JSX implementation of [HTMLAttributes type definition](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/282aa188412298daa0d86709f9150c23a0c7001f/types/react/index.d.ts#L1773).