### PR TITLE
Remove unused mount check in context Provider (-6 B)

### DIFF
--- a/src/create-context.js
+++ b/src/create-context.js
@@ -2,10 +2,6 @@ import { enqueueRender } from './component';
 
 export let i = 0;
 
-/**
- *
- * @param {any} defaultValue
- */
 export function createContext(defaultValue) {
 	const ctx = {};
 
@@ -25,11 +21,8 @@ export function createContext(defaultValue) {
 				this.shouldComponentUpdate = _props => {
 					if (props.value !== _props.value) {
 						subs.some(c => {
-							// Check if still mounted
-							if (c._parentDom) {
-								c.context = _props.value;
-								enqueueRender(c);
-							}
+							c.context = _props.value;
+							enqueueRender(c);
 						});
 					}
 				};


### PR DESCRIPTION
The mount check in Provider sCU was redundant because `renderComponent` already checks a component is mounted before attempting to rerender it. Further whenever a consumer is unmounted we remove it from the sub list.

I added some tests as well just to double check.