### PR TITLE
Inline `coerceToVNode` inside of `toChildArray` (-21 B)

### DIFF
--- a/src/create-element.js
+++ b/src/create-element.js
@@ -86,21 +86,3 @@ export function Fragment(props) {
  * @returns {vnode is import('./internal').VNode}
  */
 export const isValidElement = vnode => vnode!=null && vnode.constructor === undefined;
-
-/**
- * Coerce an untrusted value into a VNode
- * Specifically, this should be used anywhere a user could provide a boolean, string, or number where
- * a VNode or Component is desired instead
- * @param {import('./internal').VNode} possibleVNode A possible VNode
- * @returns {import('./internal').VNode | null}
- */
-export function coerceToVNode(possibleVNode) {
-	// Clone vnode if it has already been used. ceviche/#57
-	if (possibleVNode._dom!=null || possibleVNode._component!=null) {
-		let vnode = createVNode(possibleVNode.type, possibleVNode.props, possibleVNode.key, null);
-		vnode._dom = possibleVNode._dom;
-		return vnode;
-	}
-
-	return possibleVNode;
-}

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -91,11 +91,10 @@ export const isValidElement = vnode => vnode!=null && vnode.constructor === unde
  * Coerce an untrusted value into a VNode
  * Specifically, this should be used anywhere a user could provide a boolean, string, or number where
  * a VNode or Component is desired instead
- * @param {boolean | string | number | import('./internal').VNode} possibleVNode A possible VNode
+ * @param {string | number | import('./internal').VNode} possibleVNode A possible VNode
  * @returns {import('./internal').VNode | null}
  */
 export function coerceToVNode(possibleVNode) {
-	if (possibleVNode == null || typeof possibleVNode === 'boolean') return null;
 	if (typeof possibleVNode === 'string' || typeof possibleVNode === 'number') {
 		return createVNode(null, possibleVNode, null, null);
 	}

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -91,14 +91,10 @@ export const isValidElement = vnode => vnode!=null && vnode.constructor === unde
  * Coerce an untrusted value into a VNode
  * Specifically, this should be used anywhere a user could provide a boolean, string, or number where
  * a VNode or Component is desired instead
- * @param {string | number | import('./internal').VNode} possibleVNode A possible VNode
+ * @param {import('./internal').VNode} possibleVNode A possible VNode
  * @returns {import('./internal').VNode | null}
  */
 export function coerceToVNode(possibleVNode) {
-	if (typeof possibleVNode === 'string' || typeof possibleVNode === 'number') {
-		return createVNode(null, possibleVNode, null, null);
-	}
-
 	// Clone vnode if it has already been used. ceviche/#57
 	if (possibleVNode._dom!=null || possibleVNode._component!=null) {
 		let vnode = createVNode(possibleVNode.type, possibleVNode.props, possibleVNode.key, null);

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -194,9 +194,7 @@ export function toChildArray(children, callback, flattened) {
 		flattened.push(callback ? callback(createVNode(null, children, null, null)) : children);
 	}
 	else if (children._dom != null || children._component != null) {
-		let vnode = createVNode(children.type, children.props, children.key, null);
-		vnode._dom = children._dom;
-		flattened.push(callback ? callback(vnode) : vnode);
+		flattened.push(callback ? callback(createVNode(children.type, children.props, children.key, null)) : children);
 	}
 	else {
 		flattened.push(callback ? callback(children) : children);

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -1,5 +1,5 @@
 import { diff, unmount, applyRef } from './index';
-import { coerceToVNode } from '../create-element';
+import { coerceToVNode, createVNode } from '../create-element';
 import { EMPTY_OBJ, EMPTY_ARR } from '../constants';
 import { removeNode } from '../util';
 import { getDomSibling } from '../component';
@@ -176,7 +176,7 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
  * children of a virtual node
  * @param {(vnode: import('../internal').VNode) => import('../internal').VNode} [callback]
  * A function to invoke for each child before it is added to the flattened list.
- * @param {import('../internal').VNode[]} [flattened] An flat array of children to modify
+ * @param {Array<import('../internal').VNode | string | number>} [flattened] An flat array of children to modify
  * @returns {import('../internal').VNode[]}
  */
 export function toChildArray(children, callback, flattened) {
@@ -189,6 +189,9 @@ export function toChildArray(children, callback, flattened) {
 		for (let i=0; i < children.length; i++) {
 			toChildArray(children[i], callback, flattened);
 		}
+	}
+	else if (typeof children === 'string' || typeof children === 'number') {
+		flattened.push(callback ? callback(createVNode(null, children, null, null)) : children);
 	}
 	else {
 		flattened.push(callback ? callback(coerceToVNode(children)) : children);

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -1,5 +1,5 @@
 import { diff, unmount, applyRef } from './index';
-import { coerceToVNode, createVNode } from '../create-element';
+import { createVNode } from '../create-element';
 import { EMPTY_OBJ, EMPTY_ARR } from '../constants';
 import { removeNode } from '../util';
 import { getDomSibling } from '../component';

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -190,14 +190,17 @@ export function toChildArray(children, callback, flattened) {
 			toChildArray(children[i], callback, flattened);
 		}
 	}
+	else if (!callback) {
+		flattened.push(children);
+	}
 	else if (typeof children === 'string' || typeof children === 'number') {
-		flattened.push(callback ? callback(createVNode(null, children, null, null)) : children);
+		flattened.push(callback(createVNode(null, children, null, null)));
 	}
 	else if (children._dom != null || children._component != null) {
-		flattened.push(callback ? callback(createVNode(children.type, children.props, children.key, null)) : children);
+		flattened.push(callback(createVNode(children.type, children.props, children.key, null)));
 	}
 	else {
-		flattened.push(callback ? callback(children) : children);
+		flattened.push(callback(children));
 	}
 
 	return flattened;

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -193,8 +193,13 @@ export function toChildArray(children, callback, flattened) {
 	else if (typeof children === 'string' || typeof children === 'number') {
 		flattened.push(callback ? callback(createVNode(null, children, null, null)) : children);
 	}
+	else if (children._dom != null || children._component != null) {
+		let vnode = createVNode(children.type, children.props, children.key, null);
+		vnode._dom = children._dom;
+		flattened.push(callback ? callback(vnode) : vnode);
+	}
 	else {
-		flattened.push(callback ? callback(coerceToVNode(children)) : children);
+		flattened.push(callback ? callback(children) : children);
 	}
 
 	return flattened;


### PR DESCRIPTION
Inline `coerceToVNode` into the one place it was used: `toChildArray`