### PR TITLE
Golfed render

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -23,7 +23,7 @@ export function render(vnode, parentDom, replaceNode) {
 	let commitQueue = [];
 	diff(
 		parentDom,
-		isHydrating ? parentDom._children = vnode : (replaceNode || parentDom)._children = vnode,
+		(isHydrating ? parentDom : (replaceNode || parentDom))._children = vnode,
 		oldVNode || EMPTY_OBJ,
 		EMPTY_OBJ,
 		parentDom.ownerSVGElement !== undefined,


### PR DESCRIPTION
Before:
```
3657 B: preact.js.gz
3339 B: preact.js.br
3666 B: preact.module.js.gz
3359 B: preact.module.js.br
3714 B: preact.umd.js.gz
3385 B: preact.umd.js.br
```
After:
```
3655 B: preact.js.gz
3338 B: preact.js.br
3665 B: preact.module.js.gz
3356 B: preact.module.js.br
3713 B: preact.umd.js.gz
3385 B: preact.umd.js.br
```