### PR TITLE
Remove CSS custom property check from IS_NON_DIMENSIONAL

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,3 @@
 export const EMPTY_OBJ = {};
 export const EMPTY_ARR = [];
-export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|^--/i;
+export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord/i;


### PR DESCRIPTION
The only use for `IS_NON_DIMENSIONAL` is in [`setStyle`](https://github.com/preactjs/preact/blob/51f3e25237df114b822a1c6679547e2712f6f90b/src/diff/props.js#L29-L36), which already has an explicit check for `key[0] === '-'`.