### PR TITLE
Reduce line lengths in core

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,12 @@
     "*.ts",
     "dist"
   ],
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "none",
+    "useTabs": true,
+    "tabWidth": 2
+  },
   "files": [
     "src",
     "dist",

--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -10,6 +10,11 @@ import { createVNode } from './create-element';
  */
 export function cloneElement(vnode, props) {
 	props = assign(assign({}, vnode.props), props);
-	if (arguments.length>2) props.children = EMPTY_ARR.slice.call(arguments, 2);
-	return createVNode(vnode.type, props, props.key || vnode.key, props.ref || vnode.ref);
+	if (arguments.length > 2) props.children = EMPTY_ARR.slice.call(arguments, 2);
+	return createVNode(
+		vnode.type,
+		props,
+		props.key || vnode.key,
+		props.ref || vnode.ref
+	);
 }

--- a/src/component.js
+++ b/src/component.js
@@ -25,7 +25,9 @@ export function Component(props, context) {
  */
 Component.prototype.setState = function(update, callback) {
 	// only clone state when copying to nextState the first time.
-	let s = (this._nextState!==this.state && this._nextState) || (this._nextState = assign({}, this.state));
+	let s =
+		(this._nextState !== this.state && this._nextState) ||
+		(this._nextState = assign({}, this.state));
 
 	// if update() mutates state in-place, skip the copy:
 	if (typeof update!=='function' || (update = update(s, this.props))) {
@@ -113,7 +115,16 @@ function renderComponent(component) {
 
 	if (parentDom) {
 		let commitQueue = [];
-		let newDom = diff(parentDom, vnode, assign({}, vnode), component._context, parentDom.ownerSVGElement!==undefined, null, commitQueue, oldDom == null ? getDomSibling(vnode) : oldDom);
+		let newDom = diff(
+			parentDom,
+			vnode,
+			assign({}, vnode),
+			component._context,
+			parentDom.ownerSVGElement !== undefined,
+			null,
+			commitQueue,
+			oldDom == null ? getDomSibling(vnode) : oldDom
+		);
 		commitRoot(commitQueue, vnode);
 
 		if (newDom != oldDom) {
@@ -151,7 +162,10 @@ let q = [];
  * @type {(cb) => void}
  */
 /* istanbul ignore next */
-const defer = typeof Promise=='function' ? Promise.prototype.then.bind(Promise.resolve()) : setTimeout;
+const defer =
+	typeof Promise == 'function'
+		? Promise.prototype.then.bind(Promise.resolve())
+		: setTimeout;
 
 /*
  * The value of `Component.debounce` must asynchronously invoke the passed in callback. It is
@@ -169,8 +183,10 @@ let prevDebounce = options.debounceRendering;
  * @param {import('./internal').Component} c The component to rerender
  */
 export function enqueueRender(c) {
-	if ((!c._dirty && (c._dirty = true) && q.push(c) === 1) ||
-	    (prevDebounce !== options.debounceRendering)) {
+	if (
+		(!c._dirty && (c._dirty = true) && q.push(c) === 1) ||
+		prevDebounce !== options.debounceRendering
+	) {
 		prevDebounce = options.debounceRendering;
 		(options.debounceRendering || defer)(process);
 	}

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -26,7 +26,7 @@ export function createContext(defaultValue) {
 						});
 					}
 				};
-				this.sub = (c) => {
+				this.sub = c => {
 					subs.push(c);
 					let old = c.componentWillUnmount;
 					c.componentWillUnmount = () => {

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -2,13 +2,13 @@ import options from './options';
 import { assign } from './util';
 
 /**
-  * Create an virtual node (used for JSX)
-  * @param {import('./internal').VNode["type"]} type The node name or Component
-  * constructor for this virtual node
-  * @param {object | null | undefined} [props] The properties of the virtual node
-  * @param {Array<import('.').ComponentChildren>} [children] The children of the virtual node
-  * @returns {import('./internal').VNode}
-  */
+ * Create an virtual node (used for JSX)
+ * @param {import('./internal').VNode["type"]} type The node name or Component
+ * constructor for this virtual node
+ * @param {object | null | undefined} [props] The properties of the virtual node
+ * @param {Array<import('.').ComponentChildren>} [children] The children of the virtual node
+ * @returns {import('./internal').VNode}
+ */
 export function createElement(type, props, children) {
 	props = assign({}, props);
 
@@ -85,4 +85,5 @@ export function Fragment(props) {
  * @param {*} vnode
  * @returns {vnode is import('./internal').VNode}
  */
-export const isValidElement = vnode => vnode!=null && vnode.constructor === undefined;
+export const isValidElement = vnode =>
+	vnode != null && vnode.constructor === undefined;

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -23,7 +23,17 @@ import { getDomSibling } from '../component';
  * Fragments that have siblings. In most cases, it starts out as `oldChildren[0]._dom`.
  * @param {boolean} isHydrating Whether or not we are in hydration
  */
-export function diffChildren(parentDom, newParentVNode, oldParentVNode, context, isSvg, excessDomChildren, commitQueue, oldDom, isHydrating) {
+export function diffChildren(
+	parentDom,
+	newParentVNode,
+	oldParentVNode,
+	context,
+	isSvg,
+	excessDomChildren,
+	commitQueue,
+	oldDom,
+	isHydrating
+) {
 	let i, j, oldVNode, newDom, sibDom, firstChildDom, refs;
 
 	// This is a compression of oldParentVNode!=null && oldParentVNode != EMPTY_OBJ && oldParentVNode._children || EMPTY_ARR
@@ -82,7 +92,17 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 			oldVNode = oldVNode || EMPTY_OBJ;
 
 			// Morph the old element into the new one, but don't append it to the dom yet
-			newDom = diff(parentDom, childVNode, oldVNode, context, isSvg, excessDomChildren, commitQueue, oldDom, isHydrating);
+			newDom = diff(
+				parentDom,
+				childVNode,
+				oldVNode,
+				context,
+				isSvg,
+				excessDomChildren,
+				commitQueue,
+				oldDom,
+				isHydrating
+			);
 
 			if ((j = childVNode.ref) && oldVNode.ref != j) {
 				(refs || (refs=[])).push(j, childVNode._component || newDom, childVNode);
@@ -157,10 +177,16 @@ export function diffChildren(parentDom, newParentVNode, oldParentVNode, context,
 	newParentVNode._dom = firstChildDom;
 
 	// Remove children that are not part of any vnode.
-	if (excessDomChildren!=null && typeof newParentVNode.type !== 'function') for (i=excessDomChildren.length; i--; ) if (excessDomChildren[i]!=null) removeNode(excessDomChildren[i]);
+	if (excessDomChildren != null && typeof newParentVNode.type !== 'function') {
+		for (i = excessDomChildren.length; i--; ) {
+			if (excessDomChildren[i] != null) removeNode(excessDomChildren[i]);
+		}
+	}
 
 	// Remove remaining oldChildren if there are any.
-	for (i=oldChildrenLength; i--; ) if (oldChildren[i]!=null) unmount(oldChildren[i], oldChildren[i]);
+	for (i = oldChildrenLength; i--; ) {
+		if (oldChildren[i] != null) unmount(oldChildren[i], oldChildren[i]);
+	}
 
 	// Set refs only after unmount
 	if (refs) {

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -22,7 +22,17 @@ import options from '../options';
  * Fragments that have siblings. In most cases, it starts out as `oldChildren[0]._dom`.
  * @param {boolean} [isHydrating] Whether or not we are in hydration
  */
-export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChildren, commitQueue, oldDom, isHydrating) {
+export function diff(
+	parentDom,
+	newVNode,
+	oldVNode,
+	context,
+	isSvg,
+	excessDomChildren,
+	commitQueue,
+	oldDom,
+	isHydrating
+) {
 	let tmp, newType = newVNode.type;
 
 	// When passing through createElement it assigns the object
@@ -72,7 +82,12 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 				c._nextState = c.state;
 			}
 			if (newType.getDerivedStateFromProps!=null) {
-				assign(c._nextState==c.state ? (c._nextState = assign({}, c._nextState)) : c._nextState, newType.getDerivedStateFromProps(newProps, c._nextState));
+				assign(
+					c._nextState == c.state
+						? (c._nextState = assign({}, c._nextState))
+						: c._nextState,
+					newType.getDerivedStateFromProps(newProps, c._nextState)
+				);
 			}
 
 			oldProps = c.props;
@@ -139,7 +154,17 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 				snapshot = c.getSnapshotBeforeUpdate(oldProps, oldState);
 			}
 
-			diffChildren(parentDom, newVNode, oldVNode, context, isSvg, excessDomChildren, commitQueue, oldDom, isHydrating);
+			diffChildren(
+				parentDom,
+				newVNode,
+				oldVNode,
+				context,
+				isSvg,
+				excessDomChildren,
+				commitQueue,
+				oldDom,
+				isHydrating
+			);
 
 			c.base = newVNode._dom;
 
@@ -154,7 +179,16 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 			c._force = null;
 		}
 		else {
-			newVNode._dom = diffElementNodes(oldVNode._dom, newVNode, oldVNode, context, isSvg, excessDomChildren, commitQueue, isHydrating);
+			newVNode._dom = diffElementNodes(
+				oldVNode._dom,
+				newVNode,
+				oldVNode,
+				context,
+				isSvg,
+				excessDomChildren,
+				commitQueue,
+				isHydrating
+			);
 		}
 
 		if (tmp = options.diffed) tmp(newVNode);
@@ -200,7 +234,16 @@ export function commitRoot(commitQueue, root) {
  * @param {boolean} isHydrating Whether or not we are in hydration
  * @returns {import('../internal').PreactElement}
  */
-function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChildren, commitQueue, isHydrating) {
+function diffElementNodes(
+	dom,
+	newVNode,
+	oldVNode,
+	context,
+	isSvg,
+	excessDomChildren,
+	commitQueue,
+	isHydrating
+) {
 	let i;
 	let oldProps = oldVNode.props;
 	let newProps = newVNode.props;
@@ -212,7 +255,12 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
 		for (i=0; i<excessDomChildren.length; i++) {
 			const child = excessDomChildren[i];
 
-			if (child!=null && (newVNode.type===null ? child.nodeType===3 : child.localName===newVNode.type)) {
+			if (
+				child != null &&
+				(newVNode.type === null
+					? child.nodeType === 3
+					: child.localName === newVNode.type)
+			) {
 				dom = child;
 				excessDomChildren[i] = null;
 				break;
@@ -224,7 +272,11 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
 		if (newVNode.type===null) {
 			return document.createTextNode(newProps);
 		}
-		dom = isSvg ? document.createElementNS('http://www.w3.org/2000/svg', newVNode.type) : document.createElement(newVNode.type);
+
+		dom = isSvg
+			? document.createElementNS('http://www.w3.org/2000/svg', newVNode.type)
+			: document.createElement(newVNode.type);
+
 		// we created a new parent, so none of the previously attached children can be reused:
 		excessDomChildren = null;
 	}
@@ -269,13 +321,36 @@ function diffElementNodes(dom, newVNode, oldVNode, context, isSvg, excessDomChil
 
 		// If the new vnode didn't have dangerouslySetInnerHTML, diff its children
 		if (!newHtml) {
-			diffChildren(dom, newVNode, oldVNode, context, newVNode.type==='foreignObject' ? false : isSvg, excessDomChildren, commitQueue, EMPTY_OBJ, isHydrating);
+			diffChildren(
+				dom,
+				newVNode,
+				oldVNode,
+				context,
+				newVNode.type === 'foreignObject' ? false : isSvg,
+				excessDomChildren,
+				commitQueue,
+				EMPTY_OBJ,
+				isHydrating
+			);
 		}
 
 		// (as above, don't diff props during hydration)
 		if (!isHydrating) {
-			if (('value' in newProps) && newProps.value!==undefined && newProps.value !== dom.value) dom.value = newProps.value==null ? '' : newProps.value;
-			if (('checked' in newProps) && newProps.checked!==undefined && newProps.checked !== dom.checked) dom.checked = newProps.checked;
+			if (
+				'value' in newProps &&
+				newProps.value !== undefined &&
+				newProps.value !== dom.value
+			) {
+				dom.value = newProps.value == null ? '' : newProps.value;
+			}
+
+			if (
+				'checked' in newProps &&
+				newProps.checked !== undefined &&
+				newProps.checked !== dom.checked
+			) {
+				dom.checked = newProps.checked;
+			}
 		}
 	}
 

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -20,7 +20,12 @@ export function diffProps(dom, newProps, oldProps, isSvg, hydrate) {
 	}
 
 	for (i in newProps) {
-		if ((!hydrate || typeof newProps[i]=='function') && i!=='value' && i!=='checked' && oldProps[i]!==newProps[i]) {
+		if (
+			(!hydrate || typeof newProps[i] == 'function') &&
+			i !== 'value' &&
+			i !== 'checked' &&
+			oldProps[i] !== newProps[i]
+		) {
 			setProperty(dom, i, newProps[i], oldProps[i], isSvg);
 		}
 	}
@@ -31,7 +36,12 @@ function setStyle(style, key, value) {
 		style.setProperty(key, value);
 	}
 	else {
-		style[key] = typeof value==='number' && IS_NON_DIMENSIONAL.test(key)===false ? value+'px' : value==null ? '' : value;
+		style[key] =
+			typeof value === 'number' && IS_NON_DIMENSIONAL.test(key) === false
+				? value + 'px'
+				: value == null
+					? ''
+					: value;
 	}
 }
 
@@ -44,7 +54,13 @@ function setStyle(style, key, value) {
  * @param {boolean} isSvg Whether or not this DOM node is an SVG node or not
  */
 function setProperty(dom, name, value, oldValue, isSvg) {
-	name = isSvg ? (name==='className' ? 'class' : name) : (name==='class' ? 'className' : name);
+	name = isSvg
+		? name === 'className'
+			? 'class'
+			: name
+		: name === 'class'
+			? 'className'
+			: name;
 
 	if (name==='key' || name === 'children') {}
 	else if (name==='style') {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,11 @@
 export { render, hydrate } from './render';
-export { createElement, createElement as h, Fragment, createRef, isValidElement } from './create-element';
+export {
+	createElement,
+	createElement as h,
+	Fragment,
+	createRef,
+	isValidElement
+} from './create-element';
 export { Component } from './component';
 export { cloneElement } from './clone-element';
 export { createContext } from './create-context';

--- a/src/render.js
+++ b/src/render.js
@@ -17,13 +17,15 @@ export function render(vnode, parentDom, replaceNode) {
 	if (options._root) options._root(vnode, parentDom);
 
 	let isHydrating = replaceNode === IS_HYDRATE;
-	let oldVNode = isHydrating ? null : replaceNode && replaceNode._children || parentDom._children;
+	let oldVNode = isHydrating
+		? null
+		: (replaceNode && replaceNode._children) || parentDom._children;
 	vnode = createElement(Fragment, null, [vnode]);
 
 	let commitQueue = [];
 	diff(
 		parentDom,
-		(isHydrating ? parentDom : (replaceNode || parentDom))._children = vnode,
+		((isHydrating ? parentDom : replaceNode || parentDom)._children = vnode),
 		oldVNode || EMPTY_OBJ,
 		EMPTY_OBJ,
 		parentDom.ownerSVGElement !== undefined,
@@ -34,7 +36,7 @@ export function render(vnode, parentDom, replaceNode) {
 				: EMPTY_ARR.slice.call(parentDom.childNodes),
 		commitQueue,
 		replaceNode || EMPTY_OBJ,
-		isHydrating,
+		isHydrating
 	);
 	commitRoot(commitQueue, vnode);
 }


### PR DESCRIPTION
We've got some pretty gnarly long lines in core 😅 Some of these don't fit on my laptop screen lol. This PR simply re-indents some long lines so that they fit on my laptop screen lol.

Hopefully this is also helpful in the long run as it'll make diffs easier to view since they'll be less line wrapping. Also some of our more gnarly conditions may be easier to understand now that they are broken up onto multiple lines.

I didn't really consistently apply any heuristic here. Just ran through the files and reformatted ones that bothered me. If we think this is useless we can just close this PR.

Verified this does not change the byte size and so doesn't affect our output.