### PR TITLE
Simplify ternary expressions (-7 B)

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -32,8 +32,11 @@ Component.prototype.setState = function(update, callback) {
 		s = this._nextState = assign({}, this.state);
 	}
 
-	// if update() mutates state in-place, skip the copy:
-	if (typeof update !== 'function' || (update = update(s, this.props))) {
+	if (typeof update == 'function') {
+		update = update(s, this.props);
+	}
+
+	if (update) {
 		assign(s, update);
 	}
 

--- a/src/component.js
+++ b/src/component.js
@@ -25,9 +25,12 @@ export function Component(props, context) {
  */
 Component.prototype.setState = function(update, callback) {
 	// only clone state when copying to nextState the first time.
-	let s =
-		(this._nextState !== this.state && this._nextState) ||
-		(this._nextState = assign({}, this.state));
+	let s;
+	if (this._nextState !== this.state) {
+		s = this._nextState;
+	} else {
+		s = this._nextState = assign({}, this.state);
+	}
 
 	// if update() mutates state in-place, skip the copy:
 	if (typeof update !== 'function' || (update = update(s, this.props))) {

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -85,10 +85,12 @@ export function diff(
 				c._nextState = c.state;
 			}
 			if (newType.getDerivedStateFromProps != null) {
+				if (c._nextState == c.state) {
+					c._nextState = assign({}, c._nextState);
+				}
+
 				assign(
-					c._nextState == c.state
-						? (c._nextState = assign({}, c._nextState))
-						: c._nextState,
+					c._nextState,
 					newType.getDerivedStateFromProps(newProps, c._nextState)
 				);
 			}

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -55,13 +55,13 @@ function setStyle(style, key, value) {
  * @param {boolean} isSvg Whether or not this DOM node is an SVG node or not
  */
 function setProperty(dom, name, value, oldValue, isSvg) {
-	name = isSvg
-		? name === 'className'
-			? 'class'
-			: name
-		: name === 'class'
-		? 'className'
-		: name;
+	if (isSvg) {
+		if (name === 'className') {
+			name = 'class';
+		}
+	} else if (name === 'class') {
+		name = 'className';
+	}
 
 	if (name === 'key' || name === 'children') {
 	} else if (name === 'style') {

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -34,13 +34,15 @@ export function diffProps(dom, newProps, oldProps, isSvg, hydrate) {
 function setStyle(style, key, value) {
 	if (key[0] === '-') {
 		style.setProperty(key, value);
+	} else if (
+		typeof value === 'number' &&
+		IS_NON_DIMENSIONAL.test(key) === false
+	) {
+		style[key] = value + 'px';
+	} else if (value == null) {
+		style[key] = '';
 	} else {
-		style[key] =
-			typeof value === 'number' && IS_NON_DIMENSIONAL.test(key) === false
-				? value + 'px'
-				: value == null
-				? ''
-				: value;
+		style[key] = value;
 	}
 }
 


### PR DESCRIPTION
After working on #2048, I realized we had some gnarly ternary expressions that would a little hard to decipher. I played around with rewriting some into normal if statements hoping terser would properly minify them for us and it turns it did even better and saved us some bytes! A before and after comparison is provided in the comments of the PR for those curious.

Summary:
f6b39b5 Use if statement in setStyle for readability (+0 B)
8ff18fc Simplify className conditionals (-2 B)
f04da34 Simplify setState/_nextState condintional (-2 B)
f638098 Simplify update condition (-1 B)
448dbe7 Simplify nextState assignment in gDSFP handling (-2 B)
