### PR TITLE
Queue layoutEffects in component render callbacks array (+0 B)

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -229,8 +229,10 @@ export function initDebug() {
 			});
 		}
 
-		if (vnode._component && vnode._component.__hooks) {
-			let hooks = vnode._component.__hooks;
+		/** @type {import('./internal').Component} */
+		const component = vnode._component;
+		if (component && component.__hooks) {
+			let hooks = component.__hooks;
 			if (Array.isArray(hooks._list)) {
 				hooks._list.forEach(hook => {
 					if (hook._callback && (!hook._args || !Array.isArray(hook._args))) {
@@ -241,6 +243,8 @@ export function initDebug() {
 					}
 				});
 			}
+
+			// After paint effects
 			if (Array.isArray(hooks._pendingEffects)) {
 				hooks._pendingEffects.forEach((effect) => {
 					if (!Array.isArray(effect._args) && warnedComponents && !warnedComponents.useEffect.has(vnode.type)) {
@@ -251,16 +255,16 @@ export function initDebug() {
 					}
 				});
 			}
-			if (Array.isArray(hooks._pendingLayoutEffects)) {
-				hooks._pendingLayoutEffects.forEach((layoutEffect) => {
-					if (!Array.isArray(layoutEffect._args) && warnedComponents && !warnedComponents.useLayoutEffect.has(vnode.type)) {
-						warnedComponents.useLayoutEffect.set(vnode.type, true);
-						console.warn('You should provide an array of arguments as the second argument to the "useLayoutEffect" hook.\n\n' +
-							'Not doing so will invoke this effect on every render.\n\n' +
-							'This effect can be found in the render of ' + getDisplayName(vnode) + '.');
-					}
-				});
-			}
+
+			// Layout Effects
+			component._renderCallbacks.forEach((possibleEffect) => {
+				if (possibleEffect._value && !Array.isArray(possibleEffect._args) && warnedComponents && !warnedComponents.useLayoutEffect.has(vnode.type)) {
+					warnedComponents.useLayoutEffect.set(vnode.type, true);
+					console.warn('You should provide an array of arguments as the second argument to the "useLayoutEffect" hook.\n\n' +
+						'Not doing so will invoke this effect on every render.\n\n' +
+						'This effect can be found in the render of ' + getDisplayName(vnode) + '.');
+				}
+			});
 		}
 
 		if (oldDiffed) oldDiffed(vnode);

--- a/debug/src/devtools/index.js
+++ b/debug/src/devtools/index.js
@@ -9,9 +9,9 @@ import { Renderer } from './renderer';
  * @returns
  */
 function catchErrors(fn) {
-	return function(arg) {
+	return function(...args) {
 		try {
-			return fn(arg);
+			return fn(...args);
 		}
 		catch (e) {
 			/* istanbul ignore next */
@@ -148,9 +148,9 @@ export function initDevTools() {
 		if (prevAfterDiff!=null) prevAfterDiff(vnode);
 	};
 
-	options._commit = catchErrors((vnode) => {
+	options._commit = catchErrors((vnode, commitQueue) => {
 		// Call previously defined hook
-		if (prevCommitRoot!=null) prevCommitRoot(vnode);
+		if (prevCommitRoot!=null) prevCommitRoot(vnode, commitQueue);
 
 		// These cases are already handled by `unmount`
 		if (vnode==null) return;

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -26,8 +26,6 @@ export interface ComponentHooks {
 	_list: HookState[];
 	/** List of Effects to be invoked after the next frame is rendered */
 	_pendingEffects: EffectHookState[];
-	/** List of Effects to be invoked at the end of the current render */
-	_pendingLayoutEffects: EffectHookState[];
 }
 
 export interface Component extends PreactComponent<any, any> {

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -166,7 +166,14 @@ export function diff(parentDom, newVNode, oldVNode, context, isSvg, excessDomChi
 	return newVNode._dom;
 }
 
+/**
+ * @param {Array<import('../internal').Component>} commitQueue List of components
+ * which have callbacks to invoke in commitRoot
+ * @param {import('../internal').VNode} root
+ */
 export function commitRoot(commitQueue, root) {
+	if (options._commit) options._commit(root, commitQueue);
+
 	commitQueue.some(c => {
 		try {
 			commitQueue = c._renderCallbacks;
@@ -177,8 +184,6 @@ export function commitRoot(commitQueue, root) {
 			options._catchError(e, c._vnode);
 		}
 	});
-
-	if (options._commit) options._commit(root);
 }
 
 /**

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -6,7 +6,7 @@ export interface Options extends preact.Options {
 	/** Attach a hook that is invoked before a vnode is diffed. */
 	_diff?(vnode: VNode): void;
 	/** Attach a hook that is invoked after a tree was mounted or was updated. */
-	_commit?(vnode: VNode): void;
+	_commit?(vnode: VNode, commitQueue: Component[]): void;
 	/** Attach a hook that is invoked before a vnode has rendered. */
 	_render?(vnode: VNode): void;
 	/** Attach a hook that is invoked before a hook's state is queried. */

--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -173,7 +173,6 @@ export function clearOptions() {
 	delete options.diffed;
 	delete options.unmount;
 	delete options._diff;
-	delete options._commit;
 }
 
 /**


### PR DESCRIPTION
Removes 2 array allocations: 1 global array and 1 array per component using hooks! Also, I suspect that this would save us some bytes if we bring hooks into core since we are getting more reuse out of an existing construct instead of introducing new ones :grin: