### PR TITLE
Fix setState warning always being printed

### DIFF
--- a/debug/mangle.json
+++ b/debug/mangle.json
@@ -31,6 +31,7 @@
       "$_component": "__c",
       "$__html": "__html",
       "$_parent": "__p",
+      "$_parentDom": "__P",
       "$_pendingError": "__E",
       "$_processingException": "__p",
       "$_root": "__p",


### PR DESCRIPTION
This was caused by a missing mangling property.

Fixes #2056 .