### PR TITLE
Add missing `_renderCallbacks` mangle configuration

### DIFF
--- a/hooks/mangle.json
+++ b/hooks/mangle.json
@@ -16,6 +16,7 @@
       "$_diff": "__b",
       "$_commit": "__c",
       "$_render": "__r",
+      "$_renderCallbacks": "__h",
       "$_suspensions": "__u",
       "$_hook": "__h",
       "$_catchError": "__e",


### PR DESCRIPTION
This broke layout effect hooks in production builds of v10.0.3.

We've now had a couple of broken releases due to mismatched mangling configuration. We need to change the build or add a suitable test so that this doesn't happen again. For now, this fixes the immediate problem.