### PR TITLE
Adding Intergram to the demos list

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Preact supports modern browsers and IE9+:
 - [**Journalize**](https://preact-journal.herokuapp.com/) 14k offline-capable journaling PWA using preact. _([Github project](https://github.com/jpodwys/preact-journal))_.
 - [**Proxx**](https://proxx.app) A game of proximity by GoogleChromeLabs using preact. _([Github project](https://github.com/GoogleChromeLabs/proxx))_.
 - [**Web Maker**](https://webmaker.app) An offline and blazing fast frontend playground built using Preact. _([Github project](https://github.com/chinchang/web-maker))_.
+- [**Intergram**](https://www.intergram.xyz) A live chat widget linked to your Telegram messenger built using Preact. _([Github project](https://github.com/idoco/intergram))_.
 
 
 #### Runnable Examples


### PR DESCRIPTION
Hey all,

I have built a somewhat popular (790✰) open-source chat widget using Preact and thought it would be relevant to include it in the demos list. This chat widget is used in hundreds of websites and is being loaded by about ~175k unique visitors a month.

I used Preact because I wanted to make my bundle as small as possible so I would not burden the hosting website - [link](https://github.com/idoco/intergram#initial-footprint).

Would appreciate your feedback  🙂