### PR TITLE
Add 'as' html attribute to TypeScript defs

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -505,6 +505,7 @@ export namespace JSXInternal {
 		allowFullScreen?: boolean;
 		allowTransparency?: boolean;
 		alt?: string;
+		as?: string;
 		async?: boolean;
 		autocomplete?: string;
 		autoComplete?: string;


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/semantics.html#attr-link-as