### PR TITLE
(fix) Handle the stale ref for fwd (#2075)

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -417,9 +417,9 @@ function memo(c, comparer) {
  */
 function forwardRef(fn) {
 	function Forwarded(props) {
-		let ref = props.ref;
-		delete props.ref;
-		return fn(props, ref);
+		let clone = assign({}, props);
+		delete clone.ref;
+		return fn(clone, props.ref);
 	}
 	Forwarded.prototype.isReactComponent = true;
 	Forwarded._forwarded = true;

--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -359,7 +359,7 @@ describe('forwardRef', () => {
 		const Inner = forwardRef((props, ref) => {
 			const _hook = useState(null);
 			_ref = ref;
-			_set = _hook.setState;
+			_set = _hook[1];
 			return <div ref={ref} />;
 		});
 

--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -6,10 +6,11 @@ import {
 	hydrate,
 	memo,
 	useState,
+	useRef,
 	useImperativeHandle
 } from '../../src';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { setupRerender } from 'preact/test-utils';
+import { setupRerender, act } from 'preact/test-utils';
 /* eslint-disable react/jsx-boolean-value, react/display-name, prefer-arrow-callback */
 
 /** @jsx h */
@@ -350,5 +351,34 @@ describe('forwardRef', () => {
 		render(<Bar ref={spy} />, scratch);
 		expect(spy).to.be.calledOnce;
 		expect(spy).to.be.calledWithExactly({ foo: 100 });
+	});
+
+	it('stale ref missing with passed useRef', () => {
+		let _ref = null;
+		let _set = null;
+		const Inner = forwardRef((props, ref) => {
+			const [_, setState] = useState(null);
+			_ref = ref;
+			_set = setState;
+			return <div ref={ref} />;
+		});
+
+		const Parent = () => {
+			const parentRef = useRef(null);
+			return <Inner ref={parentRef}>child</Inner>;
+		};
+
+		act(() => {
+			render(<Parent />, scratch);
+		});
+
+		expect(_ref).not.to.be.undefined;
+
+		act(() => {
+			_set(1);
+			rerender();
+		});
+
+		expect(_ref).not.to.be.undefined;
 	});
 });

--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -372,13 +372,13 @@ describe('forwardRef', () => {
 			render(<Parent />, scratch);
 		});
 
-		expect(_ref).not.to.be.undefined;
+		expect(_ref.current).to.equal(scratch.firstChild);
 
 		act(() => {
 			_set(1);
 			rerender();
 		});
 
-		expect(_ref).not.to.be.undefined;
+		expect(_ref.current).to.equal(scratch.firstChild);
 	});
 });

--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -357,9 +357,9 @@ describe('forwardRef', () => {
 		let _ref = null;
 		let _set = null;
 		const Inner = forwardRef((props, ref) => {
-			const [_, setState] = useState(null);
+			const _hook = useState(null);
 			_ref = ref;
-			_set = setState;
+			_set = _hook.setState;
 			return <div ref={ref} />;
 		});
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
     "lint": "eslint src test debug compat hooks test-utils"
   },
   "eslintConfig": {
-    "extends": ["developit", "prettier"],
+    "extends": [
+      "developit",
+      "prettier"
+    ],
     "settings": {
       "react": {
         "pragma": "createElement"


### PR DESCRIPTION
This fixes #2075 .

Basically the `ref` was missing since hooks queue the rerender with the same props and those have missing `ref` vlaues since we remove that in `compat`.