### PR TITLE
Improve tree-shakeability (-13 B)

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -182,7 +182,7 @@ const defer =
  * * [Callbacks synchronous and asynchronous](https://blog.ometer.com/2011/07/24/callbacks-synchronous-and-asynchronous/)
  */
 
-let prevDebounce = options.debounceRendering;
+let prevDebounce;
 
 /**
  * Enqueue a rerender of a component

--- a/src/component.js
+++ b/src/component.js
@@ -165,9 +165,10 @@ let q = [];
 
 /**
  * Asynchronously schedule a callback
- * @type {(cb) => void}
+ * @type {(cb: () => void) => void}
  */
 /* istanbul ignore next */
+// Note the following line isn't tree-shaken by rollup cuz of rollup/rollup#2566
 const defer =
 	typeof Promise == 'function'
 		? Promise.prototype.then.bind(Promise.resolve())
@@ -194,7 +195,7 @@ export function enqueueRender(c) {
 		prevDebounce !== options.debounceRendering
 	) {
 		prevDebounce = options.debounceRendering;
-		(options.debounceRendering || defer)(process);
+		(prevDebounce || defer)(process);
 	}
 }
 

--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -1,0 +1,39 @@
+import { enqueueRender } from '../component';
+
+/**
+ * Find the closest error boundary to a thrown error and call it
+ * @param {object} error The thrown value
+ * @param {import('../internal').VNode} vnode The vnode that threw
+ * the error that was caught (except for unmounting when this parameter
+ * is the highest parent that was being unmounted)
+ * @param {import('../internal').VNode} [oldVNode] The oldVNode of the vnode
+ * that threw, if this VNode threw while diffing
+ */
+export function _catchError(error, vnode, oldVNode) {
+	/** @type {import('../internal').Component} */
+	let component;
+
+	for (; (vnode = vnode._parent); ) {
+		if ((component = vnode._component) && !component._processingException) {
+			try {
+				if (
+					component.constructor &&
+					component.constructor.getDerivedStateFromError != null
+				) {
+					component.setState(
+						component.constructor.getDerivedStateFromError(error)
+					);
+				} else if (component.componentDidCatch != null) {
+					component.componentDidCatch(error);
+				} else {
+					continue;
+				}
+				return enqueueRender((component._pendingError = component));
+			} catch (e) {
+				error = e;
+			}
+		}
+	}
+
+	throw error;
+}

--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -6,10 +6,8 @@ import { enqueueRender } from '../component';
  * @param {import('../internal').VNode} vnode The vnode that threw
  * the error that was caught (except for unmounting when this parameter
  * is the highest parent that was being unmounted)
- * @param {import('../internal').VNode} [oldVNode] The oldVNode of the vnode
- * that threw, if this VNode threw while diffing
  */
-export function _catchError(error, vnode, oldVNode) {
+export function _catchError(error, vnode) {
 	/** @type {import('../internal').Component} */
 	let component;
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -1,5 +1,5 @@
 import { EMPTY_OBJ, EMPTY_ARR } from '../constants';
-import { Component, enqueueRender } from '../component';
+import { Component } from '../component';
 import { Fragment } from '../create-element';
 import { diffChildren, toChildArray } from './children';
 import { diffProps } from './props';
@@ -438,41 +438,3 @@ export function unmount(vnode, parentVNode, skipRemove) {
 function doRender(props, state, context) {
 	return this.constructor(props, context);
 }
-
-/**
- * Find the closest error boundary to a thrown error and call it
- * @param {object} error The thrown value
- * @param {import('../internal').VNode} vnode The vnode that threw
- * the error that was caught (except for unmounting when this parameter
- * is the highest parent that was being unmounted)
- * @param {import('../internal').VNode} oldVNode The oldVNode of the vnode
- * that threw, if this VNode threw while diffing
- */
-options._catchError = function(error, vnode, oldVNode) {
-	/** @type {import('../internal').Component} */
-	let component;
-
-	for (; (vnode = vnode._parent); ) {
-		if ((component = vnode._component) && !component._processingException) {
-			try {
-				if (
-					component.constructor &&
-					component.constructor.getDerivedStateFromError != null
-				) {
-					component.setState(
-						component.constructor.getDerivedStateFromError(error)
-					);
-				} else if (component.componentDidCatch != null) {
-					component.componentDidCatch(error);
-				} else {
-					continue;
-				}
-				return enqueueRender((component._pendingError = component));
-			} catch (e) {
-				error = e;
-			}
-		}
-	}
-
-	throw error;
-};

--- a/src/options.js
+++ b/src/options.js
@@ -1,4 +1,8 @@
+import { _catchError } from './diff/catch-error';
+
 /** @type {import('./internal').Options}  */
-const options = {};
+const options = {
+	_catchError
+};
 
 export default options;


### PR DESCRIPTION
The tool [agadoo](https://www.npmjs.com/package/agadoo) tries to see if an entire library is tree-shakeable by importing an library, using none of it, and seeing if rollup tree-shakes the entire library away (or something like that...).

I curious how Preact would do with this tool and found some patterns in code we use that prevent us from being entirely tree-shakeable. Turns out fixing those patterns saves us some bytes! We have one line that is retained now when tree-shaking and thats the `Promise.prototype.then.bind` call because of rollup/rollup#2566.

Anyway, being entirely tree-shakeable may not be that useful for us cuz if you don't use any of our library you should probably remove us from your codebase lol. But anyway, thought it was a fun exercise that saved us some bytes!

Summary:
* 0cbd5be Remove prevDebounce init (-4 B)
* 4cf0c12 Inline catchError declaration into options (-2 B)
* 404b874 Remove unused param (-6 B)
* c82d8e6 Reuse prevDebounce in enqueueRender (-1 B)