### PR TITLE
Update for jsx.d.ts.

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1,3 +1,4 @@
+import * as preact from './index';
 type Defaultize<Props, Defaults> =
 	// Distribute over unions
 	Props extends any // Make any properties included in Default optional


### PR DESCRIPTION
This file was showing errors about missing preact namespace. Added import to resolve the issue.