### PR TITLE
Simplify hook scheduling logic (-17 B)

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -256,7 +256,7 @@ function afterNextFrame(callback) {
 	}
 }
 
-let prevRaf = options.requestAnimationFrame;
+let prevRaf;
 
 // Note: if someone used Component.debounce = requestAnimationFrame,
 // then effects will ALWAYS run on the NEXT frame instead of the current one, incurring a ~16ms delay.

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -260,7 +260,7 @@ function afterNextFrame(callback) {
 	}
 }
 
-// Note: if someone used Component.debounce = requestAnimationFrame,
+// Note: if someone used options.debounceRendering = requestAnimationFrame,
 // then effects will ALWAYS run on the NEXT frame instead of the current one, incurring a ~16ms delay.
 // Perhaps this is not such a big deal.
 /**

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -241,6 +241,8 @@ const RAF_TIMEOUT = 100;
  *
  * Also, schedule a timeout in parallel to the the rAF to ensure the callback is invoked
  * even if RAF doesn't fire (for example if the browser tab is not visible)
+ *
+ * @param {() => void} callback
  */
 function afterNextFrame(callback) {
 	const done = () => {
@@ -263,7 +265,7 @@ let prevRaf;
 // Perhaps this is not such a big deal.
 /**
  * Schedule afterPaintEffects flush after the browser paints
- * @type {(newQueueLength: number) => void}
+ * @param {number} newQueueLength
  */
 function afterPaint(newQueueLength) {
 	if (newQueueLength === 1 || prevRaf !== options.requestAnimationFrame) {

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -10,6 +10,13 @@ let currentComponent;
 let afterPaintEffects = [];
 
 let oldBeforeRender = options._render;
+let oldAfterDiff = options.diffed;
+let oldCommit = options._commit;
+let oldBeforeUnmount = options.unmount;
+
+const RAF_TIMEOUT = 100;
+let prevRaf;
+
 options._render = vnode => {
 	if (oldBeforeRender) oldBeforeRender(vnode);
 
@@ -23,7 +30,6 @@ options._render = vnode => {
 	}
 };
 
-let oldAfterDiff = options.diffed;
 options.diffed = vnode => {
 	if (oldAfterDiff) oldAfterDiff(vnode);
 
@@ -38,7 +44,6 @@ options.diffed = vnode => {
 	}
 };
 
-let oldCommit = options._commit;
 options._commit = (vnode, commitQueue) => {
 	commitQueue.some(component => {
 		component._renderCallbacks.forEach(invokeCleanup);
@@ -50,7 +55,6 @@ options._commit = (vnode, commitQueue) => {
 	if (oldCommit) oldCommit(vnode, commitQueue);
 };
 
-let oldBeforeUnmount = options.unmount;
 options.unmount = vnode => {
 	if (oldBeforeUnmount) oldBeforeUnmount(vnode);
 
@@ -232,8 +236,6 @@ function flushAfterPaintEffects() {
 	afterPaintEffects = [];
 }
 
-const RAF_TIMEOUT = 100;
-
 /**
  * Schedule a callback to be invoked after the browser has a chance to paint a new frame.
  * Do this by combining requestAnimationFrame (rAF) + setTimeout to invoke a callback after
@@ -257,8 +259,6 @@ function afterNextFrame(callback) {
 		raf = requestAnimationFrame(done);
 	}
 }
-
-let prevRaf;
 
 // Note: if someone used Component.debounce = requestAnimationFrame,
 // then effects will ALWAYS run on the NEXT frame instead of the current one, incurring a ~16ms delay.


### PR DESCRIPTION
Summary:
* aec90a5 Move rAF check to right before rAF call (-6 B)
* 8dc32be Remove unnecessary prevRaf init (-3 B)
* cbc79a5 Hoist all variable declarations to the top of the file (-8 B)
  I'm guessing since we were intermixing reading and writing an object, terser can't safely hoist these for us so manually doing it instead saves some bytes