### PR TITLE
In tests, import code under test by name instead of relative pa…

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,0 @@
-* Undo change to perf tests since this PR may not include updates to move to minified bundles
-* Get feedback on createElement vs h
-* Try to get VSCode intellisense to work in compat tests
-	* Perhaps put a local jsconfig.json that changes pragma to React? Or should we just import createElement from preact/compat?

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,4 @@
+* Undo change to perf tests since this PR may not include updates to move to minified bundles
+* Get feedback on createElement vs h
+* Try to get VSCode intellisense to work in compat tests
+	* Perhaps put a local jsconfig.json that changes pragma to React? Or should we just import createElement from preact/compat?

--- a/compat/test/browser/Children.test.js
+++ b/compat/test/browser/Children.test.js
@@ -4,7 +4,7 @@ import {
 	serializeHtml
 } from '../../../test/_util/helpers';
 import { div, span } from '../../../test/_util/dom';
-import React, { Children, render } from 'preact/compat';
+import React, { createElement, Children, render } from 'preact/compat';
 
 describe('Children', () => {
 	/** @type {HTMLDivElement} */

--- a/compat/test/browser/Children.test.js
+++ b/compat/test/browser/Children.test.js
@@ -3,9 +3,8 @@ import {
 	teardown,
 	serializeHtml
 } from '../../../test/_util/helpers';
-// eslint-disable-next-line no-unused-vars
-import React, { Children, render } from '../../src';
 import { div, span } from '../../../test/_util/dom';
+import React, { Children, render } from 'preact/compat';
 
 describe('Children', () => {
 	/** @type {HTMLDivElement} */

--- a/compat/test/browser/compat.test.js
+++ b/compat/test/browser/compat.test.js
@@ -1,7 +1,7 @@
-import { createElement, render } from 'preact';
+import { render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
-import React from 'preact/compat'; // eslint-disable-line
+import React from 'preact/compat';
 
 describe('imported compat in preact', () => {
 	let scratch;

--- a/compat/test/browser/compat.test.js
+++ b/compat/test/browser/compat.test.js
@@ -1,7 +1,7 @@
 import { render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
-import React from 'preact/compat';
+import React, { createElement } from 'preact/compat';
 
 describe('imported compat in preact', () => {
 	let scratch;

--- a/compat/test/browser/component.test.js
+++ b/compat/test/browser/component.test.js
@@ -1,6 +1,6 @@
 import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import React from '../../src';
+import React, { createElement } from '../../src';
 
 describe('components', () => {
 	/** @type {HTMLDivElement} */

--- a/compat/test/browser/component.test.js
+++ b/compat/test/browser/component.test.js
@@ -1,6 +1,6 @@
 import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import React, { createElement } from '../../src';
+import React, { createElement } from 'preact/compat';
 
 describe('components', () => {
 	/** @type {HTMLDivElement} */

--- a/compat/test/browser/exports.test.js
+++ b/compat/test/browser/exports.test.js
@@ -1,6 +1,6 @@
-import Compat from '../../src';
+import Compat from 'preact/compat';
 // eslint-disable-next-line no-duplicate-imports
-import * as Named from '../../src';
+import * as Named from 'preact/compat';
 
 describe('exports', () => {
 	it('should have a default export', () => {

--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -1,4 +1,5 @@
 import React, {
+	createElement,
 	render,
 	createRef,
 	forwardRef,

--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -1,5 +1,4 @@
-import {
-	createElement as h,
+import React, {
 	render,
 	createRef,
 	forwardRef,
@@ -8,12 +7,12 @@ import {
 	useState,
 	useRef,
 	useImperativeHandle
-} from '../../src';
+} from 'preact/compat';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { setupRerender, act } from 'preact/test-utils';
+
 /* eslint-disable react/jsx-boolean-value, react/display-name, prefer-arrow-callback */
 
-/** @jsx h */
 describe('forwardRef', () => {
 	/** @type {HTMLDivElement} */
 	let scratch, rerender;

--- a/compat/test/browser/index.test.js
+++ b/compat/test/browser/index.test.js
@@ -7,7 +7,7 @@ import React, {
 	unmountComponentAtNode,
 	createFactory,
 	unstable_batchedUpdates
-} from '../../src';
+} from 'preact/compat';
 import { createElement as preactH } from 'preact';
 import {
 	setupScratch,

--- a/compat/test/browser/jsx.test.js
+++ b/compat/test/browser/jsx.test.js
@@ -3,7 +3,7 @@ import {
 	teardown,
 	serializeHtml
 } from '../../../test/_util/helpers';
-import React, { isValidElement } from 'preact/compat';
+import React, { createElement, isValidElement } from 'preact/compat';
 import { createElement as preactH } from 'preact';
 
 describe('jsx', () => {

--- a/compat/test/browser/jsx.test.js
+++ b/compat/test/browser/jsx.test.js
@@ -3,8 +3,8 @@ import {
 	teardown,
 	serializeHtml
 } from '../../../test/_util/helpers';
-import React, { isValidElement } from '../../src';
-import { h as preactH } from 'preact';
+import React, { isValidElement } from 'preact/compat';
+import { createElement as preactH } from 'preact';
 
 describe('jsx', () => {
 	/** @type {HTMLDivElement} */

--- a/compat/test/browser/memo.test.js
+++ b/compat/test/browser/memo.test.js
@@ -1,8 +1,8 @@
 import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { Component, render, createElement as h, memo } from '../../src';
+import React, { Component, render, memo } from 'preact/compat';
 
-/** @jsx h */
+const h = React.createElement;
 
 describe('memo()', () => {
 	let scratch, rerender;

--- a/compat/test/browser/memo.test.js
+++ b/compat/test/browser/memo.test.js
@@ -1,6 +1,6 @@
 import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import React, { Component, render, memo } from 'preact/compat';
+import React, { createElement, Component, render, memo } from 'preact/compat';
 
 const h = React.createElement;
 

--- a/compat/test/browser/options-compat.test.js
+++ b/compat/test/browser/options-compat.test.js
@@ -1,5 +1,10 @@
 import { vnodeSpy, eventSpy } from '../../../test/_util/optionSpies';
-import React, { render, Component, createRef } from 'preact/compat';
+import React, {
+	createElement,
+	render,
+	Component,
+	createRef
+} from 'preact/compat';
 import { setupRerender } from 'preact/test-utils';
 import {
 	setupScratch,

--- a/compat/test/browser/options-compat.test.js
+++ b/compat/test/browser/options-compat.test.js
@@ -1,13 +1,11 @@
 import { vnodeSpy, eventSpy } from '../../../test/_util/optionSpies';
-import { render, createElement, Component, createRef } from '../../src';
+import React, { render, Component, createRef } from 'preact/compat';
 import { setupRerender } from 'preact/test-utils';
 import {
 	setupScratch,
 	teardown,
 	createEvent
 } from '../../../test/_util/helpers';
-
-/** @jsx createElement */
 
 describe('compat options', () => {
 	/** @type {HTMLDivElement} */

--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -1,15 +1,14 @@
-import {
-	createElement as h,
+import React, {
 	render,
 	createPortal,
 	useState,
 	Component
-} from '../../src';
+} from 'preact/compat';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { setupRerender } from 'preact/test-utils';
+
 /* eslint-disable react/jsx-boolean-value, react/display-name, prefer-arrow-callback */
 
-/** @jsx h */
 describe('Portal', () => {
 	/** @type {HTMLDivElement} */
 	let scratch;

--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -1,4 +1,5 @@
 import React, {
+	createElement,
 	render,
 	createPortal,
 	useState,

--- a/compat/test/browser/select.test.js
+++ b/compat/test/browser/select.test.js
@@ -1,7 +1,5 @@
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { render, createElement as h } from '../../src';
-
-/** @jsx h */
+import React, { render } from 'preact/compat';
 
 describe('Select', () => {
 	let scratch;

--- a/compat/test/browser/select.test.js
+++ b/compat/test/browser/select.test.js
@@ -1,5 +1,5 @@
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import React, { render } from 'preact/compat';
+import React, { createElement, render } from 'preact/compat';
 
 describe('Select', () => {
 	let scratch;

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -1,5 +1,6 @@
 import { setupRerender } from 'preact/test-utils';
 import React, {
+	createElement,
 	render,
 	Component,
 	Suspense,

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -1,15 +1,15 @@
-/* eslint-env browser, mocha */
-/** @jsx h */
 import { setupRerender } from 'preact/test-utils';
-import {
-	createElement as h,
+import React, {
 	render,
 	Component,
 	Suspense,
 	lazy,
 	Fragment
-} from '../../src/index';
+} from 'preact/compat';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
+
+const h = React.createElement;
+/* eslint-env browser, mocha */
 
 function createLazy() {
 	/** @type {(c: ComponentType) => Promise<void>} */
@@ -40,7 +40,7 @@ function createLazy() {
  * @returns {[typeof Component, () => Resolvers]}
  */
 function createSuspender(DefaultComponent) {
-	/** @type {(lazy: h.JSX.Element) => void} */
+	/** @type {(lazy: React.JSX.Element) => void} */
 	let renderLazy;
 	class Suspender extends Component {
 		constructor(props, context) {

--- a/compat/test/browser/svg.test.js
+++ b/compat/test/browser/svg.test.js
@@ -1,4 +1,4 @@
-import React from '../../src';
+import React from 'preact/compat';
 import {
 	setupScratch,
 	teardown,

--- a/compat/test/browser/svg.test.js
+++ b/compat/test/browser/svg.test.js
@@ -1,4 +1,4 @@
-import React from 'preact/compat';
+import React, { createElement } from 'preact/compat';
 import {
 	setupScratch,
 	teardown,

--- a/debug/test/browser/debug-hooks.test.js
+++ b/debug/test/browser/debug-hooks.test.js
@@ -6,13 +6,11 @@ import {
 	useMemo,
 	useCallback
 } from 'preact/hooks';
-import { initDebug } from '../../src/debug';
+import 'preact/debug';
 import { act } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
 /** @jsx createElement */
-
-initDebug();
 
 describe('debug with hooks', () => {
 	let scratch;

--- a/debug/test/browser/debug-suspense.test.js
+++ b/debug/test/browser/debug-suspense.test.js
@@ -1,5 +1,5 @@
 import { createElement, render, lazy, Suspense } from 'preact/compat';
-import { initDebug } from '../../src/debug';
+import 'preact/debug';
 import { setupRerender } from 'preact/test-utils';
 import {
 	setupScratch,
@@ -8,8 +8,6 @@ import {
 } from '../../../test/_util/helpers';
 
 /** @jsx createElement */
-
-initDebug();
 
 describe('debug with suspense', () => {
 	let scratch;

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -4,10 +4,8 @@ import {
 	teardown,
 	serializeHtml
 } from '../../../test/_util/helpers';
-import { serializeVNode, initDebug } from '../../src/debug'; // TODO: Can we somehow convert this? Perhaps move seralizeVNode tests into their own file?
+import 'preact/debug';
 import * as PropTypes from 'prop-types';
-
-initDebug();
 
 const h = createElement;
 /** @jsx createElement */
@@ -317,66 +315,6 @@ describe('debug', () => {
 
 			render(<App />, scratch);
 			expect(console.error).to.be.calledTwice;
-		});
-	});
-
-	describe('serializeVNode', () => {
-		it("should prefer a function component's displayName", () => {
-			function Foo() {
-				return <div />;
-			}
-			Foo.displayName = 'Bar';
-
-			expect(serializeVNode(<Foo />)).to.equal('<Bar />');
-		});
-
-		it("should prefer a class component's displayName", () => {
-			class Bar extends Component {
-				render() {
-					return <div />;
-				}
-			}
-			Bar.displayName = 'Foo';
-
-			expect(serializeVNode(<Bar />)).to.equal('<Foo />');
-		});
-
-		it('should serialize vnodes without children', () => {
-			expect(serializeVNode(<br />)).to.equal('<br />');
-		});
-
-		it('should serialize vnodes with children', () => {
-			expect(serializeVNode(<div>Hello World</div>)).to.equal('<div>..</div>');
-		});
-
-		it('should serialize components', () => {
-			function Foo() {
-				return <div />;
-			}
-			expect(serializeVNode(<Foo />)).to.equal('<Foo />');
-		});
-
-		it('should serialize props', () => {
-			expect(serializeVNode(<div class="foo" />)).to.equal(
-				'<div class="foo" />'
-			);
-
-			let noop = () => {};
-			expect(serializeVNode(<div onClick={noop} />)).to.equal(
-				'<div onClick="function noop() {}" />'
-			);
-
-			function Foo(props) {
-				return props.foo;
-			}
-
-			expect(serializeVNode(<Foo foo={[1, 2, 3]} />)).to.equal(
-				'<Foo foo="1,2,3" />'
-			);
-
-			expect(serializeVNode(<div prop={Object.create(null)} />)).to.equal(
-				'<div prop="[object Object]" />'
-			);
 		});
 	});
 

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -1,21 +1,16 @@
-import {
-	createElement as h,
-	render,
-	createRef,
-	Component,
-	Fragment
-} from 'preact';
+import { createElement, render, createRef, Component, Fragment } from 'preact';
 import {
 	setupScratch,
 	teardown,
 	serializeHtml
 } from '../../../test/_util/helpers';
-import { serializeVNode, initDebug } from '../../src/debug';
+import { serializeVNode, initDebug } from '../../src/debug'; // TODO: Can we somehow convert this? Perhaps move seralizeVNode tests into their own file?
 import * as PropTypes from 'prop-types';
 
 initDebug();
 
-/** @jsx h */
+const h = createElement;
+/** @jsx createElement */
 
 describe('debug', () => {
 	let scratch;

--- a/debug/test/browser/options-debug.test.js
+++ b/debug/test/browser/options-debug.test.js
@@ -10,7 +10,7 @@ import {
 import { createElement, render, Component } from 'preact';
 import { useState } from 'preact/hooks';
 import { setupRerender } from 'preact/test-utils';
-import { initDebug } from '../../src/debug';
+import 'preact/debug';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
 /** @jsx createElement */
@@ -24,10 +24,6 @@ describe('debug options', () => {
 
 	/** @type {(count: number) => void} */
 	let setCount;
-
-	before(() => {
-		initDebug();
-	});
 
 	beforeEach(() => {
 		scratch = setupScratch();

--- a/debug/test/browser/options-devtools.test.js
+++ b/debug/test/browser/options-devtools.test.js
@@ -9,7 +9,7 @@ import {
 import { createElement, render, Component } from 'preact';
 import { useState } from 'preact/hooks';
 import { setupRerender } from 'preact/test-utils';
-import { initDebug } from '../../src/debug';
+import { initDevTools } from '../../src/devtools';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
 /** @jsx createElement */
@@ -25,7 +25,7 @@ describe('devtools options', () => {
 	let setCount;
 
 	before(() => {
-		initDebug();
+		initDevTools();
 	});
 
 	beforeEach(() => {

--- a/debug/test/browser/serializeVNode.test.js
+++ b/debug/test/browser/serializeVNode.test.js
@@ -1,0 +1,62 @@
+import { createElement, Component } from 'preact';
+import { serializeVNode } from '../../src/debug';
+
+/** @jsx createElement */
+
+describe('serializeVNode', () => {
+	it("should prefer a function component's displayName", () => {
+		function Foo() {
+			return <div />;
+		}
+		Foo.displayName = 'Bar';
+
+		expect(serializeVNode(<Foo />)).to.equal('<Bar />');
+	});
+
+	it("should prefer a class component's displayName", () => {
+		class Bar extends Component {
+			render() {
+				return <div />;
+			}
+		}
+		Bar.displayName = 'Foo';
+
+		expect(serializeVNode(<Bar />)).to.equal('<Foo />');
+	});
+
+	it('should serialize vnodes without children', () => {
+		expect(serializeVNode(<br />)).to.equal('<br />');
+	});
+
+	it('should serialize vnodes with children', () => {
+		expect(serializeVNode(<div>Hello World</div>)).to.equal('<div>..</div>');
+	});
+
+	it('should serialize components', () => {
+		function Foo() {
+			return <div />;
+		}
+		expect(serializeVNode(<Foo />)).to.equal('<Foo />');
+	});
+
+	it('should serialize props', () => {
+		expect(serializeVNode(<div class="foo" />)).to.equal('<div class="foo" />');
+
+		let noop = () => {};
+		expect(serializeVNode(<div onClick={noop} />)).to.equal(
+			'<div onClick="function noop() {}" />'
+		);
+
+		function Foo(props) {
+			return props.foo;
+		}
+
+		expect(serializeVNode(<Foo foo={[1, 2, 3]} />)).to.equal(
+			'<Foo foo="1,2,3" />'
+		);
+
+		expect(serializeVNode(<div prop={Object.create(null)} />)).to.equal(
+			'<div prop="[object Object]" />'
+		);
+	});
+});

--- a/hooks/test/browser/combinations.test.js
+++ b/hooks/test/browser/combinations.test.js
@@ -1,5 +1,5 @@
 import { setupRerender, act } from 'preact/test-utils';
-import { createElement as h, render, Component } from 'preact';
+import { createElement, render, Component } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import {
 	useState,
@@ -7,10 +7,10 @@ import {
 	useEffect,
 	useLayoutEffect,
 	useRef
-} from '../../src';
+} from 'preact/hooks';
 import { scheduleEffectAssert } from '../_util/useEffectUtil';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('combinations', () => {
 	/** @type {HTMLDivElement} */

--- a/hooks/test/browser/options-hooks.test.js
+++ b/hooks/test/browser/options-hooks.test.js
@@ -7,7 +7,7 @@ import {
 import { setupRerender } from 'preact/test-utils';
 import { createElement, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { useState } from '../../src';
+import { useState } from 'preact/hooks';
 
 /** @jsx createElement */
 

--- a/hooks/test/browser/useCallback.test.js
+++ b/hooks/test/browser/useCallback.test.js
@@ -1,8 +1,8 @@
-import { createElement as h, render } from 'preact';
+import { createElement, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { useCallback } from '../../src';
+import { useCallback } from 'preact/hooks';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('useCallback', () => {
 	/** @type {HTMLDivElement} */

--- a/hooks/test/browser/useContext.test.js
+++ b/hooks/test/browser/useContext.test.js
@@ -1,9 +1,9 @@
-import { h, render, createContext, Component } from 'preact';
+import { createElement, render, createContext, Component } from 'preact';
 import { act } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { useContext, useEffect, useState } from '../../src';
+import { useContext, useEffect, useState } from 'preact/hooks';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('useContext', () => {
 	/** @type {HTMLDivElement} */

--- a/hooks/test/browser/useDebugValue.test.js
+++ b/hooks/test/browser/useDebugValue.test.js
@@ -1,8 +1,8 @@
-import { h, render, options } from 'preact';
+import { createElement, render, options } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { useDebugValue, useState } from '../../src';
+import { useDebugValue, useState } from 'preact/hooks';
 
-/** @jsx h */
+/** @jsx createElement*/
 
 describe('useDebugValue', () => {
 	/** @type {HTMLDivElement} */

--- a/hooks/test/browser/useEffect.test.js
+++ b/hooks/test/browser/useEffect.test.js
@@ -1,11 +1,11 @@
 import { act } from 'preact/test-utils';
-import { createElement as h, render } from 'preact';
+import { createElement, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { useEffect } from '../../src';
+import { useEffect } from 'preact/hooks';
 import { useEffectAssertions } from './useEffectAssertions.test';
 import { scheduleEffectAssert } from '../_util/useEffectUtil';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('useEffect', () => {
 	/** @type {HTMLDivElement} */

--- a/hooks/test/browser/useEffectAssertions.test.js
+++ b/hooks/test/browser/useEffectAssertions.test.js
@@ -1,8 +1,8 @@
 import { setupRerender } from 'preact/test-utils';
-import { createElement as h, render } from 'preact';
+import { createElement, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
-/** @jsx h */
+/** @jsx createElement */
 
 // Common behaviors between all effect hooks
 export function useEffectAssertions(useEffect, scheduleEffectAssert) {

--- a/hooks/test/browser/useImperativeHandle.test.js
+++ b/hooks/test/browser/useImperativeHandle.test.js
@@ -1,9 +1,9 @@
-import { createElement as h, render } from 'preact';
+import { createElement, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { useImperativeHandle, useRef, useState } from '../../src';
+import { useImperativeHandle, useRef, useState } from 'preact/hooks';
 import { setupRerender } from '../../../test-utils';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('useImperativeHandle', () => {
 	/** @type {HTMLDivElement} */

--- a/hooks/test/browser/useLayoutEffect.test.js
+++ b/hooks/test/browser/useLayoutEffect.test.js
@@ -1,10 +1,10 @@
 import { act } from 'preact/test-utils';
-import { createElement as h, render, Fragment } from 'preact';
+import { createElement, render, Fragment } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useEffectAssertions } from './useEffectAssertions.test';
-import { useLayoutEffect, useRef, useState } from '../../src';
+import { useLayoutEffect, useRef, useState } from 'preact/hooks';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('useLayoutEffect', () => {
 	/** @type {HTMLDivElement} */

--- a/hooks/test/browser/useMemo.test.js
+++ b/hooks/test/browser/useMemo.test.js
@@ -1,8 +1,8 @@
-import { createElement as h, render } from 'preact';
+import { createElement, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { useMemo } from '../../src';
+import { useMemo } from 'preact/hooks';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('useMemo', () => {
 	/** @type {HTMLDivElement} */

--- a/hooks/test/browser/useReducer.test.js
+++ b/hooks/test/browser/useReducer.test.js
@@ -1,9 +1,9 @@
 import { setupRerender } from 'preact/test-utils';
-import { createElement as h, render } from 'preact';
+import { createElement, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { useReducer } from '../../src';
+import { useReducer } from 'preact/hooks';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('useReducer', () => {
 	/** @type {HTMLDivElement} */

--- a/hooks/test/browser/useRef.test.js
+++ b/hooks/test/browser/useRef.test.js
@@ -1,8 +1,8 @@
-import { createElement as h, render } from 'preact';
+import { createElement, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { useRef } from '../../src';
+import { useRef } from 'preact/hooks';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('useRef', () => {
 	/** @type {HTMLDivElement} */

--- a/hooks/test/browser/useState.test.js
+++ b/hooks/test/browser/useState.test.js
@@ -1,9 +1,9 @@
 import { setupRerender } from 'preact/test-utils';
-import { createElement as h, render } from 'preact';
+import { createElement, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { useState } from '../../src';
+import { useState } from 'preact/hooks';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('useState', () => {
 	/** @type {HTMLDivElement} */

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"baseUrl": ".",
+		"checkJs": true,
+		"jsx": "react",
+		"lib": ["dom", "es5"],
+		"moduleResolution": "node",
+		"paths": {
+			"preact": ["."],
+			"preact/*": ["./*"]
+		},
+		"reactNamespace": "createElement",
+		"target": "es5"
+	},
+	"exclude": ["node_modules", "dist", "demo"]
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -172,6 +172,7 @@ module.exports = function(config) {
 				// rather than referencing source files inside the module
 				// directly
 				alias: {
+					'preact/debug': path.join(__dirname, './debug/src'),
 					'preact/compat': path.join(__dirname, './compat/src'),
 					'preact/hooks': path.join(__dirname, './hooks/src'),
 					'preact/test-utils': path.join(__dirname, './test-utils/src'),

--- a/package.json
+++ b/package.json
@@ -56,6 +56,13 @@
           ]
         }
       ],
+      "no-unused-vars": [
+        2,
+        {
+          "args": "none",
+          "varsIgnorePattern": "^h|React$"
+        }
+      ],
       "prefer-rest-params": 0,
       "prefer-spread": 0,
       "no-cond-assign": 0,

--- a/test-utils/test/shared/act.test.js
+++ b/test-utils/test/shared/act.test.js
@@ -1,8 +1,9 @@
-import { options, createElement as h, render } from 'preact';
+import { options, createElement, render } from 'preact';
 import { useEffect, useReducer, useState } from 'preact/hooks';
-
+import { act } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { act } from '../../src';
+
+/** @jsx createElement */
 
 // IE11 doesn't support `new Event()`
 function createEvent(name) {
@@ -13,7 +14,6 @@ function createEvent(name) {
 	return event;
 }
 
-/** @jsx h */
 describe('act', () => {
 	/** @type {HTMLDivElement} */
 	let scratch;

--- a/test-utils/test/shared/teardown.test.js
+++ b/test-utils/test/shared/teardown.test.js
@@ -1,22 +1,16 @@
-const { options } = require('preact');
-const { teardown } = require('../../src');
-const { setupScratch } = require('../../../test/_util/helpers');
+import { options } from 'preact';
+import { teardown } from 'preact/test-utils';
 
 describe('teardown', () => {
-	let scratch;
-	beforeEach(() => {
-		scratch = setupScratch();
-	});
-
 	it('should restore debounce', () => {
-		teardown(scratch);
+		teardown();
 		expect(options.__test__previousDebounce).to.be.undefined;
 	});
 
 	it('should flush the queue', () => {
 		const spy = sinon.spy();
 		options.__test__drainQueue = spy;
-		teardown(scratch);
+		teardown();
 		expect(spy).to.be.calledOnce;
 	});
 });

--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -1,9 +1,9 @@
-import { createElement as h, options } from '../../src';
+import { createElement, options } from 'preact';
 import { assign } from '../../src/util';
 import { clearLog, getLog } from './logCall';
 import { teardown as testUtilTeardown } from 'preact/test-utils';
 
-/** @jsx h */
+/** @jsx createElement */
 
 export function supportsPassiveEvents() {
 	let supported = false;

--- a/test/_util/optionSpies.js
+++ b/test/_util/optionSpies.js
@@ -1,6 +1,6 @@
 import { options as rawOptions } from 'preact';
 
-/** @type {import('../../src/internal').Options} */
+/** @type {import('preact/src/internal').Options} */
 let options = rawOptions;
 
 let oldVNode = options.vnode;

--- a/test/browser/cloneElement.test.js
+++ b/test/browser/cloneElement.test.js
@@ -1,4 +1,4 @@
-import { createElement, cloneElement } from '../../src/index';
+import { createElement, cloneElement } from 'preact';
 
 /** @jsx createElement */
 

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -1,9 +1,4 @@
-import {
-	createElement as h,
-	render,
-	Component,
-	Fragment
-} from '../../src/index';
+import { createElement, render, Component, Fragment } from 'preact';
 import { setupRerender } from 'preact/test-utils';
 import {
 	setupScratch,
@@ -14,7 +9,8 @@ import {
 } from '../_util/helpers';
 import { div, span, p } from '../_util/dom';
 
-/** @jsx h */
+/** @jsx createElement */
+const h = createElement;
 
 let spyAll = obj => Object.keys(obj).forEach(key => sinon.spy(obj, key));
 
@@ -571,6 +567,7 @@ describe('Components', () => {
 
 	// Test for Issue preactjs/preact#176
 	it('should remove children when root changes to text node', () => {
+		/** @type {import('preact').Component} */
 		let comp;
 
 		class Comp extends Component {

--- a/test/browser/context.test.js
+++ b/test/browser/context.test.js
@@ -1,12 +1,7 @@
-import {
-	createElement as h,
-	render,
-	Component,
-	Fragment
-} from '../../src/index';
+import { createElement, render, Component, Fragment } from 'preact';
 import { setupScratch, teardown } from '../_util/helpers';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('context', () => {
 	let scratch;

--- a/test/browser/createContext.test.js
+++ b/test/browser/createContext.test.js
@@ -1,15 +1,15 @@
 import { setupRerender, act } from 'preact/test-utils';
 import {
-	createElement as h,
+	createElement,
 	render,
 	Component,
-	createContext
+	createContext,
+	Fragment
 } from '../../src/index';
+import { i as ctxId } from '../../src/create-context'; // TODO: Rewrite tests to remove this internal dependency
 import { setupScratch, teardown } from '../_util/helpers';
-import { Fragment } from '../../src';
-import { i as ctxId } from '../../src/create-context';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('createContext', () => {
 	let scratch;

--- a/test/browser/createElementProduction.test.js
+++ b/test/browser/createElementProduction.test.js
@@ -1,4 +1,4 @@
-import { h } from '../../dist/preact';
+import { h } from 'preact';
 
 describe('createElement production build', () => {
 	it('should produce a correct structure', () => {

--- a/test/browser/focus.test.js
+++ b/test/browser/focus.test.js
@@ -1,16 +1,11 @@
 import { setupRerender } from 'preact/test-utils';
-import {
-	createElement as h,
-	render,
-	Component,
-	Fragment,
-	hydrate
-} from '../../src/index';
+import { createElement, render, Component, Fragment, hydrate } from 'preact';
 import { setupScratch, teardown } from '../_util/helpers';
 import { div, span, input as inputStr, h1, h2 } from '../_util/dom';
+
+/** @jsx createElement */
 /* eslint-disable react/jsx-boolean-value */
 
-/** @jsx h */
 describe('focus', () => {
 	/** @type {HTMLDivElement} */
 	let scratch;

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -1,15 +1,10 @@
 import { setupRerender } from 'preact/test-utils';
-import {
-	createElement as h,
-	render,
-	Component,
-	Fragment
-} from '../../src/index';
+import { createElement, render, Component, Fragment } from 'preact';
 import { setupScratch, teardown } from '../_util/helpers';
 import { span, div, ul, ol, li, section } from '../_util/dom';
 import { logCall, clearLog, getLog } from '../_util/logCall';
 
-/** @jsx h */
+/** @jsx createElement */
 /* eslint-disable react/jsx-boolean-value */
 
 describe('Fragment', () => {

--- a/test/browser/getDomSibling.test.js
+++ b/test/browser/getDomSibling.test.js
@@ -1,8 +1,8 @@
-import { h, render, Fragment } from '../../src/index';
+import { createElement, render, Fragment } from 'preact';
 import { getDomSibling } from '../../src/component';
 import { setupScratch, teardown } from '../_util/helpers';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('getDomSibling', () => {
 	/** @type {import('../../src/internal').PreactElement} */

--- a/test/browser/getDomSibling.test.js
+++ b/test/browser/getDomSibling.test.js
@@ -1,5 +1,5 @@
-import { createElement, render, Fragment } from 'preact';
-import { getDomSibling } from '../../src/component'; // TODO: Hmmmm won't work with minified builds...
+import { createElement, render, Fragment } from '../../src/';
+import { getDomSibling } from '../../src/component';
 import { setupScratch, teardown } from '../_util/helpers';
 
 /** @jsx createElement */

--- a/test/browser/getDomSibling.test.js
+++ b/test/browser/getDomSibling.test.js
@@ -1,5 +1,5 @@
 import { createElement, render, Fragment } from 'preact';
-import { getDomSibling } from '../../src/component';
+import { getDomSibling } from '../../src/component'; // TODO: Hmmmm won't work with minified builds...
 import { setupScratch, teardown } from '../_util/helpers';
 
 /** @jsx createElement */

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -1,4 +1,4 @@
-import { createElement, hydrate, Fragment } from '../../src/index';
+import { createElement, hydrate, Fragment } from 'preact';
 import {
 	setupScratch,
 	teardown,

--- a/test/browser/keys.test.js
+++ b/test/browser/keys.test.js
@@ -1,8 +1,8 @@
-import { createElement as h, Component, render } from '../../src/index';
+import { createElement, Component, render } from '../../src/index';
 import { setupScratch, teardown } from '../_util/helpers';
 import { logCall, clearLog, getLog } from '../_util/logCall';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('keys', () => {
 	/** @type {HTMLDivElement} */

--- a/test/browser/keys.test.js
+++ b/test/browser/keys.test.js
@@ -1,4 +1,4 @@
-import { createElement, Component, render } from '../../src/index';
+import { createElement, Component, render } from 'preact';
 import { setupScratch, teardown } from '../_util/helpers';
 import { logCall, clearLog, getLog } from '../_util/logCall';
 
@@ -466,16 +466,22 @@ describe('keys', () => {
 			return moved ? (
 				<div>
 					<div>1</div>
-					<Stateful2 key="b" ref={c => c ? Stateful2MovedRef = c : undefined} />
+					<Stateful2
+						key="b"
+						ref={c => (c ? (Stateful2MovedRef = c) : undefined)}
+					/>
 					<div>2</div>
-					<Stateful1 key="a" ref={c => c ? Stateful1MovedRef = c : undefined} />
+					<Stateful1
+						key="a"
+						ref={c => (c ? (Stateful1MovedRef = c) : undefined)}
+					/>
 				</div>
 			) : (
 				<div>
 					<div>1</div>
-					<Stateful1 key="a" ref={c => c ? Stateful1Ref = c : undefined} />
+					<Stateful1 key="a" ref={c => (c ? (Stateful1Ref = c) : undefined)} />
 					<div>2</div>
-					<Stateful2 key="b" ref={c => c ? Stateful2Ref = c : undefined} />
+					<Stateful2 key="b" ref={c => (c ? (Stateful2Ref = c) : undefined)} />
 				</div>
 			);
 		}

--- a/test/browser/lifecycles/componentDidCatch.test.js
+++ b/test/browser/lifecycles/componentDidCatch.test.js
@@ -1,5 +1,5 @@
 import { setupRerender } from 'preact/test-utils';
-import { createElement, render, Component, Fragment } from '../../../src/index';
+import { createElement, render, Component, Fragment } from 'preact';
 import {
 	setupScratch,
 	teardown,

--- a/test/browser/lifecycles/componentDidMount.test.js
+++ b/test/browser/lifecycles/componentDidMount.test.js
@@ -1,4 +1,4 @@
-import { createElement, render, Component } from '../../../src/index';
+import { createElement, render, Component } from 'preact';
 import { setupScratch, teardown } from '../../_util/helpers';
 
 /** @jsx createElement */

--- a/test/browser/lifecycles/componentDidUpdate.test.js
+++ b/test/browser/lifecycles/componentDidUpdate.test.js
@@ -1,5 +1,5 @@
 import { setupRerender } from 'preact/test-utils';
-import { createElement, render, Component } from '../../../src/index';
+import { createElement, render, Component } from 'preact';
 import { setupScratch, teardown } from '../../_util/helpers';
 
 /** @jsx createElement */

--- a/test/browser/lifecycles/componentWillMount.test.js
+++ b/test/browser/lifecycles/componentWillMount.test.js
@@ -1,4 +1,4 @@
-import { createElement, render, Component } from '../../../src/index';
+import { createElement, render, Component } from 'preact';
 import { setupScratch, teardown } from '../../_util/helpers';
 
 /** @jsx createElement */

--- a/test/browser/lifecycles/componentWillReceiveProps.test.js
+++ b/test/browser/lifecycles/componentWillReceiveProps.test.js
@@ -1,5 +1,5 @@
 import { setupRerender } from 'preact/test-utils';
-import { createElement, render, Component } from '../../../src/index';
+import { createElement, render, Component } from 'preact';
 import { setupScratch, teardown } from '../../_util/helpers';
 
 /** @jsx createElement */

--- a/test/browser/lifecycles/componentWillUnmount.test.js
+++ b/test/browser/lifecycles/componentWillUnmount.test.js
@@ -1,4 +1,4 @@
-import { createElement, render, Component } from '../../../src/index';
+import { createElement, render, Component } from 'preact';
 import { setupScratch, teardown, spyAll } from '../../_util/helpers';
 
 /** @jsx createElement */

--- a/test/browser/lifecycles/componentWillUpdate.test.js
+++ b/test/browser/lifecycles/componentWillUpdate.test.js
@@ -1,5 +1,5 @@
 import { setupRerender } from 'preact/test-utils';
-import { createElement, render, Component } from '../../../src/index';
+import { createElement, render, Component } from 'preact';
 import { setupScratch, teardown } from '../../_util/helpers';
 
 /** @jsx createElement */

--- a/test/browser/lifecycles/getDerivedStateFromError.test.js
+++ b/test/browser/lifecycles/getDerivedStateFromError.test.js
@@ -1,5 +1,5 @@
 import { setupRerender } from 'preact/test-utils';
-import { createElement, render, Component } from '../../../src/index';
+import { createElement, render, Component } from 'preact';
 import {
 	setupScratch,
 	teardown,

--- a/test/browser/lifecycles/getDerivedStateFromProps.test.js
+++ b/test/browser/lifecycles/getDerivedStateFromProps.test.js
@@ -1,5 +1,5 @@
 import { setupRerender } from 'preact/test-utils';
-import { createElement, render, Component } from '../../../src/index';
+import { createElement, render, Component } from 'preact';
 import { setupScratch, teardown } from '../../_util/helpers';
 
 /** @jsx createElement */

--- a/test/browser/lifecycles/getSnapshotBeforeUpdate.test.js
+++ b/test/browser/lifecycles/getSnapshotBeforeUpdate.test.js
@@ -1,5 +1,5 @@
 import { setupRerender } from 'preact/test-utils';
-import { createElement, render, Component } from '../../../src/index';
+import { createElement, render, Component } from 'preact';
 import { setupScratch, teardown } from '../../_util/helpers';
 
 /** @jsx createElement */

--- a/test/browser/lifecycles/lifecycle.test.js
+++ b/test/browser/lifecycles/lifecycle.test.js
@@ -1,8 +1,8 @@
 import { setupRerender } from 'preact/test-utils';
-import { createElement as h, render, Component } from '../../../src/index';
+import { createElement, render, Component } from 'preact';
 import { setupScratch, teardown, spyAll } from '../../_util/helpers';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('Lifecycle methods', () => {
 	/** @type {HTMLDivElement} */

--- a/test/browser/lifecycles/shouldComponentUpdate.test.js
+++ b/test/browser/lifecycles/shouldComponentUpdate.test.js
@@ -1,5 +1,5 @@
 import { setupRerender } from 'preact/test-utils';
-import { createElement, render, Component, Fragment } from '../../../src/index';
+import { createElement, render, Component, Fragment } from 'preact';
 import { setupScratch, teardown } from '../../_util/helpers';
 
 /** @jsx createElement */

--- a/test/browser/performance.test.js
+++ b/test/browser/performance.test.js
@@ -1,8 +1,11 @@
 /*global coverage, ENABLE_PERFORMANCE, NODE_ENV*/
 /*eslint no-console:0*/
-/** @jsx createElement */
+/** @jsx h */
 import { setupScratch, teardown } from '../_util/helpers';
-import { createElement, Component, render, hydrate } from 'preact';
+let { createElement: h, Component, render, hydrate } = require(NODE_ENV ===
+	'production'
+	? '../../dist/preact.min.js'
+	: '../../dist/preact');
 
 const MULTIPLIER = ENABLE_PERFORMANCE ? (coverage ? 5 : 1) : 999999;
 

--- a/test/browser/performance.test.js
+++ b/test/browser/performance.test.js
@@ -1,11 +1,8 @@
 /*global coverage, ENABLE_PERFORMANCE, NODE_ENV*/
 /*eslint no-console:0*/
-/** @jsx h */
+/** @jsx createElement */
 import { setupScratch, teardown } from '../_util/helpers';
-let { createElement: h, Component, render, hydrate } = require(NODE_ENV ===
-	'production'
-	? '../../dist/preact.min.js'
-	: '../../dist/preact');
+import { createElement, Component, render, hydrate } from 'preact';
 
 const MULTIPLIER = ENABLE_PERFORMANCE ? (coverage ? 5 : 1) : 999999;
 

--- a/test/browser/refs.test.js
+++ b/test/browser/refs.test.js
@@ -1,13 +1,8 @@
 import { setupRerender } from 'preact/test-utils';
-import {
-	createElement as h,
-	render,
-	Component,
-	createRef
-} from '../../src/index';
+import { createElement, render, Component, createRef } from 'preact';
 import { setupScratch, teardown } from '../_util/helpers';
 
-/** @jsx h */
+/** @jsx createElement */
 
 // gives call count and argument errors names (otherwise sinon just uses "spy"):
 let spy = (name, ...args) => {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1,7 +1,7 @@
 /* global DISABLE_FLAKEY */
 
 import { setupRerender } from 'preact/test-utils';
-import { createElement as h, render, Component } from '../../src/index';
+import { createElement, render, Component, options } from 'preact';
 import {
 	setupScratch,
 	teardown,
@@ -13,9 +13,8 @@ import {
 	supportsDataList
 } from '../_util/helpers';
 import { clearLog, getLog, logCall } from '../_util/logCall';
-import options from '../../src/options';
 
-/** @jsx h */
+/** @jsx createElement */
 
 function getAttributes(node) {
 	let attrs = {};

--- a/test/browser/select.test.js
+++ b/test/browser/select.test.js
@@ -1,7 +1,7 @@
-import { createElement as h, render } from '../../src/index';
+import { createElement, render } from 'preact';
 import { setupScratch, teardown } from '../_util/helpers';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('Select', () => {
 	let scratch;

--- a/test/browser/spec.test.js
+++ b/test/browser/spec.test.js
@@ -1,8 +1,8 @@
 import { setupRerender } from 'preact/test-utils';
-import { createElement as h, render, Component } from '../../src/index';
+import { createElement, render, Component } from 'preact';
 import { setupScratch, teardown } from '../_util/helpers';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('Component spec', () => {
 	let scratch, rerender;

--- a/test/browser/svg.test.js
+++ b/test/browser/svg.test.js
@@ -1,7 +1,7 @@
-import { createElement as h, render } from '../../src/index';
+import { createElement, render } from 'preact';
 import { setupScratch, teardown, sortAttributes } from '../_util/helpers';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('svg', () => {
 	let scratch;

--- a/test/browser/toChildArray.test.js
+++ b/test/browser/toChildArray.test.js
@@ -1,4 +1,4 @@
-import { createElement, render, toChildArray } from '../../src/index';
+import { createElement, render, toChildArray } from 'preact';
 import {
 	setupScratch,
 	teardown,

--- a/test/node/index.test.js
+++ b/test/node/index.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import * as preact from '../../src/index';
+import * as preact from 'preact';
 
 describe('build artifact', () => {
 	// #1075 Check that the build artifact has the correct exports

--- a/test/node/index.test.js
+++ b/test/node/index.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import * as preact from 'preact';
+import * as preact from '../../';
 
 describe('build artifact', () => {
 	// #1075 Check that the build artifact has the correct exports

--- a/test/shared/createContext.test.js
+++ b/test/shared/createContext.test.js
@@ -1,10 +1,8 @@
-import { createElement as h, createContext } from '../../src/index';
-// import { VNode } from '../../src/vnode';
+import { createElement, createContext } from 'preact';
 import { expect } from 'chai';
 
-/*eslint-env browser, mocha */
-
-/** @jsx h */
+/** @jsx createElement */
+/* eslint-env browser, mocha */
 
 describe('createContext', () => {
 	it('should return a Provider and a Consumer', () => {

--- a/test/shared/createContext.test.js
+++ b/test/shared/createContext.test.js
@@ -1,4 +1,4 @@
-import { createElement, createContext } from 'preact';
+import { createElement, createContext } from '../../';
 import { expect } from 'chai';
 
 /** @jsx createElement */

--- a/test/shared/createElement.test.js
+++ b/test/shared/createElement.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'preact';
+import { createElement } from '../../';
 import { expect } from 'chai';
 
 const h = createElement;

--- a/test/shared/createElement.test.js
+++ b/test/shared/createElement.test.js
@@ -1,10 +1,9 @@
-import { createElement as h } from '../../src/index';
-// import { VNode } from '../../src/vnode';
+import { createElement } from 'preact';
 import { expect } from 'chai';
 
+const h = createElement;
+/** @jsx createElement */
 /*eslint-env browser, mocha */
-
-/** @jsx h */
 
 // const buildVNode = (nodeName, attributes, children=[]) => ({
 // 	nodeName,

--- a/test/shared/exports.test.js
+++ b/test/shared/exports.test.js
@@ -8,7 +8,7 @@ import {
 	hydrate,
 	cloneElement,
 	options
-} from 'preact';
+} from '../../';
 import { expect } from 'chai';
 
 describe('preact', () => {

--- a/test/shared/exports.test.js
+++ b/test/shared/exports.test.js
@@ -8,7 +8,7 @@ import {
 	hydrate,
 	cloneElement,
 	options
-} from '../../src/index';
+} from 'preact';
 import { expect } from 'chai';
 
 describe('preact', () => {

--- a/test/shared/isValidElement.test.js
+++ b/test/shared/isValidElement.test.js
@@ -1,4 +1,4 @@
-import { createElement, isValidElement, Component } from '../../';
+import { createElement, isValidElement, Component } from '../../src/';
 import { expect } from 'chai';
 
 /** @jsx createElement */

--- a/test/shared/isValidElement.test.js
+++ b/test/shared/isValidElement.test.js
@@ -1,7 +1,7 @@
-import { h, isValidElement, Component } from '../../src/index';
+import { createElement, isValidElement, Component } from 'preact';
 import { expect } from 'chai';
 
-/** @jsx h */
+/** @jsx createElement */
 
 describe('isValidElement', () => {
 	it('should check if the argument is a valid vnode', () => {

--- a/test/shared/isValidElement.test.js
+++ b/test/shared/isValidElement.test.js
@@ -1,4 +1,4 @@
-import { createElement, isValidElement, Component } from 'preact';
+import { createElement, isValidElement, Component } from '../../';
 import { expect } from 'chai';
 
 /** @jsx createElement */

--- a/test/ts/Component-test.tsx
+++ b/test/ts/Component-test.tsx
@@ -1,11 +1,11 @@
-import "mocha";
-import { expect } from "chai";
+import 'mocha';
+import { expect } from 'chai';
 import {
 	createElement,
 	Component,
 	RenderableProps,
 	Fragment
-} from "../../src/";
+} from '../../src/';
 
 export class ContextComponent extends Component<{ foo: string }> {
 	getChildContext() {
@@ -91,18 +91,21 @@ class RandomChildrenComponent extends Component<RandomChildrenComponentProps> {
 			return val;
 		}
 		if (span) {
-			return <span>hi</span>
+			return <span>hi</span>;
 		}
 		return null;
 	}
 }
 
 class StaticComponent extends Component<SimpleComponentProps, SimpleState> {
-	static getDerivedStateFromProps(props: SimpleComponentProps, state: SimpleState): Partial<SimpleState> {
+	static getDerivedStateFromProps(
+		props: SimpleComponentProps,
+		state: SimpleState
+	): Partial<SimpleState> {
 		return {
 			...props,
 			...state
-		}
+		};
 	}
 
 	static getDerivedStateFromError(err: Error) {
@@ -121,33 +124,33 @@ function MapperItem(props: { foo: number }) {
 }
 
 function Mapper() {
-	return [1, 2, 3].map(x => <MapperItem foo={x} key={x}/>)
+	return [1, 2, 3].map(x => <MapperItem foo={x} key={x} />);
 }
 
-describe("Component", () => {
-	const component = new SimpleComponent({ initialName: "da name" });
+describe('Component', () => {
+	const component = new SimpleComponent({ initialName: 'da name' });
 
-	it("has state", () => {
-		expect(component.state.name).to.eq("da name");
+	it('has state', () => {
+		expect(component.state.name).to.eq('da name');
 	});
 
-	it("has props", () => {
-		expect(component.props.initialName).to.eq("da name");
+	it('has props', () => {
+		expect(component.props.initialName).to.eq('da name');
 	});
 
-	it("has no base when not mounted", () => {
+	it('has no base when not mounted', () => {
 		expect(component.base).to.not.exist;
 	});
 
-	describe("setState", () => {
+	describe('setState', () => {
 		// No need to execute these tests. because we only need to check if
 		// the types are working. Executing them would require the DOM.
 		// TODO: Run TS tests in our standard karma setup
-		it.skip("can be used with an object", () => {
-			component.setState({ name: "another name" });
+		it.skip('can be used with an object', () => {
+			component.setState({ name: 'another name' });
 		});
 
-		it.skip("can be used with a function", () => {
+		it.skip('can be used with a function', () => {
 			const updater = (state: any, props: any) => ({
 				name: `${state.name} - ${props.initialName}`
 			});
@@ -155,8 +158,8 @@ describe("Component", () => {
 		});
 	});
 
-	describe("render", () => {
-		it("can return null", () => {
+	describe('render', () => {
+		it('can return null', () => {
 			const comp = new SimpleComponent({ initialName: null });
 			const actual = comp.render();
 
@@ -164,12 +167,14 @@ describe("Component", () => {
 		});
 	});
 
-	describe("Fragment", () => {
+	describe('Fragment', () => {
 		it('should render nested Fragments', () => {
-			var vnode = <Fragment>
+			var vnode = (
+				<Fragment>
 					<Fragment>foo</Fragment>
 					bar
 				</Fragment>
+			);
 
 			expect(vnode.type).to.be.equal(Fragment);
 		});

--- a/test/ts/VNode-test.tsx
+++ b/test/ts/VNode-test.tsx
@@ -1,5 +1,5 @@
-import "mocha";
-import { expect } from "chai";
+import 'mocha';
+import { expect } from 'chai';
 import {
 	createElement,
 	Component,
@@ -9,25 +9,21 @@ import {
 	ComponentFactory,
 	VNode,
 	ComponentChildren
-} from "../../src";
+} from '../../src';
 
 function getDisplayType(vnode: VNode | string | number) {
 	if (typeof vnode === 'string' || typeof vnode == 'number') {
 		return vnode.toString();
-	}
-	else if (typeof vnode.type == 'string') {
+	} else if (typeof vnode.type == 'string') {
 		return vnode.type;
-	}
-	else {
+	} else {
 		return vnode.type.displayName;
 	}
 }
 
 class SimpleComponent extends Component<{}, {}> {
 	render() {
-		return (
-			<div>{this.props.children}</div>
-		);
+		return <div>{this.props.children}</div>;
 	}
 }
 
@@ -36,34 +32,32 @@ const SimpleFunctionalComponent = () => <div />;
 const a: ComponentFactory = SimpleComponent;
 const b: ComponentFactory = SimpleFunctionalComponent;
 
-describe("VNode TS types", () => {
-	it("is returned by h", () => {
-		const actual = <div className="wow"/>;
-		expect(actual).to.include.all.keys(
-			"type", "props", "key"
-		);
+describe('VNode TS types', () => {
+	it('is returned by h', () => {
+		const actual = <div className="wow" />;
+		expect(actual).to.include.all.keys('type', 'props', 'key');
 	});
 
-	it("has a nodeName of string when html element", () => {
+	it('has a nodeName of string when html element', () => {
 		const div = <div>Hi!</div>;
-		expect(div.type).to.equal("div");
+		expect(div.type).to.equal('div');
 	});
 
-	it("has a nodeName equal to the construction function when SFC", () => {
+	it('has a nodeName equal to the construction function when SFC', () => {
 		const sfc = <SimpleFunctionalComponent />;
 		expect(sfc.type).to.be.instanceOf(Function);
 		const constructor = sfc.type as FunctionalComponent<any>;
-		expect(constructor.name).to.eq("SimpleFunctionalComponent");
+		expect(constructor.name).to.eq('SimpleFunctionalComponent');
 	});
 
-	it("has a nodeName equal to the constructor of a component", () => {
+	it('has a nodeName equal to the constructor of a component', () => {
 		const sfc = <SimpleComponent />;
 		expect(sfc.type).to.be.instanceOf(Function);
 		const constructor = sfc.type as ComponentConstructor<any>;
-		expect(constructor.name).to.eq("SimpleComponent");
+		expect(constructor.name).to.eq('SimpleComponent');
 	});
 
-	it("has children which is an array of string or other vnodes", () => {
+	it('has children which is an array of string or other vnodes', () => {
 		const comp = (
 			<SimpleComponent>
 				<SimpleComponent>child1</SimpleComponent>
@@ -72,21 +66,17 @@ describe("VNode TS types", () => {
 		);
 
 		expect(comp.props.children).to.be.instanceOf(Array);
-		expect(comp.props.children[1]).to.be.a("string");
+		expect(comp.props.children[1]).to.be.a('string');
 	});
 
-	it("children type should work with toChildArray", () => {
-		const comp: VNode = (
-			<SimpleComponent>
-				child1 {1}
-			</SimpleComponent>
-		);
+	it('children type should work with toChildArray', () => {
+		const comp: VNode = <SimpleComponent>child1 {1}</SimpleComponent>;
 
 		const children = toChildArray(comp.props.children);
 		expect(children).to.have.lengthOf(2);
 	});
 
-	it("toChildArray should filter out some types", () => {
+	it('toChildArray should filter out some types', () => {
 		const compChild = <SimpleComponent />;
 		const comp: VNode = (
 			<SimpleComponent>
@@ -95,20 +85,20 @@ describe("VNode TS types", () => {
 				{false}
 				{2}
 				{undefined}
-				{["b", "c"]}
+				{['b', 'c']}
 				{compChild}
 			</SimpleComponent>
 		);
 
 		const children = toChildArray(comp.props.children);
-		expect(children).to.deep.equal(["a", 2, "b", "c", compChild]);
+		expect(children).to.deep.equal(['a', 2, 'b', 'c', compChild]);
 	});
 
-	it("functions like getDisplayType should work", () => {
+	it('functions like getDisplayType should work', () => {
 		function TestComp(props: { children?: ComponentChildren }) {
 			return <div>{props.children}</div>;
 		}
-		TestComp.displayName = "TestComp";
+		TestComp.displayName = 'TestComp';
 
 		const compChild = <TestComp />;
 		const comp: VNode = (
@@ -118,48 +108,67 @@ describe("VNode TS types", () => {
 				{false}
 				{2}
 				{undefined}
-				{["b", "c"]}
+				{['b', 'c']}
 				{compChild}
 			</SimpleComponent>
 		);
 
 		const types = toChildArray(comp.props.children).map(getDisplayType);
-		expect(types).to.deep.equal(["a", "2", "b", "c", "TestComp"]);
-	})
+		expect(types).to.deep.equal(['a', '2', 'b', 'c', 'TestComp']);
+	});
 });
 
-class ComponentWithFunctionChild extends Component<{ children: (num: number) => string; }> {
-	render() { return null; }
+class ComponentWithFunctionChild extends Component<{
+	children: (num: number) => string;
+}> {
+	render() {
+		return null;
+	}
 }
 
-<ComponentWithFunctionChild>{num => num.toFixed(2)}</ComponentWithFunctionChild>;
+<ComponentWithFunctionChild>
+	{num => num.toFixed(2)}
+</ComponentWithFunctionChild>;
 
-class ComponentWithStringChild extends Component<{ children: string; }> {
-	render() { return null; }
+class ComponentWithStringChild extends Component<{ children: string }> {
+	render() {
+		return null;
+	}
 }
 
 <ComponentWithStringChild>child</ComponentWithStringChild>;
 
-class ComponentWithNumberChild extends Component<{ children: number; }> {
-	render() { return null; }
+class ComponentWithNumberChild extends Component<{ children: number }> {
+	render() {
+		return null;
+	}
 }
 
 <ComponentWithNumberChild>{1}</ComponentWithNumberChild>;
 
-class ComponentWithBooleanChild extends Component<{ children: boolean; }> {
-	render() { return null; }
+class ComponentWithBooleanChild extends Component<{ children: boolean }> {
+	render() {
+		return null;
+	}
 }
 
 <ComponentWithBooleanChild>{false}</ComponentWithBooleanChild>;
 
-class ComponentWithNullChild extends Component<{ children: null; }> {
-	render() { return null; }
+class ComponentWithNullChild extends Component<{ children: null }> {
+	render() {
+		return null;
+	}
 }
 
 <ComponentWithNullChild>{null}</ComponentWithNullChild>;
 
-class ComponentWithNumberChildren extends Component<{ children: number[]; }> {
-	render() { return null; }
+class ComponentWithNumberChildren extends Component<{ children: number[] }> {
+	render() {
+		return null;
+	}
 }
 
-<ComponentWithNumberChildren>{1}{2}</ComponentWithNumberChildren>;
+<ComponentWithNumberChildren>
+	{1}
+	{2}
+</ComponentWithNumberChildren>;

--- a/test/ts/hoc-test.tsx
+++ b/test/ts/hoc-test.tsx
@@ -1,31 +1,29 @@
-import { expect } from "chai";
+import { expect } from 'chai';
 import {
 	createElement,
 	ComponentFactory,
 	ComponentConstructor,
 	Component
-} from "../../src";
-import {
-	SimpleComponent,
-	SimpleComponentProps
-} from "./Component-test";
+} from '../../src';
+import { SimpleComponent, SimpleComponentProps } from './Component-test';
 
 export interface highlightedProps {
 	isHighlighted: boolean;
 }
 
-export function highlighted<T>(Wrappable: ComponentFactory<T>): ComponentConstructor<T & highlightedProps> {
+export function highlighted<T>(
+	Wrappable: ComponentFactory<T>
+): ComponentConstructor<T & highlightedProps> {
 	return class extends Component<T & highlightedProps> {
-
 		constructor(props: T & highlightedProps) {
 			super(props);
 		}
 
 		render() {
-			let className = this.props.isHighlighted ? "highlighted" : "";
+			let className = this.props.isHighlighted ? 'highlighted' : '';
 			return (
 				<div className={className}>
-					<Wrappable {...this.props}/>
+					<Wrappable {...this.props} />
 				</div>
 			);
 		}
@@ -33,18 +31,20 @@ export function highlighted<T>(Wrappable: ComponentFactory<T>): ComponentConstru
 		toString() {
 			return `Highlighted ${Wrappable.name}`;
 		}
-	}
+	};
 }
 
-const HighlightedSimpleComponent = highlighted<SimpleComponentProps>(SimpleComponent);
+const HighlightedSimpleComponent = highlighted<SimpleComponentProps>(
+	SimpleComponent
+);
 
-describe("hoc", () => {
-	it("wraps the given component", () => {
+describe('hoc', () => {
+	it('wraps the given component', () => {
 		const highlight = new HighlightedSimpleComponent({
-			initialName: "initial name",
+			initialName: 'initial name',
 			isHighlighted: true
 		});
 
-		expect(highlight.toString()).to.eq("Highlighted SimpleComponent");
+		expect(highlight.toString()).to.eq('Highlighted SimpleComponent');
 	});
 });

--- a/test/ts/jsx-namespacce-test.tsx
+++ b/test/ts/jsx-namespacce-test.tsx
@@ -1,10 +1,10 @@
-import { createElement, Component } from "../../src";
+import { createElement, Component } from '../../src';
 
 // declare global JSX types that should not be mixed with preact's internal types
 declare global {
 	namespace JSX {
 		interface Element {
-			unknownProperty: string
+			unknownProperty: string;
 		}
 	}
 }

--- a/test/ts/tsconfig.json
+++ b/test/ts/tsconfig.json
@@ -3,21 +3,13 @@
 		"target": "es6",
 		"module": "es6",
 		"moduleResolution": "node",
-		"lib": [
-			"es6",
-			"dom"
-		],
+		"lib": ["es6", "dom"],
 		"strict": true,
-		"typeRoots": [
-			"../../"
-		],
+		"typeRoots": ["../../"],
 		"types": [],
 		"forceConsistentCasingInFileNames": true,
 		"jsx": "react",
 		"jsxFactory": "createElement"
 	},
-	"include": [
-		"./**/*.ts",
-		"./**/*.tsx"
-	]
+	"include": ["./**/*.ts", "./**/*.tsx"]
 }


### PR DESCRIPTION
I'd like to explore the possibility of running our test suite against our build output, so our tests more closely match what our users are doing. I think the first step to do that is to change our test imports to import the source code by name (e.g. `import {} from 'preact'`) instead of by relative path (e.g. `import {} from `../../src/'`). This PR enables us to change what our tests import in the karma config (that'll come in a later PR, assuming running tests against minified output works).

To make VSCode intellisense happy, I added a `jsconfig.json` that tells VSCode where the code for imports like `preact` and `preact/compat` live, so it can provide us guidance.

A couple other changes that fall out of trying to do this:

1. All tests now use `createElement` for JSX since the `jsconfig.json` can only specify one `reactNamespace`.
2. I separated out the `serializeVNode` tests into its own file since it has to import `serializeVNode` directly from source because `serializeVNode` isn't exported by `preact/debug`.
3. Same for `getDomSibling` - Since it is directly testing an internal method, it will have to import directly from `src`.
4. Some tests are hardcoded to use `h` so you'll see `const h = createElement;` in some test files. I tried to not modify tests directly in this PR to verify I didn't break any of them, so I did this little workaround instead.
5. I updated the `node` and `shared` tests to point to the root of the repo so they run against minified builds now! It was easy enough so I thought why not?