### PR TITLE
.d.ts: re-export FunctionComponent from preact/compat

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -31,6 +31,8 @@ declare namespace React {
 
 	// Preact Defaults
 	export import Component = preact.Component;
+	export import FunctionComponent = preact.FunctionComponent;
+	export import FC = preact.FunctionComponent;
 	export import createContext = preact.createContext;
 	export import createRef = preact.createRef;
 	export import Fragment = preact.Fragment;


### PR DESCRIPTION
to make `preact/compat` a more complete replacement of `@types/react`

------

Propose to add these aliases, to make (IMHO common) code like

```ts
const SomeComponent: React.FC<Props> = ...
```

work when we `import React from 'preact/compat'`.