### PR TITLE
#2077 update readme for preact/devtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ new webpack.DefinePlugin({
 When enabled, warnings are logged to the console when undefined components or string refs
 are detected.
 
-### Developer Tools
+### Developer Tools (v8 or earlier)
 
 If you only want to include devtool integration, without runtime error checking, you can
 replace `preact/debug` in the above example with `preact/devtools`. This option doesn't


### PR DESCRIPTION
resolves preactjs/preact#2077 updated readme to specify preact/devtools is only available in earlier versions