### PR TITLE
Have the children ref array always initialized (-10B)

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -34,7 +34,8 @@ export function diffChildren(
 	oldDom,
 	isHydrating
 ) {
-	let i, j, oldVNode, newDom, sibDom, firstChildDom, refs;
+	let i, j, oldVNode, newDom, sibDom, firstChildDom;
+	let refs = [];
 
 	// This is a compression of oldParentVNode!=null && oldParentVNode != EMPTY_OBJ && oldParentVNode._children || EMPTY_ARR
 	// as EMPTY_OBJ._children should be `undefined`.
@@ -112,7 +113,6 @@ export function diffChildren(
 				);
 
 				if ((j = childVNode.ref) && oldVNode.ref != j) {
-					if (!refs) refs = [];
 					if (oldVNode.ref) refs.push(oldVNode.ref, null, childVNode);
 					refs.push(j, childVNode._component || newDom, childVNode);
 				}
@@ -205,10 +205,8 @@ export function diffChildren(
 	}
 
 	// Set refs only after unmount
-	if (refs) {
-		for (i = 0; i < refs.length; i++) {
-			applyRef(refs[i], refs[++i], refs[++i]);
-		}
+	for (i = 0; i < refs.length; i++) {
+		applyRef(refs[i], refs[++i], refs[++i]);
 	}
 }
 


### PR DESCRIPTION
Hey @JoviDeCroock I wanted to add this suggestion on your PR at #2055, and I was on my phone and it seems that it stayed in a pending state rather that adding it. Anyway, if we always keep the `refs = []` initialised we could shave `-10B`.