### PR TITLE
Do not check for prototype in newType

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -63,7 +63,7 @@ export function diff(
 				clearProcessingException = c._processingException = c._pendingError;
 			} else {
 				// Instantiate the new component
-				if ('prototype' in newType && newType.prototype.render) {
+				if (newType.prototype.render) {
 					newVNode._component = c = new newType(newProps, cctx); // eslint-disable-line new-cap
 				} else {
 					newVNode._component = c = new Component(newProps, cctx);


### PR DESCRIPTION
This change removes the check for `prototype` on `newType`, if the check is only present to detect classes.

If I understand correctly:
- By checking `'prototype' in newType` the script assumes `newType` is an object, otherwise this could throw if `newType` were a primitive.
- The purpose of the `if` statement checking `'prototype' in newType` is to detect classes.

Therefore, knowing that all functions have a `prototype`, this check is potentially unnecessary.