### PR TITLE
Enable better Webpack tree shaking

### DIFF
--- a/compat/package.json
+++ b/compat/package.json
@@ -7,6 +7,7 @@
   "main": "dist/compat.js",
   "module": "dist/compat.module.js",
   "umd:main": "dist/compat.umd.js",
+  "sideEffects": false,
   "source": "src/index.js",
   "types": "src/index.d.ts",
   "license": "MIT",

--- a/hooks/package.json
+++ b/hooks/package.json
@@ -7,6 +7,7 @@
   "main": "dist/hooks.js",
   "module": "dist/hooks.module.js",
   "umd:main": "dist/hooks.umd.js",
+  "sideEffects": false,
   "source": "src/index.js",
   "license": "MIT",
   "types": "src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "module": "dist/preact.module.js",
   "umd:main": "dist/preact.umd.js",
   "unpkg": "dist/preact.umd.js",
+  "sideEffects": false,
   "source": "src/index.js",
   "license": "MIT",
   "funding": {


### PR DESCRIPTION
Add `"sideEffects": false` to `package.json` files in `preact`, `preact/hooks` and `preact/compat` to enable improved tree shaking of unused exports, i.e. when using an immediately-invoked function to generate something which is exported (which may perform additional side effects, hence why Webpack doesn't optimize this by default).

-4.2 KB bundle size when importing only `memo` from `preact/compat`; not sure if there is any improvement in `preact` or `preact/hooks`.