### PR TITLE
Fix wrong DOM order on suspend inside Fragment

### DIFF
--- a/compat/mangle.json
+++ b/compat/mangle.json
@@ -20,7 +20,7 @@
       "$_root": "__",
       "$_commit": "__c",
       "$_suspensions": "__u",
-      "$_fallback": "__f",
+      "$_detachOnNextRender": "__b",
       "$_diff": "__b",
       "$_render": "__r",
       "$_hook": "__h",

--- a/compat/src/internal.d.ts
+++ b/compat/src/internal.d.ts
@@ -34,5 +34,5 @@ export interface SuspenseState {
 export interface SuspenseComponent
 	extends PreactComponent<SuspenseProps, SuspenseState> {
 	_suspensions: number;
-	_fallback: VNode<any>;
+	_detachOnNextRender: boolean;
 }

--- a/compat/src/internal.d.ts
+++ b/compat/src/internal.d.ts
@@ -33,6 +33,6 @@ export interface SuspenseState {
 
 export interface SuspenseComponent
 	extends PreactComponent<SuspenseProps, SuspenseState> {
-	_suspensions: Array<Promise<any>>;
+	_suspensions: number;
 	_fallback: VNode<any>;
 }

--- a/compat/src/internal.d.ts
+++ b/compat/src/internal.d.ts
@@ -28,7 +28,7 @@ export interface VNode<T = any> extends PreactVNode<T> {
 }
 
 export interface SuspenseState {
-	_parkedChildren: VNode<any>[];
+	_suspended: VNode<any>[];
 }
 
 export interface SuspenseComponent

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -56,14 +56,14 @@ Suspense.prototype._childDidSuspend = function(promise) {
 
 	const onSuspensionComplete = () => {
 		if (!--c._suspensions) {
-			this._detachOnNextRender = false;
+			c._detachOnNextRender = false;
 			c._vnode._children[0]._children = c.state._suspended;
 			c.setState({ _suspended: null });
 		}
 	};
 
 	if (!c._suspensions++) {
-		this._detachOnNextRender = true;
+		c._detachOnNextRender = true;
 		c.setState({ _suspended: c._vnode._children[0]._children });
 	}
 	promise.then(onSuspensionComplete, onSuspensionComplete);

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -939,7 +939,7 @@ describe('suspense', () => {
 			});
 	});
 
-	it('should correctly render Suspense components inside Fragments', async () => {
+	it('should correctly render Suspense components inside Fragments', () => {
 		// Issue #2106.
 
 		const [Lazy1, resolve1] = createLazy();
@@ -971,17 +971,22 @@ describe('suspense', () => {
 			`${loadingHtml}${loadingHtml}${loadingHtml}`
 		);
 
-		await resolve2(() => <span>2</span>);
-		await resolve1(() => <span>1</span>);
-		rerender();
-		expect(scratch.innerHTML).to.eql(
-			`<span>1</span><span>2</span>${loadingHtml}`
-		);
-
-		await resolve3(() => <span>3</span>);
-		rerender();
-		expect(scratch.innerHTML).to.eql(
-			`<span>1</span><span>2</span><span>3</span>`
-		);
+		resolve2(() => <span>2</span>)
+			.then(() => {
+				return resolve1(() => <span>1</span>);
+			})
+			.then(() => {
+				rerender();
+				expect(scratch.innerHTML).to.eql(
+					`<span>1</span><span>2</span>${loadingHtml}`
+				);
+				return resolve3(() => <span>3</span>);
+			})
+			.then(() => {
+				rerender();
+				expect(scratch.innerHTML).to.eql(
+					`<span>1</span><span>2</span><span>3</span>`
+				);
+			});
 	});
 });

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -916,7 +916,7 @@ describe('suspense', () => {
 
 		expect(scratch.innerHTML).to.equal(loadingHtml);
 
-		resolve1(() => <b>1</b>)
+		return resolve1(() => <b>1</b>)
 			.then(() => {
 				rerender();
 				expect(scratch.innerHTML).to.equal(loadingHtml);
@@ -971,7 +971,7 @@ describe('suspense', () => {
 			`${loadingHtml}${loadingHtml}${loadingHtml}`
 		);
 
-		resolve2(() => <span>2</span>)
+		return resolve2(() => <span>2</span>)
 			.then(() => {
 				return resolve1(() => <span>1</span>);
 			})

--- a/debug/test/browser/debug-suspense.test.js
+++ b/debug/test/browser/debug-suspense.test.js
@@ -9,6 +9,14 @@ import {
 
 /** @jsx createElement */
 
+async function waitResolved(suspense) {
+	while (suspense._component._suspensions > 0) {
+		await new Promise(resolve => {
+			setTimeout(resolve, 10);
+		});
+	}
+}
+
 describe('debug with suspense', () => {
 	let scratch;
 	let errors = [];
@@ -75,7 +83,7 @@ describe('debug with suspense', () => {
 			expect(console.error).to.not.be.called;
 
 			return loader
-				.then(() => Promise.all(suspense._component._suspensions))
+				.then(() => waitResolved(suspense))
 				.then(() => {
 					rerender();
 					expect(errors.length).to.equal(1);
@@ -101,7 +109,7 @@ describe('debug with suspense', () => {
 				render(suspense, scratch);
 
 				return loader
-					.then(() => Promise.all(suspense._component._suspensions))
+					.then(() => waitResolved(suspense))
 					.then(() => {
 						expect(console.warn).to.be.calledTwice;
 						expect(warnings[1].includes('MyLazyLoaded')).to.equal(true);
@@ -124,7 +132,7 @@ describe('debug with suspense', () => {
 				render(suspense, scratch);
 
 				return loader
-					.then(() => Promise.all(suspense._component._suspensions))
+					.then(() => waitResolved(suspense))
 					.then(() => {
 						expect(console.warn).to.be.calledTwice;
 						expect(warnings[1].includes('HelloLazy')).to.equal(true);


### PR DESCRIPTION
This pull request fixes issue #2106 and refactors the Suspense implementation for smaller code size.
 * Modify the Suspense lifecycle to be more explicit:
   * On the first suspended child set the `_detachOnNextRender` flag and force a new render with `setState`.
   * On the next render detach the old suspended children from DOM and replace them with an empty list of children.
 * Use a counter to keep track of the unresolved promises instead of an array of the promises.
 * Add a test for issue #2106.
 * Fix Suspense test "should correctly render nested Suspense components", it didn't return a promise.
 * Add a test for children suspending with the same promise.
 * Add a test ensuring that no children will be rendered if any of them suspends.

The changes in this PR bring down the compat.js.gz bundle size by 38 bytes (from 2700 B to 2662 B).

Fixes #2106.