### PR TITLE
Add test to cover hooks debug helper

### DIFF
--- a/debug/test/browser/debug-hooks.test.js
+++ b/debug/test/browser/debug-hooks.test.js
@@ -77,6 +77,20 @@ describe('debug with hooks', () => {
 		expect(fn).to.throw(/Hook can only be invoked from render/);
 	});
 
+	it('should throw an error when invoked outside of a component before render', () => {
+		function Foo(props) {
+			useEffect(() => {}); // Pretend to use a hook
+			return props.children;
+		}
+
+		const fn = () =>
+			act(() => {
+				useState();
+				render(<Foo>Hello!</Foo>, scratch);
+			});
+		expect(fn).to.throw(/Hook can only be invoked from render/);
+	});
+
 	it('should warn for argumentless useEffect hooks', () => {
 		const App = () => {
 			const [state] = useState('test');


### PR DESCRIPTION
This PR brings our statement and line code coverage to 100% which should prevent coveralls from saying code coverage decreased on PRs that reduce the number of lines (e.g. 989/990 < 997/998, but no longer! 989/989 == 998/998)

After this PR goes in, if coveralls says that code coverage decreased then that means it actually did, and you should probably double check your tests cases are comprehensive.

P.S. Occasionally, I've seen Travis not run our complete test suite, so if you see coverage drop, that could also be a reason. Restarting the travis build should fix it.