### PR TITLE
Consolidate VNode compat options (-62 B)

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -229,13 +229,27 @@ function createElement(...args) {
 	return normalizeVNode(vnode);
 }
 
+let classNameDescriptor = {
+	configurable: true,
+	get() {
+		return this.class;
+	}
+};
+
 /**
  * Normalize a vnode
  * @param {import('./internal').VNode} vnode
  */
 function normalizeVNode(vnode) {
+	// Alias `class` prop to `className` if available
+	let a = vnode.props;
+	if (a.class || a.className) {
+		classNameDescriptor.enumerable = 'className' in a;
+		if (a.className) a.class = a.className;
+		Object.defineProperty(a, 'className', classNameDescriptor);
+	}
+
 	vnode.preactCompatNormalized = true;
-	applyClassName(vnode);
 	return vnode;
 }
 
@@ -310,26 +324,6 @@ function unmountComponentAtNode(container) {
 	}
 	return false;
 }
-
-/**
- * Alias `class` prop to `className` if available
- * @param {import('./internal').VNode} vnode
- */
-function applyClassName(vnode) {
-	let a = vnode.props;
-	if (a.class || a.className) {
-		classNameDescriptor.enumerable = 'className' in a;
-		if (a.className) a.class = a.className;
-		Object.defineProperty(a, 'className', classNameDescriptor);
-	}
-}
-
-let classNameDescriptor = {
-	configurable: true,
-	get() {
-		return this.class;
-	}
-};
 
 /**
  * Check if two objects have a different shape

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -441,9 +441,6 @@ options.vnode = vnode => {
 		type._patchedLifecycles = true;
 	}
 
-	// TODO: Removing this saves 16 bytes!
-	vnode.preactCompatNormalized = true;
-
 	if (oldVNodeHook) oldVNodeHook(vnode);
 };
 

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -53,24 +53,6 @@ function createFactory(type) {
 }
 
 /**
- * Normalize DOM vnode properties.
- * @param {import('./internal').VNode} vnode The vnode to normalize props of
- * @param {object | null | undefined} props props to normalize
- */
-function handleElementVNode(vnode, props) {
-	let shouldSanitize, attrs, i;
-	for (i in props) if ((shouldSanitize = CAMEL_PROPS.test(i))) break;
-	if (shouldSanitize) {
-		attrs = vnode.props = {};
-		for (i in props) {
-			attrs[
-				CAMEL_PROPS.test(i) ? i.replace(/([A-Z0-9])/, '-$1').toLowerCase() : i
-			] = props[i];
-		}
-	}
-}
-
-/**
  * Proxy render() since React returns a Component reference.
  * @param {import('./internal').VNode} vnode VNode tree to render
  * @param {import('./internal').PreactElement} parent DOM node to render vnode tree into
@@ -222,7 +204,18 @@ function createElement(...args) {
 			});
 			delete props.value;
 		}
-		handleElementVNode(vnode, props);
+
+		// Normalize DOM vnode properties.
+		let shouldSanitize, attrs, i;
+		for (i in props) if ((shouldSanitize = CAMEL_PROPS.test(i))) break;
+		if (shouldSanitize) {
+			attrs = vnode.props = {};
+			for (i in props) {
+				attrs[
+					CAMEL_PROPS.test(i) ? i.replace(/([A-Z0-9])/, '-$1').toLowerCase() : i
+				] = props[i];
+			}
+		}
 	}
 
 	vnode.preactCompatNormalized = false;

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -329,7 +329,7 @@ function memo(c, comparer) {
  * Pass ref down to a child. This is mainly used in libraries with HOCs that
  * wrap components. Using `forwardRef` there is an easy way to get a reference
  * of the wrapped component instead of one of the wrapper itself.
- * @param {import('./internal').ForwardFn} fn
+ * @param {import('./index').ForwardFn} fn
  * @returns {import('./internal').FunctionalComponent}
  */
 function forwardRef(fn) {
@@ -411,11 +411,10 @@ options.vnode = vnode => {
 	}
 
 	// Alias `class` prop to `className` if available
-	let a = vnode.props;
-	if (a.class || a.className) {
-		classNameDescriptor.enumerable = 'className' in a;
-		if (a.className) a.class = a.className;
-		Object.defineProperty(a, 'className', classNameDescriptor);
+	if (props.class || props.className) {
+		classNameDescriptor.enumerable = 'className' in props;
+		if (props.className) props.class = props.className;
+		Object.defineProperty(props, 'className', classNameDescriptor);
 	}
 
 	// Events


### PR DESCRIPTION
Currently the compat src has VNode compat functions spread across a couple different functions making it hard to modify (should I add it `normalizeVNode`? `createElement`? `handleElementVNode`?).

This PR simplifies VNode compat by inline all of those disparate functions into the `options.vnode` hook. Every vnode that is created (including `cloneElement`) goes through this options hook so it guarantees VNode compat is consistently applied.

Also saves some bytes!