### PR TITLE
Fix internal Suspense-related typings

### DIFF
--- a/compat/src/internal.d.ts
+++ b/compat/src/internal.d.ts
@@ -28,11 +28,11 @@ export interface VNode<T = any> extends PreactVNode<T> {
 }
 
 export interface SuspenseState {
-	_suspended: VNode<any>[];
+	_suspended: VNode<any>;
 }
 
 export interface SuspenseComponent
 	extends PreactComponent<SuspenseProps, SuspenseState> {
 	_suspensions: number;
-	_detachOnNextRender: boolean;
+	_detachOnNextRender: null | VNode<any>;
 }

--- a/compat/src/internal.d.ts
+++ b/compat/src/internal.d.ts
@@ -28,7 +28,7 @@ export interface VNode<T = any> extends PreactVNode<T> {
 }
 
 export interface SuspenseState {
-	_suspended: VNode<any>;
+	_suspended?: null | VNode<any>;
 }
 
 export interface SuspenseComponent

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -3,22 +3,18 @@ import { assign } from '../../src/util';
 
 const oldCatchError = options._catchError;
 options._catchError = function(error, newVNode, oldVNode) {
-	if (error.then && oldVNode) {
+	if (error.then) {
 		/** @type {import('./internal').Component} */
 		let component;
 		let vnode = newVNode;
 
 		for (; (vnode = vnode._parent); ) {
 			if ((component = vnode._component) && component._childDidSuspend) {
-				newVNode._dom = oldVNode._dom;
-				newVNode._children = oldVNode._children;
-
 				// Don't call oldCatchError if we found a Suspense
 				return component._childDidSuspend(error);
 			}
 		}
 	}
-
 	oldCatchError(error, newVNode, oldVNode);
 };
 

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -1,4 +1,4 @@
-import { Component, createElement, options, Fragment } from 'preact';
+import { Component, createElement, options } from 'preact';
 import { assign } from '../../src/util';
 
 const oldCatchError = options._catchError;
@@ -15,8 +15,8 @@ options._catchError = function(error, newVNode, oldVNode) {
 					newVNode._children = oldVNode._children;
 				}
 
-				component._childDidSuspend(error);
-				return; // Don't call oldCatchError if we found a Suspense
+				// Don't call oldCatchError if we found a Suspense
+				return component._childDidSuspend(error);
 			}
 		}
 	}
@@ -72,7 +72,7 @@ Suspense.prototype.render = function(props, state) {
 	}
 
 	return [
-		createElement(Fragment, null, state._suspended ? null : props.children),
+		createElement(Component, null, state._suspended ? null : props.children),
 		state._suspended && props.fallback
 	];
 };


### PR DESCRIPTION
This pull request fixes the Suspense-related types in compat/src/internal.d.ts that Yours Truly broke in #2107.

To sweeten the deal there are a couple of small code golfs that bring compat.js.gz size down by 4 bytes (from 2655 B to 2651 B) 🙂