### PR TITLE
Remove redundant if clause in suspense _catchError

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -10,10 +10,8 @@ options._catchError = function(error, newVNode, oldVNode) {
 
 		for (; (vnode = vnode._parent); ) {
 			if ((component = vnode._component) && component._childDidSuspend) {
-				if (oldVNode) {
-					newVNode._dom = oldVNode._dom;
-					newVNode._children = oldVNode._children;
-				}
+				newVNode._dom = oldVNode._dom;
+				newVNode._children = oldVNode._children;
 
 				component._childDidSuspend(error);
 				return; // Don't call oldCatchError if we found a Suspense


### PR DESCRIPTION
Remove redundant if clause in suspense _catchError

As mentioned in Slack this condition is already present on line 6

=> -4B in compat