### PR TITLE
Suspended components should rerender through sCU

### DIFF
--- a/compat/src/internal.d.ts
+++ b/compat/src/internal.d.ts
@@ -37,6 +37,7 @@ export interface SuspenseState {
 
 export interface SuspenseComponent
 	extends PreactComponent<SuspenseProps, SuspenseState> {
-	_suspensions: number;
+	_pendingSuspensionCount: number;
+	_suspenders: Component[];
 	_detachOnNextRender: null | VNode<any>;
 }

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -129,7 +129,7 @@ describe('suspense', () => {
 	});
 
 	it('should support lazy', () => {
-		const LazyComp = () => <div>Hello from LazyComp</div>;
+		const LazyComp = ({ name }) => <div>Hello from {name}</div>;
 
 		/** @type {() => Promise<void>} */
 		let resolve;
@@ -146,7 +146,7 @@ describe('suspense', () => {
 
 		render(
 			<Suspense fallback={<div>Suspended...</div>}>
-				<Lazy />
+				<Lazy name="LazyComp" />
 			</Suspense>,
 			scratch
 		); // Render initial state

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -1434,7 +1434,8 @@ describe('suspense', () => {
 	});
 
 	it('should render delayed lazy components through components using shouldComponentUpdate', () => {
-		const [Suspender, suspend] = createSuspender(() => <i>-1</i>);
+		const [Suspender1, suspend1] = createSuspender(() => <i>1</i>);
+		const [Suspender2, suspend2] = createSuspender(() => <i>2</i>);
 
 		class Blocker extends Component {
 			shouldComponentUpdate() {
@@ -1443,9 +1444,9 @@ describe('suspense', () => {
 			render(props) {
 				return (
 					<b>
-						<i>0</i>
+						<i>a</i>
 						{props.children}
-						<i>2</i>
+						<i>d</i>
 					</b>
 				);
 			}
@@ -1454,25 +1455,39 @@ describe('suspense', () => {
 		render(
 			<Suspense fallback={<div>Suspended...</div>}>
 				<Blocker>
-					<Suspender />
+					<Suspender1 />
+					<Suspender2 />
 				</Blocker>
 			</Suspense>,
 			scratch
 		);
-		expect(scratch.innerHTML).to.equal('<b><i>0</i><i>-1</i><i>2</i></b>');
+		expect(scratch.innerHTML).to.equal(
+			'<b><i>a</i><i>1</i><i>2</i><i>d</i></b>'
+		);
 
-		const [resolve] = suspend();
+		const [resolve1] = suspend1();
+		const [resolve2] = suspend2();
 		rerender();
 		expect(scratch.innerHTML).to.equal('<div>Suspended...</div>');
 
-		return resolve(() => <i>1</i>).then(() => {
-			rerender();
-			expect(scratch.innerHTML).to.equal('<b><i>0</i><i>1</i><i>2</i></b>');
-		});
+		return resolve1(() => <i>b</i>)
+			.then(() => {
+				rerender();
+				expect(scratch.innerHTML).to.equal('<div>Suspended...</div>');
+
+				return resolve2(() => <i>c</i>);
+			})
+			.then(() => {
+				rerender();
+				expect(scratch.innerHTML).to.equal(
+					'<b><i>a</i><i>b</i><i>c</i><i>d</i></b>'
+				);
+			});
 	});
 
 	it('should render initially lazy components through components using shouldComponentUpdate', () => {
-		const [Lazy, resolve] = createLazy();
+		const [Lazy1, resolve1] = createLazy();
+		const [Lazy2, resolve2] = createLazy();
 
 		class Blocker extends Component {
 			shouldComponentUpdate() {
@@ -1481,9 +1496,9 @@ describe('suspense', () => {
 			render(props) {
 				return (
 					<b>
-						<i>0</i>
+						<i>a</i>
 						{props.children}
-						<i>2</i>
+						<i>d</i>
 					</b>
 				);
 			}
@@ -1492,7 +1507,8 @@ describe('suspense', () => {
 		render(
 			<Suspense fallback={<div>Suspended...</div>}>
 				<Blocker>
-					<Lazy />
+					<Lazy1 />
+					<Lazy2 />
 				</Blocker>
 			</Suspense>,
 			scratch
@@ -1500,10 +1516,19 @@ describe('suspense', () => {
 		rerender();
 		expect(scratch.innerHTML).to.equal('<div>Suspended...</div>');
 
-		return resolve(() => <i>1</i>).then(() => {
-			rerender();
-			expect(scratch.innerHTML).to.equal('<b><i>0</i><i>1</i><i>2</i></b>');
-		});
+		return resolve1(() => <i>b</i>)
+			.then(() => {
+				rerender();
+				expect(scratch.innerHTML).to.equal('<div>Suspended...</div>');
+
+				return resolve2(() => <i>c</i>);
+			})
+			.then(() => {
+				rerender();
+				expect(scratch.innerHTML).to.equal(
+					'<b><i>a</i><i>b</i><i>c</i><i>d</i></b>'
+				);
+			});
 	});
 
 	it('should render initially lazy components through createContext', () => {

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -5,7 +5,8 @@ import React, {
 	Component,
 	Suspense,
 	lazy,
-	Fragment
+	Fragment,
+	createContext
 } from 'preact/compat';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
@@ -1432,7 +1433,7 @@ describe('suspense', () => {
 		);
 	});
 
-	it('should render through components using shouldComponentUpdate', () => {
+	it('should render lazy components through components using shouldComponentUpdate', () => {
 		const [Suspender, suspend] = createSuspender(() => <i>-1</i>);
 
 		class Blocker extends Component {
@@ -1467,6 +1468,28 @@ describe('suspense', () => {
 		return resolve(() => <i>1</i>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.equal('<b><i>0</i><i>1</i><i>2</i></b>');
+		});
+	});
+
+	it('should render lazy components through createContext', () => {
+		const ctx = createContext(null);
+		const [Lazy, resolve] = createLazy();
+
+		const suspense = (
+			<Suspense fallback={<div>Suspended...</div>}>
+				<ctx.Provider value="123">
+					<ctx.Consumer>{value => <Lazy value={value} />}</ctx.Consumer>
+				</ctx.Provider>
+			</Suspense>
+		);
+
+		render(suspense, scratch);
+		rerender();
+		expect(scratch.innerHTML).to.eql(`<div>Suspended...</div>`);
+
+		return resolve(props => <div>{props.value}</div>).then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.eql(`<div>123</div>`);
 		});
 	});
 });

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -1431,4 +1431,42 @@ describe('suspense', () => {
 			'<section><div>Suspender un-suspended</div></section>'
 		);
 	});
+
+	it('should render through components using shouldComponentUpdate', () => {
+		const [Suspender, suspend] = createSuspender(() => <i>-1</i>);
+
+		class Blocker extends Component {
+			shouldComponentUpdate() {
+				return false;
+			}
+			render(props) {
+				return (
+					<b>
+						<i>0</i>
+						{props.children}
+						<i>2</i>
+					</b>
+				);
+			}
+		}
+
+		render(
+			<Suspense fallback={<div>Suspended...</div>}>
+				<Blocker>
+					<Suspender />
+				</Blocker>
+			</Suspense>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal('<b><i>0</i><i>-1</i><i>2</i></b>');
+
+		const [resolve] = suspend();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div>Suspended...</div>');
+
+		return resolve(() => <i>1</i>).then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.equal('<b><i>0</i><i>1</i><i>2</i></b>');
+		});
+	});
 });

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -398,7 +398,7 @@ Component.prototype.forceUpdate = function(callback) {
 		);
 	} else if (this._parentDom == null) {
 		console.warn(
-			`Can't call "this.setState" on an unmounted component. This is a no-op, ` +
+			`Can't call "this.forceUpdate" on an unmounted component. This is a no-op, ` +
 				`but it indicates a memory leak in your application. To fix, cancel all ` +
 				`subscriptions and asynchronous tasks in the componentWillUnmount method.` +
 				`\n\n${getOwnerStack(this._vnode)}`

--- a/debug/test/browser/debug-suspense.test.js
+++ b/debug/test/browser/debug-suspense.test.js
@@ -10,6 +10,7 @@ import {
 /** @jsx createElement */
 
 describe('debug with suspense', () => {
+	/** @type {HTMLDivElement} */
 	let scratch;
 	let rerender;
 	let errors = [];
@@ -71,8 +72,10 @@ describe('debug with suspense', () => {
 				</Suspense>
 			);
 			render(suspense, scratch);
+			rerender(); // render fallback
 
 			expect(console.error).to.not.be.called;
+			expect(serializeHtml(scratch)).to.equal('<div>fallback...</div>');
 
 			return loader.then(() => {
 				rerender();
@@ -97,11 +100,15 @@ describe('debug with suspense', () => {
 					</Suspense>
 				);
 				render(suspense, scratch);
+				rerender(); // Render fallback
+
+				expect(serializeHtml(scratch)).to.equal('<div>fallback...</div>');
 
 				return loader.then(() => {
 					rerender();
 					expect(console.warn).to.be.calledTwice;
 					expect(warnings[1].includes('MyLazyLoaded')).to.equal(true);
+					expect(serializeHtml(scratch)).to.equal('<div>Hi there</div>');
 				});
 			});
 
@@ -119,15 +126,19 @@ describe('debug with suspense', () => {
 					</Suspense>
 				);
 				render(suspense, scratch);
+				rerender(); // Render fallback
+
+				expect(serializeHtml(scratch)).to.equal('<div>fallback...</div>');
 
 				return loader.then(() => {
 					rerender();
 					expect(console.warn).to.be.calledTwice;
 					expect(warnings[1].includes('HelloLazy')).to.equal(true);
+					expect(serializeHtml(scratch)).to.equal('<div>Hi there</div>');
 				});
 			});
 
-			it('should not log a component if lazy throws', () => {
+			it("should not log a component if lazy loader's Promise rejects", () => {
 				const loader = Promise.reject(new Error('Hey there'));
 				const FakeLazy = lazy(() => loader);
 				FakeLazy.propTypes = {};
@@ -137,6 +148,9 @@ describe('debug with suspense', () => {
 					</Suspense>,
 					scratch
 				);
+				rerender(); // Render fallback
+
+				expect(serializeHtml(scratch)).to.equal('<div>fallback...</div>');
 
 				return loader.catch(() => {
 					try {


### PR DESCRIPTION
Resurrecting the awesome work @sventschui did in #1660 now built on top of @jviide and @prateekbh suspense changes. Just calls `forceUpdate` on the suspended component to guarantee it rerenders when the promise resolves.

Fixes #2176