### PR TITLE
Remove _unmount in mangle files

### DIFF
--- a/compat/mangle.json
+++ b/compat/mangle.json
@@ -24,8 +24,7 @@
       "$_diff": "__b",
       "$_render": "__r",
       "$_hook": "__h",
-      "$_catchError": "__e",
-      "$_unmount": "_e"
+      "$_catchError": "__e"
     }
   }
 }

--- a/hooks/mangle.json
+++ b/hooks/mangle.json
@@ -19,8 +19,7 @@
       "$_renderCallbacks": "__h",
       "$_suspensions": "__u",
       "$_hook": "__h",
-      "$_catchError": "__e",
-      "$_unmount": "_e"
+      "$_catchError": "__e"
     }
   }
 }

--- a/mangle.json
+++ b/mangle.json
@@ -41,8 +41,7 @@
       "$_commit": "__c",
       "$_render": "__r",
       "$_hook": "__h",
-      "$_catchError": "__e",
-      "$_unmount": "_e"
+      "$_catchError": "__e"
     }
   }
 }


### PR DESCRIPTION
If I used preact 10.0.5 and `createPortal` and change the parent, I have a problem.




![스크린샷 2019-11-20 오후 1 57 02](https://user-images.githubusercontent.com/3433062/69211282-ebfb2880-0ba0-11ea-9d7c-3d7d093e0d51.png)
![스크린샷 2019-11-20 오후 1 57 17](https://user-images.githubusercontent.com/3433062/69211284-ebfb2880-0ba0-11ea-8fc3-645add386fb8.png)

This function is also exported to index.js.
https://github.com/preactjs/preact/blob/master/src/index.js

![스크린샷 2019-11-20 오후 2 21 44](https://user-images.githubusercontent.com/3433062/69211340-24026b80-0ba1-11ea-98ec-4118bdc7e3be.png)

However, the mangle tool renamed `_unmount` to `_e`.

![스크린샷 2019-11-20 오후 2 23 21](https://user-images.githubusercontent.com/3433062/69211448-6f1c7e80-0ba1-11ea-9651-6f6adc911ca4.png)
