### PR TITLE
Move key and ref to src/internal.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,8 +13,6 @@ declare namespace preact {
 	interface VNode<P = {}> {
 		type: ComponentType<P> | string;
 		props: P & { children: ComponentChildren };
-		key: Key;
-		ref: Ref<any> | null;
 		/**
 		 * The time this `vnode` started rendering. Will only be set when
 		 * the devtools are attached.

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -47,18 +47,20 @@ export interface VNode<P = {}> extends preact.VNode<P> {
 	// Redefine type here using our internal ComponentFactory type
 	type: string | ComponentFactory<P>;
 	props: P & { children: preact.ComponentChildren };
-	_children: Array<VNode<any>> | null;
-	_parent: VNode | null;
-	_depth: number | null;
+	key?: preact.Key;
+	ref?: preact.Ref<any> | null;
+	_children?: Array<VNode<any>> | null;
+	_parent?: VNode | null;
+	_depth?: number | null;
 	/**
 	 * The [first (for Fragments)] DOM child of a VNode
 	 */
-	_dom: PreactElement | Text | null;
+	_dom?: PreactElement | Text | null;
 	/**
 	 * The last dom child of a Fragment, or components that return a Fragment
 	 */
-	_lastDomChild: PreactElement | Text | null;
-	_component: Component | null;
+	_lastDomChild?: PreactElement | Text | null;
+	_component?: Component | null;
 	constructor: undefined;
 }
 


### PR DESCRIPTION
As same as `_parent` property,
It is not necessary that user know about `key` property and `ref` property of VNode.
I think it may be better to change `ref` and `key` to  `_ref` and `_key`.