### PR TITLE
Move constructor to src/index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,6 +15,7 @@ declare namespace preact {
 		props: P & { children: ComponentChildren };
 		key: Key;
 		ref: Ref<any> | null;
+		constructor: undefined;
 		/**
 		 * The time this `vnode` started rendering. Will only be set when
 		 * the devtools are attached.

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -59,7 +59,6 @@ export interface VNode<P = {}> extends preact.VNode<P> {
 	 */
 	_lastDomChild: PreactElement | Text | null;
 	_component: Component | null;
-	constructor: undefined;
 }
 
 export interface Component<P = {}, S = {}> extends preact.Component<P, S> {


### PR DESCRIPTION
This works.

```js
class Foo extends Component {
  render() {
    return {"type":"h1","props":{"children":"bar"}, constructor: undefined }
  }
}
```

This does not work.


```js
class Foo extends Component {
  render() {
    return {"type":"h1","props":{"children":"bar"} }
  }
}
```

Therefore, I think `constructor` property is alway necessary in VNode.