### PR TITLE
Adding documentation for code structure

### DIFF
--- a/CODE_STRUCTURE.md
+++ b/CODE_STRUCTURE.md
@@ -1,0 +1,11 @@
+# Code Structure
+
+Preact does not have any depenpendencies its code is organized into three main folders
+
+- **src**: The core part of preact (imported as "preact")
+- **hooks**: Utilities realated to hooks (imported as "preact/hooks")
+- **compact**: Providing functionality making it compactible with react ( imported as "preact/compact")
+- **demo**: Contains demo's
+- **test**: Tests for code
+
+Preact uses **microbundle** for dev bundling


### PR DESCRIPTION
This is the first time for me diving into **Preact** internals. I think it would be nice to have the code structure and **Preact** internals documented in markdown file so that it would be easy for people to contribute to the repo. I just added basic structure of folders (which might not be right) but more could done to improve to documentation of internals making it even easier for people to get started with internals.