### PR TITLE
Improve test DOM helpers

### DIFF
--- a/compat/test/browser/Children.test.js
+++ b/compat/test/browser/Children.test.js
@@ -90,7 +90,7 @@ describe('Children', () => {
 				</Foo>,
 				scratch
 			);
-			let expected = div([span('foo'), span(div('bar'))].join(''));
+			let expected = div([span('foo'), span(div('bar'))]);
 			expect(serializeHtml(scratch)).to.equal(expected);
 		});
 
@@ -116,7 +116,7 @@ describe('Children', () => {
 				</Foo>,
 				scratch
 			);
-			let expected = div([span('foo'), span(div('bar'))].join(''));
+			let expected = div([span('foo'), span(div('bar'))]);
 			expect(serializeHtml(scratch)).to.equal(expected);
 		});
 	});

--- a/test/_util/dom.js
+++ b/test/_util/dom.js
@@ -1,44 +1,52 @@
 /**
- * A helper to generate innerHTML validation strings containing spans
- * @param {string | number} contents The contents of the span, as a string
+ * Serialize contents
+ * @typedef {string | number | Array<string | number>} Contents
+ * @param {Contents} contents
  */
-export const span = contents => `<span>${contents}</span>`;
+const serialize = contents =>
+	Array.isArray(contents) ? contents.join('') : contents.toString();
+
+/**
+ * A helper to generate innerHTML validation strings containing spans
+ * @param {Contents} contents The contents of the span, as a string
+ */
+export const span = contents => `<span>${serialize(contents)}</span>`;
 
 /**
  * A helper to generate innerHTML validation strings containing divs
- * @param {string | number} contents The contents of the div, as a string
+ * @param {Contents} contents The contents of the div, as a string
  */
-export const div = contents => `<div>${contents}</div>`;
+export const div = contents => `<div>${serialize(contents)}</div>`;
 
 /**
  * A helper to generate innerHTML validation strings containing p
- * @param {string | number} contents The contents of the p, as a string
+ * @param {Contents} contents The contents of the p, as a string
  */
-export const p = contents => `<p>${contents}</p>`;
+export const p = contents => `<p>${serialize(contents)}</p>`;
 
 /**
  * A helper to generate innerHTML validation strings containing sections
- * @param {string | number} contents The contents of the section, as a string
+ * @param {Contents} contents The contents of the section, as a string
  */
-export const section = contents => `<section>${contents}</section>`;
+export const section = contents => `<section>${serialize(contents)}</section>`;
 
 /**
  * A helper to generate innerHTML validation strings containing uls
- * @param {string | number} contents The contents of the ul, as a string
+ * @param {Contents} contents The contents of the ul, as a string
  */
-export const ul = contents => `<ul>${contents}</ul>`;
+export const ul = contents => `<ul>${serialize(contents)}</ul>`;
 
 /**
  * A helper to generate innerHTML validation strings containing ols
- * @param {string | number} contents The contents of the ol, as a string
+ * @param {Contents} contents The contents of the ol, as a string
  */
-export const ol = contents => `<ol>${contents}</ol>`;
+export const ol = contents => `<ol>${serialize(contents)}</ol>`;
 
 /**
  * A helper to generate innerHTML validation strings containing lis
- * @param {string | number} contents The contents of the li, as a string
+ * @param {Contents} contents The contents of the li, as a string
  */
-export const li = contents => `<li>${contents}</li>`;
+export const li = contents => `<li>${serialize(contents)}</li>`;
 
 /**
  * A helper to generate innerHTML validation strings containing inputs
@@ -47,12 +55,12 @@ export const input = () => `<input type="text">`;
 
 /**
  * A helper to generate innerHTML validation strings containing inputs
- * @param {string | number} contents The contents of the h1
+ * @param {Contents} contents The contents of the h1
  */
-export const h1 = contents => `<h1>${contents}</h1>`;
+export const h1 = contents => `<h1>${serialize(contents)}</h1>`;
 
 /**
  * A helper to generate innerHTML validation strings containing inputs
- * @param {string | number} contents The contents of the h2
+ * @param {Contents} contents The contents of the h2
  */
-export const h2 = contents => `<h2>${contents}</h2>`;
+export const h2 = contents => `<h2>${serialize(contents)}</h2>`;

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -2126,7 +2126,7 @@ describe('Components', () => {
 			toggleMaybeNull();
 			rerender();
 
-			expect(scratch.innerHTML).to.equal([p('child')].join(''));
+			expect(scratch.innerHTML).to.equal(p('child'));
 			expect(maybe.base).to.equalNode(null, 'toggleMaybe - maybe.base');
 			expect(child.base).to.equalNode(
 				scratch.firstChild,
@@ -2144,7 +2144,7 @@ describe('Components', () => {
 			swapChildTag();
 			rerender();
 
-			expect(scratch.innerHTML).to.equal([span('child')].join(''));
+			expect(scratch.innerHTML).to.equal(span('child'));
 			expect(maybe.base).to.equalNode(null, 'swapChildTag - maybe.base');
 			expect(child.base).to.equalNode(
 				scratch.firstChild,
@@ -2171,7 +2171,7 @@ describe('Components', () => {
 				scratch
 			);
 
-			expect(scratch.innerHTML).to.equal([p('child')].join(''));
+			expect(scratch.innerHTML).to.equal(p('child'));
 			expect(maybe.base).to.equalNode(null, 'initial - maybe.base');
 			expect(child.base).to.equalNode(
 				scratch.firstChild,
@@ -2183,7 +2183,7 @@ describe('Components', () => {
 			swapChildTag();
 			rerender();
 
-			expect(scratch.innerHTML).to.equal([span('child')].join(''));
+			expect(scratch.innerHTML).to.equal(span('child'));
 			expect(maybe.base).to.equalNode(null, 'swapChildTag - maybe.base');
 			expect(child.base).to.equalNode(
 				scratch.firstChild,
@@ -2250,7 +2250,7 @@ describe('Components', () => {
 			toggleMaybeNull();
 			rerender();
 
-			expect(scratch.innerHTML).to.equal([p('child')].join(''));
+			expect(scratch.innerHTML).to.equal(p('child'));
 			expect(maybe.base).to.equalNode(null, 'toggleMaybe - maybe.base');
 			expect(child.base).to.equalNode(
 				scratch.firstChild,
@@ -2268,7 +2268,7 @@ describe('Components', () => {
 			swapChildTag();
 			rerender();
 
-			expect(scratch.innerHTML).to.equal([span('child')].join(''));
+			expect(scratch.innerHTML).to.equal(span('child'));
 			expect(maybe.base).to.equalNode(null, 'swapChildTag - maybe.base');
 			expect(child.base).to.equalNode(
 				scratch.firstChild,
@@ -2297,7 +2297,7 @@ describe('Components', () => {
 				scratch
 			);
 
-			expect(scratch.innerHTML).to.equal([p('child')].join(''));
+			expect(scratch.innerHTML).to.equal(p('child'));
 			expect(maybe.base).to.equalNode(null, 'initial - maybe.base');
 			expect(child.base).to.equalNode(
 				scratch.firstChild,
@@ -2309,7 +2309,7 @@ describe('Components', () => {
 			swapChildTag();
 			rerender();
 
-			expect(scratch.innerHTML).to.equal([span('child')].join(''));
+			expect(scratch.innerHTML).to.equal(span('child'));
 			expect(maybe.base).to.equalNode(null, 'swapChildTag - maybe.base');
 			expect(child.base).to.equalNode(
 				scratch.firstChild,
@@ -2384,7 +2384,7 @@ describe('Components', () => {
 			toggleMaybeNull();
 			rerender();
 
-			expect(scratch.innerHTML).to.equal([p('child')].join(''));
+			expect(scratch.innerHTML).to.equal(p('child'));
 			expect(maybe.base).to.equalNode(null, 'toggleMaybe - maybe.base');
 			expect(child.base).to.equalNode(
 				scratch.firstChild,
@@ -2421,7 +2421,7 @@ describe('Components', () => {
 				scratch
 			);
 
-			expect(scratch.innerHTML).to.equal([p('child')].join(''));
+			expect(scratch.innerHTML).to.equal(p('child'));
 			expect(maybe.base).to.equalNode(null, 'initial - maybe.base');
 			expect(child.base).to.equalNode(
 				scratch.firstChild,

--- a/test/browser/focus.test.js
+++ b/test/browser/focus.test.js
@@ -61,13 +61,11 @@ describe('focus', () => {
 	 * @param {Array<number | string>} after
 	 */
 	function getListHtml(before, after) {
-		return div(
-			[
-				...before.map(i => span(i)),
-				inputStr(),
-				...after.map(i => span(i))
-			].join('')
-		);
+		return div([
+			...before.map(i => span(i)),
+			inputStr(),
+			...after.map(i => span(i))
+		]);
 	}
 
 	beforeEach(() => {
@@ -392,7 +390,7 @@ describe('focus', () => {
 	});
 
 	it('should maintain focus when hydrating', () => {
-		const html = div([span('1'), span('2'), span('3'), inputStr()].join(''));
+		const html = div([span('1'), span('2'), span('3'), inputStr()]);
 
 		scratch.innerHTML = html;
 		const input = focusInput();
@@ -462,9 +460,7 @@ describe('focus', () => {
 		rerender();
 
 		expect(scratch.innerHTML).to.equal(
-			div(
-				[h1('Heading'), 'Hello World', h2('yo'), 'foobar', inputStr()].join('')
-			)
+			div([h1('Heading'), 'Hello World', h2('yo'), 'foobar', inputStr()])
 		);
 		expect(document.activeElement).to.equalNode(input, 'After rerender');
 	});
@@ -521,9 +517,7 @@ describe('focus', () => {
 		rerender();
 
 		expect(scratch.innerHTML).to.equal(
-			div(
-				[h1('Heading'), 'Hello World', h2('yo'), 'foobar', inputStr()].join('')
-			)
+			div([h1('Heading'), 'Hello World', h2('yo'), 'foobar', inputStr()])
 		);
 		expect(input.selectionStart).to.equal(2);
 		expect(input.selectionEnd).to.equal(5);

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -220,18 +220,14 @@ describe('Fragment', () => {
 		}
 
 		render(<App />, scratch);
-		expect(scratch.innerHTML).to.equal(
-			div([span(1), span(2), span(2)].join(''))
-		);
+		expect(scratch.innerHTML).to.equal(div([span(1), span(2), span(2)]));
 
 		setState({ i: 1 });
 
 		clearLog();
 		rerender();
 
-		expect(scratch.innerHTML).to.equal(
-			div([div(1), span(2), span(2)].join(''))
-		);
+		expect(scratch.innerHTML).to.equal(div([div(1), span(2), span(2)]));
 		expectDomLogToBe([
 			'<div>.appendChild(#text)',
 			'<div>122.insertBefore(<div>1, <span>1)',
@@ -669,13 +665,9 @@ describe('Fragment', () => {
 			);
 		}
 
-		const htmlForTrue = div(
-			[div('foo'), div(div('Hello')), div('boop')].join('')
-		);
+		const htmlForTrue = div([div('foo'), div(div('Hello')), div('boop')]);
 
-		const htmlForFalse = div(
-			[div('beep'), div(div('Hello')), div('bar')].join('')
-		);
+		const htmlForFalse = div([div('beep'), div(div('Hello')), div('bar')]);
 
 		clearLog();
 		render(<Foo condition={true} />, scratch);
@@ -729,7 +721,7 @@ describe('Fragment', () => {
 			);
 		}
 
-		const html = div([span('1'), div('Hello'), span('2')].join(''));
+		const html = div([span('1'), div('Hello'), span('2')]);
 
 		clearLog();
 		render(<Foo condition={true} />, scratch);
@@ -848,7 +840,7 @@ describe('Fragment', () => {
 		);
 
 		expect(scratch.innerHTML).to.equal(
-			div([div(0), div(1), div(2), div(3), div(4), div(5)].join(''))
+			div([div(0), div(1), div(2), div(3), div(4), div(5)])
 		);
 	});
 
@@ -973,17 +965,15 @@ describe('Fragment', () => {
 		render(<Todo />, scratch);
 
 		expect(scratch.innerHTML).to.equal(
-			ul(
-				[
-					li('A header'),
-					li('a'),
-					li('b'),
-					li('A divider'),
-					li('c'),
-					li('d'),
-					li('A footer')
-				].join('')
-			)
+			ul([
+				li('A header'),
+				li('a'),
+				li('b'),
+				li('A divider'),
+				li('c'),
+				li('d'),
+				li('A footer')
+			])
 		);
 	});
 
@@ -1127,7 +1117,7 @@ describe('Fragment', () => {
 			</ol>
 		);
 
-		const html = ol([li('0'), li('1'), li('2'), li('3')].join(''));
+		const html = ol([li('0'), li('1'), li('2'), li('3')]);
 
 		clearLog();
 		render(<Foo condition={true} />, scratch);
@@ -1193,11 +1183,9 @@ describe('Fragment', () => {
 			</ol>
 		);
 
-		const htmlForTrue = ol(
-			[li('0'), li('1'), li('2'), li('3'), li('4')].join('')
-		);
+		const htmlForTrue = ol([li('0'), li('1'), li('2'), li('3'), li('4')]);
 
-		const htmlForFalse = ol([li('0'), li('3'), li('4')].join(''));
+		const htmlForFalse = ol([li('0'), li('3'), li('4')]);
 
 		clearLog();
 		render(<Foo condition={true} />, scratch);
@@ -1274,13 +1262,23 @@ describe('Fragment', () => {
 			</ol>
 		);
 
-		const htmlForTrue = ol(
-			[li('0'), li('1'), li('2'), li('3'), li('4'), li('5')].join('')
-		);
+		const htmlForTrue = ol([
+			li('0'),
+			li('1'),
+			li('2'),
+			li('3'),
+			li('4'),
+			li('5')
+		]);
 
-		const htmlForFalse = ol(
-			[li('4'), li('5'), li('0'), li('1'), li('2'), li('3')].join('')
-		);
+		const htmlForFalse = ol([
+			li('4'),
+			li('5'),
+			li('0'),
+			li('1'),
+			li('2'),
+			li('3')
+		]);
 
 		clearLog();
 		render(<Foo condition={true} />, scratch);
@@ -1331,9 +1329,9 @@ describe('Fragment', () => {
 			</ol>
 		);
 
-		const htmlForTrue = ol([li(0), li(1), li(2), li(2)].join(''));
+		const htmlForTrue = ol([li(0), li(1), li(2), li(2)]);
 
-		const htmlForFalse = ol([li(2), li(2), li(3), li(4)].join(''));
+		const htmlForFalse = ol([li(2), li(2), li(3), li(4)]);
 
 		clearLog();
 		render(<Foo condition={true} />, scratch);
@@ -1402,9 +1400,9 @@ describe('Fragment', () => {
 			</ol>
 		);
 
-		const htmlForTrue = ol([li(0), li(1), li(2), li(3)].join(''));
+		const htmlForTrue = ol([li(0), li(1), li(2), li(3)]);
 
-		const htmlForFalse = ol([li(2), li(3), li(4), li(5)].join(''));
+		const htmlForFalse = ol([li(2), li(3), li(4), li(5)]);
 
 		clearLog();
 		render(<Foo condition={true} />, scratch);
@@ -1473,13 +1471,14 @@ describe('Fragment', () => {
 			);
 		}
 
-		const htmlForTrue = div(
-			[div('foo'), div(div('Hello')), div('boop'), div('boop')].join('')
-		);
+		const htmlForTrue = div([
+			div('foo'),
+			div(div('Hello')),
+			div('boop'),
+			div('boop')
+		]);
 
-		const htmlForFalse = div(
-			[div('beep'), div(div('Hello')), div('bar')].join('')
-		);
+		const htmlForFalse = div([div('beep'), div(div('Hello')), div('bar')]);
 
 		clearLog();
 		render(<Foo condition={true} />, scratch);
@@ -1551,25 +1550,21 @@ describe('Fragment', () => {
 			);
 		}
 
-		const htmlForTrue = div(
-			[
-				div('foo'),
-				div(div('Hello')),
-				div('boop'),
-				div('boop'),
-				div('boop')
-			].join('')
-		);
+		const htmlForTrue = div([
+			div('foo'),
+			div(div('Hello')),
+			div('boop'),
+			div('boop'),
+			div('boop')
+		]);
 
-		const htmlForFalse = div(
-			[
-				div('beep'),
-				div('beep'),
-				div('beep'),
-				div(div('Hello')),
-				div('bar')
-			].join('')
-		);
+		const htmlForFalse = div([
+			div('beep'),
+			div('beep'),
+			div('beep'),
+			div(div('Hello')),
+			div('bar')
+		]);
 
 		clearLog();
 		render(<Foo condition={true} />, scratch);
@@ -1612,7 +1607,7 @@ describe('Fragment', () => {
 		/**
 		 * @type {(props: { values: Array<string | number>}) => JSX.Element}
 		 */
-		const Foo = ({ values }) => ((
+		const Foo = ({ values }) => (
 			<ol>
 				<li>a</li>
 				<Fragment>
@@ -1622,10 +1617,10 @@ describe('Fragment', () => {
 				</Fragment>
 				<li>b</li>
 			</ol>
-		));
+		);
 
 		const getHtml = values =>
-			ol([li('a'), ...values.map(value => li(value)), li('b')].join(''));
+			ol([li('a'), ...values.map(value => li(value)), li('b')]);
 
 		let values = [0, 1, 2];
 		clearLog();
@@ -1678,7 +1673,7 @@ describe('Fragment', () => {
 
 		const htmlForTrue = [div(1), div(2)].join('');
 
-		const htmlForFalse = div([div(3), div(4)].join(''));
+		const htmlForFalse = div([div(3), div(4)]);
 
 		clearLog();
 		render(<Foo condition={true} />, scratch);
@@ -1750,11 +1745,16 @@ describe('Fragment', () => {
 			</ol>
 		);
 
-		const htmlForTrue = ol(
-			[li('0'), li('1'), li('2'), li('3'), li('4'), li('5')].join('')
-		);
+		const htmlForTrue = ol([
+			li('0'),
+			li('1'),
+			li('2'),
+			li('3'),
+			li('4'),
+			li('5')
+		]);
 
-		const htmlForFalse = ol([li('0'), li('1'), li('4'), li('5')].join(''));
+		const htmlForFalse = ol([li('0'), li('1'), li('4'), li('5')]);
 
 		clearLog();
 		render(<Foo condition={true} />, scratch);
@@ -1818,7 +1818,7 @@ describe('Fragment', () => {
 		);
 
 		render(<Foo />, scratch);
-		expect(scratch.innerHTML).to.equal(ol([li(1)].join('')));
+		expect(scratch.innerHTML).to.equal(ol(li(1)));
 	});
 
 	it('should properly render Components that return Fragments and use shouldComponentUpdate #1415', () => {
@@ -1862,7 +1862,7 @@ describe('Fragment', () => {
 			}
 		}
 
-		const successHtml = div(div([div(1), div(2), div(3)].join('')));
+		const successHtml = div(div([div(1), div(2), div(3)]));
 
 		const errorHtml = div(div('Error!'));
 
@@ -2005,7 +2005,7 @@ describe('Fragment', () => {
 		);
 
 		expect(scratch.innerHTML).to.eql(
-			div([div('A'), div('B1'), div('B2'), div('C')].join(''))
+			div([div('A'), div('B1'), div('B2'), div('C')])
 		);
 
 		clearLog();
@@ -2013,7 +2013,7 @@ describe('Fragment', () => {
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(
-			div([div('A'), section('B3'), section('B4'), div('C')].join(''))
+			div([div('A'), section('B3'), section('B4'), div('C')])
 		);
 		expectDomLogToBe([
 			'<section>.appendChild(#text)',
@@ -2458,17 +2458,14 @@ describe('Fragment', () => {
 
 		render(<App />, scratch);
 
-		expect(scratch.innerHTML).to.eql(
-			div([div('A'), div('C')].join('')),
-			'initial'
-		);
+		expect(scratch.innerHTML).to.eql(div([div('A'), div('C')]), 'initial');
 
 		clearLog();
 		updateB();
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(
-			div([div('A'), div('B'), div('C')].join('')),
+			div([div('A'), div('B'), div('C')]),
 			'updateB'
 		);
 		expectDomLogToBe([
@@ -2481,7 +2478,7 @@ describe('Fragment', () => {
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(
-			div([span('A2'), div('B'), div('C')].join('')),
+			div([span('A2'), div('B'), div('C')]),
 			'updateA'
 		);
 		expectDomLogToBe([

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -35,7 +35,7 @@ describe('hydrate()', () => {
 	});
 
 	it('should reuse existing DOM', () => {
-		const html = ul([li('1'), li('2'), li('3')].join(''));
+		const html = ul([li('1'), li('2'), li('3')]);
 
 		scratch.innerHTML = html;
 		clearLog();
@@ -54,7 +54,7 @@ describe('hydrate()', () => {
 	});
 
 	it('should reuse existing DOM when given components', () => {
-		const html = ul([li('1'), li('2'), li('3')].join(''));
+		const html = ul([li('1'), li('2'), li('3')]);
 
 		scratch.innerHTML = html;
 		clearLog();
@@ -73,7 +73,7 @@ describe('hydrate()', () => {
 	});
 
 	it('should add missing nodes to existing DOM when hydrating', () => {
-		const html = ul([li('1')].join(''));
+		const html = ul([li('1')]);
 
 		scratch.innerHTML = html;
 		clearLog();
@@ -87,9 +87,7 @@ describe('hydrate()', () => {
 			scratch
 		);
 
-		expect(scratch.innerHTML).to.equal(
-			ul([li('1'), li('2'), li('3')].join(''))
-		);
+		expect(scratch.innerHTML).to.equal(ul([li('1'), li('2'), li('3')]));
 		expect(getLog()).to.deep.equal([
 			'<li>.appendChild(#text)',
 			'<ul>1.appendChild(<li>2)',
@@ -99,7 +97,7 @@ describe('hydrate()', () => {
 	});
 
 	it('should remove extra nodes from existing DOM when hydrating', () => {
-		const html = ul([li('1'), li('2'), li('3'), li('4')].join(''));
+		const html = ul([li('1'), li('2'), li('3'), li('4')]);
 
 		scratch.innerHTML = html;
 		clearLog();
@@ -113,9 +111,7 @@ describe('hydrate()', () => {
 			scratch
 		);
 
-		expect(scratch.innerHTML).to.equal(
-			ul([li('1'), li('2'), li('3')].join(''))
-		);
+		expect(scratch.innerHTML).to.equal(ul([li('1'), li('2'), li('3')]));
 		expect(getLog()).to.deep.equal(['<li>4.remove()']);
 	});
 
@@ -148,7 +144,7 @@ describe('hydrate()', () => {
 	});
 
 	it('should correctly hydrate with Fragments', () => {
-		const html = ul([li('1'), li('2'), li('3'), li('4')].join(''));
+		const html = ul([li('1'), li('2'), li('3'), li('4')]);
 
 		scratch.innerHTML = html;
 		clearLog();
@@ -171,7 +167,7 @@ describe('hydrate()', () => {
 
 	it('should correctly hydrate root Fragments', () => {
 		const html = [
-			ul([li('1'), li('2'), li('3'), li('4')].join('')),
+			ul([li('1'), li('2'), li('3'), li('4')]),
 			div('sibling')
 		].join('');
 
@@ -205,7 +201,7 @@ describe('hydrate()', () => {
 	it.skip('should override incorrect pre-existing DOM with VNodes passed into render', () => {
 		const initialHtml = [
 			div('sibling'),
-			ul([li('1'), li('4'), li('3'), li('2')].join(''))
+			ul([li('1'), li('4'), li('3'), li('2')])
 		].join('');
 
 		scratch.innerHTML = initialHtml;
@@ -227,7 +223,7 @@ describe('hydrate()', () => {
 		);
 
 		const finalHtml = [
-			ul([li('1'), li('2'), li('3'), li('4')].join('')),
+			ul([li('1'), li('2'), li('3'), li('4')]),
 			div('sibling')
 		].join('');
 

--- a/test/browser/keys.test.js
+++ b/test/browser/keys.test.js
@@ -1,6 +1,7 @@
 import { createElement, Component, render } from 'preact';
 import { setupScratch, teardown } from '../_util/helpers';
 import { logCall, clearLog, getLog } from '../_util/logCall';
+import { div } from '../_util/dom';
 
 /** @jsx createElement */
 
@@ -29,13 +30,13 @@ describe('keys', () => {
 	}
 
 	/** @type {(props: {values: any[]}) => any} */
-	const List = props => ((
+	const List = props => (
 		<ol>
 			{props.values.map(value => (
 				<li key={value}>{value}</li>
 			))}
 		</ol>
-	));
+	);
 
 	/**
 	 * Move an element in an array from one index to another
@@ -345,10 +346,12 @@ describe('keys', () => {
 
 		ops = [];
 		render(<Foo condition />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>Stateful</div>');
 		expect(ops).to.deep.equal(['Mount Stateful'], 'initial mount');
 
 		ops = [];
 		render(<Foo condition={false} />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>Stateful</div>');
 		expect(ops).to.deep.equal(
 			['Unmount Stateful', 'Mount Stateful'],
 			'switching keys 1'
@@ -356,6 +359,7 @@ describe('keys', () => {
 
 		ops = [];
 		render(<Foo condition />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>Stateful</div>');
 		expect(ops).to.deep.equal(
 			['Unmount Stateful', 'Mount Stateful'],
 			'switching keys 2'
@@ -373,10 +377,12 @@ describe('keys', () => {
 
 		ops = [];
 		render(<Foo keyed />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>Stateful</div>');
 		expect(ops).to.deep.equal(['Mount Stateful'], 'initial mount with key');
 
 		ops = [];
 		render(<Foo keyed={false} />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>Stateful</div>');
 		expect(ops).to.deep.equal(
 			['Unmount Stateful', 'Mount Stateful'],
 			'switching from keyed to unkeyed'
@@ -384,6 +390,7 @@ describe('keys', () => {
 
 		ops = [];
 		render(<Foo keyed />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>Stateful</div>');
 		expect(ops).to.deep.equal(
 			['Unmount Stateful', 'Mount Stateful'],
 			'switching from unkeyed to keyed'
@@ -419,9 +426,17 @@ describe('keys', () => {
 			);
 		}
 
+		const expectedHtml = div([
+			div(1),
+			div('Stateful1'),
+			div(2),
+			div('Stateful2')
+		]);
+
 		ops = [];
 		render(<Foo moved={false} />, scratch);
 
+		expect(scratch.innerHTML).to.equal(expectedHtml);
 		expect(ops).to.deep.equal(['Mount Stateful1', 'Mount Stateful2']);
 		expect(Stateful1Ref).to.exist;
 		expect(Stateful2Ref).to.exist;
@@ -429,6 +444,7 @@ describe('keys', () => {
 		ops = [];
 		render(<Foo moved />, scratch);
 
+		expect(scratch.innerHTML).to.equal(expectedHtml);
 		expect(ops).to.deep.equal([
 			'Unmount Stateful2',
 			'Unmount Stateful1',
@@ -441,6 +457,7 @@ describe('keys', () => {
 		ops = [];
 		render(<Foo moved={false} />, scratch);
 
+		expect(scratch.innerHTML).to.equal(expectedHtml);
 		expect(ops).to.deep.equal([
 			'Unmount Stateful2',
 			'Unmount Stateful1',
@@ -486,9 +503,24 @@ describe('keys', () => {
 			);
 		}
 
+		const htmlForFalse = div([
+			div(1),
+			div('Stateful1'),
+			div(2),
+			div('Stateful2')
+		]);
+
+		const htmlForTrue = div([
+			div(1),
+			div('Stateful2'),
+			div(2),
+			div('Stateful1')
+		]);
+
 		ops = [];
 		render(<Foo moved={false} />, scratch);
 
+		expect(scratch.innerHTML).to.equal(htmlForFalse);
 		expect(ops).to.deep.equal(['Mount Stateful1', 'Mount Stateful2']);
 		expect(Stateful1Ref).to.exist;
 		expect(Stateful2Ref).to.exist;
@@ -496,6 +528,7 @@ describe('keys', () => {
 		ops = [];
 		render(<Foo moved />, scratch);
 
+		expect(scratch.innerHTML).to.equal(htmlForTrue);
 		expect(ops).to.deep.equal(['Update Stateful2', 'Update Stateful1']);
 		expect(Stateful1MovedRef).to.equal(Stateful1Ref);
 		expect(Stateful2MovedRef).to.equal(Stateful2Ref);
@@ -503,6 +536,7 @@ describe('keys', () => {
 		ops = [];
 		render(<Foo moved={false} />, scratch);
 
+		expect(scratch.innerHTML).to.equal(htmlForFalse);
 		expect(ops).to.deep.equal(['Update Stateful1', 'Update Stateful2']);
 		expect(Stateful1Ref).to.equal(Stateful1MovedRef);
 		expect(Stateful2Ref).to.equal(Stateful2MovedRef);
@@ -537,9 +571,17 @@ describe('keys', () => {
 			);
 		}
 
+		const expectedHtml = div([
+			div(1),
+			div('Stateful1'),
+			div(2),
+			div('Stateful2')
+		]);
+
 		ops = [];
 		render(<Foo unkeyed={false} />, scratch);
 
+		expect(scratch.innerHTML).to.equal(expectedHtml);
 		expect(ops).to.deep.equal(['Mount Stateful1', 'Mount Stateful2']);
 		expect(Stateful1Ref).to.exist;
 		expect(Stateful2Ref).to.exist;
@@ -547,6 +589,7 @@ describe('keys', () => {
 		ops = [];
 		render(<Foo unkeyed />, scratch);
 
+		expect(scratch.innerHTML).to.equal(expectedHtml);
 		expect(ops).to.deep.equal([
 			'Unmount Stateful2',
 			'Unmount Stateful1',
@@ -559,6 +602,7 @@ describe('keys', () => {
 		ops = [];
 		render(<Foo unkeyed={false} />, scratch);
 
+		expect(scratch.innerHTML).to.equal(expectedHtml);
 		expect(ops).to.deep.equal([
 			'Unmount Stateful2',
 			'Unmount Stateful1',
@@ -587,9 +631,13 @@ describe('keys', () => {
 		}
 
 		render(<Foo condition />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<div><div>Hello</div><div>bar</div></div>'
+		);
 		clearLog();
 
 		render(<Foo />, scratch);
+		expect(scratch.innerHTML).to.equal('<div><div>Hello</div></div>');
 		expect(getLog()).to.deep.equal(['<div>bar.remove()']);
 	});
 });


### PR DESCRIPTION
While playing around with some tests, I realized it was silly that these helpers didn't do the `join` for you. Adding that now which enables Prettier to format things a little nicer.