### PR TITLE
Initialize compat options when relevant functions are called

### DIFF
--- a/compat/src/Component.js
+++ b/compat/src/Component.js
@@ -1,12 +1,30 @@
-import { Component as PreactComponent } from 'preact';
-import { installReactCompat, isReactCompatInstalled } from './render';
+import { Component as PreactComponent } from '../../src/index';
+// import { installReactCompat, isReactCompatInstalled } from './render';
 
-export class Component extends PreactComponent {
-	constructor(props, context) {
-		super(props, context);
+// export class Component extends PreactComponent {
+// 	constructor(props, context) {
+// 		super(props, context);
+//
+// 		if (!isReactCompatInstalled) {
+// 			installReactCompat();
+// 		}
+// 	}
+// }
 
-		if (!isReactCompatInstalled) {
-			installReactCompat();
-		}
-	}
+export function Component() {
+	PreactComponent.apply(this, arguments);
+
+	// if (!isReactCompatInstalled) {
+	// 	installReactCompat();
+	// }
+
+	// this.setState = PreactComponent.prototype.setState;
+	// this.forceUpdate = PreactComponent.prototype.forceUpdate;
+	// this.render = PreactComponent.prototype.render;
 }
+
+// Component.prototype.setState = PreactComponent.prototype.setState;
+// Component.prototype.forceUpdate = PreactComponent.prototype.forceUpdate;
+// Component.prototype.render = PreactComponent.prototype.render;
+
+// Component.prototype = Object.create(PreactComponent);

--- a/compat/src/Component.js
+++ b/compat/src/Component.js
@@ -1,0 +1,12 @@
+import { Component as PreactComponent } from 'preact';
+import { installReactCompat, isReactCompatInstalled } from './render';
+
+export class Component extends PreactComponent {
+	constructor(props, context) {
+		super(props, context);
+
+		if (!isReactCompatInstalled) {
+			installReactCompat();
+		}
+	}
+}

--- a/compat/src/PureComponent.js
+++ b/compat/src/PureComponent.js
@@ -1,4 +1,4 @@
-import { Component } from 'preact';
+import { Component } from './Component';
 import { shallowDiffers } from './util';
 
 /**

--- a/compat/src/PureComponent.js
+++ b/compat/src/PureComponent.js
@@ -4,16 +4,33 @@ import { shallowDiffers } from './util';
 /**
  * Component class with a predefined `shouldComponentUpdate` implementation
  */
-export class PureComponent extends Component {
-	constructor(props) {
-		super(props);
-		// Some third-party libraries check if this property is present
-		this.isPureReactComponent = true;
-	}
+// export class PureComponent extends Component {
+// 	constructor(props) {
+// 		super(props);
+// 		// Some third-party libraries check if this property is present
+// 		this.isPureReactComponent = true;
+// 	}
+//
+// 	shouldComponentUpdate(props, state) {
+// 		return (
+// 			shallowDiffers(this.props, props) || shallowDiffers(this.state, state)
+// 		);
+// 	}
+// }
 
-	shouldComponentUpdate(props, state) {
-		return (
-			shallowDiffers(this.props, props) || shallowDiffers(this.state, state)
-		);
-	}
+export function PureComponent(props, context) {
+	this.props = props;
+	this.context = context;
+
+	// Some third-party libraries check if this property is present
+	// this.isReactComponent = {};
+	// this.isPureReactComponent = true;
 }
+
+PureComponent.prototype.isReactComponent = {};
+PureComponent.prototype.isPureReactComponent = true;
+PureComponent.prototype.setState = Component.prototype.setState;
+PureComponent.prototype.forceUpdate = Component.prototype.forceUpdate;
+PureComponent.prototype.shouldComponentUpdate = function(props, state) {
+	return shallowDiffers(this.props, props) || shallowDiffers(this.state, state);
+};

--- a/compat/src/TODO.md
+++ b/compat/src/TODO.md
@@ -1,0 +1,54 @@
+# Tree shaking in compat TODO
+
+## Classes
+
+### The problem
+
+In order to enable tree-shaking, we need to transform our classes into a tree-shakeable form.
+
+If a class doesn't use inheritance, then the standard prototype assignments should be tree-shakeable. However classes that inherit (or manually inherit using `Suspense.prototype = new Component()`) are not tree-shakeable by default. BabelJS compiles classes into function closures with a `/*#__PURE__*/` comment informing tree-shakers that this closure can be safely removed if unused.
+
+However for Preact, since we bundle our code output, rollup sees these classes as used (because they are exported) and terser minifies the output and removes the comments. This means our classes don't get compiled away if a consumer of Preact doesn't use them because of the lack of a `/*#__PURE__*/` comment.
+
+### Possible solutions
+
+One option is to modify terser to add a new option to keep `/*#__PURE__*/` comments in source (probably pretty difficult...).
+
+Another idea would be to manually code the classes to be tree-shakeable and not use inheritance.
+
+Some code I tried out:
+
+```js
+// portals.js
+var ContextProvider = function ContextProvider() {};
+ContextProvider.prototype.getChildContext = function getChildContext() {
+	return this.props.context;
+};
+ContextProvider.prototype.render = function render(props) {
+	return props.children;
+};
+```
+
+```js
+// PureComponent.js
+export function PureComponent() {
+	this.isPureReactComponent = true;
+}
+PureComponent.prototype.shouldComponentUpdate = function(props, state) {
+	return shallowDiffers(this.props, props) || shallowDiffers(this.state, state);
+};
+```
+
+```js
+// suspense.js
+
+// Comment out the following line to remove a side-effect
+// Suspense.prototype = new Component();
+```
+
+```js
+// suspense-list.js
+
+// Comment out the following line to remove a side-effect
+// SuspenseList.prototype = new Component();
+```

--- a/compat/src/TODO.md
+++ b/compat/src/TODO.md
@@ -31,6 +31,7 @@ ContextProvider.prototype.render = function render(props) {
 
 ```js
 // PureComponent.js
+// DOESN'T WORK CUZ CONSUMERS NEED TO BE ABLE TO CALL SETSTATE
 export function PureComponent() {
 	this.isPureReactComponent = true;
 }

--- a/compat/src/forwardRef.js
+++ b/compat/src/forwardRef.js
@@ -1,15 +1,20 @@
 import { options } from 'preact';
 import { assign } from './util';
 
-let oldVNodeHook = options.vnode;
-options.vnode = vnode => {
-	if (vnode.type && vnode.type._forwarded && vnode.ref) {
-		vnode.props.ref = vnode.ref;
-		vnode.ref = null;
-	}
+export let isForwardRefInstalled = false;
+export function installForwardRef() {
+	let oldVNodeHook = options.vnode;
+	options.vnode = vnode => {
+		if (vnode.type && vnode.type._forwarded && vnode.ref) {
+			vnode.props.ref = vnode.ref;
+			vnode.ref = null;
+		}
 
-	if (oldVNodeHook) oldVNodeHook(vnode);
-};
+		if (oldVNodeHook) oldVNodeHook(vnode);
+	};
+
+	isForwardRefInstalled = true;
+}
 
 /**
  * Pass ref down to a child. This is mainly used in libraries with HOCs that
@@ -19,6 +24,10 @@ options.vnode = vnode => {
  * @returns {import('./internal').FunctionalComponent}
  */
 export function forwardRef(fn) {
+	if (!isForwardRefInstalled) {
+		installForwardRef();
+	}
+
 	function Forwarded(props) {
 		let clone = assign({}, props);
 		delete clone.ref;

--- a/compat/src/forwardRef.js
+++ b/compat/src/forwardRef.js
@@ -1,20 +1,4 @@
-import { options } from 'preact';
 import { assign } from './util';
-
-export let isForwardRefInstalled = false;
-export function installForwardRef() {
-	let oldVNodeHook = options.vnode;
-	options.vnode = vnode => {
-		if (vnode.type && vnode.type._forwarded && vnode.ref) {
-			vnode.props.ref = vnode.ref;
-			vnode.ref = null;
-		}
-
-		if (oldVNodeHook) oldVNodeHook(vnode);
-	};
-
-	isForwardRefInstalled = true;
-}
 
 /**
  * Pass ref down to a child. This is mainly used in libraries with HOCs that
@@ -24,10 +8,6 @@ export function installForwardRef() {
  * @returns {import('./internal').FunctionalComponent}
  */
 export function forwardRef(fn) {
-	if (!isForwardRefInstalled) {
-		installForwardRef();
-	}
-
 	function Forwarded(props) {
 		let clone = assign({}, props);
 		delete clone.ref;

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -1,5 +1,4 @@
 import {
-	createElement,
 	render as preactRender,
 	cloneElement as preactCloneElement,
 	createRef,
@@ -26,7 +25,7 @@ import { Children } from './Children';
 import { Suspense, lazy } from './suspense';
 import { SuspenseList } from './suspense-list';
 import { createPortal } from './portals';
-import { render, REACT_ELEMENT_TYPE } from './render';
+import { createElement, render, REACT_ELEMENT_TYPE } from './render';
 
 const version = '16.8.0'; // trick libraries to think we are react
 

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -1,6 +1,7 @@
 import {
 	render as preactRender,
 	cloneElement as preactCloneElement,
+	isValidElement as preactIsValidElement,
 	createRef,
 	Component,
 	createContext,
@@ -43,7 +44,10 @@ function createFactory(type) {
  * @returns {boolean}
  */
 function isValidElement(element) {
-	return !!element && element.$$typeof === REACT_ELEMENT_TYPE;
+	return (
+		(!!element && element.$$typeof === REACT_ELEMENT_TYPE) ||
+		preactIsValidElement(element)
+	);
 }
 
 /**

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -3,7 +3,6 @@ import {
 	cloneElement as preactCloneElement,
 	isValidElement as preactIsValidElement,
 	createRef,
-	Component,
 	createContext,
 	Fragment
 } from 'preact';
@@ -27,6 +26,7 @@ import { Suspense, lazy } from './suspense';
 import { SuspenseList } from './suspense-list';
 import { createPortal } from './portals';
 import { createElement, render, REACT_ELEMENT_TYPE } from './render';
+import { Component } from './Component';
 
 const version = '16.8.0'; // trick libraries to think we are react
 

--- a/compat/src/memo.js
+++ b/compat/src/memo.js
@@ -1,6 +1,5 @@
 import { createElement } from 'preact';
 import { shallowDiffers, assign } from './util';
-import { installForwardRef, isForwardRefInstalled } from './forwardRef';
 
 /**
  * Memoize a component, so that it only updates when the props actually have
@@ -10,10 +9,6 @@ import { installForwardRef, isForwardRefInstalled } from './forwardRef';
  * @returns {import('./internal').FunctionalComponent}
  */
 export function memo(c, comparer) {
-	if (!isForwardRefInstalled) {
-		installForwardRef();
-	}
-
 	function shouldUpdate(nextProps) {
 		let ref = this.props.ref;
 		let updateRef = ref == nextProps.ref;

--- a/compat/src/memo.js
+++ b/compat/src/memo.js
@@ -1,5 +1,6 @@
 import { createElement } from 'preact';
 import { shallowDiffers, assign } from './util';
+import { installForwardRef, isForwardRefInstalled } from './forwardRef';
 
 /**
  * Memoize a component, so that it only updates when the props actually have
@@ -9,6 +10,10 @@ import { shallowDiffers, assign } from './util';
  * @returns {import('./internal').FunctionalComponent}
  */
 export function memo(c, comparer) {
+	if (!isForwardRefInstalled) {
+		installForwardRef();
+	}
+
 	function shouldUpdate(nextProps) {
 		let ref = this.props.ref;
 		let updateRef = ref == nextProps.ref;

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -9,6 +9,9 @@ import { applyEventNormalization } from './events';
 
 const CAMEL_PROPS = /^(?:accent|alignment|arabic|baseline|cap|clip|color|fill|flood|font|glyph|horiz|marker|overline|paint|stop|strikethrough|stroke|text|underline|unicode|units|v|vector|vert|word|writing|x)[A-Z]/;
 
+// Some libraries like `react-virtualized` explicitly check for this.
+Component.prototype.isReactComponent = {};
+
 /* istanbul ignore next */
 export const REACT_ELEMENT_TYPE =
 	(typeof Symbol !== 'undefined' &&
@@ -78,9 +81,6 @@ const classNameDescriptor = {
 
 let isReactCompatInstalled = false;
 function installReactCompat() {
-	// Some libraries like `react-virtualized` explicitly check for this.
-	Component.prototype.isReactComponent = {};
-
 	let oldEventHook = options.event;
 	options.event = e => {
 		if (oldEventHook) e = oldEventHook(e);

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -1,5 +1,6 @@
 import {
 	render as preactRender,
+	createElement as preactCreateElement,
 	options,
 	toChildArray,
 	Component
@@ -8,15 +9,20 @@ import { applyEventNormalization } from './events';
 
 const CAMEL_PROPS = /^(?:accent|alignment|arabic|baseline|cap|clip|color|fill|flood|font|glyph|horiz|marker|overline|paint|stop|strikethrough|stroke|text|underline|unicode|units|v|vector|vert|word|writing|x)[A-Z]/;
 
-// Some libraries like `react-virtualized` explicitly check for this.
-Component.prototype.isReactComponent = {};
-
 /* istanbul ignore next */
 export const REACT_ELEMENT_TYPE =
 	(typeof Symbol !== 'undefined' &&
 		Symbol.for &&
 		Symbol.for('react.element')) ||
 	0xeac7;
+
+export function createElement() {
+	if (!isReactCompatInstalled) {
+		installReactCompat();
+	}
+
+	return preactCreateElement.apply(null, arguments);
+}
 
 /**
  * Proxy render() since React returns a Component reference.
@@ -26,6 +32,10 @@ export const REACT_ELEMENT_TYPE =
  * @returns {import('./internal').Component | null} The root component reference or null
  */
 export function render(vnode, parent, callback) {
+	if (!isReactCompatInstalled) {
+		installReactCompat();
+	}
+
 	// React destroys any existing DOM nodes, see #1727
 	// ...but only on the first render, see #1828
 	if (parent._children == null) {
@@ -39,13 +49,6 @@ export function render(vnode, parent, callback) {
 
 	return vnode ? vnode._component : null;
 }
-
-let oldEventHook = options.event;
-options.event = e => {
-	if (oldEventHook) e = oldEventHook(e);
-	e.persist = () => {};
-	return (e.nativeEvent = e);
-};
 
 // Patch in `UNSAFE_*` lifecycle hooks
 function setSafeDescriptor(proto, key) {
@@ -66,77 +69,94 @@ function setSafeDescriptor(proto, key) {
 	}
 }
 
-let classNameDescriptor = {
+const classNameDescriptor = {
 	configurable: true,
 	get() {
 		return this.class;
 	}
 };
 
-let oldVNodeHook = options.vnode;
-options.vnode = vnode => {
-	vnode.$$typeof = REACT_ELEMENT_TYPE;
+let isReactCompatInstalled = false;
+function installReactCompat() {
+	// Some libraries like `react-virtualized` explicitly check for this.
+	Component.prototype.isReactComponent = {};
 
-	let type = vnode.type;
-	let props = vnode.props;
+	let oldEventHook = options.event;
+	options.event = e => {
+		if (oldEventHook) e = oldEventHook(e);
+		e.persist = () => {};
+		return (e.nativeEvent = e);
+	};
 
-	// Apply DOM VNode compat
-	if (typeof type != 'function') {
-		// Apply defaultValue to value
-		if (props.defaultValue) {
-			if (!props.value && props.value !== 0) {
-				props.value = props.defaultValue;
-			}
-			delete props.defaultValue;
-		}
+	let oldVNodeHook = options.vnode;
+	options.vnode = vnode => {
+		vnode.$$typeof = REACT_ELEMENT_TYPE;
 
-		// Add support for array select values: <select value={[]} />
-		if (Array.isArray(props.value) && props.multiple && type === 'select') {
-			toChildArray(props.children).forEach(child => {
-				if (props.value.indexOf(child.props.value) != -1) {
-					child.props.selected = true;
+		let type = vnode.type;
+		let props = vnode.props;
+
+		// Apply DOM VNode compat
+		if (typeof type != 'function') {
+			// Apply defaultValue to value
+			if (props.defaultValue) {
+				if (!props.value && props.value !== 0) {
+					props.value = props.defaultValue;
 				}
-			});
-			delete props.value;
-		}
+				delete props.defaultValue;
+			}
 
-		// Normalize DOM vnode properties.
-		let shouldSanitize, attrs, i;
-		for (i in props) if ((shouldSanitize = CAMEL_PROPS.test(i))) break;
-		if (shouldSanitize) {
-			attrs = vnode.props = {};
-			for (i in props) {
-				attrs[
-					CAMEL_PROPS.test(i) ? i.replace(/([A-Z0-9])/, '-$1').toLowerCase() : i
-				] = props[i];
+			// Add support for array select values: <select value={[]} />
+			if (Array.isArray(props.value) && props.multiple && type === 'select') {
+				toChildArray(props.children).forEach(child => {
+					if (props.value.indexOf(child.props.value) != -1) {
+						child.props.selected = true;
+					}
+				});
+				delete props.value;
+			}
+
+			// Normalize DOM vnode properties.
+			let shouldSanitize, attrs, i;
+			for (i in props) if ((shouldSanitize = CAMEL_PROPS.test(i))) break;
+			if (shouldSanitize) {
+				attrs = vnode.props = {};
+				for (i in props) {
+					attrs[
+						CAMEL_PROPS.test(i)
+							? i.replace(/([A-Z0-9])/, '-$1').toLowerCase()
+							: i
+					] = props[i];
+				}
 			}
 		}
-	}
 
-	// Alias `class` prop to `className` if available
-	if (props.class || props.className) {
-		classNameDescriptor.enumerable = 'className' in props;
-		if (props.className) props.class = props.className;
-		Object.defineProperty(props, 'className', classNameDescriptor);
-	}
+		// Alias `class` prop to `className` if available
+		if (props.class || props.className) {
+			classNameDescriptor.enumerable = 'className' in props;
+			if (props.className) props.class = props.className;
+			Object.defineProperty(props, 'className', classNameDescriptor);
+		}
 
-	// Events
-	applyEventNormalization(vnode);
+		// Events
+		applyEventNormalization(vnode);
 
-	// Component base class compat
-	// We can't just patch the base component class, because components that use
-	// inheritance and are transpiled down to ES5 will overwrite our patched
-	// getters and setters. See #1941
-	if (
-		typeof type === 'function' &&
-		!type._patchedLifecycles &&
-		type.prototype
-	) {
-		setSafeDescriptor(type.prototype, 'componentWillMount');
-		setSafeDescriptor(type.prototype, 'componentWillReceiveProps');
-		setSafeDescriptor(type.prototype, 'componentWillUpdate');
-		type._patchedLifecycles = true;
-	}
+		// Component base class compat
+		// We can't just patch the base component class, because components that use
+		// inheritance and are transpiled down to ES5 will overwrite our patched
+		// getters and setters. See #1941
+		if (
+			typeof type === 'function' &&
+			!type._patchedLifecycles &&
+			type.prototype
+		) {
+			setSafeDescriptor(type.prototype, 'componentWillMount');
+			setSafeDescriptor(type.prototype, 'componentWillReceiveProps');
+			setSafeDescriptor(type.prototype, 'componentWillUpdate');
+			type._patchedLifecycles = true;
+		}
 
-	if (oldVNodeHook) oldVNodeHook(vnode);
-};
+		if (oldVNodeHook) oldVNodeHook(vnode);
+	};
+
+	isReactCompatInstalled = true;
+}

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -9,9 +9,6 @@ import { applyEventNormalization } from './events';
 
 const CAMEL_PROPS = /^(?:accent|alignment|arabic|baseline|cap|clip|color|fill|flood|font|glyph|horiz|marker|overline|paint|stop|strikethrough|stroke|text|underline|unicode|units|v|vector|vert|word|writing|x)[A-Z]/;
 
-// Some libraries like `react-virtualized` explicitly check for this.
-Component.prototype.isReactComponent = {};
-
 /* istanbul ignore next */
 export const REACT_ELEMENT_TYPE =
 	(typeof Symbol !== 'undefined' &&
@@ -79,8 +76,11 @@ const classNameDescriptor = {
 	}
 };
 
-let isReactCompatInstalled = false;
-function installReactCompat() {
+export let isReactCompatInstalled = false;
+export function installReactCompat() {
+	// Some libraries like `react-virtualized` explicitly check for this.
+	Component.prototype.isReactComponent = {};
+
 	let oldEventHook = options.event;
 	options.event = e => {
 		if (oldEventHook) e = oldEventHook(e);

--- a/compat/src/suspense-list.js
+++ b/compat/src/suspense-list.js
@@ -1,4 +1,5 @@
-import { Component, toChildArray } from 'preact';
+import { toChildArray } from 'preact';
+import { Component } from './Component';
 import { suspended } from './suspense.js';
 
 // Indexes to linked list nodes (nodes are stored as arrays to save bytes).

--- a/compat/src/suspense-list.js
+++ b/compat/src/suspense-list.js
@@ -1,5 +1,4 @@
 import { toChildArray } from 'preact';
-import { Component } from './Component';
 import { suspended } from './suspense.js';
 
 // Indexes to linked list nodes (nodes are stored as arrays to save bytes).
@@ -52,11 +51,6 @@ const resolve = (list, child, node) => {
 		list._next = node = node[NEXT_NODE];
 	}
 };
-
-// Things we do here to save some bytes but are not proper JS inheritance:
-// - call `new Component()` as the prototype
-// - do not set `Suspense.prototype.constructor` to `Suspense`
-SuspenseList.prototype = new Component();
 
 SuspenseList.prototype._suspended = function(child) {
 	const list = this;

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -1,5 +1,6 @@
 import { Component, createElement, options } from 'preact';
 import { assign } from './util';
+import { installForwardRef, isForwardRefInstalled } from './forwardRef';
 
 let isSuspenseInstalled;
 function installSuspense() {
@@ -113,6 +114,10 @@ export function suspended(vnode) {
 }
 
 export function lazy(loader) {
+	if (!isForwardRefInstalled) {
+		installForwardRef();
+	}
+
 	let prom;
 	let component;
 	let error;

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -1,4 +1,5 @@
-import { Component, createElement, options } from 'preact';
+import { createElement, options } from 'preact';
+import { Component } from './Component';
 import { assign } from './util';
 
 let isSuspenseInstalled;

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -47,7 +47,7 @@ export function Suspense() {
 // Things we do here to save some bytes but are not proper JS inheritance:
 // - call `new Component()` as the prototype
 // - do not set `Suspense.prototype.constructor` to `Suspense`
-Suspense.prototype = new Component();
+Suspense.prototype.setState = Component.prototype.setState;
 
 /**
  * @param {Promise} promise The thrown promise

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -1,6 +1,5 @@
 import { Component, createElement, options } from 'preact';
 import { assign } from './util';
-import { installForwardRef, isForwardRefInstalled } from './forwardRef';
 
 let isSuspenseInstalled;
 function installSuspense() {
@@ -114,10 +113,6 @@ export function suspended(vnode) {
 }
 
 export function lazy(loader) {
-	if (!isForwardRefInstalled) {
-		installForwardRef();
-	}
-
 	let prom;
 	let component;
 	let error;

--- a/compat/test/browser/memo.test.js
+++ b/compat/test/browser/memo.test.js
@@ -1,11 +1,19 @@
 import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import React, { createElement, Component, render, memo } from 'preact/compat';
+import React, {
+	createElement,
+	Component,
+	render,
+	memo,
+	createRef
+} from 'preact/compat';
 
 const h = React.createElement;
 
 describe('memo()', () => {
-	let scratch, rerender;
+	/**@type {HTMLDivElement} */
+	let scratch;
+	let rerender;
 
 	beforeEach(() => {
 		scratch = setupScratch();
@@ -54,7 +62,6 @@ describe('memo()', () => {
 
 	it('should support adding refs', () => {
 		let spy = sinon.spy();
-
 		let ref = null;
 
 		function Foo() {
@@ -74,18 +81,24 @@ describe('memo()', () => {
 				return <Memoized ref={ref} />;
 			}
 		}
+
 		render(<App />, scratch);
-
 		expect(spy).to.be.calledOnce;
+		expect(ref).to.be.null;
 
-		ref = {};
+		ref = createRef();
+		update();
+		rerender();
+
+		expect(ref.current).not.to.be.undefined;
+		expect(ref.current.constructor.name).to.equal('Foo');
+		expect(spy).to.be.calledTwice; // TODO: not sure whether this is in-line with react...
 
 		update();
 		rerender();
 
 		expect(ref.current).not.to.be.undefined;
-
-		// TODO: not sure whether this is in-line with react...
+		expect(ref.current.constructor.name).to.equal('Foo');
 		expect(spy).to.be.calledTwice;
 	});
 

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -10,9 +10,19 @@ import options from './options';
  */
 export function createElement(type, props, children) {
 	let normalizedProps = {},
-		i;
+		i,
+		ref;
+
 	for (i in props) {
-		if (i !== 'key' && i !== 'ref') normalizedProps[i] = props[i];
+		if (i == 'ref') {
+			if (type && type._forwarded) {
+				normalizedProps[i] = props[i];
+			} else {
+				ref = props[i];
+			}
+		} else if (i !== 'key') {
+			normalizedProps[i] = props[i];
+		}
 	}
 
 	if (arguments.length > 3) {
@@ -36,12 +46,7 @@ export function createElement(type, props, children) {
 		}
 	}
 
-	return createVNode(
-		type,
-		normalizedProps,
-		props && props.key,
-		props && props.ref
-	);
+	return createVNode(type, normalizedProps, props && props.key, ref);
 }
 
 /**


### PR DESCRIPTION
With this change, the only pieces left that [`agadoo`](https://npm.im/agadoo) can't treeshake out of compat are Suspense and SuspenseList because they inherit from Component, which they need to do because they call `setState` :/

Total Change:
compat.js.gz: +24 B
preact.js.gz: +5 B

Related: #1529 