### PR TITLE
cut bytes in shouldComponentUpdate

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -124,19 +124,12 @@ export function diff(
 					c.shouldComponentUpdate != null &&
 					c.shouldComponentUpdate(newProps, c._nextState, cctx) === false
 				) {
-					c.props = newProps;
+					c.props = oldVNode.props = newProps;
 					c.state = c._nextState;
 					c._dirty = false;
-					c._vnode = newVNode;
-					newVNode._dom = oldVNode._dom;
-					newVNode._children = oldVNode._children;
+					c._vnode = oldVNode;
 					if (c._renderCallbacks.length) {
 						commitQueue.push(c);
-					}
-					for (tmp = 0; tmp < newVNode._children.length; tmp++) {
-						if (newVNode._children[tmp]) {
-							newVNode._children[tmp]._parent = newVNode;
-						}
 					}
 					break outer;
 				}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -127,7 +127,10 @@ export function diff(
 					c.props = oldVNode.props = newProps;
 					c.state = c._nextState;
 					c._dirty = false;
-					c._vnode = oldVNode;
+					oldVNode._parent = newVNode._parent;
+					oldVNode._parent._children[
+						oldVNode._parent._children.indexOf(newVNode)
+					] = oldVNode;
 					if (c._renderCallbacks.length) {
 						commitQueue.push(c);
 					}


### PR DESCRIPTION
I was checking to switch over to a data structure where we dispose our newVNodes all the time so we never run into major gc runs for our long-living oldVNodes to be cleaned up.

Preferably we make our newVNodes short-lived so that it's easy to cleanup.

Wanted to do this incrementally and saw something that immediately gave us advantages + byte savings

EDIT: seems like it will be an all or nothing, some tests aren't running on my machine...

The complicated part about this being that we will differentiate between first render and subsequent, first will need to be based on the newVNode instead of the oldVNode and after we adapt the old to the new one