### PR TITLE
Disable benchmarks on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dev": "microbundle watch --raw --format cjs",
     "dev:hooks": "microbundle watch --raw --format cjs --cwd hooks",
     "dev:compat": "microbundle watch --raw --format cjs --cwd compat --globals 'preact/hooks=preactHooks'",
-    "test": "npm-run-all lint build test:unit test:karma:bench",
+    "test": "npm-run-all lint build test:unit",
     "test:unit": "run-p test:mocha test:karma test:ts",
     "test:ts": "run-p test:ts:*",
     "test:ts:core": "tsc -p test/ts/ && mocha --require \"@babel/register\" test/ts/**/*-test.js",


### PR DESCRIPTION
Running benchmarks on the CI assumes that we always test in the same environment. This doesn't seem to be the case as sometimes the tests are passing and sometimes not. This leads me to conclude that we are assigned a random machine/vm with different specs and workloads.

Fixes build failures in various PRs like #2160 and #2166 .