### PR TITLE
Add component stack in debug warnings

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,5 @@
+const DEV = process.env.NODE_ENV !== 'production';
+
 module.exports = function(api) {
 	api.cache(true);
 
@@ -16,9 +18,10 @@ module.exports = function(api) {
 		],
 		plugins: [
 			'@babel/plugin-proposal-object-rest-spread',
+			DEV && '@babel/plugin-transform-react-jsx-source',
 			'@babel/plugin-transform-react-jsx',
 			'babel-plugin-transform-async-to-promises'
-		],
+		].filter(Boolean),
 		ignore: ['./dist']
 	};
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,4 @@
-const DEV = process.env.NODE_ENV !== 'production';
-
+// Only used for mocha tests. For karma, see karma.config.js
 module.exports = function(api) {
 	api.cache(true);
 
@@ -18,10 +17,9 @@ module.exports = function(api) {
 		],
 		plugins: [
 			'@babel/plugin-proposal-object-rest-spread',
-			DEV && '@babel/plugin-transform-react-jsx-source',
 			'@babel/plugin-transform-react-jsx',
 			'babel-plugin-transform-async-to-promises'
-		].filter(Boolean),
+		],
 		ignore: ['./dist']
 	};
 };

--- a/debug/mangle.json
+++ b/debug/mangle.json
@@ -41,7 +41,8 @@
       "$_render": "__r",
       "$_hook": "__h",
       "$_catchError": "__e",
-      "$_unmount": "_e"
+      "$_unmount": "_e",
+      "$_owner": "__o"
     }
   }
 }

--- a/debug/src/component-stack.js
+++ b/debug/src/component-stack.js
@@ -21,6 +21,9 @@ let renderStack = [];
  *   )
  * }
  * ```
+ *
+ * Note: A `vnode` may be hoisted to the root scope due to compiler
+ * optimiztions. In these cases the `_owner` will be different.
  */
 let ownerStack = [];
 

--- a/debug/src/component-stack.js
+++ b/debug/src/component-stack.js
@@ -1,0 +1,50 @@
+import { options, Fragment } from 'preact';
+import { getDisplayName } from './devtools/custom';
+
+let oldDiff = options._diff;
+let oldDiffed = options.diffed;
+let oldRoot = options._root;
+
+let stack = [];
+
+/**
+ * Return the component stack that was captured up to this point.
+ */
+export function getComponentStack() {
+	return stack.reduce((acc, vnode) => {
+		acc += `  in ${getDisplayName(vnode)}`;
+
+		const source = vnode.__source;
+		if (source) {
+			acc += ` (at ${source.fileName}:${source.lineNumber})`;
+		}
+
+		return (acc += '\n');
+	}, '');
+}
+
+/**
+ * Setup code to capture the component trace while rendering. Note that
+ * we cannot simply traverse `vnode._parent` upwards, because we have some
+ * debug messages for `this.setState` where the `vnode` is `undefined`.
+ */
+export function setupComponentStack() {
+	options.diffed = vnode => {
+		stack.pop();
+		if (oldDiffed) oldDiffed(vnode);
+	};
+
+	options._diff = vnode => {
+		if (typeof vnode.type === 'function') {
+			if (vnode.type !== Fragment) {
+				stack.push(vnode);
+			}
+		}
+		if (oldDiff) oldDiff(vnode);
+	};
+
+	options._root = (vnode, parent) => {
+		stack = [];
+		if (oldRoot) oldRoot(vnode, parent);
+	};
+}

--- a/debug/src/component-stack.js
+++ b/debug/src/component-stack.js
@@ -8,6 +8,14 @@ let oldRoot = options._root;
 let stack = [];
 
 /**
+ * If the user doesn't have `@babel/plugin-transform-react-jsx-source`
+ * somewhere in his tool chain we can't print the filename and source
+ * location of a component. In that case we just omit that, but we'll
+ * print a helpful message to the console, notifying the user of it.
+ */
+let hasBabelPlugin = false;
+
+/**
  * Return the component stack that was captured up to this point.
  */
 export function getComponentStack() {
@@ -17,6 +25,11 @@ export function getComponentStack() {
 		const source = vnode.__source;
 		if (source) {
 			acc += ` (at ${source.fileName}:${source.lineNumber})`;
+		} else if (!hasBabelPlugin) {
+			hasBabelPlugin = true;
+			console.warn(
+				'Add @babel/plugin-transform-react-jsx-source to get a more detailed component stack. Note that you should not add it to production builds of your App for bundle size reasons.'
+			);
 		}
 
 		return (acc += '\n');

--- a/debug/test/browser/component-stack-2.test.js
+++ b/debug/test/browser/component-stack-2.test.js
@@ -1,0 +1,54 @@
+import { createElement, render, Component } from 'preact';
+import 'preact/debug';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+
+/** @jsx createElement */
+
+// This test is not part of component-stack.test.js to avoid it being
+// transpiled with '@babel/plugin-transform-react-jsx-source' enabled.
+
+describe('component stack', () => {
+	/** @type {HTMLDivElement} */
+	let scratch;
+
+	let errors = [];
+	let warnings = [];
+
+	beforeEach(() => {
+		scratch = setupScratch();
+
+		errors = [];
+		warnings = [];
+		sinon.stub(console, 'error').callsFake(e => errors.push(e));
+		sinon.stub(console, 'warn').callsFake(w => warnings.push(w));
+	});
+
+	afterEach(() => {
+		console.error.restore();
+		console.warn.restore();
+		teardown(scratch);
+	});
+
+	it('should print a warning when "@babel/plugin-transform-react-jsx-source" is not installed', () => {
+		function Foo() {
+			return <Thrower />;
+		}
+
+		class Thrower extends Component {
+			constructor(props) {
+				super(props);
+				this.setState({ foo: 1 });
+			}
+
+			render() {
+				return <div>foo</div>;
+			}
+		}
+
+		render(<Foo />, scratch);
+
+		expect(
+			warnings[0].indexOf('@babel/plugin-transform-react-jsx-source') > -1
+		).to.equal(true);
+	});
+});

--- a/debug/test/browser/component-stack.test.js
+++ b/debug/test/browser/component-stack.test.js
@@ -1,0 +1,85 @@
+import { createElement, render, Component } from 'preact';
+import 'preact/debug';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+
+/** @jsx createElement */
+
+describe('component stack', () => {
+	/** @type {HTMLDivElement} */
+	let scratch;
+
+	let errors = [];
+	let warnings = [];
+
+	const getWarningStack = () => warnings[0].split('\n\n')[1];
+
+	beforeEach(() => {
+		scratch = setupScratch();
+
+		errors = [];
+		warnings = [];
+		sinon.stub(console, 'error').callsFake(e => errors.push(e));
+		sinon.stub(console, 'warn').callsFake(w => warnings.push(w));
+	});
+
+	afterEach(() => {
+		console.error.restore();
+		console.warn.restore();
+		teardown(scratch);
+	});
+
+	it('should print component stack', () => {
+		function Foo() {
+			return <Thrower />;
+		}
+
+		class Thrower extends Component {
+			constructor(props) {
+				super(props);
+				this.setState({ foo: 1 });
+			}
+
+			render() {
+				return <div>foo</div>;
+			}
+		}
+
+		render(<Foo />, scratch);
+
+		let lines = getWarningStack().split('\n');
+		expect(lines[0].indexOf('Foo') > -1).to.equal(true);
+		expect(lines[1].indexOf('Thrower') > -1).to.equal(true);
+	});
+
+	it('should only print owners', () => {
+		function Foo(props) {
+			return <div>{props.children}</div>;
+		}
+
+		function Bar() {
+			return (
+				<Foo>
+					<Thrower />
+				</Foo>
+			);
+		}
+
+		class Thrower extends Component {
+			constructor(props) {
+				super(props);
+				this.setState({ foo: 1 });
+			}
+
+			render() {
+				return <div>foo</div>;
+			}
+		}
+
+		render(<Bar />, scratch);
+
+		let lines = getWarningStack().split('\n');
+		expect(lines[0].indexOf('Bar') > -1).to.equal(true);
+		expect(lines[1].indexOf('Foo') > -1).to.equal(true);
+		expect(lines[2].indexOf('Thrower') > -1).to.equal(true);
+	});
+});

--- a/debug/test/browser/component-stack.test.js
+++ b/debug/test/browser/component-stack.test.js
@@ -11,7 +11,7 @@ describe('component stack', () => {
 	let errors = [];
 	let warnings = [];
 
-	const getWarningStack = () => warnings[0].split('\n\n')[1];
+	const getStack = arr => arr[0].split('\n\n')[1];
 
 	beforeEach(() => {
 		scratch = setupScratch();
@@ -46,9 +46,9 @@ describe('component stack', () => {
 
 		render(<Foo />, scratch);
 
-		let lines = getWarningStack().split('\n');
-		expect(lines[0].indexOf('Foo') > -1).to.equal(true);
-		expect(lines[1].indexOf('Thrower') > -1).to.equal(true);
+		let lines = getStack(warnings).split('\n');
+		expect(lines[0].indexOf('Thrower') > -1).to.equal(true);
+		expect(lines[1].indexOf('Foo') > -1).to.equal(true);
 	});
 
 	it('should only print owners', () => {
@@ -65,21 +65,22 @@ describe('component stack', () => {
 		}
 
 		class Thrower extends Component {
-			constructor(props) {
-				super(props);
-				this.setState({ foo: 1 });
-			}
-
 			render() {
-				return <div>foo</div>;
+				return (
+					<table>
+						<td>
+							<tr>foo</tr>
+						</td>
+					</table>
+				);
 			}
 		}
 
 		render(<Bar />, scratch);
 
-		let lines = getWarningStack().split('\n');
-		expect(lines[0].indexOf('Bar') > -1).to.equal(true);
-		expect(lines[1].indexOf('Foo') > -1).to.equal(true);
-		expect(lines[2].indexOf('Thrower') > -1).to.equal(true);
+		let lines = getStack(errors).split('\n');
+		expect(lines[0].indexOf('td') > -1).to.equal(true);
+		expect(lines[1].indexOf('Thrower') > -1).to.equal(true);
+		expect(lines[2].indexOf('Bar') > -1).to.equal(true);
 	});
 });

--- a/debug/test/browser/debug-hooks.test.js
+++ b/debug/test/browser/debug-hooks.test.js
@@ -98,9 +98,11 @@ describe('debug with hooks', () => {
 			return <p>{state}</p>;
 		};
 		render(<App />, scratch);
-		expect(warnings[0]).to.match(/You should provide an array of arguments/);
+		// Skip first warning which is about missing babel plugin for better
+		// debug messages
+		expect(warnings[1]).to.match(/You should provide an array of arguments/);
 		render(<App />, scratch);
-		expect(warnings[1]).to.be.undefined;
+		expect(warnings[2]).to.be.undefined;
 	});
 
 	it('should warn for argumentless useLayoutEffect hooks', () => {

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -44,6 +44,7 @@ module.exports = {
 					],
 					plugins: [
 						[require.resolve('@babel/plugin-transform-runtime')],
+						[require.resolve('@babel/plugin-transform-react-jsx-source')],
 						[
 							require.resolve('@babel/plugin-transform-react-jsx'),
 							{ pragma: 'h', pragmaFrag: 'Fragment' }
@@ -78,6 +79,7 @@ module.exports = {
 						[require.resolve('@babel/preset-react')]
 					],
 					plugins: [
+						[require.resolve('@babel/plugin-transform-react-jsx-source')],
 						[
 							require.resolve('@babel/plugin-transform-react-jsx'),
 							{ pragma: 'createElement', pragmaFrag: 'Fragment' }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -61,6 +61,33 @@ var localLaunchers = {
 	}
 };
 
+const babelOptions = (options = {}) => {
+	return {
+		babelrc: false,
+		cacheDirectory: true,
+		presets: [
+			[
+				'@babel/preset-env',
+				{
+					loose: true,
+					exclude: ['@babel/plugin-transform-typeof-symbol'],
+					targets: {
+						browsers: ['last 2 versions', 'IE >= 9']
+					}
+				}
+			]
+		],
+		plugins: [
+			coverage && ['istanbul', { include: '**/src/**/*.js' }],
+			'@babel/plugin-proposal-object-rest-spread',
+			options.debug && '@babel/plugin-transform-react-jsx-source',
+			'@babel/plugin-transform-react-jsx',
+			'babel-plugin-transform-async-to-promises'
+		].filter(Boolean),
+		ignore: ['./dist']
+	};
+};
+
 module.exports = function(config) {
 	config.set({
 		browsers: sauceLabs
@@ -134,16 +161,22 @@ module.exports = function(config) {
 
 				/* Transpile source and test files */
 				rules: [
+					// Special case for babel plugins that should not be enabled
+					// in production mode and only be enabled for specific
+					// test files
 					{
 						enforce: 'pre',
+						test: /(component-stack|debug)\.test\.js$/,
+						exclude: /node_modules/,
+						loader: 'babel-loader',
+						options: babelOptions({ debug: true })
+					},
+
+					{
 						test: /\.jsx?$/,
 						exclude: /node_modules/,
 						loader: 'babel-loader',
-						options: {
-							plugins: coverage
-								? [['istanbul', { include: '**/src/**/*.js' }]]
-								: []
-						}
+						options: babelOptions()
 					}
 				]
 			},

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "@babel/core": "^7.7.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
     "@babel/plugin-transform-react-jsx": "^7.7.0",
+    "@babel/plugin-transform-react-jsx-source": "^7.7.4",
     "@babel/preset-env": "^7.7.1",
     "@babel/register": "^7.7.0",
     "@types/chai": "^4.1.2",


### PR DESCRIPTION
This PR adds a component stack trace to errors and warning messages in `preact/debug`. See the following screenshot for an example.

![Screenshot from 2019-12-11 22-48-04](https://user-images.githubusercontent.com/1062408/70663476-b4940f00-1c68-11ea-89f5-0d0be45a6a85.png)

Fixes #2177

*Tasks:*

- [x] Fix failing tests
- [x] Check if we could support proper component owners instead of parents
  - Note: `@babel/plugin-transform-react-jsx-self` doesn't support arrow functions, so it's a deal breaker