### PR TITLE
Fix componentWillReceiveProps when calling setState/forceUpdate

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -113,7 +113,7 @@ export function diff(
 			} else {
 				if (
 					newType.getDerivedStateFromProps == null &&
-					c._force == null &&
+					newProps !== oldProps &&
 					c.componentWillReceiveProps != null
 				) {
 					c.componentWillReceiveProps(newProps, cctx);


### PR DESCRIPTION
Fixes #2185

`componentWillReceiveProps` doesn't get called when calling `setState` or `forceUpdate` and receiving props.

`componentWillReceiveProps` never gets called as `this.setState/forceUpdate` will set `component._force = false/true`, so `_force` will not be `null` or `undefined` as expected in [`diff/index.js`](https://github.com/preactjs/preact/blob/master/src/diff/index.js):
```js
if (
  newType.getDerivedStateFromProps == null &&
  c._force == null &&
  c.componentWillReceiveProps != null
) {
  c.componentWillReceiveProps(newProps, cctx);
}
```

Instead of using the `_force` flag, I've decided to check the equality of `oldProps` and `newProps` to check whether props have changed. I've added a test for this case too. It would be great to know if I'm missing an edge case with this fix?

This fix also drops the size by `-6B` 🎉 