### PR TITLE
Workaround for sinon esm bundle

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -172,6 +172,14 @@ module.exports = function(config) {
 						options: babelOptions({ debug: true })
 					},
 
+					// Special case for sinon.js which ships ES2015+ code in their
+					// esm bundle
+					{
+						test: /node_modules\/sinon\/.*\.jsx?$/,
+						loader: 'babel-loader',
+						options: babelOptions()
+					},
+
 					{
 						test: /\.jsx?$/,
 						exclude: /node_modules/,


### PR DESCRIPTION
Looks like something changed in `sinon`. Their module bundle is not in ES5 anymore, so we need to transpile that ourselves to make our test suite run in IE11.