### PR TITLE
[WIP] Bugfix: Component's default render() should render nothing

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -1,4 +1,4 @@
-import { Component, createElement, options } from 'preact';
+import { Component, createElement, options, Fragment } from 'preact';
 import { assign } from './util';
 
 const oldCatchError = options._catchError;
@@ -92,7 +92,7 @@ Suspense.prototype.render = function(props, state) {
 	}
 
 	return [
-		createElement(Component, null, state._suspended ? null : props.children),
+		createElement(Fragment, null, state._suspended ? null : props.children),
 		state._suspended && props.fallback
 	];
 };

--- a/src/component.js
+++ b/src/component.js
@@ -76,7 +76,7 @@ Component.prototype.forceUpdate = function(callback) {
  * ancestor's `getChildContext()`
  * @returns {import('./index').ComponentChildren | void}
  */
-Component.prototype.render = Fragment;
+Component.prototype.render = () => {};
 
 /**
  * @param {import('./internal').VNode} vnode

--- a/src/component.js
+++ b/src/component.js
@@ -1,7 +1,6 @@
 import { assign } from './util';
 import { diff, commitRoot } from './diff/index';
 import options from './options';
-import { Fragment } from './create-element';
 
 /**
  * Base Component class. Provides `setState()` and `forceUpdate()`, which

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -485,7 +485,7 @@ describe('Components', () => {
 
 			sinon.spy(Foo.prototype, 'render');
 
-			render(<Foo {...PROPS} />, scratch);
+			render(<Foo {...PROPS}>children <strong>should not</strong> be rendered.</Foo>, scratch);
 
 			expect(Foo.prototype.render)
 				.to.have.been.calledOnce.and.to.have.been.calledWithMatch(PROPS, {}, {})

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -485,7 +485,12 @@ describe('Components', () => {
 
 			sinon.spy(Foo.prototype, 'render');
 
-			render(<Foo {...PROPS}>children <strong>should not</strong> be rendered.</Foo>, scratch);
+			render(
+				<Foo {...PROPS}>
+					children <strong>should not</strong> be rendered.
+				</Foo>,
+				scratch
+			);
 
 			expect(Foo.prototype.render)
 				.to.have.been.calledOnce.and.to.have.been.calledWithMatch(PROPS, {}, {})

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -492,13 +492,8 @@ describe('Components', () => {
 				scratch
 			);
 
-			expect(Foo.prototype.render)
-				.to.have.been.calledOnce.and.to.have.been.calledWithMatch(PROPS, {}, {})
-				.and.to.have.returned(undefined);
-			expect(instance.props).to.deep.equal(PROPS);
-			expect(instance.state).to.deep.equal({});
-			expect(instance.context).to.deep.equal({});
-
+			// Can't check on props here without deeply making the children array
+			expect(Foo.prototype.render).to.have.returned(undefined);
 			expect(scratch.innerHTML).to.equal('');
 		});
 	});


### PR DESCRIPTION
Currently it uses Fragment as its implementation to reduce size, but Fragment renders `props.children`. This means that components inheriting from Component without providing their own render() method render their children by default.