### PR TITLE
Proposal for error boundary hook

### DIFF
--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -128,12 +128,6 @@ export function useDebugValue<T>(
 	formatter?: (value: T) => string | number
 ): void;
 
-export interface ComponentFunction<P = {}> {
-	(props: P, error?: Error): preact.ComponentChild;
-	displayName?: string;
-}
-
-export function errorBoundary<P = {}>(
-	fn: ComponentFunction<P>,
+export function useErrorBoundary(
 	callback: () => Promise<void> | void
-): preact.FunctionalComponent<P>;
+): [string | undefined, () => void];

--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -127,3 +127,13 @@ export function useDebugValue<T>(
 	value: T,
 	formatter?: (value: T) => string | number
 ): void;
+
+export interface ComponentFunction<P = {}> {
+	(props: P, error?: Error): preact.ComponentChild;
+	displayName?: string;
+}
+
+export function errorBoundary<P = {}>(
+	fn: ComponentFunction<P>,
+	callback: () => Promise<void> | void
+): preact.FunctionalComponent<P>;

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -222,23 +222,20 @@ export function useDebugValue(value, formatter) {
 	}
 }
 
-export function errorBoundary(fn, callback) {
-	function Boundary(props) {
-		const errState = useState();
-
-		if (!currentComponent.componentDidCatch) {
-			currentComponent.componentDidCatch = err => {
-				if (callback) callback(err);
-				errState[1](err);
-			};
-		}
-
-		return fn(props, errState[0]);
+export function useErrorBoundary(cb) {
+	const errState = useState();
+	if (!currentComponent.componentDidCatch) {
+		currentComponent.componentDidCatch = err => {
+			if (cb) cb(err);
+			errState[1](err);
+		};
 	}
-
-	Boundary.displayName = 'ErrorBoundary(' + (fn.displayName || fn.name) + ')';
-
-	return Boundary;
+	return [
+		errState[0],
+		() => {
+			errState[1](undefined);
+		}
+	];
 }
 
 /**

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -223,18 +223,18 @@ export function useDebugValue(value, formatter) {
 }
 
 export function errorBoundary(fn, callback) {
-	let setErr;
-
 	function Boundary(props) {
-		const result = useState();
-		setErr = result[1];
-		return fn(props, result[0]);
-	}
+		const errState = useState();
 
-	Boundary._catch = err => {
-		if (callback) callback(err);
-		setErr(err);
-	};
+		if (!currentComponent.componentDidCatch) {
+			currentComponent.componentDidCatch = err => {
+				if (callback) callback(err);
+				errState[1](err);
+			};
+		}
+
+		return fn(props, errState[0]);
+	}
 
 	Boundary.displayName = 'ErrorBoundary(' + (fn.displayName || fn.name) + ')';
 

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -222,6 +222,25 @@ export function useDebugValue(value, formatter) {
 	}
 }
 
+export function errorBoundary(fn, callback) {
+	let setErr;
+
+	function Boundary(props) {
+		const result = useState();
+		setErr = result[1];
+		return fn(props, result[0]);
+	}
+
+	Boundary._catch = err => {
+		if (callback) callback(err);
+		setErr(err);
+	};
+
+	Boundary.displayName = 'ErrorBoundary(' + (fn.displayName || fn.name) + ')';
+
+	return Boundary;
+}
+
 /**
  * After paint effects consumer.
  */

--- a/hooks/test/browser/errorBoundary.test.js
+++ b/hooks/test/browser/errorBoundary.test.js
@@ -1,0 +1,34 @@
+import { createElement, render } from 'preact';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { errorBoundary } from 'preact/hooks';
+import { setupRerender } from 'preact/test-utils';
+
+/** @jsx createElement */
+
+describe('errorBoundary', () => {
+	/** @type {HTMLDivElement} */
+	let scratch, rerender;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+		rerender = setupRerender();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('catches errors', () => {
+		const Throws = () => {
+			throw new Error('test');
+		};
+
+		const App = errorBoundary((props, err) => {
+			return err ? <p>Error</p> : <Throws />;
+		});
+
+		render(<App />, scratch);
+		rerender();
+		expect(scratch.innerHTML).to.equal('<p>Error</p>');
+	});
+});

--- a/hooks/test/browser/errorBoundary.test.js
+++ b/hooks/test/browser/errorBoundary.test.js
@@ -19,18 +19,26 @@ describe('errorBoundary', () => {
 	});
 
 	it('catches errors', () => {
+		let resetErr,
+			success = false;
 		const Throws = () => {
 			throw new Error('test');
 		};
 
 		const App = props => {
-			const [err] = useErrorBoundary();
-			return err ? <p>Error</p> : <Throws />;
+			const [err, reset] = useErrorBoundary();
+			resetErr = reset;
+			return err ? <p>Error</p> : success ? <p>Success</p> : <Throws />;
 		};
 
 		render(<App />, scratch);
 		rerender();
 		expect(scratch.innerHTML).to.equal('<p>Error</p>');
+
+		success = true;
+		resetErr();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<p>Success</p>');
 	});
 
 	it('calls the errorBoundary callback', () => {

--- a/hooks/test/browser/errorBoundary.test.js
+++ b/hooks/test/browser/errorBoundary.test.js
@@ -1,6 +1,6 @@
 import { createElement, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { errorBoundary } from 'preact/hooks';
+import { useErrorBoundary } from 'preact/hooks';
 import { setupRerender } from 'preact/test-utils';
 
 /** @jsx createElement */
@@ -23,9 +23,10 @@ describe('errorBoundary', () => {
 			throw new Error('test');
 		};
 
-		const App = errorBoundary((props, err) => {
+		const App = props => {
+			const [err] = useErrorBoundary();
 			return err ? <p>Error</p> : <Throws />;
-		});
+		};
 
 		render(<App />, scratch);
 		rerender();
@@ -39,9 +40,10 @@ describe('errorBoundary', () => {
 			throw error;
 		};
 
-		const App = errorBoundary((props, err) => {
+		const App = props => {
+			const [err] = useErrorBoundary(spy);
 			return err ? <p>Error</p> : <Throws />;
-		}, spy);
+		};
 
 		render(<App />, scratch);
 		rerender();

--- a/hooks/test/browser/errorBoundary.test.js
+++ b/hooks/test/browser/errorBoundary.test.js
@@ -31,4 +31,22 @@ describe('errorBoundary', () => {
 		rerender();
 		expect(scratch.innerHTML).to.equal('<p>Error</p>');
 	});
+
+	it('calls the errorBoundary callback', () => {
+		const spy = sinon.spy();
+		const error = new Error('test');
+		const Throws = () => {
+			throw error;
+		};
+
+		const App = errorBoundary((props, err) => {
+			return err ? <p>Error</p> : <Throws />;
+		}, spy);
+
+		render(<App />, scratch);
+		rerender();
+		expect(scratch.innerHTML).to.equal('<p>Error</p>');
+		expect(spy).to.be.calledOnce;
+		expect(spy).to.be.calledWith(error);
+	});
 });

--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -14,7 +14,9 @@ export function _catchError(error, vnode) {
 	for (; (vnode = vnode._parent); ) {
 		if ((component = vnode._component) && !component._processingException) {
 			try {
-				if (
+				if (vnode.type._catch) {
+					vnode.type._catch(error);
+				} else if (
 					component.constructor &&
 					component.constructor.getDerivedStateFromError != null
 				) {

--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -14,9 +14,7 @@ export function _catchError(error, vnode) {
 	for (; (vnode = vnode._parent); ) {
 		if ((component = vnode._component) && !component._processingException) {
 			try {
-				if (vnode.type._catch) {
-					vnode.type._catch(error);
-				} else if (
+				if (
 					component.constructor &&
 					component.constructor.getDerivedStateFromError != null
 				) {


### PR DESCRIPTION
This is in no-way final, I would like to light the discussion on this. Would love some external opinions as well.

This PR can facilitate moving components to their own package since it does not rely on a lifecycle or something similar.

In the long term I would like to use the line from this PR: https://github.com/preactjs/preact/pull/2200/files#diff-b5e3843a998fbd0144a6ac5b1b7536a4R21

To tranfsorm it into

```
hasCaught = options._catch()
```

Where options._catch could listen for a lifecycle or whatever is needed in other api's like composition