### PR TITLE
fix compat hydration

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -26,7 +26,7 @@ import { Children } from './Children';
 import { Suspense, lazy } from './suspense';
 import { SuspenseList } from './suspense-list';
 import { createPortal } from './portals';
-import { render, REACT_ELEMENT_TYPE } from './render';
+import { hydrate, render, REACT_ELEMENT_TYPE } from './render';
 
 const version = '16.8.0'; // trick libraries to think we are react
 
@@ -100,7 +100,7 @@ export {
 	version,
 	Children,
 	render,
-	render as hydrate,
+	hydrate,
 	unmountComponentAtNode,
 	createPortal,
 	createElement,

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -34,6 +34,10 @@ export function render(vnode, parent, callback) {
 		}
 	}
 
+	return hydrate(vnode, parent, callback);
+}
+
+export function hydrate(vnode, parent, callback) {
 	preactRender(vnode, parent);
 	if (typeof callback === 'function') callback();
 

--- a/compat/test/browser/hydrate.test.js
+++ b/compat/test/browser/hydrate.test.js
@@ -1,0 +1,25 @@
+import React, { hydrate } from 'preact/compat';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+
+describe('compat hydrate', () => {
+	/** @type {HTMLDivElement} */
+	let scratch;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('should render react-style jsx', () => {
+		const input = document.createElement('input');
+		scratch.appendChild(input);
+		input.focus();
+		expect(document.activeElement).to.equal(input);
+
+		hydrate(<input />, scratch);
+		expect(document.activeElement).to.equal(input);
+	});
+});


### PR DESCRIPTION
In current master we unmount the entire tree when hydrating because `x._children` is `undefined` that's why we need a separate method for hydration