### PR TITLE
Shorten and correct renderToString dependency error

### DIFF
--- a/compat/server.js
+++ b/compat/server.js
@@ -3,9 +3,8 @@ var renderToString;
 try {
 	renderToString = dep(require('preact-render-to-string'));
 } catch (e) {
-	throw new Error(
-		'You seem to be missing the "preact-render-to-string" dependency.\n' +
-			'You can add this by using "npm install --save preact-render-to-string@next".'
+	throw Error(
+		'renderToString() error: missing "preact-render-to-string" dependency.'
 	);
 }
 


### PR DESCRIPTION
No longer need `@next`, and as such we can probably drop the extended explanation of how to install from npm.