### PR TITLE
Add onReset/onFormData to Form Event types

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -437,6 +437,11 @@ export namespace JSXInternal {
 		onSubmitCapture?: GenericEventHandler<Target>;
 		onInvalid?: GenericEventHandler<Target>;
 		onInvalidCapture?: GenericEventHandler<Target>;
+		onReset?: GenericEventHandler<Target>;
+		onResetCapture?: GenericEventHandler<Target>;
+		onFormData?: GenericEventHandler<Target>;
+		onFormDataCapture?: GenericEventHandler<Target>;
+
 
 		// Keyboard Events
 		onKeyDown?: KeyboardEventHandler<Target>;


### PR DESCRIPTION
Add types for missing events that are [a part of HTML 5.](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/reset_event#Events)