### PR TITLE
[DRAFT] Handle subtree replaced via replaceNode

### DIFF
--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -188,7 +188,7 @@ describe('Portal', () => {
 		}
 
 		render(<App />, root);
-		expect(dialog.childNodes.length).to.equal(2);
+		expect(dialog.childNodes.length).to.equal(1);
 		render(null, root);
 		expect(dialog.childNodes.length).to.equal(0);
 	});

--- a/src/render.js
+++ b/src/render.js
@@ -2,6 +2,7 @@ import { EMPTY_OBJ, EMPTY_ARR } from './constants';
 import { commitRoot, diff } from './diff/index';
 import { createElement, Fragment } from './create-element';
 import options from './options';
+import { removeNode } from './util';
 
 const IS_HYDRATE = EMPTY_OBJ;
 
@@ -22,10 +23,12 @@ export function render(vnode, parentDom, replaceNode) {
 		: (replaceNode && replaceNode._children) || parentDom._children;
 	vnode = createElement(Fragment, null, [vnode]);
 
+	const selectedDomRoot = isHydrating ? parentDom : replaceNode || parentDom;
+
 	let commitQueue = [];
 	diff(
 		parentDom,
-		((isHydrating ? parentDom : replaceNode || parentDom)._children = vnode),
+		(selectedDomRoot._children = vnode),
 		oldVNode || EMPTY_OBJ,
 		EMPTY_OBJ,
 		parentDom.ownerSVGElement !== undefined,
@@ -39,6 +42,9 @@ export function render(vnode, parentDom, replaceNode) {
 		isHydrating
 	);
 	commitRoot(commitQueue, vnode);
+
+	if (!isHydrating && replaceNode && vnode._dom !== replaceNode)
+		removeNode(replaceNode);
 }
 
 /**

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1271,9 +1271,12 @@ describe('render()', () => {
 		scratch.appendChild(container);
 		render(<div>Hello</div>, scratch, scratch.firstElementChild);
 		expect(scratch.innerHTML).to.equal('<div>Hello</div>');
+		const child = scratch.firstElementChild;
 
 		render(<div>Hello</div>, scratch, scratch.firstElementChild);
 		expect(scratch.innerHTML).to.equal('<div>Hello</div>');
+
+		expect(scratch.firstElementChild).to.equal(child);
 	});
 
 	it('should replaceNode after rendering', () => {
@@ -1281,11 +1284,15 @@ describe('render()', () => {
 			return <p>{i}</p>;
 		}
 
+		scratch.innerHTML = '';
 		render(<App i={2} />, scratch);
 		expect(scratch.innerHTML).to.equal('<p>2</p>');
+		const child = scratch.firstElementChild;
 
-		render(<App i={3} />, scratch, scratch.firstChild);
+		render(<App i={3} />, scratch, child);
 		expect(scratch.innerHTML).to.equal('<p>3</p>');
+
+		expect(scratch.firstElementChild).to.equal(child);
 	});
 
 	it('should not cause infinite loop with referentially equal props', () => {
@@ -1325,7 +1332,7 @@ describe('render()', () => {
 		it('should use replaceNode as render root and not inject into it', () => {
 			const childA = scratch.querySelector('#a');
 			render(<div id="a">contents</div>, scratch, childA);
-			expect(scratch.querySelector('#a')).to.equalNode(childA);
+			expect(scratch.querySelector('#a')).to.equal(childA);
 			expect(childA.innerHTML).to.equal('contents');
 		});
 
@@ -1392,6 +1399,20 @@ describe('render()', () => {
 			expect(scratch.innerHTML).to.equal(
 				`${expectedA}${expectedB}${expectedC}`
 			);
+		});
+
+		it('should replace type-mismatched nodes', () => {
+			scratch.innerHTML = '';
+			render(<a />, scratch);
+			scratch.innerHTML += '';
+			render(<b />, scratch, scratch.firstChild);
+			expect(scratch.innerHTML).to.equal(`<b></b>`);
+		});
+
+		it('should replace the provided node if unmatched', () => {
+			scratch.innerHTML = `<a>a</a>`;
+			render(<b>b</b>, scratch, scratch.firstChild);
+			expect(scratch.innerHTML).to.equal(`<b>b</b>`);
 		});
 	});
 });


### PR DESCRIPTION
I really don't like the solution I came up with here. This is a case where `excessDomChildren` should end up with `[<a></a>]` in it which should remove the orphaned root element. I tried for quite a while to figure out why this was not the case, and installed a bunch of logging into these tests to figure it out. In the end I could get the tests passing by tweaking `excessDomChildren` to flush for known Fragment roots rendered using `replaceNode`, but doing so broke all the Portals tests.