### PR TITLE
Allow lazy() usage with non-default imports

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -129,7 +129,7 @@ export function lazy(loader) {
 			prom = loader();
 			prom.then(
 				exports => {
-					component = exports.default;
+					component = exports.default || exports;
 				},
 				e => {
 					error = e;


### PR DESCRIPTION
Example:

```js
lazy(() => import('./foo').foo)
```