### PR TITLE
Fix Text nodes being re-rendered unnecessarily

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -306,7 +306,7 @@ function diffElementNodes(
 			excessDomChildren[excessDomChildren.indexOf(dom)] = null;
 		}
 
-		if (oldProps !== newProps) {
+		if (oldProps !== newProps && !isHydrating && dom.data != newProps) {
 			dom.data = newProps;
 		}
 	} else if (newVNode !== oldVNode) {


### PR DESCRIPTION
During hydration, we always diff against an empty object as a stand-in for the old VNode. This means `newVNode.props` is never equal to `oldVNode.props`. However, hydration should never produce DOM mutations.

This PR addresses the `newProps !== oldProps` false positive by bypassing Text updates during hydration. It also adds an additional safeguard because in practise I've been seeing Text updates where the new text is exactly the same as the text contents present in the DOM tree. Assuming this happens reasonably often, it's cheaper to check for equality than it is to invalidate layout.