### PR TITLE
don't assign null when the ref isn't assigned to the current vn…

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -406,7 +406,7 @@ export function unmount(vnode, parentVNode, skipRemove) {
 	if (options.unmount) options.unmount(vnode);
 
 	if ((r = vnode.ref)) {
-		if (!vnode.ref.current || vnode.ref.current === vnode._dom)
+		if (!r.current || r.current === vnode._dom)
 			applyRef(r, null, parentVNode);
 	}
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -406,7 +406,8 @@ export function unmount(vnode, parentVNode, skipRemove) {
 	if (options.unmount) options.unmount(vnode);
 
 	if ((r = vnode.ref)) {
-		applyRef(r, null, parentVNode);
+		if (!vnode.ref.current || vnode.ref.current === vnode._dom)
+			applyRef(r, null, parentVNode);
 	}
 
 	let dom;

--- a/test/browser/refs.test.js
+++ b/test/browser/refs.test.js
@@ -92,9 +92,7 @@ describe('refs', () => {
 		const events = [];
 		const App = () => (
 			<div ref={r => events.push('called with ' + (r && r.tagName))}>
-				<h1 ref={r => events.push('called with ' + (r && r.tagName))}>
-					hi
-				</h1>
+				<h1 ref={r => events.push('called with ' + (r && r.tagName))}>hi</h1>
 			</div>
 		);
 
@@ -435,6 +433,26 @@ describe('refs', () => {
 
 		render(<input type="text" ref={autoFocus} value="foo" />, scratch);
 		expect(input.value).to.equal('foo');
+	});
+
+	it('should correctly set nested child refs', () => {
+		const ref = createRef();
+		const App = ({ open }) =>
+			open ? (
+				<div class="open" key="open">
+					<div ref={ref} />
+				</div>
+			) : (
+				<div class="closes" key="closed">
+					<div ref={ref} />
+				</div>
+			);
+
+		render(<App />, scratch);
+		expect(ref.current).to.not.be.null;
+
+		render(<App open />, scratch);
+		expect(ref.current).to.not.be.null;
 	});
 
 	it('should correctly call child refs for un-keyed children on re-render', () => {


### PR DESCRIPTION
This scenario occurs when a parent unmounts a vnode and assigns null to the ref, making the already mounted newChild have an invalid ref.

Trying to see if I'm missing any edge cases (note that this doesn't fix for functions yet) I think this is pretty inherent to how we diff atm

So with this it will still do fail for the `ref={arg => x}` case where the unmounting component will still be called with null so if assigning to the same ref will fail

Possible solution: move applying of refs for the updated/created tree to `commitRoot` and separate ref removal and ref appliance from eachother that way we can do the `null` calls first and then apply refs

Fixes: https://github.com/preactjs/preact/issues/2194