### PR TITLE
Add dom.data during hydration to avoid redundantly adding text…

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -306,7 +306,7 @@ function diffElementNodes(
 			excessDomChildren[excessDomChildren.indexOf(dom)] = null;
 		}
 
-		if (oldProps !== newProps && !isHydrating && dom.data != newProps) {
+		if (oldProps !== newProps && dom.data != newProps) {
 			dom.data = newProps;
 		}
 	} else if (newVNode !== oldVNode) {
@@ -406,8 +406,7 @@ export function unmount(vnode, parentVNode, skipRemove) {
 	if (options.unmount) options.unmount(vnode);
 
 	if ((r = vnode.ref)) {
-		if (!r.current || r.current === vnode._dom)
-			applyRef(r, null, parentVNode);
+		if (!r.current || r.current === vnode._dom) applyRef(r, null, parentVNode);
 	}
 
 	let dom;

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -266,4 +266,14 @@ describe('hydrate()', () => {
 		scratch.firstChild.click();
 		expect(spy).to.be.calledOnce;
 	});
+
+	// #2237
+	it('should not redundantly add text nodes', () => {
+		scratch.innerHTML = '<div id="test"><p>hello bar</p></div>';
+		const element = document.getElementById('test');
+		const Component = props => <p>hello {props.foo}</p>;
+
+		hydrate(<Component foo="bar" />, element);
+		expect(element.innerHTML).to.equal('<p>hello bar</p>');
+	});
 });


### PR DESCRIPTION
Due to the dom not being available as a node `diffChildren` will double add this text if we don't set the dom.data

I have been looking at solving it in `diffChildren` but the problem persists itself like this:
```
LOG: 'oldDom', hello bar
LOG: 'newChldren', ['hello ', 'bar']
LOG: 'oldChldren', []
LOG: 'excess', [hello bar]
```

So we effectively come in at the first newChild and diff it with oldDom, next up we have no oldDom and we just append it to the text node.

A potential perf improvement would be to check if the `parent.innerHTML === props` this would allow us to skip childDiffing for that text node (if it does not contain any dom nodes).

Fixes https://github.com/preactjs/preact/issues/2237