### PR TITLE
Release 10.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
Mainly due to an issue found in `10.2.0`. See #2237.