### PR TITLE
Remove process.env check which broke borwsers

### DIFF
--- a/debug/src/index.js
+++ b/debug/src/index.js
@@ -1,7 +1,5 @@
 import { initDebug } from './debug';
 import { initDevTools } from './devtools';
 
-if (process.env.NODE_ENV === 'development') {
-	initDebug();
-	initDevTools();
-}
+initDebug();
+initDevTools();


### PR DESCRIPTION
This PR removes the `process.env.NODE_ENV === "development"` check around the main functions in `preact/debug`. This makes `debug` compatible with browser which don't have a `process` object.

If users of bundlers don't want to include `preact/debug` they now need to wrap it into an `if`-statement:

```js
if (process.env.NODE_ENV !== "production") {
  require("preact/debug")
}
```

Fixes #2253 