### PR TITLE
Include support for customised built-in elements

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -294,9 +294,12 @@ function diffElementNodes(
 		if (newVNode.type === null) {
 			return document.createTextNode(newProps);
 		}
+
+		const builtIn = newProps.is;
+
 		dom = isSvg
 			? document.createElementNS('http://www.w3.org/2000/svg', newVNode.type)
-			: document.createElement(newVNode.type);
+			: document.createElement(newVNode.type, builtIn && { is: builtIn });
 		// we created a new parent, so none of the previously attached children can be reused:
 		excessDomChildren = null;
 	}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -295,11 +295,12 @@ function diffElementNodes(
 			return document.createTextNode(newProps);
 		}
 
-		const builtIn = newProps.is;
-
 		dom = isSvg
 			? document.createElementNS('http://www.w3.org/2000/svg', newVNode.type)
-			: document.createElement(newVNode.type, builtIn && { is: builtIn });
+			: document.createElement(
+					newVNode.type,
+					newProps.is && { is: newProps.is }
+			  );
 		// we created a new parent, so none of the previously attached children can be reused:
 		excessDomChildren = null;
 	}

--- a/test/browser/customBuiltInElements.test.js
+++ b/test/browser/customBuiltInElements.test.js
@@ -1,0 +1,42 @@
+import { createElement, render, Component } from 'preact';
+import { setupScratch, teardown } from '../_util/helpers';
+
+/** @jsx createElement */
+
+describe('customised built-in elements', () => {
+	let scratch;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('should create built in elements correctly', () => {
+		class Foo extends Component {
+			constructor(props) {
+				super(props);
+				return true;
+			}
+			render() {
+				return <div is="built-in" />;
+			}
+		}
+
+		const spy = sinon.spy();
+
+		class BuiltIn extends HTMLDivElement {
+			connectedCallback() {
+				spy();
+			}
+		}
+
+		customElements.define('built-in', BuiltIn, { extends: 'div' });
+
+		render(<Foo />, scratch);
+
+		expect(spy).to.have.been.calledOnce;
+	});
+});


### PR DESCRIPTION
This PR adds the additional second argument when invoking document.createElement to provide support for [customised built-in elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#Customized_built-in_elements).