### PR TITLE
Add test coverage for createElement

### DIFF
--- a/test/shared/createElement.test.js
+++ b/test/shared/createElement.test.js
@@ -157,6 +157,20 @@ describe('createElement(jsx)', () => {
 			.that.equals('textstuff');
 	});
 
+	it('should NOT set children prop when null', () => {
+		let r = h('foo', null, null);
+
+		expect(r).to.be.an('object')
+		expect(r).not.have.nested.property('props.children')
+	})
+
+	it('should NOT set children prop when unspecified', () => {
+		let r = h('foo', null);
+
+		expect(r).to.be.an('object')
+		expect(r).not.have.nested.property('props.children')
+	})
+
 	it('should NOT merge adjacent text children', () => {
 		let r = h(
 			'foo',
@@ -214,6 +228,7 @@ describe('createElement(jsx)', () => {
 				null
 			]);
 	});
+	
 	it('should not merge children that are boolean values', () => {
 		let r = h('foo', null, 'one', true, 'two', false, 'three');
 

--- a/test/shared/createElement.test.js
+++ b/test/shared/createElement.test.js
@@ -158,17 +158,22 @@ describe('createElement(jsx)', () => {
 	});
 
 	it('should NOT set children prop when null', () => {
-		let r = h('foo', null, null);
+		let r = h('foo', {foo : 'bar'}, null);
 
-		expect(r).to.be.an('object')
-		expect(r).not.have.nested.property('props.children')
+		expect(r)
+			.to.be.an('object')
+			.to.have.nested.property('props.foo')
+			.not.to.have.nested.property('props.children')
+			
 	})
 
 	it('should NOT set children prop when unspecified', () => {
-		let r = h('foo', null);
+		let r = h('foo', {foo : 'bar'});
 
-		expect(r).to.be.an('object')
-		expect(r).not.have.nested.property('props.children')
+		expect(r)
+			.to.be.an('object')
+			.to.have.nested.property('props.foo')
+			.not.to.have.nested.property('props.children')
 	})
 
 	it('should NOT merge adjacent text children', () => {


### PR DESCRIPTION
Added two tests for `createElement`:
- When `children` parameter is passed to the function as `null`
- When `children` parameter is not passed to the function at all

*PS: Newbie to contributing*