### PR TITLE
Fix className patch not applied to props

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -84,6 +84,13 @@ options.vnode = vnode => {
 	let type = vnode.type;
 	let props = vnode.props;
 
+	// Alias `class` prop to `className` if available
+	if (props.class || props.className) {
+		classNameDescriptor.enumerable = 'className' in props;
+		if (props.className) props.class = props.className;
+		Object.defineProperty(props, 'className', classNameDescriptor);
+	}
+
 	// Apply DOM VNode compat
 	if (typeof type != 'function') {
 		// Apply defaultValue to value
@@ -115,13 +122,6 @@ options.vnode = vnode => {
 				] = props[i];
 			}
 		}
-	}
-
-	// Alias `class` prop to `className` if available
-	if (props.class || props.className) {
-		classNameDescriptor.enumerable = 'className' in props;
-		if (props.className) props.class = props.className;
-		Object.defineProperty(props, 'className', classNameDescriptor);
 	}
 
 	// Events

--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -140,4 +140,14 @@ describe('compat render', () => {
 		render(<Foo className="foo" />, scratch);
 		expect(scratch.firstChild.className).to.equal('foo');
 	});
+
+	// Issue #2275
+	it('should normalize class+className + DOM properties', () => {
+		function Foo(props) {
+			return <ul {...props} class="old" />;
+		}
+
+		render(<Foo fontSize="xlarge" className="new" />, scratch);
+		expect(scratch.firstChild.className).to.equal('new');
+	});
 });


### PR DESCRIPTION
This error was caused by our `className` patch being applied to the wrong `props` reference. Whenever a component is in play like with most CSS-in-JS solutions and we attempt to normalize `props` we'll create a new reference.

https://github.com/preactjs/preact/blob/8164289af82e0f463492ce68527d2c5f51e6fccb/compat/src/render.js#L111

A few lines later we attached the `className` patch, but we didn't update the reference of our `props` variable to point to the new object.

Since the order of our normalizations isn't important, the easiest fix is to move the `className` check before the other where `props` will be assigned a new variable.

Fixes #2275