### PR TITLE
Fix Children.map not flattening result

### DIFF
--- a/compat/src/Children.js
+++ b/compat/src/Children.js
@@ -2,7 +2,9 @@ import { toChildArray } from 'preact';
 
 const mapFn = (children, fn) => {
 	if (!children) return null;
-	return toChildArray(children).map(fn);
+	return toChildArray(children)
+		.map(fn)
+		.reduce((acc, value) => acc.concat(value), []);
 };
 
 // This API is completely unnecessary for Preact, so it's basically passthrough.

--- a/compat/src/Children.js
+++ b/compat/src/Children.js
@@ -2,9 +2,10 @@ import { toChildArray } from 'preact';
 
 const mapFn = (children, fn) => {
 	if (!children) return null;
-	return toChildArray(children)
-		.map(fn)
-		.reduce((acc, value) => acc.concat(value), []);
+	return toChildArray(children).reduce(
+		(acc, value) => acc.concat(fn(value)),
+		[]
+	);
 };
 
 // This API is completely unnecessary for Preact, so it's basically passthrough.

--- a/compat/test/browser/Children.test.js
+++ b/compat/test/browser/Children.test.js
@@ -98,6 +98,29 @@ describe('Children', () => {
 			render(<Foo />, scratch);
 			expect(serializeHtml(scratch)).to.equal('<div></div>');
 		});
+
+		it('should flatten result', () => {
+			const ProblemChild = ({ children }) => {
+				return React.Children.map(children, child => {
+					return React.Children.map(child.props.children, x => x);
+				}).filter(React.isValidElement);
+			};
+
+			const App = () => {
+				return (
+					<ProblemChild>
+						<div>
+							<div>1</div>
+							<div>2</div>
+						</div>
+					</ProblemChild>
+				);
+			};
+
+			render(<App />, scratch);
+
+			expect(scratch.textContent).to.equal('12');
+		});
 	});
 
 	describe('.forEach', () => {

--- a/compat/test/browser/isValidElement.test.js
+++ b/compat/test/browser/isValidElement.test.js
@@ -8,6 +8,8 @@ describe('isValidElement', () => {
 		expect(isValidElement(true)).to.equal(false);
 		expect(isValidElement('foo')).to.equal(false);
 		expect(isValidElement(123)).to.equal(false);
+		expect(isValidElement([])).to.equal(false);
+		expect(isValidElement({})).to.equal(false);
 	});
 
 	it('should detect a preact vnode', () => {


### PR DESCRIPTION
Just checked against the implementation in React and they flatten the result of `Children.map`. We didn't do that which lead to an `array` of children being passed to `isValidElement`. Because `arrays` are not valid children they were filtered out.

Fixes #2286 .