### PR TITLE
Reduce reads of dom.nextSibling

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -105,7 +105,7 @@ export function initDebug() {
 					`\n\n${getOwnerStack(vnode)}`
 			);
 		} else if (type != null && typeof type === 'object') {
-			if (type._lastDomChild !== undefined && type._dom !== undefined) {
+			if (type._lastDomChildSibling !== undefined && type._dom !== undefined) {
 				throw new Error(
 					`Invalid type passed to createElement(): ${type}\n\n` +
 						'Did you accidentally pass a JSX literal as JSX twice?\n\n' +
@@ -133,10 +133,10 @@ export function initDebug() {
 			);
 		} else if (
 			type === 'tr' &&
-			(parentVNode.type !== 'thead' &&
-				parentVNode.type !== 'tfoot' &&
-				parentVNode.type !== 'tbody' &&
-				parentVNode.type !== 'table')
+			parentVNode.type !== 'thead' &&
+			parentVNode.type !== 'tfoot' &&
+			parentVNode.type !== 'tbody' &&
+			parentVNode.type !== 'table'
 		) {
 			console.error(
 				'Improper nesting of table. Your <tr> should have a <thead/tbody/tfoot/table> parent.' +

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -105,7 +105,7 @@ export function initDebug() {
 					`\n\n${getOwnerStack(vnode)}`
 			);
 		} else if (type != null && typeof type === 'object') {
-			if (type._lastDomChildSibling !== undefined && type._dom !== undefined) {
+			if (type._children !== undefined && type._dom !== undefined) {
 				throw new Error(
 					`Invalid type passed to createElement(): ${type}\n\n` +
 						'Did you accidentally pass a JSX literal as JSX twice?\n\n' +

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -80,7 +80,7 @@ describe('debug', () => {
 	it('should print an error on double jsx conversion', () => {
 		let Foo = <div />;
 		let fn = () => render(h(<Foo />), scratch);
-		expect(fn).to.throw(/createElement/);
+		expect(fn).to.throw(/JSX twice/);
 	});
 
 	it('should add __source to the vnode in debug mode.', () => {

--- a/mangle.json
+++ b/mangle.json
@@ -18,7 +18,7 @@
     "cname": 6,
     "props": {
       "$_depth": "__b",
-      "$_lastDomChild": "__d",
+      "$_lastDomChildSibling": "__d",
       "$_dirty": "__d",
       "$_force": "__e",
       "$_nextState": "__s",

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -68,11 +68,11 @@ export function createVNode(type, props, key, ref) {
 		_parent: null,
 		_depth: 0,
 		_dom: null,
-		// _lastDomChild must be initialized to undefined b/c it will eventually
+		// _lastDomChildSibling must be initialized to undefined b/c it will eventually
 		// be set to dom.nextSibling which can return `null` and it is important
-		// to be able to distinguish between an uninitialized _lastDomChild and
-		// a _lastDomChild that has been set to `null`
-		_lastDomChild: undefined,
+		// to be able to distinguish between an uninitialized _lastDomChildSibling and
+		// a _lastDomChildSibling that has been set to `null`
+		_lastDomChildSibling: undefined,
 		_component: null,
 		constructor: undefined
 	};

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -68,7 +68,11 @@ export function createVNode(type, props, key, ref) {
 		_parent: null,
 		_depth: 0,
 		_dom: null,
-		_lastDomChild: null,
+		// _lastDomChild must be initialized to undefined b/c it will eventually
+		// be set to dom.nextSibling which can return `null` and it is important
+		// to be able to distinguish between an uninitialized _lastDomChild and
+		// a _lastDomChild that has been set to `null`
+		_lastDomChild: undefined,
 		_component: null,
 		constructor: undefined
 	};

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -146,6 +146,7 @@ export function diffChildren(
 
 						outer: if (oldDom == null || oldDom.parentNode !== parentDom) {
 							parentDom.appendChild(newDom);
+							nextDom = null;
 						} else {
 							// `j<oldChildrenLength; j+=2` is an alternative to `j++<oldChildrenLength/2`
 							for (
@@ -158,6 +159,7 @@ export function diffChildren(
 								}
 							}
 							parentDom.insertBefore(newDom, oldDom);
+							nextDom = oldDom;
 						}
 
 						// Browsers will infer an option's `value` from `textContent` when

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -124,17 +124,17 @@ export function diffChildren(
 					}
 
 					let nextDom;
-					if (childVNode._lastDomChild !== undefined) {
+					if (childVNode._lastDomChildSibling !== undefined) {
 						// Only Fragments or components that return Fragment like VNodes will
-						// have a non-undefined _lastDomChild. Continue the diff from the sibling
+						// have a non-undefined _lastDomChildSibling. Continue the diff from the sibling
 						// of last DOM child of this child VNode
-						nextDom = childVNode._lastDomChild;
+						nextDom = childVNode._lastDomChildSibling;
 
-						// Eagerly cleanup _lastDomChild. We don't need to persist the value because
+						// Eagerly cleanup _lastDomChildSibling. We don't need to persist the value because
 						// it is only used by `diffChildren` to determine where to resume the diff after
 						// diffing Components and Fragments. Once we store it the nextDOM local var, we
 						// can clean up the property
-						childVNode._lastDomChild = undefined;
+						childVNode._lastDomChildSibling = undefined;
 					} else if (
 						excessDomChildren == oldVNode ||
 						newDom != oldDom ||
@@ -186,14 +186,14 @@ export function diffChildren(
 
 					if (typeof newParentVNode.type == 'function') {
 						// Because the newParentVNode is Fragment-like, we need to set it's
-						// _lastDomChild property to the nextSibling of its last child DOM node.
+						// _lastDomChildSibling property to the nextSibling of its last child DOM node.
 						//
 						// `oldDom` contains the correct value here because if the last child
-						// is a Fragment-like, then oldDom has already been set to that child's _lastDomChild.
+						// is a Fragment-like, then oldDom has already been set to that child's _lastDomChildSibling.
 						// If the last child is a DOM VNode, then oldDom will be set to that DOM
 						// node's nextSibling.
 
-						newParentVNode._lastDomChild = oldDom;
+						newParentVNode._lastDomChildSibling = oldDom;
 					}
 				}
 			}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -419,9 +419,9 @@ export function unmount(vnode, parentVNode, skipRemove) {
 		skipRemove = (dom = vnode._dom) != null;
 	}
 
-	// Must be set to `undefined` to properly clean up `_lastDomChild`
+	// Must be set to `undefined` to properly clean up `_lastDomChildSibling`
 	// for which `null` is a valid value. See comment in `create-element.js`
-	vnode._dom = vnode._lastDomChild = undefined;
+	vnode._dom = vnode._lastDomChildSibling = undefined;
 
 	if ((r = vnode._component) != null) {
 		if (r.componentWillUnmount) {

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -419,7 +419,9 @@ export function unmount(vnode, parentVNode, skipRemove) {
 		skipRemove = (dom = vnode._dom) != null;
 	}
 
-	vnode._dom = vnode._lastDomChild = null;
+	// Must be set to `undefined` to properly clean up `_lastDomChild`
+	// for which `null` is a valid value. See comment in `create-element.js`
+	vnode._dom = vnode._lastDomChild = undefined;
 
 	if ((r = vnode._component) != null) {
 		if (r.componentWillUnmount) {

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -57,7 +57,7 @@ export interface VNode<P = {}> extends preact.VNode<P> {
 	/**
 	 * The last dom child of a Fragment, or components that return a Fragment
 	 */
-	_lastDomChild: PreactElement | Text | null;
+	_lastDomChildSibling: PreactElement | Text | null;
 	_component: Component | null;
 	constructor: undefined;
 }

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -1886,7 +1886,7 @@ describe('Fragment', () => {
 		expect(scratch.innerHTML).to.equal(successHtml);
 	});
 
-	it('should use the last dom node for _lastDomChild', () => {
+	it('should properly render Fragments whose last child is a component returning null', () => {
 		let Noop = () => null;
 		let update;
 		class App extends Component {


### PR DESCRIPTION
While exploring ways to use `getDomSibling` to replace `nextSibling` in `diffChildren`, I discovered that `_lastDomChild` should really be `_lastDomChildSibling`. The only thing our code uses `_lastDomChild` for is to [determine what DOM node the diff should continue with](https://github.com/preactjs/preact/blob/383443976e418033e448505aa6b4c53a07a65be4/src/diff/children.js#L176) after diffing a Component/Fragment.

However when Components/Fragments are nested (like the example below) each Component reads it's child's `_lastDomChild` property and reads the `nextSibling` property. If the Components are the last child of their parent's (like the example below), then this `nextSibling` read is redundant to the read that it's child already performed. Note: it's only useless when the Component is the last child because the result of `oldDom = newDom.nextSibling` is thrown away. In diffChildren, `oldDom` is only used to determine what DOM the diff should use for siblings. When the Component doesn't have any siblings, the value of `oldDom` is thrown away and `_lastDomChild` is used instead in the parent.

```jsx
<Provider1>
  <Provider2>
    <Child>
      <div />
    </Child>
  </Provider2>
</Provider1>
```

In other words, what we really want to bubble up while diffing Components/Fragments isn't the last DOM child of the Component, but what DOM should the diff continue with. So this PR changes `_lastDomChild` to `_lastDomChildSibling`.

I also used this change to precalculate what `oldDom` should be in situations where we know it without having to read `nextSibling`