### PR TITLE
Preserve state when using placeholders

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -1,7 +1,7 @@
 import { EMPTY_OBJ, EMPTY_ARR } from '../constants';
 import { Component } from '../component';
 import { Fragment } from '../create-element';
-import { diffChildren, toChildArray } from './children';
+import { diffChildren } from './children';
 import { diffProps } from './props';
 import { assign, removeNode } from '../util';
 import options from '../options';
@@ -165,9 +165,7 @@ export function diff(
 			tmp = c.render(c.props, c.state, c.context);
 			let isTopLevelFragment =
 				tmp != null && tmp.type == Fragment && tmp.key == null;
-			newVNode._children = toChildArray(
-				isTopLevelFragment ? tmp.props.children : tmp
-			);
+			newVNode._children = isTopLevelFragment ? tmp.props.children : tmp;
 
 			if (c.getChildContext != null) {
 				context = assign(assign({}, context), c.getChildContext());

--- a/test/browser/keys.test.js
+++ b/test/browser/keys.test.js
@@ -1,4 +1,5 @@
-import { createElement, Component, render } from 'preact';
+import { createElement, Component, render, createRef } from 'preact';
+import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../_util/helpers';
 import { logCall, clearLog, getLog } from '../_util/logCall';
 import { div } from '../_util/dom';
@@ -8,6 +9,9 @@ import { div } from '../_util/dom';
 describe('keys', () => {
 	/** @type {HTMLDivElement} */
 	let scratch;
+
+	/** @type {() => void} */
+	let rerender;
 
 	/** @type {string[]} */
 	let ops;
@@ -59,6 +63,7 @@ describe('keys', () => {
 
 	beforeEach(() => {
 		scratch = setupScratch();
+		rerender = setupRerender();
 		ops = [];
 	});
 
@@ -639,5 +644,102 @@ describe('keys', () => {
 		render(<Foo />, scratch);
 		expect(scratch.innerHTML).to.equal('<div><div>Hello</div></div>');
 		expect(getLog()).to.deep.equal(['<div>bar.remove()']);
+	});
+
+	it('should preserve state of Components when using null or booleans as placeholders', () => {
+		class Stateful extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { count: 0 };
+			}
+			increment() {
+				this.setState({ count: this.state.count + 1 });
+			}
+			componentDidUpdate() {
+				ops.push(`Update ${this.props.name}`);
+			}
+			componentDidMount() {
+				ops.push(`Mount ${this.props.name}`);
+			}
+			componentWillUnmount() {
+				ops.push(`Unmount ${this.props.name}`);
+			}
+			render() {
+				return (
+					<div>
+						{this.props.name}: {this.state.count}
+					</div>
+				);
+			}
+		}
+
+		const s1ref = createRef();
+		const s2ref = createRef();
+		const s3ref = createRef();
+
+		function App({ first = null, second = false }) {
+			return [first, second, <Stateful name="third" ref={s3ref} />];
+		}
+
+		// Mount third stateful - Initial render
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>third: 0</div>');
+		expect(ops).to.deep.equal(['Mount third'], 'mount third');
+
+		// Update third stateful
+		ops = [];
+		s3ref.current.increment();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div>third: 1</div>');
+		expect(ops).to.deep.equal(['Update third'], 'update third');
+
+		// Mount first stateful
+		ops = [];
+		render(<App first={<Stateful name="first" ref={s1ref} />} />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<div>first: 0</div><div>third: 1</div>'
+		);
+		expect(ops).to.deep.equal(['Mount first', 'Update third'], 'mount first');
+
+		// Update first stateful
+		ops = [];
+		s1ref.current.increment();
+		s3ref.current.increment();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div>first: 1</div><div>third: 2</div>'
+		);
+		expect(ops).to.deep.equal(['Update third', 'Update first'], 'update first');
+
+		// Mount second stateful
+		ops = [];
+		render(
+			<App
+				first={<Stateful name="first" ref={s1ref} />}
+				second={<Stateful name="second" ref={s2ref} />}
+			/>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal(
+			'<div>first: 1</div><div>second: 0</div><div>third: 2</div>'
+		);
+		expect(ops).to.deep.equal(
+			['Update first', 'Mount second', 'Update third'],
+			'mount second'
+		);
+
+		// Update second stateful
+		ops = [];
+		s1ref.current.increment();
+		s2ref.current.increment();
+		s3ref.current.increment();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div>first: 2</div><div>second: 1</div><div>third: 3</div>'
+		);
+		expect(ops).to.deep.equal(
+			['Update third', 'Update second', 'Update first'],
+			'update second'
+		);
 	});
 });

--- a/test/browser/lifecycles/shouldComponentUpdate.test.js
+++ b/test/browser/lifecycles/shouldComponentUpdate.test.js
@@ -163,7 +163,8 @@ describe('Lifecycle methods', () => {
 
 		it('should clear renderCallbacks', () => {
 			const spy = sinon.spy();
-			let c, renders = 0;
+			let c,
+				renders = 0;
 
 			class App extends Component {
 				constructor() {
@@ -247,7 +248,6 @@ describe('Lifecycle methods', () => {
 			expect(Foo.prototype.render).to.have.been.calledTwice;
 			expect(Foo.prototype.shouldComponentUpdate).to.not.have.been.called;
 		});
-
 
 		it('should not block queued child forceUpdate', () => {
 			let i = 0;
@@ -706,5 +706,25 @@ describe('Lifecycle methods', () => {
 
 			expect(scratch.textContent).to.equal('foo');
 		});
+	});
+
+	it('should correctly render when sCU component has null children', () => {
+		class App extends Component {
+			shouldComponentUpdate() {
+				return false;
+			}
+			render() {
+				return [null, <div>Hello World!</div>, null];
+			}
+		}
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>Hello World!</div>');
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>Hello World!</div>');
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>Hello World!</div>');
 	});
 });


### PR DESCRIPTION
Add a test and fix a bug where `null`, `false`, and `true` were removed from the render result before going into `diffChildren`. Calling `toChildArray` without a callback removes the values mentioned above, which we were doing on the result of render before going into `diffChildren`.