### PR TITLE
Fix: Resolves Node submodule subpath error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,216 +1,216 @@
 {
-	"name": "preact",
-	"amdName": "preact",
-	"version": "10.3.0",
-	"private": false,
-	"description": "Fast 3kb React-compatible Virtual DOM library.",
-	"main": "dist/preact.js",
-	"module": "dist/preact.module.js",
-	"umd:main": "dist/preact.umd.js",
-	"unpkg": "dist/preact.umd.js",
-	"source": "src/index.js",
-	"exports": {
-		"./compat": {
-			"require": "./compat/dist/compat.js",
-			"import": "./compat/dist/compat.module.js",
-			"browser": "./compat/dist/compat.umd.js"
-		},
-		"./debug": {
-			"require": "./debug/dist/debug.js",
-			"import": "./debug/dist/debug.module.js",
-			"browser": "./debug/dist/debug.umd.js"
-		},
-		"./hooks": {
-			"require": "./hooks/dist/hooks.js",
-			"import": "./hooks/dist/hooks.module.js",
-			"browser": "./hooks/dist/hooks.umd.js"
-		},
-		"./test-utils": {
-			"require": "./test-utils/dist/testUtils.js",
-			"import": "./test-utils/dist/testUtils.module.js",
-			"browser": "./test-utils/dist/testUtils.umd.js"
-		},
-		"./compat/server": {
-			"require": "./compat/server.js"
-		}
-	},
-	"license": "MIT",
-	"funding": {
-		"type": "opencollective",
-		"url": "https://opencollective.com/preact"
-	},
-	"types": "src/index.d.ts",
-	"scripts": {
-		"build": "npm-run-all --parallel build:* && cp dist/preact.js dist/preact.min.js",
-		"build:core": "microbundle build --raw",
-		"build:debug": "microbundle build --raw --cwd debug",
-		"build:devtools": "microbundle build --raw --cwd devtools",
-		"build:hooks": "microbundle build --raw --cwd hooks",
-		"build:test-utils": "microbundle build --raw --cwd test-utils",
-		"build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks'",
-		"dev": "microbundle watch --raw --format cjs",
-		"dev:hooks": "microbundle watch --raw --format cjs --cwd hooks",
-		"dev:compat": "microbundle watch --raw --format cjs --cwd compat --globals 'preact/hooks=preactHooks'",
-		"test": "npm-run-all lint build test:unit",
-		"test:unit": "run-p test:mocha test:karma test:ts",
-		"test:ts": "run-p test:ts:*",
-		"test:ts:core": "tsc -p test/ts/ && mocha --require \"@babel/register\" test/ts/**/*-test.js",
-		"test:ts:compat": "tsc -p compat/test/ts/",
-		"test:mocha": "mocha --recursive --require \"@babel/register\" test/shared test/node",
-		"test:karma": "cross-env COVERAGE=true karma start karma.conf.js --single-run",
-		"test:mocha:watch": "npm run test:mocha -- --watch",
-		"test:karma:watch": "karma start karma.conf.js --no-single-run",
-		"test:karma:hooks": "cross-env COVERAGE=false karma start karma.conf.js --grep=hooks/test/browser/**.js --no-single-run",
-		"test:karma:test-utils": "cross-env PERFORMANCE=false COVERAGE=false karma start karma.conf.js --grep=test-utils/test/shared/**.js --no-single-run",
-		"test:karma:bench": "cross-env PERFORMANCE=true COVERAGE=false karma start karma.conf.js --grep=test/benchmarks/**.js --single-run",
-		"benchmark": "npm run test:karma:bench -- no-single-run",
-		"lint": "eslint src test debug compat hooks test-utils"
-	},
-	"eslintConfig": {
-		"extends": [
-			"developit",
-			"prettier"
-		],
-		"settings": {
-			"react": {
-				"pragma": "createElement"
-			}
-		},
-		"rules": {
-			"camelcase": [
-				1,
-				{
-					"allow": [
-						"__test__*",
-						"unstable_*",
-						"UNSAFE_*"
-					]
-				}
-			],
-			"no-unused-vars": [
-				2,
-				{
-					"args": "none",
-					"varsIgnorePattern": "^h|React$"
-				}
-			],
-			"prefer-rest-params": 0,
-			"prefer-spread": 0,
-			"no-cond-assign": 0,
-			"react/jsx-no-bind": 0,
-			"react/no-danger": "off",
-			"react/prefer-stateless-function": 0,
-			"react/sort-comp": 0,
-			"jest/valid-expect": 0,
-			"jest/no-disabled-tests": 0,
-			"react/no-find-dom-node": 0
-		}
-	},
-	"eslintIgnore": [
-		"test/fixtures",
-		"test/ts/",
-		"*.ts",
-		"dist"
-	],
-	"prettier": {
-		"singleQuote": true,
-		"trailingComma": "none",
-		"useTabs": true,
-		"tabWidth": 2
-	},
-	"lint-staged": {
-		"**/*.{js,jsx,ts,tsx}": [
-			"prettier --write",
-			"git add"
-		]
-	},
-	"husky": {
-		"hooks": {
-			"pre-commit": "lint-staged"
-		}
-	},
-	"files": [
-		"src",
-		"dist",
-		"compat/dist",
-		"compat/src",
-		"compat/server.js",
-		"compat/package.json",
-		"debug/dist",
-		"debug/src",
-		"debug/package.json",
-		"devtools/dist",
-		"devtools/src",
-		"devtools/package.json",
-		"hooks/dist",
-		"hooks/src",
-		"hooks/package.json",
-		"test-utils/src",
-		"test-utils/package.json",
-		"test-utils/dist"
-	],
-	"keywords": [
-		"preact",
-		"react",
-		"ui",
-		"user interface",
-		"virtual dom",
-		"vdom",
-		"components",
-		"dom diff"
-	],
-	"authors": [
-		"Jason Miller <jason@developit.ca>"
-	],
-	"repository": "preactjs/preact",
-	"bugs": "https://github.com/preactjs/preact/issues",
-	"homepage": "https://preactjs.com",
-	"devDependencies": {
-		"@babel/core": "^7.7.0",
-		"@babel/plugin-proposal-object-rest-spread": "^7.6.2",
-		"@babel/plugin-transform-react-jsx": "^7.7.0",
-		"@babel/plugin-transform-react-jsx-source": "^7.7.4",
-		"@babel/preset-env": "^7.7.1",
-		"@babel/register": "^7.7.0",
-		"@types/chai": "^4.1.2",
-		"@types/mocha": "^5.0.0",
-		"@types/node": "^10.5.2",
-		"babel-loader": "^8.0.6",
-		"babel-plugin-istanbul": "^5.2.0",
-		"babel-plugin-transform-async-to-promises": "^0.8.15",
-		"benchmark": "^2.1.4",
-		"chai": "^4.1.2",
-		"coveralls": "^3.0.0",
-		"cross-env": "^5.2.0",
-		"diff": "^3.5.0",
-		"eslint": "5.15.1",
-		"eslint-config-developit": "^1.1.1",
-		"eslint-config-prettier": "^6.5.0",
-		"eslint-plugin-react": "7.12.4",
-		"husky": "^3.0.9",
-		"karma": "^3.0.0",
-		"karma-chai-sinon": "^0.1.5",
-		"karma-chrome-launcher": "^2.2.0",
-		"karma-coverage": "^1.1.2",
-		"karma-mocha": "^1.3.0",
-		"karma-mocha-reporter": "^2.2.5",
-		"karma-sauce-launcher": "^1.2.0",
-		"karma-sinon": "^1.0.5",
-		"karma-source-map-support": "^1.3.0",
-		"karma-sourcemap-loader": "^0.3.7",
-		"karma-webpack": "^3.0.5",
-		"lint-staged": "^9.4.2",
-		"lodash": "^4.17.10",
-		"microbundle": "^0.11.0",
-		"mocha": "^5.2.0",
-		"npm-merge-driver-install": "^1.1.1",
-		"npm-run-all": "^4.0.0",
-		"prettier": "^1.18.2",
-		"prop-types": "^15.7.2",
-		"sinon": "^6.1.3",
-		"sinon-chai": "^3.0.0",
-		"travis-size-report": "^1.0.1",
-		"typescript": "^3.0.1",
-		"webpack": "^4.3.0"
-	}
+  "name": "preact",
+  "amdName": "preact",
+  "version": "10.3.0",
+  "private": false,
+  "description": "Fast 3kb React-compatible Virtual DOM library.",
+  "main": "dist/preact.js",
+  "module": "dist/preact.module.js",
+  "umd:main": "dist/preact.umd.js",
+  "unpkg": "dist/preact.umd.js",
+  "source": "src/index.js",
+  "exports": {
+    "./compat": {
+      "require": "./compat/dist/compat.js",
+      "import": "./compat/dist/compat.module.js",
+      "browser": "./compat/dist/compat.umd.js"
+    },
+    "./debug": {
+      "require": "./debug/dist/debug.js",
+      "import": "./debug/dist/debug.module.js",
+      "browser": "./debug/dist/debug.umd.js"
+    },
+    "./hooks": {
+      "require": "./hooks/dist/hooks.js",
+      "import": "./hooks/dist/hooks.module.js",
+      "browser": "./hooks/dist/hooks.umd.js"
+    },
+    "./test-utils": {
+      "require": "./test-utils/dist/testUtils.js",
+      "import": "./test-utils/dist/testUtils.module.js",
+      "browser": "./test-utils/dist/testUtils.umd.js"
+    },
+    "./compat/server": {
+      "require": "./compat/server.js"
+    }
+  },
+  "license": "MIT",
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+  },
+  "types": "src/index.d.ts",
+  "scripts": {
+    "build": "npm-run-all --parallel build:* && cp dist/preact.js dist/preact.min.js",
+    "build:core": "microbundle build --raw",
+    "build:debug": "microbundle build --raw --cwd debug",
+    "build:devtools": "microbundle build --raw --cwd devtools",
+    "build:hooks": "microbundle build --raw --cwd hooks",
+    "build:test-utils": "microbundle build --raw --cwd test-utils",
+    "build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks'",
+    "dev": "microbundle watch --raw --format cjs",
+    "dev:hooks": "microbundle watch --raw --format cjs --cwd hooks",
+    "dev:compat": "microbundle watch --raw --format cjs --cwd compat --globals 'preact/hooks=preactHooks'",
+    "test": "npm-run-all lint build test:unit",
+    "test:unit": "run-p test:mocha test:karma test:ts",
+    "test:ts": "run-p test:ts:*",
+    "test:ts:core": "tsc -p test/ts/ && mocha --require \"@babel/register\" test/ts/**/*-test.js",
+    "test:ts:compat": "tsc -p compat/test/ts/",
+    "test:mocha": "mocha --recursive --require \"@babel/register\" test/shared test/node",
+    "test:karma": "cross-env COVERAGE=true karma start karma.conf.js --single-run",
+    "test:mocha:watch": "npm run test:mocha -- --watch",
+    "test:karma:watch": "karma start karma.conf.js --no-single-run",
+    "test:karma:hooks": "cross-env COVERAGE=false karma start karma.conf.js --grep=hooks/test/browser/**.js --no-single-run",
+    "test:karma:test-utils": "cross-env PERFORMANCE=false COVERAGE=false karma start karma.conf.js --grep=test-utils/test/shared/**.js --no-single-run",
+    "test:karma:bench": "cross-env PERFORMANCE=true COVERAGE=false karma start karma.conf.js --grep=test/benchmarks/**.js --single-run",
+    "benchmark": "npm run test:karma:bench -- no-single-run",
+    "lint": "eslint src test debug compat hooks test-utils"
+  },
+  "eslintConfig": {
+    "extends": [
+      "developit",
+      "prettier"
+    ],
+    "settings": {
+      "react": {
+        "pragma": "createElement"
+      }
+    },
+    "rules": {
+      "camelcase": [
+        1,
+        {
+          "allow": [
+            "__test__*",
+            "unstable_*",
+            "UNSAFE_*"
+          ]
+        }
+      ],
+      "no-unused-vars": [
+        2,
+        {
+          "args": "none",
+          "varsIgnorePattern": "^h|React$"
+        }
+      ],
+      "prefer-rest-params": 0,
+      "prefer-spread": 0,
+      "no-cond-assign": 0,
+      "react/jsx-no-bind": 0,
+      "react/no-danger": "off",
+      "react/prefer-stateless-function": 0,
+      "react/sort-comp": 0,
+      "jest/valid-expect": 0,
+      "jest/no-disabled-tests": 0,
+      "react/no-find-dom-node": 0
+    }
+  },
+  "eslintIgnore": [
+    "test/fixtures",
+    "test/ts/",
+    "*.ts",
+    "dist"
+  ],
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "none",
+    "useTabs": true,
+    "tabWidth": 2
+  },
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "files": [
+    "src",
+    "dist",
+    "compat/dist",
+    "compat/src",
+    "compat/server.js",
+    "compat/package.json",
+    "debug/dist",
+    "debug/src",
+    "debug/package.json",
+    "devtools/dist",
+    "devtools/src",
+    "devtools/package.json",
+    "hooks/dist",
+    "hooks/src",
+    "hooks/package.json",
+    "test-utils/src",
+    "test-utils/package.json",
+    "test-utils/dist"
+  ],
+  "keywords": [
+    "preact",
+    "react",
+    "ui",
+    "user interface",
+    "virtual dom",
+    "vdom",
+    "components",
+    "dom diff"
+  ],
+  "authors": [
+    "Jason Miller <jason@developit.ca>"
+  ],
+  "repository": "preactjs/preact",
+  "bugs": "https://github.com/preactjs/preact/issues",
+  "homepage": "https://preactjs.com",
+  "devDependencies": {
+    "@babel/core": "^7.7.0",
+    "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
+    "@babel/plugin-transform-react-jsx": "^7.7.0",
+    "@babel/plugin-transform-react-jsx-source": "^7.7.4",
+    "@babel/preset-env": "^7.7.1",
+    "@babel/register": "^7.7.0",
+    "@types/chai": "^4.1.2",
+    "@types/mocha": "^5.0.0",
+    "@types/node": "^10.5.2",
+    "babel-loader": "^8.0.6",
+    "babel-plugin-istanbul": "^5.2.0",
+    "babel-plugin-transform-async-to-promises": "^0.8.15",
+    "benchmark": "^2.1.4",
+    "chai": "^4.1.2",
+    "coveralls": "^3.0.0",
+    "cross-env": "^5.2.0",
+    "diff": "^3.5.0",
+    "eslint": "5.15.1",
+    "eslint-config-developit": "^1.1.1",
+    "eslint-config-prettier": "^6.5.0",
+    "eslint-plugin-react": "7.12.4",
+    "husky": "^3.0.9",
+    "karma": "^3.0.0",
+    "karma-chai-sinon": "^0.1.5",
+    "karma-chrome-launcher": "^2.2.0",
+    "karma-coverage": "^1.1.2",
+    "karma-mocha": "^1.3.0",
+    "karma-mocha-reporter": "^2.2.5",
+    "karma-sauce-launcher": "^1.2.0",
+    "karma-sinon": "^1.0.5",
+    "karma-source-map-support": "^1.3.0",
+    "karma-sourcemap-loader": "^0.3.7",
+    "karma-webpack": "^3.0.5",
+    "lint-staged": "^9.4.2",
+    "lodash": "^4.17.10",
+    "microbundle": "^0.11.0",
+    "mocha": "^5.2.0",
+    "npm-merge-driver-install": "^1.1.1",
+    "npm-run-all": "^4.0.0",
+    "prettier": "^1.18.2",
+    "prop-types": "^15.7.2",
+    "sinon": "^6.1.3",
+    "sinon-chai": "^3.0.0",
+    "travis-size-report": "^1.0.1",
+    "typescript": "^3.0.1",
+    "webpack": "^4.3.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,213 +1,216 @@
 {
-  "name": "preact",
-  "amdName": "preact",
-  "version": "10.3.0",
-  "private": false,
-  "description": "Fast 3kb React-compatible Virtual DOM library.",
-  "main": "dist/preact.js",
-  "module": "dist/preact.module.js",
-  "umd:main": "dist/preact.umd.js",
-  "unpkg": "dist/preact.umd.js",
-  "source": "src/index.js",
-  "exports": {
-    "./compat": {
-      "require": "./compat/dist/compat.js",
-      "import": "./compat/dist/compat.module.js",
-      "browser": "./compat/dist/compat.umd.js"
-    },
-    "./debug": {
-      "require": "./debug/dist/debug.js",
-      "import": "./debug/dist/debug.module.js",
-      "browser": "./debug/dist/debug.umd.js"
-    },
-    "./hooks": {
-      "require": "./hooks/dist/hooks.js",
-      "import": "./hooks/dist/hooks.module.js",
-      "browser": "./hooks/dist/hooks.umd.js"
-    },
-    "./test-utils": {
-      "require": "./test-utils/dist/testUtils.js",
-      "import": "./test-utils/dist/testUtils.module.js",
-      "browser": "./test-utils/dist/testUtils.umd.js"
-    }
-  },
-  "license": "MIT",
-  "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/preact"
-  },
-  "types": "src/index.d.ts",
-  "scripts": {
-    "build": "npm-run-all --parallel build:* && cp dist/preact.js dist/preact.min.js",
-    "build:core": "microbundle build --raw",
-    "build:debug": "microbundle build --raw --cwd debug",
-    "build:devtools": "microbundle build --raw --cwd devtools",
-    "build:hooks": "microbundle build --raw --cwd hooks",
-    "build:test-utils": "microbundle build --raw --cwd test-utils",
-    "build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks'",
-    "dev": "microbundle watch --raw --format cjs",
-    "dev:hooks": "microbundle watch --raw --format cjs --cwd hooks",
-    "dev:compat": "microbundle watch --raw --format cjs --cwd compat --globals 'preact/hooks=preactHooks'",
-    "test": "npm-run-all lint build test:unit",
-    "test:unit": "run-p test:mocha test:karma test:ts",
-    "test:ts": "run-p test:ts:*",
-    "test:ts:core": "tsc -p test/ts/ && mocha --require \"@babel/register\" test/ts/**/*-test.js",
-    "test:ts:compat": "tsc -p compat/test/ts/",
-    "test:mocha": "mocha --recursive --require \"@babel/register\" test/shared test/node",
-    "test:karma": "cross-env COVERAGE=true karma start karma.conf.js --single-run",
-    "test:mocha:watch": "npm run test:mocha -- --watch",
-    "test:karma:watch": "karma start karma.conf.js --no-single-run",
-    "test:karma:hooks": "cross-env COVERAGE=false karma start karma.conf.js --grep=hooks/test/browser/**.js --no-single-run",
-    "test:karma:test-utils": "cross-env PERFORMANCE=false COVERAGE=false karma start karma.conf.js --grep=test-utils/test/shared/**.js --no-single-run",
-    "test:karma:bench": "cross-env PERFORMANCE=true COVERAGE=false karma start karma.conf.js --grep=test/benchmarks/**.js --single-run",
-    "benchmark": "npm run test:karma:bench -- no-single-run",
-    "lint": "eslint src test debug compat hooks test-utils"
-  },
-  "eslintConfig": {
-    "extends": [
-      "developit",
-      "prettier"
-    ],
-    "settings": {
-      "react": {
-        "pragma": "createElement"
-      }
-    },
-    "rules": {
-      "camelcase": [
-        1,
-        {
-          "allow": [
-            "__test__*",
-            "unstable_*",
-            "UNSAFE_*"
-          ]
-        }
-      ],
-      "no-unused-vars": [
-        2,
-        {
-          "args": "none",
-          "varsIgnorePattern": "^h|React$"
-        }
-      ],
-      "prefer-rest-params": 0,
-      "prefer-spread": 0,
-      "no-cond-assign": 0,
-      "react/jsx-no-bind": 0,
-      "react/no-danger": "off",
-      "react/prefer-stateless-function": 0,
-      "react/sort-comp": 0,
-      "jest/valid-expect": 0,
-      "jest/no-disabled-tests": 0,
-      "react/no-find-dom-node": 0
-    }
-  },
-  "eslintIgnore": [
-    "test/fixtures",
-    "test/ts/",
-    "*.ts",
-    "dist"
-  ],
-  "prettier": {
-    "singleQuote": true,
-    "trailingComma": "none",
-    "useTabs": true,
-    "tabWidth": 2
-  },
-  "lint-staged": {
-    "**/*.{js,jsx,ts,tsx}": [
-      "prettier --write",
-      "git add"
-    ]
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
-  "files": [
-    "src",
-    "dist",
-    "compat/dist",
-    "compat/src",
-    "compat/server.js",
-    "compat/package.json",
-    "debug/dist",
-    "debug/src",
-    "debug/package.json",
-    "devtools/dist",
-    "devtools/src",
-    "devtools/package.json",
-    "hooks/dist",
-    "hooks/src",
-    "hooks/package.json",
-    "test-utils/src",
-    "test-utils/package.json",
-    "test-utils/dist"
-  ],
-  "keywords": [
-    "preact",
-    "react",
-    "ui",
-    "user interface",
-    "virtual dom",
-    "vdom",
-    "components",
-    "dom diff"
-  ],
-  "authors": [
-    "Jason Miller <jason@developit.ca>"
-  ],
-  "repository": "preactjs/preact",
-  "bugs": "https://github.com/preactjs/preact/issues",
-  "homepage": "https://preactjs.com",
-  "devDependencies": {
-    "@babel/core": "^7.7.0",
-    "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
-    "@babel/plugin-transform-react-jsx": "^7.7.0",
-    "@babel/plugin-transform-react-jsx-source": "^7.7.4",
-    "@babel/preset-env": "^7.7.1",
-    "@babel/register": "^7.7.0",
-    "@types/chai": "^4.1.2",
-    "@types/mocha": "^5.0.0",
-    "@types/node": "^10.5.2",
-    "babel-loader": "^8.0.6",
-    "babel-plugin-istanbul": "^5.2.0",
-    "babel-plugin-transform-async-to-promises": "^0.8.15",
-    "benchmark": "^2.1.4",
-    "chai": "^4.1.2",
-    "coveralls": "^3.0.0",
-    "cross-env": "^5.2.0",
-    "diff": "^3.5.0",
-    "eslint": "5.15.1",
-    "eslint-config-developit": "^1.1.1",
-    "eslint-config-prettier": "^6.5.0",
-    "eslint-plugin-react": "7.12.4",
-    "husky": "^3.0.9",
-    "karma": "^3.0.0",
-    "karma-chai-sinon": "^0.1.5",
-    "karma-chrome-launcher": "^2.2.0",
-    "karma-coverage": "^1.1.2",
-    "karma-mocha": "^1.3.0",
-    "karma-mocha-reporter": "^2.2.5",
-    "karma-sauce-launcher": "^1.2.0",
-    "karma-sinon": "^1.0.5",
-    "karma-source-map-support": "^1.3.0",
-    "karma-sourcemap-loader": "^0.3.7",
-    "karma-webpack": "^3.0.5",
-    "lint-staged": "^9.4.2",
-    "lodash": "^4.17.10",
-    "microbundle": "^0.11.0",
-    "mocha": "^5.2.0",
-    "npm-merge-driver-install": "^1.1.1",
-    "npm-run-all": "^4.0.0",
-    "prettier": "^1.18.2",
-    "prop-types": "^15.7.2",
-    "sinon": "^6.1.3",
-    "sinon-chai": "^3.0.0",
-    "travis-size-report": "^1.0.1",
-    "typescript": "^3.0.1",
-    "webpack": "^4.3.0"
-  }
+	"name": "preact",
+	"amdName": "preact",
+	"version": "10.3.0",
+	"private": false,
+	"description": "Fast 3kb React-compatible Virtual DOM library.",
+	"main": "dist/preact.js",
+	"module": "dist/preact.module.js",
+	"umd:main": "dist/preact.umd.js",
+	"unpkg": "dist/preact.umd.js",
+	"source": "src/index.js",
+	"exports": {
+		"./compat": {
+			"require": "./compat/dist/compat.js",
+			"import": "./compat/dist/compat.module.js",
+			"browser": "./compat/dist/compat.umd.js"
+		},
+		"./debug": {
+			"require": "./debug/dist/debug.js",
+			"import": "./debug/dist/debug.module.js",
+			"browser": "./debug/dist/debug.umd.js"
+		},
+		"./hooks": {
+			"require": "./hooks/dist/hooks.js",
+			"import": "./hooks/dist/hooks.module.js",
+			"browser": "./hooks/dist/hooks.umd.js"
+		},
+		"./test-utils": {
+			"require": "./test-utils/dist/testUtils.js",
+			"import": "./test-utils/dist/testUtils.module.js",
+			"browser": "./test-utils/dist/testUtils.umd.js"
+		},
+		"./compat/server": {
+			"require": "./compat/server.js"
+		}
+	},
+	"license": "MIT",
+	"funding": {
+		"type": "opencollective",
+		"url": "https://opencollective.com/preact"
+	},
+	"types": "src/index.d.ts",
+	"scripts": {
+		"build": "npm-run-all --parallel build:* && cp dist/preact.js dist/preact.min.js",
+		"build:core": "microbundle build --raw",
+		"build:debug": "microbundle build --raw --cwd debug",
+		"build:devtools": "microbundle build --raw --cwd devtools",
+		"build:hooks": "microbundle build --raw --cwd hooks",
+		"build:test-utils": "microbundle build --raw --cwd test-utils",
+		"build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks'",
+		"dev": "microbundle watch --raw --format cjs",
+		"dev:hooks": "microbundle watch --raw --format cjs --cwd hooks",
+		"dev:compat": "microbundle watch --raw --format cjs --cwd compat --globals 'preact/hooks=preactHooks'",
+		"test": "npm-run-all lint build test:unit",
+		"test:unit": "run-p test:mocha test:karma test:ts",
+		"test:ts": "run-p test:ts:*",
+		"test:ts:core": "tsc -p test/ts/ && mocha --require \"@babel/register\" test/ts/**/*-test.js",
+		"test:ts:compat": "tsc -p compat/test/ts/",
+		"test:mocha": "mocha --recursive --require \"@babel/register\" test/shared test/node",
+		"test:karma": "cross-env COVERAGE=true karma start karma.conf.js --single-run",
+		"test:mocha:watch": "npm run test:mocha -- --watch",
+		"test:karma:watch": "karma start karma.conf.js --no-single-run",
+		"test:karma:hooks": "cross-env COVERAGE=false karma start karma.conf.js --grep=hooks/test/browser/**.js --no-single-run",
+		"test:karma:test-utils": "cross-env PERFORMANCE=false COVERAGE=false karma start karma.conf.js --grep=test-utils/test/shared/**.js --no-single-run",
+		"test:karma:bench": "cross-env PERFORMANCE=true COVERAGE=false karma start karma.conf.js --grep=test/benchmarks/**.js --single-run",
+		"benchmark": "npm run test:karma:bench -- no-single-run",
+		"lint": "eslint src test debug compat hooks test-utils"
+	},
+	"eslintConfig": {
+		"extends": [
+			"developit",
+			"prettier"
+		],
+		"settings": {
+			"react": {
+				"pragma": "createElement"
+			}
+		},
+		"rules": {
+			"camelcase": [
+				1,
+				{
+					"allow": [
+						"__test__*",
+						"unstable_*",
+						"UNSAFE_*"
+					]
+				}
+			],
+			"no-unused-vars": [
+				2,
+				{
+					"args": "none",
+					"varsIgnorePattern": "^h|React$"
+				}
+			],
+			"prefer-rest-params": 0,
+			"prefer-spread": 0,
+			"no-cond-assign": 0,
+			"react/jsx-no-bind": 0,
+			"react/no-danger": "off",
+			"react/prefer-stateless-function": 0,
+			"react/sort-comp": 0,
+			"jest/valid-expect": 0,
+			"jest/no-disabled-tests": 0,
+			"react/no-find-dom-node": 0
+		}
+	},
+	"eslintIgnore": [
+		"test/fixtures",
+		"test/ts/",
+		"*.ts",
+		"dist"
+	],
+	"prettier": {
+		"singleQuote": true,
+		"trailingComma": "none",
+		"useTabs": true,
+		"tabWidth": 2
+	},
+	"lint-staged": {
+		"**/*.{js,jsx,ts,tsx}": [
+			"prettier --write",
+			"git add"
+		]
+	},
+	"husky": {
+		"hooks": {
+			"pre-commit": "lint-staged"
+		}
+	},
+	"files": [
+		"src",
+		"dist",
+		"compat/dist",
+		"compat/src",
+		"compat/server.js",
+		"compat/package.json",
+		"debug/dist",
+		"debug/src",
+		"debug/package.json",
+		"devtools/dist",
+		"devtools/src",
+		"devtools/package.json",
+		"hooks/dist",
+		"hooks/src",
+		"hooks/package.json",
+		"test-utils/src",
+		"test-utils/package.json",
+		"test-utils/dist"
+	],
+	"keywords": [
+		"preact",
+		"react",
+		"ui",
+		"user interface",
+		"virtual dom",
+		"vdom",
+		"components",
+		"dom diff"
+	],
+	"authors": [
+		"Jason Miller <jason@developit.ca>"
+	],
+	"repository": "preactjs/preact",
+	"bugs": "https://github.com/preactjs/preact/issues",
+	"homepage": "https://preactjs.com",
+	"devDependencies": {
+		"@babel/core": "^7.7.0",
+		"@babel/plugin-proposal-object-rest-spread": "^7.6.2",
+		"@babel/plugin-transform-react-jsx": "^7.7.0",
+		"@babel/plugin-transform-react-jsx-source": "^7.7.4",
+		"@babel/preset-env": "^7.7.1",
+		"@babel/register": "^7.7.0",
+		"@types/chai": "^4.1.2",
+		"@types/mocha": "^5.0.0",
+		"@types/node": "^10.5.2",
+		"babel-loader": "^8.0.6",
+		"babel-plugin-istanbul": "^5.2.0",
+		"babel-plugin-transform-async-to-promises": "^0.8.15",
+		"benchmark": "^2.1.4",
+		"chai": "^4.1.2",
+		"coveralls": "^3.0.0",
+		"cross-env": "^5.2.0",
+		"diff": "^3.5.0",
+		"eslint": "5.15.1",
+		"eslint-config-developit": "^1.1.1",
+		"eslint-config-prettier": "^6.5.0",
+		"eslint-plugin-react": "7.12.4",
+		"husky": "^3.0.9",
+		"karma": "^3.0.0",
+		"karma-chai-sinon": "^0.1.5",
+		"karma-chrome-launcher": "^2.2.0",
+		"karma-coverage": "^1.1.2",
+		"karma-mocha": "^1.3.0",
+		"karma-mocha-reporter": "^2.2.5",
+		"karma-sauce-launcher": "^1.2.0",
+		"karma-sinon": "^1.0.5",
+		"karma-source-map-support": "^1.3.0",
+		"karma-sourcemap-loader": "^0.3.7",
+		"karma-webpack": "^3.0.5",
+		"lint-staged": "^9.4.2",
+		"lodash": "^4.17.10",
+		"microbundle": "^0.11.0",
+		"mocha": "^5.2.0",
+		"npm-merge-driver-install": "^1.1.1",
+		"npm-run-all": "^4.0.0",
+		"prettier": "^1.18.2",
+		"prop-types": "^15.7.2",
+		"sinon": "^6.1.3",
+		"sinon-chai": "^3.0.0",
+		"travis-size-report": "^1.0.1",
+		"typescript": "^3.0.1",
+		"webpack": "^4.3.0"
+	}
 }


### PR DESCRIPTION
After installing v10.3.0 (which implements Node submodule path support), _and_ if you are using Node v13, you will encounter this error:
```shell
(node:75051) ExperimentalWarning: Conditional exports is an experimental feature. This feature could change at any time
(node:75051) UnhandledPromiseRejectionWarning: Error: Package exports for '/Users/4cm4k1/Code/personal-website/node_modules/preact' do not define a './compat/server' subpath
    at applyExports (internal/modules/cjs/loader.js:529:13)
    at resolveExports (internal/modules/cjs/loader.js:549:12)
    at Function.Module._findPath (internal/modules/cjs/loader.js:664:22)
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:967:27)
    at Function.Module._load (internal/modules/cjs/loader.js:862:27)
    at Module.require (internal/modules/cjs/loader.js:1040:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (/Users/4cm4k1/Code/personal-website/node_modules/react-dom/server.js:1:18)
    at Module._compile (internal/modules/cjs/loader.js:1151:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1171:10)
(node:75051) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:75051) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
This PR adds `./compat/server.js` as an export path, which is currently only written in `require` syntax, and resolves the error. 😄 