### PR TITLE
removes warning from tests by removing console.log in render.test.js

### DIFF
--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -190,7 +190,6 @@ describe('compat render', () => {
 		update();
 		rerender();
 
-		console.log(scratch.textContent);
 		expect(/Failed/g.test(scratch.textContent)).to.equal(
 			false,
 			'not enumerable'


### PR DESCRIPTION
Removes a forgotten console.log from the render.test.js that I saw while working on some unsuccessful code golfing