### PR TITLE
Fix className not being applied when set to an empty string

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -86,7 +86,7 @@ options.vnode = vnode => {
 	// Alias `class` prop to `className` if available
 	if (props.class != props.className) {
 		classNameDescriptor.enumerable = 'className' in props;
-		if (props.className) props.class = props.className;
+		if (props.className != null) props.class = props.className;
 		Object.defineProperty(props, 'className', classNameDescriptor);
 	}
 

--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -146,6 +146,15 @@ describe('compat render', () => {
 		expect(scratch.firstChild.className).to.equal('foo');
 	});
 
+	it('should normalize className when it has an empty string', () => {
+		function Foo(props) {
+			expect(props.className).to.equal('');
+			return <div className="">foo</div>;
+		}
+
+		render(<Foo className="" />, scratch);
+	});
+
 	// Issue #2275
 	it('should normalize class+className + DOM properties', () => {
 		function Foo(props) {


### PR DESCRIPTION
Fixes: https://github.com/preactjs/preact/issues/2308

When `className` is an empty string we override it with a get property that returns the undefined `class` property instead