### PR TITLE
move to umd and make browser a modular export

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     ".": {
       "require": "./dist/preact.js",
       "import": "./dist/preact.module.js",
-      "browser": "./dist/preact.umd.js"
+      "browser": "./dist/preact.module.js",
+      "umd": "./dist/preact.umd.js"
     },
     "./compat": {
       "require": "./compat/dist/compat.js",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "./test-utils": {
       "require": "./test-utils/dist/testUtils.js",
       "import": "./test-utils/dist/testUtils.module.js",
-      "browser": "./test-utils/dist/testUtils.umd.js",
+      "browser": "./test-utils/dist/testUtils.module.js",
       "umd": "./test-utils/dist/testUtils.umd.js"
     },
     "./compat/server": {

--- a/package.json
+++ b/package.json
@@ -13,22 +13,26 @@
     "./compat": {
       "require": "./compat/dist/compat.js",
       "import": "./compat/dist/compat.module.js",
-      "browser": "./compat/dist/compat.umd.js"
+      "browser": "./compat/dist/compat.module.js",
+      "umd": "./compat/dist/compat.umd.js"
     },
     "./debug": {
-      "require": "./debug/dist/debug.js",
+      "require": "./compat/dist/debug.js",
       "import": "./debug/dist/debug.module.js",
-      "browser": "./debug/dist/debug.umd.js"
+      "browser": "./debug/dist/debug.module.js",
+      "umd": "./debug/dist/debug.umd.js"
     },
     "./hooks": {
       "require": "./hooks/dist/hooks.js",
       "import": "./hooks/dist/hooks.module.js",
-      "browser": "./hooks/dist/hooks.umd.js"
+      "browser": "./hooks/dist/hooks.module.js",
+      "umd": "./hooks/dist/hooks.umd.js"
     },
     "./test-utils": {
       "require": "./test-utils/dist/testUtils.js",
       "import": "./test-utils/dist/testUtils.module.js",
-      "browser": "./test-utils/dist/testUtils.umd.js"
+      "browser": "./test-utils/dist/testUtils.umd.js",
+      "umd": "./test-utils/dist/testUtils.umd.js"
     },
     "./compat/server": {
       "require": "./compat/server.js"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "umd": "./compat/dist/compat.umd.js"
     },
     "./debug": {
-      "require": "./compat/dist/debug.js",
+      "require": "./debug/dist/debug.js",
       "import": "./debug/dist/debug.module.js",
       "browser": "./debug/dist/debug.module.js",
       "umd": "./debug/dist/debug.umd.js"


### PR DESCRIPTION
This was proposed in: https://github.com/preactjs/preact/issues/2282#issuecomment-578995288

Would like some eyes on this