### PR TITLE
tools: add package.json to package.exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "./compat/server": {
       "require": "./compat/server.js"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./": "./"
   },
   "license": "MIT",
   "funding": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     },
     "./compat/server": {
       "require": "./compat/server.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "license": "MIT",
   "funding": {


### PR DESCRIPTION
When the export map was added the ability to import / require
the `package.json` was lost as it wasn't included in the map.

This adds back the functionality by explicitly adding it to the map.

Refs: https://github.com/pikapkg/snowpack/pull/193