### PR TITLE
TS: Make useErrorBoundary's callback param optional

### DIFF
--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -129,5 +129,5 @@ export function useDebugValue<T>(
 ): void;
 
 export function useErrorBoundary(
-	callback: () => Promise<void> | void
+	callback?: () => Promise<void> | void
 ): [string | undefined, () => void];


### PR DESCRIPTION
According to the [docs](https://preactjs.com/guide/v10/hooks/#useerrorboundary), the callback parameter in useErrorBoundary is supposed to be optional, and after testing it myself (just to be sure!), it does seem to be the case.

This pull request changes the parameter to be optional.
