### PR TITLE
fix children.map/forEach (missing index)

### DIFF
--- a/compat/src/Children.js
+++ b/compat/src/Children.js
@@ -3,7 +3,7 @@ import { toChildArray } from 'preact';
 const mapFn = (children, fn) => {
 	if (!children) return null;
 	return toChildArray(children).reduce(
-		(acc, value) => acc.concat(fn(value)),
+		(acc, value, index) => acc.concat(fn(value, index)),
 		[]
 	);
 };

--- a/compat/test/browser/Children.test.js
+++ b/compat/test/browser/Children.test.js
@@ -121,6 +121,38 @@ describe('Children', () => {
 
 			expect(scratch.textContent).to.equal('12');
 		});
+
+		it('should call with indices', () => {
+			const assertion = [];
+			const ProblemChild = ({ children }) => {
+				return React.Children.map(children, (child, i) => {
+					assertion.push(i);
+					return React.Children.map(child.props.children, (x, j) => {
+						assertion.push(j);
+						return x;
+					});
+				}).filter(React.isValidElement);
+			};
+
+			const App = () => {
+				return (
+					<ProblemChild>
+						<div>
+							<div>1</div>
+							<div>2</div>
+						</div>
+						<div>
+							<div>3</div>
+							<div>4</div>
+						</div>
+					</ProblemChild>
+				);
+			};
+
+			render(<App />, scratch);
+			expect(scratch.textContent).to.equal('1234');
+			expect(assertion.length).to.equal(6);
+		});
 	});
 
 	describe('.forEach', () => {

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -163,7 +163,6 @@ export function diff(
 			c._parentDom = parentDom;
 
 			tmp = c.render(c.props, c.state, c.context);
-
 			let isTopLevelFragment =
 				tmp != null && tmp.type == Fragment && tmp.key == null;
 			newVNode._children = isTopLevelFragment ? tmp.props.children : tmp;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -164,10 +164,9 @@ export function diff(
 
 			tmp = c.render(c.props, c.state, c.context);
 
-			newVNode._children =
-				tmp != null && tmp.type == Fragment && tmp.key == null
-					? tmp.props.children
-					: tmp;
+			let isTopLevelFragment =
+				tmp != null && tmp.type == Fragment && tmp.key == null;
+			newVNode._children = isTopLevelFragment ? tmp.props.children : tmp;
 
 			if (c.getChildContext != null) {
 				context = assign(assign({}, context), c.getChildContext());

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -163,9 +163,11 @@ export function diff(
 			c._parentDom = parentDom;
 
 			tmp = c.render(c.props, c.state, c.context);
-			let isTopLevelFragment =
-				tmp != null && tmp.type == Fragment && tmp.key == null;
-			newVNode._children = isTopLevelFragment ? tmp.props.children : tmp;
+
+			newVNode._children =
+				tmp != null && tmp.type == Fragment && tmp.key == null
+					? tmp.props.children
+					: tmp;
 
 			if (c.getChildContext != null) {
 				context = assign(assign({}, context), c.getChildContext());


### PR DESCRIPTION
Fixes: https://github.com/preactjs/preact/issues/2321

When mapping over the children they were missing the second parameter (currentIndex)