### PR TITLE
Remove array provided to fn in React.Children map and forEach

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -105,11 +105,11 @@ declare namespace React {
 	export const Children: {
 		map<T extends preact.ComponentChild, R>(
 			children: T | T[],
-			fn: (child: T, i: number, array: T[]) => R
+			fn: (child: T, i: number) => R
 		): R[];
 		forEach<T extends preact.ComponentChild>(
 			children: T | T[],
-			fn: (child: T, i: number, array: T[]) => void
+			fn: (child: T, i: number) => void
 		): void;
 		count: (children: preact.ComponentChildren) => number;
 		only: (children: preact.ComponentChildren) => preact.ComponentChild;


### PR DESCRIPTION
The children provided to `React.Children.map` and `React.Children.forEach` [isn't provided in`preact/compat`](https://github.com/preactjs/preact/blob/47b0dac0b840bf17cc62d6dc5808bacab4669ab2/compat/src/Children.js#L6), and [React doesn't provide it either](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ea0d6d6fd8d6929a272267de5b5aee94e5e35158/types/react/index.d.ts#L2791).