### PR TITLE
tooling: "exports" adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     },
     "./compat": {
       "browser": "./compat/dist/compat.module.js",
-      "umd": "./compat/dist/compat.umd.js"
+      "umd": "./compat/dist/compat.umd.js",
       "require": "./compat/dist/compat.js",
       "import": "./compat/dist/compat.module.js"
     },
     "./debug": {
       "browser": "./debug/dist/debug.module.js",
-      "umd": "./debug/dist/debug.umd.js"
+      "umd": "./debug/dist/debug.umd.js",
       "require": "./debug/dist/debug.js",
       "import": "./debug/dist/debug.module.js"
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "./compat/server": {
       "require": "./compat/server.js"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./": "./"
   },
   "license": "MIT",
   "funding": {

--- a/package.json
+++ b/package.json
@@ -11,40 +11,39 @@
   "source": "src/index.js",
   "exports": {
     ".": {
-      "require": "./dist/preact.js",
-      "import": "./dist/preact.module.js",
       "browser": "./dist/preact.module.js",
-      "umd": "./dist/preact.umd.js"
+      "umd": "./dist/preact.umd.js",
+      "import": "./dist/preact.module.js",
+      "require": "./dist/preact.js"
     },
     "./compat": {
-      "require": "./compat/dist/compat.js",
-      "import": "./compat/dist/compat.module.js",
       "browser": "./compat/dist/compat.module.js",
       "umd": "./compat/dist/compat.umd.js"
+      "require": "./compat/dist/compat.js",
+      "import": "./compat/dist/compat.module.js"
     },
     "./debug": {
-      "require": "./debug/dist/debug.js",
-      "import": "./debug/dist/debug.module.js",
       "browser": "./debug/dist/debug.module.js",
       "umd": "./debug/dist/debug.umd.js"
+      "require": "./debug/dist/debug.js",
+      "import": "./debug/dist/debug.module.js"
     },
     "./hooks": {
-      "require": "./hooks/dist/hooks.js",
-      "import": "./hooks/dist/hooks.module.js",
       "browser": "./hooks/dist/hooks.module.js",
-      "umd": "./hooks/dist/hooks.umd.js"
+      "umd": "./hooks/dist/hooks.umd.js",
+      "require": "./hooks/dist/hooks.js",
+      "import": "./hooks/dist/hooks.module.js"
     },
     "./test-utils": {
-      "require": "./test-utils/dist/testUtils.js",
-      "import": "./test-utils/dist/testUtils.module.js",
       "browser": "./test-utils/dist/testUtils.module.js",
-      "umd": "./test-utils/dist/testUtils.umd.js"
+      "umd": "./test-utils/dist/testUtils.umd.js",
+      "require": "./test-utils/dist/testUtils.js",
+      "import": "./test-utils/dist/testUtils.module.js"
     },
     "./compat/server": {
       "require": "./compat/server.js"
     },
-    "./package.json": "./package.json",
-    "./": "./"
+    "./package.json": "./package.json"
   },
   "license": "MIT",
   "funding": {


### PR DESCRIPTION
This PR updates the `"exports"` definitions to match the expectations of logical conditional exports ordering (https://github.com/nodejs/node/pull/31008).

The idea there is that we can think of the "exports" object as an ordered conditional like a series of if statements, which was integrated with feedback from tooling authors.

The definitions written here though would never match the "browser" or "umd" conditions because the "require" or "import" condition would act as a catch-all, like having an `if (true)` with further if statements below.

The general rule is to put the most specific conditional exports first, although I can appreciate if this might seem counter-intuitive.

Further discussion / feedback welcome.