### PR TITLE
Match useErrorBoundary type with componentDidCatch

### DIFF
--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -130,4 +130,4 @@ export function useDebugValue<T>(
 
 export function useErrorBoundary(
 	callback?: () => Promise<void> | void
-): [string | undefined, () => void];
+): [any, () => void];


### PR DESCRIPTION
Something I had forgotten when doing the previous pull request, useErrorBoundary unexpectedly returned string type even though componentDidCatch returns an explicit any. This pull request should address that.