### PR TITLE
Select polyfill alt

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -340,7 +340,7 @@ function diffElementNodes(
 			}
 		}
 
-		diffProps(dom, newProps, oldProps, isSvg, isHydrating);
+		diffProps(dom, newProps, oldProps, isSvg, isHydrating, newVNode.type);
 
 		newVNode._children = newVNode.props.children;
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -338,11 +338,6 @@ function diffElementNodes(
 					dom.innerHTML = (newHtml && newHtml.__html) || '';
 				}
 			}
-
-			if (newVNode.type === 'select') {
-				newProps.onChange = newProps.onInput;
-				newProps.onInput = undefined;
-			}
 		}
 
 		diffProps(dom, newProps, oldProps, isSvg, isHydrating);

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -10,12 +10,12 @@ import options from '../options';
  * @param {boolean} isSvg Whether or not this node is an SVG node
  * @param {boolean} hydrate Whether or not we are in hydration mode
  */
-export function diffProps(dom, newProps, oldProps, isSvg, hydrate) {
+export function diffProps(dom, newProps, oldProps, isSvg, hydrate, type) {
 	let i;
 
 	for (i in oldProps) {
 		if (!(i in newProps)) {
-			setProperty(dom, i, null, oldProps[i], isSvg);
+			setProperty(dom, i, null, oldProps[i], isSvg, type);
 		}
 	}
 
@@ -26,7 +26,7 @@ export function diffProps(dom, newProps, oldProps, isSvg, hydrate) {
 			i !== 'checked' &&
 			oldProps[i] !== newProps[i]
 		) {
-			setProperty(dom, i, newProps[i], oldProps[i], isSvg);
+			setProperty(dom, i, newProps[i], oldProps[i], isSvg, type);
 		}
 	}
 }
@@ -54,7 +54,7 @@ function setStyle(style, key, value) {
  * @param {*} oldValue The old value the property had
  * @param {boolean} isSvg Whether or not this DOM node is an SVG node or not
  */
-function setProperty(dom, name, value, oldValue, isSvg) {
+function setProperty(dom, name, value, oldValue, isSvg, type) {
 	if (isSvg) {
 		if (name === 'className') {
 			name = 'class';
@@ -98,9 +98,8 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 		let nameLower = name.toLowerCase();
 		name = (nameLower in dom ? nameLower : name).slice(2);
 		
-		// Fix <select onInput> not firing in Edge <= 18.
-		// We test for .options here because the text is already in source.
-		if (name === 'input' && 'options' in dom) name = 'change';
+		// Fix onInput not firing on select/radio/checkbox in Edge <= 18.
+		if (name === 'input' && /^(select|input(rad|che))$/.test(type+props.type)) name = 'change';
 
 		if (value) {
 			if (!oldValue) dom.addEventListener(name, eventProxy, useCapture);

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -62,7 +62,7 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 	} else if (name === 'class') {
 		name = 'className';
 	}
-
+	
 	if (name === 'key' || name === 'children') {
 	} else if (name === 'style') {
 		const s = dom.style;
@@ -97,6 +97,10 @@ function setProperty(dom, name, value, oldValue, isSvg) {
 		let useCapture = name !== (name = name.replace(/Capture$/, ''));
 		let nameLower = name.toLowerCase();
 		name = (nameLower in dom ? nameLower : name).slice(2);
+		
+		// Fix <select onInput> not firing in Edge <= 18.
+		// We test for .options here because the text is already in source.
+		if (name === 'input' && 'options' in dom) name = 'change';
 
 		if (value) {
 			if (!oldValue) dom.addEventListener(name, eventProxy, useCapture);

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -99,7 +99,10 @@ function setProperty(dom, name, value, oldValue, isSvg, type) {
 		name = (nameLower in dom ? nameLower : name).slice(2);
 		
 		// Fix onInput not firing on select/radio/checkbox in Edge <= 18.
-		if (name === 'input' && /^(select|input(rad|che))$/.test(type+props.type)) name = 'change';
+		if (name === 'input' && (
+			type === 'select' ||
+			type === 'input' && /rad|check/.test(props.type)
+		)) name = 'change';
 
 		if (value) {
 			if (!oldValue) dom.addEventListener(name, eventProxy, useCapture);


### PR DESCRIPTION
Alternative solution. There are a few properties that exist on `<select>` elements but not other inputs. This isn't ideal from a performance perspective, but the check only runs on `onInput` handlers, so the impact should be minimal. Alternatively, we could plumb `vnode` through prop diffing functions and check `vnode.type`.

Properties audit:

```js
const select = document.createElement('select');
const others = ['input', 'textarea', 'div', 'option', 'optgroup'].map(x=>document.createElement(x));
others.push(document.createTextNode(''));
for (let i in select) {
  if (!others.some(o => i in o)) {
    console.log(`select.${i} = ${select[i]}.`);
  }
}

/*
// results:
select.options = [object HTMLOptionsCollection]
select.selectedOptions = [object HTMLCollection]
select.selectedIndex = -1.
select.item = function item() { [native code] }
select.namedItem = function namedItem() { [native code] }
select.add = function add() { [native code] }
*/
```