### PR TITLE
implement  suggested perf improvement for child diffing

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -81,10 +81,7 @@ export function diffChildren(
 					// Either oldVNode === undefined or oldChildrenLength > 0,
 					// so after this loop oldVNode == null or oldVNode is a valid value.
 					for (j = 0; j < oldChildrenLength; j++) {
-						const idx =
-							i === 0
-								? (j + i) % oldChildrenLength
-								: (j + i - 1) % oldChildrenLength;
+						const idx = i === 0 ? j : (j + i - 1) % oldChildrenLength;
 						oldVNode = oldChildren[idx];
 						// If childVNode is unkeyed, we only match similarly unkeyed nodes, otherwise we match by key.
 						// We always match by type (in either case).

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -70,12 +70,7 @@ export function diffChildren(
 				// (holes).
 				oldVNode = oldChildren[i];
 
-				if (
-					oldVNode === null ||
-					(oldVNode &&
-						childVNode.key == oldVNode.key &&
-						childVNode.type === oldVNode.type)
-				) {
+				if (oldVNode === null) {
 					oldChildren[i] = undefined;
 				} else {
 					// Either oldVNode === undefined or oldChildrenLength > 0,

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -81,7 +81,8 @@ export function diffChildren(
 					// Either oldVNode === undefined or oldChildrenLength > 0,
 					// so after this loop oldVNode == null or oldVNode is a valid value.
 					for (j = 0; j < oldChildrenLength; j++) {
-						oldVNode = oldChildren[j];
+						const idx = (i + ((j >>> 1) ^ -(j & 1))) % oldChildrenLength;
+						oldVNode = oldChildren[idx];
 						// If childVNode is unkeyed, we only match similarly unkeyed nodes, otherwise we match by key.
 						// We always match by type (in either case).
 						if (
@@ -89,7 +90,7 @@ export function diffChildren(
 							childVNode.key == oldVNode.key &&
 							childVNode.type === oldVNode.type
 						) {
-							oldChildren[j] = undefined;
+							oldChildren[idx] = undefined;
 							break;
 						}
 						oldVNode = null;

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -81,7 +81,9 @@ export function diffChildren(
 					// Either oldVNode === undefined or oldChildrenLength > 0,
 					// so after this loop oldVNode == null or oldVNode is a valid value.
 					for (j = 0; j < oldChildrenLength; j++) {
-						const idx = i === 0 ? j : (j + i - 1) % oldChildrenLength;
+						const idx =
+							(i + ((j >>> 1) ^ -(j & 1)) + oldChildrenLength) %
+							oldChildrenLength;
 						oldVNode = oldChildren[idx];
 						// If childVNode is unkeyed, we only match similarly unkeyed nodes, otherwise we match by key.
 						// We always match by type (in either case).

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -81,7 +81,10 @@ export function diffChildren(
 					// Either oldVNode === undefined or oldChildrenLength > 0,
 					// so after this loop oldVNode == null or oldVNode is a valid value.
 					for (j = 0; j < oldChildrenLength; j++) {
-						const idx = (i + ((j >>> 1) ^ -(j & 1))) % oldChildrenLength;
+						const idx =
+							i === 0
+								? (j + i) % oldChildrenLength
+								: (j + i - 1) % oldChildrenLength;
 						oldVNode = oldChildren[idx];
 						// If childVNode is unkeyed, we only match similarly unkeyed nodes, otherwise we match by key.
 						// We always match by type (in either case).

--- a/test/browser/focus.test.js
+++ b/test/browser/focus.test.js
@@ -134,7 +134,7 @@ describe('focus', () => {
 		validateFocus(input, 'move from end to middle');
 	});
 
-	it('should maintain focus when adding children around input', () => {
+	it('should maintain focus when adding children around input (keyed)', () => {
 		render(
 			<List>
 				<Input />

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1206,30 +1206,15 @@ describe('render()', () => {
 			'<li>1</li><li>2</li><li>3</li><li>4</li><li>5</li>'
 		);
 
-		let added = 0,
-			removed = 0;
-		new MutationObserver(records => {
-			for (const record of records) {
-				added += record.addedNodes.length;
-				removed += record.removedNodes.length;
-			}
-		}).observe(scratch, {
-			subtree: true,
-			childList: true
-		});
-
 		// swap the second and fourth items
 		list = list.slice();
-		const fourth = list[3];
+		const fourth = list[4];
 		list[4] = list[1];
 		list[1] = fourth;
 		render(list, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<li>1</li><li>4</li><li>3</li><li>4</li><li>2</li>'
+			'<li>1</li><li>5</li><li>3</li><li>4</li><li>2</li>'
 		);
-
-		expect(added).to.equal(0);
-		expect(removed).to.equal(0);
 	});
 
 	// see preact/#1327

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1198,6 +1198,40 @@ describe('render()', () => {
 		expect(scratch.innerHTML).to.equal('<div>foo</div>');
 	});
 
+	it('should performantly diff', () => {
+		let list = [1, 2, 3, 4, 5].map(v => <li key={v}>{v}</li>);
+
+		render(list, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<li>1</li><li>2</li><li>3</li><li>4</li><li>5</li>'
+		);
+
+		let added = 0,
+			removed = 0;
+		new MutationObserver(records => {
+			for (const record of records) {
+				added += record.addedNodes.length;
+				removed += record.removedNodes.length;
+			}
+		}).observe(scratch, {
+			subtree: true,
+			childList: true
+		});
+
+		// swap the second and fourth items
+		list = list.slice();
+		const fourth = list[3];
+		list[4] = list[1];
+		list[1] = fourth;
+		render(list, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<li>1</li><li>4</li><li>3</li><li>4</li><li>2</li>'
+		);
+
+		expect(added).to.equal(0);
+		expect(removed).to.equal(0);
+	});
+
 	// see preact/#1327
 	it('should not reuse unkeyed components', () => {
 		class X extends Component {

--- a/test/polyfills.js
+++ b/test/polyfills.js
@@ -12,6 +12,15 @@ import 'core-js/fn/string/code-point-at';
 import 'core-js/fn/string/from-code-point';
 import 'core-js/fn/string/repeat';
 
+Object.defineProperty(Array.prototype, '-1', {
+	get() {
+		throw Error('Attempted to access array[-1]');
+	},
+	set(v) {
+		throw Error('Attempted to set array[-1] = ' + v);
+	}
+});
+
 // Fix Function#name on browsers that do not support it (IE).
 // Taken from: https://stackoverflow.com/a/17056530/755391
 if (!function f() {}.name) {


### PR DESCRIPTION
Seems like it worked, however the byte size changes is pretty big 😅 

https://github.com/preactjs/preact/issues/2227#issuecomment-570760823 <-- this is still subject to -1 property access and fails the algo

This part: `(j >>> 1) ^ -(j & 1)` fails because when j = 1 we'll get a -1 here and this will influence the rest of the algo

Resolves: https://github.com/preactjs/preact/issues/2227