### PR TITLE
Fix diff against wrong oldDom in diffChildren

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -98,6 +98,12 @@ export function diffChildren(
 
 				oldVNode = oldVNode || EMPTY_OBJ;
 
+				// If the previous node was a placeholder we pick a new value
+				// for oldDom
+				if (oldDom === undefined) {
+					oldDom = oldVNode._dom || null;
+				}
+
 				// Morph the old element into the new one, but don't append it to the dom yet
 				newDom = diff(
 					parentDom,
@@ -197,6 +203,9 @@ export function diffChildren(
 
 						newParentVNode._nextDom = oldDom;
 					}
+				} else {
+					// If newDom is null we have a placeholder node
+					oldDom = undefined;
 				}
 			}
 


### PR DESCRIPTION
This PR fixes an issue with reconciliation of placeholders in `diffChildren`. We picked the correct `vnode` to diff, but the wrong old dom node in those scenarios.

Only suspense-related tests are failing for now. Need to check what's going on there. In the meantime this is a draft.

Fixes #2350 
