### PR TITLE
Improve null placeholder DOM placement

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -98,12 +98,6 @@ export function diffChildren(
 
 				oldVNode = oldVNode || EMPTY_OBJ;
 
-				// If the previous node was a placeholder we pick a new value
-				// for oldDom
-				// if (oldDom === undefined) {
-				// 	oldDom = oldVNode._dom || getDomSibling(oldVNode)
-				// }
-
 				// Morph the old element into the new one, but don't append it to the dom yet
 				newDom = diff(
 					parentDom,
@@ -203,15 +197,13 @@ export function diffChildren(
 
 						newParentVNode._nextDom = oldDom;
 					}
-				}
-				// else {
-				// 	oldDom = undefined;
-				// }
-				else if (
+				} else if (
 					oldDom &&
 					oldVNode._dom == oldDom &&
 					oldDom.parentNode != parentDom
 				) {
+					// The above condition is handle null placeholders. See test in placeholder.test.js:
+					// `efficiently replace null placeholders in parent rerenders`
 					oldDom = getDomSibling(oldVNode);
 				}
 			}

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -98,6 +98,12 @@ export function diffChildren(
 
 				oldVNode = oldVNode || EMPTY_OBJ;
 
+				// If the previous node was a placeholder we pick a new value
+				// for oldDom
+				// if (oldDom === undefined) {
+				// 	oldDom = oldVNode._dom || getDomSibling(oldVNode)
+				// }
+
 				// Morph the old element into the new one, but don't append it to the dom yet
 				newDom = diff(
 					parentDom,
@@ -197,6 +203,16 @@ export function diffChildren(
 
 						newParentVNode._nextDom = oldDom;
 					}
+				}
+				// else {
+				// 	oldDom = undefined;
+				// }
+				else if (
+					oldDom &&
+					oldVNode._dom == oldDom &&
+					oldDom.parentNode != parentDom
+				) {
+					oldDom = getDomSibling(oldVNode);
 				}
 			}
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -202,7 +202,7 @@ export function diffChildren(
 					oldVNode._dom == oldDom &&
 					oldDom.parentNode != parentDom
 				) {
-					// The above condition is handle null placeholders. See test in placeholder.test.js:
+					// The above condition is to handle null placeholders. See test in placeholder.test.js:
 					// `efficiently replace null placeholders in parent rerenders`
 					oldDom = getDomSibling(oldVNode);
 				}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -165,7 +165,11 @@ export function diff(
 			tmp = c.render(c.props, c.state, c.context);
 			let isTopLevelFragment =
 				tmp != null && tmp.type == Fragment && tmp.key == null;
-			newVNode._children = isTopLevelFragment ? tmp.props.children : tmp;
+			newVNode._children = isTopLevelFragment
+				? tmp.props.children
+				: Array.isArray(tmp)
+				? tmp
+				: [tmp];
 
 			if (c.getChildContext != null) {
 				context = assign(assign({}, context), c.getChildContext());

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -1752,7 +1752,7 @@ describe('Components', () => {
 			}
 		}
 
-		let condition = false;
+		let renderChildDiv = false;
 
 		let child;
 		class Child extends Component {
@@ -1761,7 +1761,7 @@ describe('Components', () => {
 			}
 			render() {
 				child = this;
-				if (!condition) return null;
+				if (!renderChildDiv) return null;
 				return <div class="child" />;
 			}
 		}
@@ -1786,14 +1786,14 @@ describe('Components', () => {
 		expect(getDom(child)).to.equalNode(child.base);
 
 		parent.setState({});
-		condition = true;
+		renderChildDiv = true;
 		child.forceUpdate();
 		expect(getDom(child)).to.equalNode(child.base);
 		rerender();
 
 		expect(getDom(child)).to.equalNode(child.base);
 
-		condition = false;
+		renderChildDiv = false;
 		app.setState({});
 		child.forceUpdate();
 		rerender();

--- a/test/browser/placeholders.test.js
+++ b/test/browser/placeholders.test.js
@@ -26,12 +26,12 @@ describe('null placeholders', () => {
 	 * @param {string} name
 	 * @returns {[import('preact').ComponentClass, import('preact').RefObject<{ toggle(): void }>]}
 	 */
-	function createStatefulNullable(name, initialShow = true) {
+	function createStatefulNullable(name) {
 		let ref = createRef();
 		class Nullable extends Component {
 			constructor(props) {
 				super(props);
-				this.state = { show: initialShow };
+				this.state = { show: props.initialShow || true };
 				ref.current = this;
 			}
 			toggle() {
@@ -101,51 +101,38 @@ describe('null placeholders', () => {
 	});
 
 	it('should preserve state of Components when using null or booleans as placeholders', () => {
-		/**
-		 * @param {string} name
-		 * @returns {[import('preact').ComponentClass, import('preact').RefObject<{ increment(): void }]}
-		 */
-		function createCounter(name) {
-			const ref = createRef();
-			class Stateful extends Component {
-				constructor(props) {
-					super(props);
-					this.state = { count: 0 };
-					ref.current = this;
-				}
-				increment() {
-					this.setState({ count: this.state.count + 1 });
-				}
-				componentDidUpdate() {
-					ops.push(`Update ${name}`);
-				}
-				componentDidMount() {
-					ops.push(`Mount ${name}`);
-				}
-				componentWillUnmount() {
-					ops.push(`Unmount ${name}`);
-				}
-				render() {
-					return (
-						<div>
-							{name}: {this.state.count}
-						</div>
-					);
-				}
+		class Stateful extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { count: 0 };
 			}
-
-			return [Stateful, ref];
+			increment() {
+				this.setState({ count: this.state.count + 1 });
+			}
+			componentDidUpdate() {
+				ops.push(`Update ${this.props.name}`);
+			}
+			componentDidMount() {
+				ops.push(`Mount ${this.props.name}`);
+			}
+			componentWillUnmount() {
+				ops.push(`Unmount ${this.props.name}`);
+			}
+			render() {
+				return (
+					<div>
+						{this.props.name}: {this.state.count}
+					</div>
+				);
+			}
 		}
 
-		const [Stateful1, s1ref] = createCounter('first');
-		const [Stateful2, s2ref] = createCounter('second');
-		const [Stateful3, s3ref] = createCounter('third');
+		const s1ref = createRef();
+		const s2ref = createRef();
+		const s3ref = createRef();
 
-		/**
-		 * @param {{first: any; second: any}} props
-		 */
 		function App({ first = null, second = false }) {
-			return [first, second, <Stateful3 />];
+			return [first, second, <Stateful name="third" ref={s3ref} />];
 		}
 
 		// Mount third stateful - Initial render
@@ -162,7 +149,7 @@ describe('null placeholders', () => {
 
 		// Mount first stateful
 		ops = [];
-		render(<App first={<Stateful1 />} />, scratch);
+		render(<App first={<Stateful name="first" ref={s1ref} />} />, scratch);
 		expect(scratch.innerHTML).to.equal(
 			'<div>first: 0</div><div>third: 1</div>'
 		);
@@ -180,7 +167,13 @@ describe('null placeholders', () => {
 
 		// Mount second stateful
 		ops = [];
-		render(<App first={<Stateful1 />} second={<Stateful2 />} />, scratch);
+		render(
+			<App
+				first={<Stateful name="first" ref={s1ref} />}
+				second={<Stateful name="second" ref={s2ref} />}
+			/>,
+			scratch
+		);
 		expect(scratch.innerHTML).to.equal(
 			'<div>first: 1</div><div>second: 0</div><div>third: 2</div>'
 		);

--- a/test/browser/placeholders.test.js
+++ b/test/browser/placeholders.test.js
@@ -250,7 +250,7 @@ describe('null placeholders', () => {
 	});
 
 	// See preactjs/preact#2350
-	xit('should efficiently replace null placeholders in parent rerenders (#2350)', () => {
+	it('should efficiently replace null placeholders in parent rerenders (#2350)', () => {
 		// This Nullable only changes when it's parent rerenders
 		const Nullable1 = createNullable('Nullable 1');
 		const Nullable2 = createNullable('Nullable 2');

--- a/test/browser/placeholders.test.js
+++ b/test/browser/placeholders.test.js
@@ -101,6 +101,7 @@ describe('null placeholders', () => {
 	});
 
 	it('should preserve state of Components when using null or booleans as placeholders', () => {
+		// Must be the same class for all children in <App /> for this test to be valid
 		class Stateful extends Component {
 			constructor(props) {
 				super(props);


### PR DESCRIPTION
Previously if a Component went from rendering DOM to rendering `null`, our child diffing algorithm would have to re-place all children after the DOM that was removed. This PR improves the diffing algorithm to detect when this has happened and continue diffing from the removed DOM node's sibling.

Also reverts a change I made to a test in #2352 that invalidated the test.

Fixes #2350 