### PR TITLE
Combine searches in excessDomChildren into the same code block

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -271,15 +271,19 @@ function diffElementNodes(
 	// Tracks entering and exiting SVG namespace when descending through the tree.
 	isSvg = newVNode.type === 'svg' || isSvg;
 
-	if (dom == null && excessDomChildren != null) {
+	if (excessDomChildren != null) {
 		for (i = 0; i < excessDomChildren.length; i++) {
 			const child = excessDomChildren[i];
 
+			// if newVNode matches an element in excessDomChildren or the `dom`
+			// argument matches an element in excessDomChildren, remove it from
+			// excessDomChildren so it isn't later removed in diffChildren
 			if (
 				child != null &&
-				(newVNode.type === null
+				((newVNode.type === null
 					? child.nodeType === 3
-					: child.localName === newVNode.type)
+					: child.localName === newVNode.type) ||
+					dom == child)
 			) {
 				dom = child;
 				excessDomChildren[i] = null;
@@ -304,16 +308,11 @@ function diffElementNodes(
 	}
 
 	if (newVNode.type === null) {
-		if (excessDomChildren != null) {
-			excessDomChildren[excessDomChildren.indexOf(dom)] = null;
-		}
-
 		if (oldProps !== newProps && dom.data != newProps) {
 			dom.data = newProps;
 		}
 	} else if (newVNode !== oldVNode) {
 		if (excessDomChildren != null) {
-			excessDomChildren[excessDomChildren.indexOf(dom)] = null;
 			excessDomChildren = EMPTY_ARR.slice.call(dom.childNodes);
 		}
 


### PR DESCRIPTION
While working on some other changes, I realized that we had some situations where we assign `null` to `excessDomChildren[-1]`. So this PR started as a fix to prevent `-1` index assignments and I ended up shaving some bytes too! However, this PR does replace an `indexOf` look up with a `for` loop (where the byte savings come from). If we wanted to add back the use of `indexOf` it would add 2 bytes on top of master.