### PR TITLE
Remove useEffect and useLayoutEffect warnings in debug

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -298,45 +298,6 @@ export function initDebug() {
 					}
 				});
 			}
-
-			// After paint effects
-			if (Array.isArray(hooks._pendingEffects)) {
-				hooks._pendingEffects.forEach(effect => {
-					if (
-						!Array.isArray(effect._args) &&
-						warnedComponents &&
-						!warnedComponents.useEffect.has(vnode.type)
-					) {
-						warnedComponents.useEffect.set(vnode.type, true);
-						let componentName = getDisplayName(vnode);
-						console.warn(
-							'You should provide an array of arguments as the second argument to the "useEffect" hook.\n\n' +
-								'Not doing so will invoke this effect on every render.\n\n' +
-								`This effect can be found in the render of ${componentName}.` +
-								`\n\n${getOwnerStack(vnode)}`
-						);
-					}
-				});
-			}
-
-			// Layout Effects
-			component._renderCallbacks.forEach(possibleEffect => {
-				if (
-					possibleEffect._value &&
-					!Array.isArray(possibleEffect._args) &&
-					warnedComponents &&
-					!warnedComponents.useLayoutEffect.has(vnode.type)
-				) {
-					warnedComponents.useLayoutEffect.set(vnode.type, true);
-					let componentName = getDisplayName(vnode);
-					console.warn(
-						'You should provide an array of arguments as the second argument to the "useLayoutEffect" hook.\n\n' +
-							'Not doing so will invoke this effect on every render.\n\n' +
-							`This effect can be found in the render of ${componentName}.` +
-							`\n\n${getOwnerStack(vnode)}`
-					);
-				}
-			});
 		}
 
 		if (oldDiffed) oldDiffed(vnode);


### PR DESCRIPTION
There are valid use cases where useEffect and useLayoutEffect must be used without a dependency array. As these warnings are not configurable, they are a massive deterioration of the developer experience as it makes the console really messy.

In my option there shouldn't be (non-configurable) warnings while using the API as designed. 
The **dependency array is described as optional** for all useEffect, useLayoutEffect and useImperativeHandle in the react docs.
https://reactjs.org/docs/hooks-reference.html#useeffect

eg. my console gets flooded with 100s of warnings like:
```
You should provide an array of arguments as the second argument to the "useLayoutEffect" hook.
Not doing so will invoke this effect on every render.
```

Currently using useImperativeHandle can also trigger a misleading useLayoutEffect warning, as it accepts an empty deps array as well and uses useLayoutEffect in its implementation 
https://github.com/preactjs/preact/blob/master/hooks/src/index.js#L178

**Examples:**
- using refs after render to measure, manipulate focus, animate
- read and write refs in effects
- sync dom nodes with external libs
- eg. see popular libraries like react-spring (useSpring)

These cases are better covered by the react hooks eslint plugin:
https://www.npmjs.com/package/eslint-plugin-react-hooks#installation