### PR TITLE
[performance] Large performance boost in debug mode

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -248,11 +248,14 @@ export function initDebug() {
 	const deprecatedProto = Object.create({}, deprecatedAttributes);
 
 	options.vnode = vnode => {
-		let props = vnode.props;
-		if (props != null && ('__source' in props || '__self' in props)) {
-			let i,
-				newProps = (vnode.props = {});
-			for (i in props) {
+		const props = vnode.props;
+		if (
+			vnode.type !== null &&
+			props != null &&
+			('__source' in props || '__self' in props)
+		) {
+			const newProps = (vnode.props = {});
+			for (let i in props) {
 				const v = props[i];
 				if (i === '__source') vnode.__source = v;
 				else if (i === '__self') vnode.__self = v;

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -245,19 +245,21 @@ export function initDebug() {
 		children: warn('children', 'use vnode.props.children')
 	};
 
+	const deprecatedProto = Object.create({}, deprecatedAttributes);
+
 	options.vnode = vnode => {
-		let source, self;
-		if (vnode.props && vnode.props.__source) {
-			source = vnode.props.__source;
-			delete vnode.props.__source;
+		let props = vnode.props;
+		if (props != null && ('__source' in props || '__self' in props)) {
+			let i,
+				newProps = (vnode.props = {});
+			for (i in props) {
+				const v = props[i];
+				if (i === '__source') vnode.__source = v;
+				else if (i === '__self') vnode.__self = v;
+				else newProps[i] = v;
+			}
 		}
-		if (vnode.props && vnode.props.__self) {
-			self = vnode.props.__self;
-			delete vnode.props.__self;
-		}
-		vnode.__self = self;
-		vnode.__source = source;
-		Object.defineProperties(vnode, deprecatedAttributes);
+		Object.setPrototypeOf(vnode, deprecatedProto);
 		if (oldVnode) oldVnode(vnode);
 	};
 


### PR DESCRIPTION
This PR changes the implementation of `preact/debug`'s vnode hook to achieve 250% faster vnode creation and traversal in debug mode.

I noticed this when working with massive recursive component trees that rerender on every keystroke. In development when preact-cli automatically injects `preact/debug`, I was seeing debug's vnode hook quite a bit in profiles. With this change, it's gone.

[Benchmark showing the improvement:](https://esbench.com/bench/5e4cac3f328a52009e8b1abd)

<a href="https://esbench.com/bench/5e4cac3f328a52009e8b1abd"><img src="https://user-images.githubusercontent.com/105127/74802957-59eee300-52a9-11ea-98cb-7fe17bdc7bd4.png" width="519"></a>