### PR TITLE
Fix static hydration

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -1,5 +1,6 @@
 import {
 	render as preactRender,
+	hydrate as preactHydrate,
 	options,
 	toChildArray,
 	Component
@@ -33,11 +34,14 @@ export function render(vnode, parent, callback) {
 		}
 	}
 
-	return hydrate(vnode, parent, callback);
+	preactRender(vnode, parent);
+	if (typeof callback === 'function') callback();
+
+	return vnode ? vnode._component : null;
 }
 
 export function hydrate(vnode, parent, callback) {
-	preactRender(vnode, parent);
+	preactHydrate(vnode, parent);
 	if (typeof callback === 'function') callback();
 
 	return vnode ? vnode._component : null;

--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -2,9 +2,6 @@ import React, {
 	createElement,
 	render,
 	Component,
-	useRef,
-	useState,
-	useEffect,
 	hydrate
 } from 'preact/compat';
 import { setupRerender, act } from 'preact/test-utils';
@@ -261,7 +258,6 @@ describe('compat render', () => {
 		expect(mountSpy).to.be.calledOnce;
 		expect(updateSpy).to.not.be.calledOnce;
 
-		console.log('--- hydrating ---');
 		act(() => {
 			hydrate(
 				<StaticContent staticMode>

--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -1,5 +1,13 @@
-import React, { createElement, render, Component } from 'preact/compat';
-import { setupRerender } from 'preact/test-utils';
+import React, {
+	createElement,
+	render,
+	Component,
+	useRef,
+	useState,
+	useEffect,
+	hydrate
+} from 'preact/compat';
+import { setupRerender, act } from 'preact/test-utils';
 import {
 	setupScratch,
 	teardown,
@@ -203,5 +211,69 @@ describe('compat render', () => {
 			false,
 			'not enumerable'
 		);
+	});
+
+	it('should support static content', () => {
+		const updateSpy = sinon.spy();
+		const mountSpy = sinon.spy();
+		const renderSpy = sinon.spy();
+
+		function StaticContent({ children, element = 'div', staticMode }) {
+			// if we're in the server or a spa navigation, just render it
+			if (!staticMode) {
+				return createElement(element, {
+					children
+				});
+			}
+
+			// avoid re-render on the client
+			return createElement(element, {
+				dangerouslySetInnerHTML: { __html: '' }
+			});
+		}
+
+		class App extends Component {
+			componentDidMount() {
+				mountSpy();
+			}
+
+			componentDidUpdate() {
+				updateSpy();
+			}
+
+			render() {
+				renderSpy();
+				return <div>Staticness</div>;
+			}
+		}
+
+		act(() => {
+			render(
+				<StaticContent staticMode={false}>
+					<App />
+				</StaticContent>,
+				scratch
+			);
+		});
+
+		expect(scratch.innerHTML).to.eq('<div><div>Staticness</div></div>');
+		expect(renderSpy).to.be.calledOnce;
+		expect(mountSpy).to.be.calledOnce;
+		expect(updateSpy).to.not.be.calledOnce;
+
+		console.log('--- hydrating ---');
+		act(() => {
+			hydrate(
+				<StaticContent staticMode>
+					<App />
+				</StaticContent>,
+				scratch
+			);
+		});
+
+		expect(scratch.innerHTML).to.eq('<div><div>Staticness</div></div>');
+		expect(renderSpy).to.be.calledOnce;
+		expect(mountSpy).to.be.calledOnce;
+		expect(updateSpy).to.not.be.calledOnce;
 	});
 });


### PR DESCRIPTION
So I was looking into https://github.com/preactjs/preact/issues/2364 and discovered that because we are diffing props we come to a scenario where we use the output from `createElement` (`createElement` is called with in the test case `App` as a child due to the render tree being Static --> App). This is problematic when we hit [this line](https://github.com/preactjs/preact/blob/master/src/diff/index.js#L342) this reassigns `newHtml`  to a falsy value, being an empty string.

This initiates us going into `diffChildren` and using the allocated `_children` from the `render(<Static><App />)` which is inherent to JSX.

Now I'm not fully aware if not diffing attributes in this case is a problem because I'm not fully aware of how many people output differences on DOM-nodes between server and client when coming from React.