### PR TITLE
Fixed JSX SVG attribute names not being converted to the correct attribute names in the DOM.

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -7,7 +7,7 @@ import {
 } from 'preact';
 import { applyEventNormalization } from './events';
 
-const CAMEL_PROPS = /^(?:accent|alignment|arabic|baseline|cap|color|fill|flood|font|glyph|horiz|marker|overline|paint|stop|strikethrough|stroke|text|underline|unicode|units|v|vector|vert|word|writing|x)[A-Z]/;
+const CAMEL_PROPS = /^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|fill|flood|font|glyph(?!R)|horiz|marker(?!H|W|U)|overline|paint|stop|strikethrough|stroke|text(?!L)|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/;
 
 // Some libraries like `react-virtualized` explicitly check for this.
 Component.prototype.isReactComponent = {};

--- a/compat/test/browser/svg.test.js
+++ b/compat/test/browser/svg.test.js
@@ -67,18 +67,27 @@ describe('svg', () => {
 		);
 	});
 
-	it('should render SVG to DOM without name (clipPathUnits) attribute manipulation', () => {
+	it('should render correct SVG attribute names to the DOM', () => {
 		React.render(
-			<svg>
-				<clipPath clipPathUnits="objectBoundingBox">
-					<polygon points="0,100 50,25 50,75 100,0" />
-				</clipPath>
-			</svg>,
+			<svg
+				clipPath="value"
+				clipRule="value"
+				clipPathUnits="value"
+				glyphOrientationHorizontal="value"
+				glyphRef="value"
+				markerStart="value"
+				markerHeight="value"
+				markerUnits="value"
+				markerWidth="value"
+				x1="value"
+				xChannelSelector="value"
+			/>,
 			scratch
 		);
+
 		expect(serializeHtml(scratch)).to.eql(
 			sortAttributes(
-				'<svg><clipPath clipPathUnits="objectBoundingBox"><polygon points="0,100 50,25 50,75 100,0" /></clipPath></svg>'
+				'<svg clip-path="value" clip-rule="value" clipPathUnits="value" glyph-orientationhorizontal="value" glyphRef="value" marker-start="value" markerHeight="value" markerUnits="value" markerWidth="value" x1="value" xChannelSelector="value"></svg>'
 			)
 		);
 	});


### PR DESCRIPTION
This fixes [an issue that I found where `clipPath` does not convert correctly to `clip-path`](https://github.com/preactjs/preact-compat/issues/538) (I accidentally raised the issue in the old `preact-compat` repository). Both `clipPath` and `clipRule` were broken in [this fix for `clipPathUnits`](https://github.com/preactjs/preact/pull/2251/files).

However, after looking through the [MDN SVG attributes list](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute), @jamesb3ll and I found other attributes that were not getting converted correctly, so I've also included them in this fix.

Thanks to @jamesb3ll for coming up with a nice regular expression and identifying other SVG attributes that weren't being converted correctly!