### PR TITLE
Fix incorrect warning on setState inside cWM

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -337,11 +337,17 @@ export function initDebug() {
 const setState = Component.prototype.setState;
 Component.prototype.setState = function(update, callback) {
 	if (this._vnode == null) {
-		console.warn(
-			`Calling "this.setState" inside the constructor of a component is a ` +
-				`no-op and might be a bug in your application. Instead, set ` +
-				`"this.state = {}" directly.\n\n${getOwnerStack(getCurrentVNode())}`
-		);
+		// `this._vnode` will be `null` during componentWillMount. But it
+		// is perfectly valid to call `setState` during cWM. So we
+		// need an additional check to verify that we are dealing with a
+		// call inside constructor.
+		if (this.state == null) {
+			console.warn(
+				`Calling "this.setState" inside the constructor of a component is a ` +
+					`no-op and might be a bug in your application. Instead, set ` +
+					`"this.state = {}" directly.\n\n${getOwnerStack(getCurrentVNode())}`
+			);
+		}
 	} else if (this._parentDom == null) {
 		console.warn(
 			`Can't call "this.setState" on an unmounted component. This is a no-op, ` +

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -143,6 +143,20 @@ describe('debug', () => {
 		expect(console.warn.args[0]).to.match(/no-op/);
 	});
 
+	it('should NOT warn when calling setState inside the cWM', () => {
+		class Foo extends Component {
+			componentWillMount() {
+				this.setState({ foo: true });
+			}
+			render() {
+				return <div>foo</div>;
+			}
+		}
+
+		render(<Foo />, scratch);
+		expect(console.warn).to.not.be.called;
+	});
+
 	it('should warn when calling setState on an unmounted Component', () => {
 		let setState;
 


### PR DESCRIPTION
This PR fixes an incorrect warning when calling `setState` inside `componentWillMount`. This is perfectly valid in React and already supported in Preact. We just erroneously displayed a warning.

Reported via Slack.