### PR TITLE
Fix event.isPropagationStopped()

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -52,7 +52,12 @@ options.event = e => {
 	if (oldEventHook) e = oldEventHook(e);
 	e.persist = () => {};
 	e.isDefaultPrevented = () => e.defaultPrevented;
-	e.isPropagationStopped = () => e.stopPropagation;
+	const stopPropagation = e.stopPropagation;
+	event.stopPropagation = function() {
+		stopPropagation.call(this);
+		this.isPropagationStopped = () => true;
+	};
+	e.isPropagationStopped = () => false;
 	return (e.nativeEvent = e);
 };
 

--- a/compat/test/browser/events.test.js
+++ b/compat/test/browser/events.test.js
@@ -34,17 +34,15 @@ describe('preact/compat events', () => {
 
 		expect(spy).to.be.calledOnce;
 		const event = spy.args[0][0];
-		expect(event).to.haveOwnProperty('persist');
-		expect(event).to.haveOwnProperty('nativeEvent');
-		expect(event).to.haveOwnProperty('isDefaultPrevented');
-		expect(event).to.haveOwnProperty('isPropagationStopped');
-		expect(typeof event.persist).to.equal('function');
-		expect(typeof event.isDefaultPrevented).to.equal('function');
-		expect(typeof event.isPropagationStopped).to.equal('function');
+		expect(event.persist()).to.be.undefined;
+		expect(event.isDefaultPrevented()).to.be.false;
+		expect(event.isPropagationStopped()).to.be.false;
 
-		expect(() => event.persist()).to.not.throw();
-		expect(() => event.isDefaultPrevented()).to.not.throw();
-		expect(() => event.isPropagationStopped()).to.not.throw();
+		event.preventDefault();
+		expect(event.isDefaultPrevented()).to.be.true;
+
+		event.stopPropagation();
+		expect(event.isPropagationStopped()).to.be.true;
 	});
 
 	it('should normalize ondoubleclick event', () => {


### PR DESCRIPTION
`event.isPropagationStopped` should return boolean, not function.
https://reactjs.org/docs/events.html
https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation