### PR TITLE
Fix Options.event type definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -249,7 +249,7 @@ declare namespace preact {
 		unmount?(vnode: VNode): void;
 		/** Attach a hook that is invoked after a vnode has rendered. */
 		diffed?(vnode: VNode): void;
-		event?(e: Event): void;
+		event?(e: Event): any;
 		requestAnimationFrame?: typeof requestAnimationFrame;
 		debounceRendering?(cb: () => void): void;
 		useDebugValue?(value: string | number): void;


### PR DESCRIPTION
Return value of `Options.event()` replaces event of event handler.
Therefore,  `Options.event()`  returns value.
https://github.com/preactjs/preact/blob/9038db5f6aa4d0e1203bc4a9f6423a4dcbf46962/src/diff/props.js#L160