### PR TITLE
Update cloneElement typings

### DIFF
--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -7,6 +7,7 @@ import { createVNode } from './create-element';
  * @param {import('./internal').VNode} vnode The virtual DOM element to clone
  * @param {object} props Attributes/props to add when cloning
  * @param {Array<import('./index').ComponentChildren>} rest Any additional arguments will be used as replacement children.
+ * @returns {import('./internal').VNode}
  */
 export function cloneElement(vnode, props) {
 	props = assign(assign({}, vnode.props), props);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,7 +17,7 @@ declare namespace preact {
 		/**
 		 * ref is not guaranteed by React.ReactElement, for compatiblity reasons
 		 * with popular react libs we define it as optional too
-		*/
+		 */
 		ref?: Ref<any> | null;
 		/**
 		 * The time this `vnode` started rendering. Will only be set when
@@ -176,15 +176,15 @@ declare namespace preact {
 	function createElement(
 		type: string,
 		props:
-			| JSXInternal.HTMLAttributes &
+			| (JSXInternal.HTMLAttributes &
 					JSXInternal.SVGAttributes &
-					Record<string, any>
+					Record<string, any>)
 			| null,
 		...children: ComponentChildren[]
 	): VNode<any>;
 	function createElement<P>(
 		type: ComponentType<P>,
-		props: Attributes & P | null,
+		props: (Attributes & P) | null,
 		...children: ComponentChildren[]
 	): VNode<any>;
 	namespace createElement {
@@ -194,15 +194,15 @@ declare namespace preact {
 	function h(
 		type: string,
 		props:
-			| JSXInternal.HTMLAttributes &
+			| (JSXInternal.HTMLAttributes &
 					JSXInternal.SVGAttributes &
-					Record<string, any>
+					Record<string, any>)
 			| null,
 		...children: ComponentChildren[]
 	): VNode<any>;
 	function h<P>(
 		type: ComponentType<P>,
-		props: Attributes & P | null,
+		props: (Attributes & P) | null,
 		...children: ComponentChildren[]
 	): VNode<any>;
 	namespace h {
@@ -223,10 +223,10 @@ declare namespace preact {
 		parent: Element | Document | ShadowRoot | DocumentFragment
 	): void;
 	function cloneElement(
-		vnode: JSX.Element,
+		vnode: VNode<any>,
 		props?: any,
 		...children: ComponentChildren[]
-	): JSX.Element;
+	): VNode<any>;
 
 	//
 	// Preact Built-in Components

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -227,6 +227,11 @@ declare namespace preact {
 		props?: any,
 		...children: ComponentChildren[]
 	): VNode<any>;
+	function cloneElement<P>(
+		vnode: VNode<P>,
+		props?: any,
+		...children: ComponentChildren[]
+	): VNode<P>;
 
 	//
 	// Preact Built-in Components

--- a/test/browser/cloneElement.test.js
+++ b/test/browser/cloneElement.test.js
@@ -8,7 +8,6 @@ describe('cloneElement', () => {
 		const instance = <Comp prop1={1}>hello</Comp>;
 		const clone = cloneElement(instance);
 
-		expect(clone.prototype).to.equal(instance.prototype);
 		expect(clone.type).to.equal(instance.type);
 		expect(clone.props).not.to.equal(instance.props); // Should be a different object...
 		expect(clone.props).to.deep.equal(instance.props); // with the same properties
@@ -19,7 +18,6 @@ describe('cloneElement', () => {
 		const instance = <Foo prop1={1} prop2={2} />;
 		const clone = cloneElement(instance, { prop1: -1, newProp: -2 });
 
-		expect(clone.prototype).to.equal(instance.prototype);
 		expect(clone.type).to.equal(instance.type);
 		expect(clone.props).not.to.equal(instance.props);
 		expect(clone.props.prop1).to.equal(-1);
@@ -32,7 +30,6 @@ describe('cloneElement', () => {
 		const instance = <Foo>hello</Foo>;
 		const clone = cloneElement(instance, null, 'world', '!');
 
-		expect(clone.prototype).to.equal(instance.prototype);
 		expect(clone.type).to.equal(instance.type);
 		expect(clone.props).not.to.equal(instance.props);
 		expect(clone.props.children).to.deep.equal(['world', '!']);

--- a/test/browser/cloneElement.test.js
+++ b/test/browser/cloneElement.test.js
@@ -8,6 +8,7 @@ describe('cloneElement', () => {
 		const instance = <Comp prop1={1}>hello</Comp>;
 		const clone = cloneElement(instance);
 
+		expect(clone.prototype).to.equal(instance.prototype);
 		expect(clone.type).to.equal(instance.type);
 		expect(clone.props).not.to.equal(instance.props); // Should be a different object...
 		expect(clone.props).to.deep.equal(instance.props); // with the same properties
@@ -18,6 +19,7 @@ describe('cloneElement', () => {
 		const instance = <Foo prop1={1} prop2={2} />;
 		const clone = cloneElement(instance, { prop1: -1, newProp: -2 });
 
+		expect(clone.prototype).to.equal(instance.prototype);
 		expect(clone.type).to.equal(instance.type);
 		expect(clone.props).not.to.equal(instance.props);
 		expect(clone.props.prop1).to.equal(-1);
@@ -30,6 +32,7 @@ describe('cloneElement', () => {
 		const instance = <Foo>hello</Foo>;
 		const clone = cloneElement(instance, null, 'world', '!');
 
+		expect(clone.prototype).to.equal(instance.prototype);
 		expect(clone.type).to.equal(instance.type);
 		expect(clone.props).not.to.equal(instance.props);
 		expect(clone.props.children).to.deep.equal(['world', '!']);

--- a/test/ts/VNode-test.tsx
+++ b/test/ts/VNode-test.tsx
@@ -8,7 +8,8 @@ import {
 	ComponentConstructor,
 	ComponentFactory,
 	VNode,
-	ComponentChildren
+	ComponentChildren,
+	cloneElement
 } from '../../src';
 
 function getDisplayType(vnode: VNode | string | number) {
@@ -115,6 +116,19 @@ describe('VNode TS types', () => {
 
 		const types = toChildArray(comp.props.children).map(getDisplayType);
 		expect(types).to.deep.equal(['a', '2', 'b', 'c', 'TestComp']);
+	});
+
+	it('component should work with cloneElement', () => {
+		const comp: VNode = (
+			<SimpleComponent>
+				<div>child 1</div>
+			</SimpleComponent>
+		);
+		const clone = cloneElement(comp);
+
+		expect(comp.type).to.equal(clone.type);
+		expect(comp.props).not.to.equal(clone.props);
+		expect(comp.props).to.deep.equal(clone.props);
 	});
 });
 

--- a/test/ts/VNode-test.tsx
+++ b/test/ts/VNode-test.tsx
@@ -124,7 +124,7 @@ describe('VNode TS types', () => {
 				<div>child 1</div>
 			</SimpleComponent>
 		);
-		const clone = cloneElement(comp);
+		const clone: VNode = cloneElement(comp);
 
 		expect(comp.type).to.equal(clone.type);
 		expect(comp.props).not.to.equal(clone.props);

--- a/test/ts/VNode-test.tsx
+++ b/test/ts/VNode-test.tsx
@@ -130,6 +130,15 @@ describe('VNode TS types', () => {
 		expect(comp.props).not.to.equal(clone.props);
 		expect(comp.props).to.deep.equal(clone.props);
 	});
+
+	it('component should work with cloneElement using generics', () => {
+		const comp: VNode<string> = <SimpleComponent></SimpleComponent>;
+		const clone: VNode<string> = cloneElement<string>(comp);
+
+		expect(comp.type).to.equal(clone.type);
+		expect(comp.props).not.to.equal(clone.props);
+		expect(comp.props).to.deep.equal(clone.props);
+	});
 });
 
 class ComponentWithFunctionChild extends Component<{


### PR DESCRIPTION
## What am I trying to achieve?
Resolves https://github.com/preactjs/preact/issues/2363

Updating `cloneElement` type definitions for the `vnode` param and its returned value.

## What approach did I use?
Mostly following Preact's [contribution guidelines](https://github.com/preactjs/preact/blob/master/CONTRIBUTING.md):

- Updated the function's JSDoc block
- Added a test
- Ran `test:ts` and `karma:test:watch` to make sure tests still pass