### PR TITLE
Add support for babel jsx/jsxs/jsxDEV

### DIFF
--- a/src/create-element.js
+++ b/src/create-element.js
@@ -54,9 +54,11 @@ export function createElement(type, props, children) {
  * diffing it against its children
  * @param {import('./internal').VNode["ref"]} ref The ref property that will
  * receive a reference to its created child
+ * @param {import('./internal').VNode["ref"]} source The ref property that will
+ * receive a reference to its created child
  * @returns {import('./internal').VNode}
  */
-export function createVNode(type, props, key, ref) {
+export function createVNode(type, props, key, ref, source, self) {
 	// V8 seems to be better at detecting type shapes if the object is allocated from the same call site
 	// Do not inline into createElement and coerceToVNode!
 	const vnode = {
@@ -74,7 +76,11 @@ export function createVNode(type, props, key, ref) {
 		// a _nextDom that has been set to `null`
 		_nextDom: undefined,
 		_component: null,
-		constructor: undefined
+		constructor: undefined,
+
+		// These are added by babel and used to generate component stacks.
+		__source: source,
+		__self: self
 	};
 
 	if (options.vnode) options.vnode(vnode);
@@ -110,14 +116,7 @@ export function jsx(type, props, key, isStaticChildren, source, self) {
 		}
 	}
 
-	const vnode = createVNode(type, props, key, props && props.ref);
-
-	// TODO: Should this be inlined into `createVNode`?
-	if (source || self) {
-		vnode.__source = source;
-		vnode.__self = self;
-	}
-	return vnode;
+	return createVNode(type, props, key, props && props.ref, source, self);
 }
 
 // The difference between `jsxs` and `jsx` is that the former is used by babel

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -82,6 +82,51 @@ export function createVNode(type, props, key, ref) {
 	return vnode;
 }
 
+/**
+ * Create an virtual node (used for JSX). It's the successor of `createElement`.
+ * @param {import('./internal').VNode["type"]} type The node name or Component
+ * constructor for this virtual node
+ * @param {object | null | undefined} [props] The properties of the virtual node
+ * @param {string | undefined} [key] Optional key
+ * @param {boolean} [isStaticChildren] Marks if `jsx` or `jsxs` should be used.
+ * For us they are the same thing as our debug warnings live in a separate
+ * module (`preact/debug`). Only available via `jsxDEV`
+ * @param {import('./internal').DevSource} [source] Optional source location
+ * info from babel. Only available via `jsxDEV`
+ * @param {import('./internal').DevSource} [self] Optional reference to the
+ * component this node is part of. Only available via `jsxDEV`
+ * @returns {import('./internal').VNode}
+ */
+export function jsx(type, props, key, isStaticChildren, source, self) {
+	let i;
+
+	// If a Component VNode, check for and apply defaultProps
+	// Note: type may be undefined in development, must never error here.
+	if (typeof type === 'function' && type.defaultProps != null) {
+		for (i in type.defaultProps) {
+			if (props[i] === undefined) {
+				props[i] = type.defaultProps[i];
+			}
+		}
+	}
+
+	const vnode = createVNode(type, props, key, props && props.ref);
+
+	// TODO: Should this be inlined into `createVNode`?
+	if (source || self) {
+		vnode.__source = source;
+		vnode.__self = self;
+	}
+	return vnode;
+}
+
+// The difference between `jsxs` and `jsx` is that the former is used by babel
+// when the node has more than one child
+export const jsxs = jsx;
+
+// Same as `jsx`, but with supplied `source` and `self` information
+export const jsxDEV = jsx;
+
 export function createRef() {
 	return {};
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,9 @@ export { render, hydrate } from './render';
 export {
 	createElement,
 	createElement as h,
+	jsx,
+	jsxs,
+	jsxDEV,
 	Fragment,
 	createRef,
 	isValidElement

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -91,3 +91,8 @@ export interface PreactContext extends preact.Context<any> {
 	_id: string;
 	_defaultValue: any;
 }
+
+export interface DevSource {
+	fileName: string;
+	lineNumber: number;
+}

--- a/test/browser/babel-jsx.test.js
+++ b/test/browser/babel-jsx.test.js
@@ -1,0 +1,37 @@
+import { jsx } from 'preact';
+import { setupScratch, teardown } from '../_util/helpers';
+
+describe('Babel jsx/jsxDEV', () => {
+	let scratch;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('should keep ref in props', () => {
+		const ref = () => null;
+		const vnode = jsx('div', { ref });
+		expect(vnode.props.ref).to.equal(ref);
+		expect(vnode.ref).to.equal(ref);
+	});
+
+	it('should add keys', () => {
+		const vnode = jsx('div', null, 'foo');
+		expect(vnode.key).to.equal('foo');
+	});
+
+	it('should support source and self', () => {
+		const self = 'foo';
+		const source = {
+			fileName: '/foo.js',
+			lineNumber: 2
+		};
+		const vnode = jsx('div', null, 'foo', false, source, self);
+		expect(vnode.__source).to.equal(source);
+		expect(vnode.__self).to.equal(self);
+	});
+});

--- a/test/shared/createElement.test.js
+++ b/test/shared/createElement.test.js
@@ -74,7 +74,9 @@ describe('createElement(jsx)', () => {
 			'props',
 			'key',
 			'ref',
-			'constructor'
+			'constructor',
+			'source',
+			'self'
 		]);
 	});
 
@@ -158,23 +160,22 @@ describe('createElement(jsx)', () => {
 	});
 
 	it('should NOT set children prop when null', () => {
-		let r = h('foo', {foo : 'bar'}, null);
+		let r = h('foo', { foo: 'bar' }, null);
 
 		expect(r)
 			.to.be.an('object')
 			.to.have.nested.property('props.foo')
-			.not.to.have.nested.property('props.children')
-			
-	})
+			.not.to.have.nested.property('props.children');
+	});
 
 	it('should NOT set children prop when unspecified', () => {
-		let r = h('foo', {foo : 'bar'});
+		let r = h('foo', { foo: 'bar' });
 
 		expect(r)
 			.to.be.an('object')
 			.to.have.nested.property('props.foo')
-			.not.to.have.nested.property('props.children')
-	})
+			.not.to.have.nested.property('props.children');
+	});
 
 	it('should NOT merge adjacent text children', () => {
 		let r = h(
@@ -233,7 +234,7 @@ describe('createElement(jsx)', () => {
 				null
 			]);
 	});
-	
+
 	it('should not merge children that are boolean values', () => {
 		let r = h('foo', null, 'one', true, 'two', false, 'three');
 


### PR DESCRIPTION
There is currently undergoing work to create a successor to `createElement`.

Advantages:

- `ref` is not deleted from `props`. This means no need for `forwardRef` anymore as one can just do ```const Foo = props => <div ref={props.ref} />```
- `key` is a separate argument and not part of `props` anymore. This prevents duplicated keys when spreading `props` on different nodes in the same depth.
- Better perf, because we don't have to iterate over `props` anymore.

More information:

- [RFC](https://github.com/reactjs/rfcs/blob/createlement-rfc/text/0000-create-element-changes.md) where the changes were proposed
- Work in Progress babel plugin: https://github.com/babel/babel/pull/11154