### PR TITLE
Context plumbing top --> bottom

### DIFF
--- a/src/create-context.js
+++ b/src/create-context.js
@@ -20,12 +20,14 @@ export function createContext(defaultValue) {
 				};
 				this.shouldComponentUpdate = _props => {
 					if (props.value !== _props.value) {
+						subs.sort((a, b) => b._vnode._depth - a._vnode._depth);
 						subs.some(c => {
 							c.context = _props.value;
 							enqueueRender(c);
 						});
 					}
 				};
+
 				this.sub = c => {
 					subs.push(c);
 					let old = c.componentWillUnmount;

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -20,11 +20,12 @@ export function createContext(defaultValue) {
 				};
 				this.shouldComponentUpdate = _props => {
 					if (props.value !== _props.value) {
-						subs.sort((a, b) => b._vnode._depth - a._vnode._depth);
-						subs.some(c => {
-							c.context = _props.value;
-							enqueueRender(c);
-						});
+						subs
+							.sort((a, b) => b._vnode._depth - a._vnode._depth)
+							.some(c => {
+								c.context = _props.value;
+								enqueueRender(c);
+							});
 					}
 				};
 


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/2393

This sorts the updateQueue for the context subscribers from top to bottom to avoid inconsistent trees