### PR TITLE
Sort new renderqueue items

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -212,7 +212,7 @@ function process() {
 		// process() calls won't get scheduled.
 		rerenderCount = 1;
 		queue.some(c => {
-			if (c && c._dirty) renderComponent(c);
+			if (c._dirty) renderComponent(c);
 		});
 	}
 }

--- a/src/component.js
+++ b/src/component.js
@@ -208,9 +208,8 @@ function process() {
 	while ((rerenderCount = rerenderQueue.length)) {
 		queue = rerenderQueue.sort((a, b) => a._vnode._depth - b._vnode._depth);
 		rerenderQueue = [];
-		// Pretend momentarily that renderQueue has items in it so unnecessary
-		// process() calls won't get scheduled.
-		rerenderCount = 1;
+		// Don't update `renderCount` yet. Keep its value non-zero to prevent unnecessary
+		// process() calls from getting scheduled while `queue` is still being consumed.
 		queue.some(c => {
 			if (c._dirty) renderComponent(c);
 		});

--- a/src/component.js
+++ b/src/component.js
@@ -200,10 +200,12 @@ export function enqueueRender(c) {
 
 /** Flush the render queue by rerendering all queued components */
 function process() {
-	let c;
-	rerenderQueue.sort((a, b) => b._vnode._depth - a._vnode._depth);
-	while ((c = rerenderQueue.pop())) {
-		// forceUpdate's callback argument is reused here to indicate a non-forced update.
-		if (c._dirty) renderComponent(c);
+	let q;
+	while (rerenderQueue.length) {
+		q = rerenderQueue.sort((a, b) => a._vnode._depth - b._vnode._depth);
+		rerenderQueue = [];
+		q.some(c => {
+			if (c._dirty) renderComponent(c);
+		});
 	}
 }

--- a/test/browser/placeholders.test.js
+++ b/test/browser/placeholders.test.js
@@ -164,7 +164,7 @@ describe('null placeholders', () => {
 		expect(scratch.innerHTML).to.equal(
 			'<div>first: 1</div><div>third: 2</div>'
 		);
-		expect(ops).to.deep.equal(['Update third', 'Update first'], 'update first');
+		expect(ops).to.deep.equal(['Update first', 'Update third'], 'update first');
 
 		// Mount second stateful
 		ops = [];
@@ -193,7 +193,7 @@ describe('null placeholders', () => {
 			'<div>first: 2</div><div>second: 1</div><div>third: 3</div>'
 		);
 		expect(ops).to.deep.equal(
-			['Update third', 'Update second', 'Update first'],
+			['Update first', 'Update second', 'Update third'],
 			'update second'
 		);
 	});
@@ -224,8 +224,8 @@ describe('null placeholders', () => {
 		rerender();
 		expect(scratch.innerHTML).to.equal(div([div(1), div(3)]));
 		expect(getLog()).to.deep.equal([
-			'<div>Nullable.remove()',
-			'<div>Nullable2.remove()'
+			'<div>Nullable2.remove()',
+			'<div>Nullable.remove()'
 		]);
 
 		clearLog();
@@ -237,9 +237,9 @@ describe('null placeholders', () => {
 		);
 		expect(getLog()).to.deep.equal([
 			'<div>.appendChild(#text)',
-			'<div>13.insertBefore(<div>Nullable, <div>3)',
+			'<div>13.appendChild(<div>Nullable2)',
 			'<div>.appendChild(#text)',
-			'<div>1Nullable3.appendChild(<div>Nullable2)'
+			'<div>13Nullable2.insertBefore(<div>Nullable, <div>3)'
 		]);
 	});
 

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1485,4 +1485,38 @@ describe('render()', () => {
 			);
 		});
 	});
+
+	it('should not call options.debounceRendering unnecessarily', () => {
+		let comp;
+
+		class A extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { updates: 0 };
+				comp = this;
+			}
+
+			render() {
+				return <div>{this.state.updates}</div>;
+			}
+		}
+
+		render(<A />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>0</div>');
+
+		const sandbox = sinon.createSandbox();
+		try {
+			sandbox.spy(options, 'debounceRendering');
+
+			comp.setState({ updates: 1 }, () => {
+				comp.setState({ updates: 2 });
+			});
+			rerender();
+			expect(scratch.innerHTML).to.equal('<div>2</div>');
+
+			expect(options.debounceRendering).to.have.been.calledOnce;
+		} finally {
+			sandbox.restore();
+		}
+	});
 });


### PR DESCRIPTION
This pull request attempts to fix #2393 by modifying how the global `renderQueue` is processed. 

Currently `renderQueue` is sorted by vnode depth before its items are processed, but if new items get queued during processing (and `renderQueue.length > 1`) then those new items are also processed _without_ them getting sorted by depth first.

This pull attempts fixing that. When `renderQueue` is processed, it's item count is checked. If there are no items then we can stop. Otherwise the queue is sorted by depth and stored into a temporary variable while `renderQueue` itself is reinitialized with a new, _empty_ array. Now the "old" queued items get processed and any new items get added to the new `renderQueue` list.

After the all old items have been processed the new `renderQueue` is checked & sorted again, and the cycle starts anew.

A great test from @JoviDeCroock's alternative PR #2395 is also included here.

Fixes #2393