### PR TITLE
Fix useErrorBoundary hook callback type

### DIFF
--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -129,5 +129,5 @@ export function useDebugValue<T>(
 ): void;
 
 export function useErrorBoundary(
-	callback?: () => Promise<void> | void
+	callback?: (error: any) => Promise<void> | void
 ): [any, () => void];


### PR DESCRIPTION
Fixes TypeScript typings for useErrorBoundary to match documentation and actual code<sup>[\[1\]][1]</sup>, allowing to get error through the parameter of its callback<sup>[\[2\]][2]</sup>.

Example of previously failing code:

```ts
const [error] = useErrorBoundary(error => {
//                               ^~~~~~~~~~
// Argument of type '(error: any) => void' is not assignable to
// parameter of type '() => void | Promise<void>'.ts(2345)
//
	console.log(error);
});
```

[1]: https://git.io/JvrIP (/hooks/src/index.js:243:44)
[2]: https://preactjs.com/guide/v10/hooks/#useerrorboundary