### PR TITLE
Fix mui Popover integration

### DIFF
--- a/compat/src/forwardRef.js
+++ b/compat/src/forwardRef.js
@@ -1,14 +1,13 @@
 import { options } from 'preact';
 import { assign } from './util';
 
-let oldVNodeHook = options.vnode;
-options.vnode = vnode => {
+let oldDiffHook = options._diff;
+options._diff = vnode => {
 	if (vnode.type && vnode.type._forwarded && vnode.ref) {
 		vnode.props.ref = vnode.ref;
 		vnode.ref = null;
 	}
-
-	if (oldVNodeHook) oldVNodeHook(vnode);
+	if (oldDiffHook) oldDiffHook(vnode);
 };
 
 /**
@@ -24,8 +23,7 @@ export function forwardRef(fn) {
 		delete clone.ref;
 		return fn(clone, props.ref);
 	}
-	Forwarded.prototype.isReactComponent = true;
-	Forwarded._forwarded = true;
+	Forwarded.prototype.isReactComponent = Forwarded._forwarded = true;
 	Forwarded.displayName = 'ForwardRef(' + (fn.displayName || fn.name) + ')';
 	return Forwarded;
 }

--- a/compat/src/portals.js
+++ b/compat/src/portals.js
@@ -46,7 +46,7 @@ function Portal(props) {
 			_this._container = container;
 			// Render our wrapping element into temp.
 			render(wrap, container, _this._temp);
-			_this._children = this._temp._children;
+			_this._children = _this._temp._children;
 		} else {
 			// When we have mounted and the vnode is present it means the
 			// props have changed or a parent is triggering a rerender.

--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -393,7 +393,7 @@ describe('forwardRef', () => {
 		const Transition = ({ children }) => {
 			const state = useState(0);
 			forceTransition = state[1];
-			expect(children.ref).to.exist;
+			expect(children.ref).to.not.be.undefined;
 			if (state[0] === 0) expect(children.props.ref).to.be.undefined;
 			return children;
 		};

--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -393,7 +393,7 @@ describe('forwardRef', () => {
 		const Transition = ({ children }) => {
 			const state = useState(0);
 			forceTransition = state[1];
-			expect(children.ref).to.not.be.undefined;
+			expect(children.ref).to.exist;
 			if (state[0] === 0) expect(children.props.ref).to.be.undefined;
 			return children;
 		};

--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -381,4 +381,32 @@ describe('forwardRef', () => {
 
 		expect(_ref.current).to.equal(scratch.firstChild);
 	});
+
+	it('should forward at diff time instead vnode-creation.', () => {
+		let ref, set;
+		const Wrapper = forwardRef((_props, ref) => <div ref={ref}>Wrapper</div>);
+		const Transition = ({ children }) => {
+			const state = useState(0);
+			set = state[1];
+			expect(children.ref).to.not.be.undefined;
+			return <div>{children}</div>;
+		};
+
+		const App = () => {
+			ref = useRef();
+			return (
+				<Transition>
+					<Wrapper ref={ref} />
+				</Transition>
+			);
+		};
+
+		render(<App />, scratch);
+
+		act(() => {
+			set(1);
+		});
+
+		expect(ref.current.innerHTML).to.equal('Wrapper');
+	});
 });

--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -7,7 +7,8 @@ import React, {
 	memo,
 	useState,
 	useRef,
-	useImperativeHandle
+	useImperativeHandle,
+	createPortal
 } from 'preact/compat';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { setupRerender, act } from 'preact/test-utils';
@@ -383,28 +384,43 @@ describe('forwardRef', () => {
 	});
 
 	it('should forward at diff time instead vnode-creation.', () => {
-		let ref, set;
+		let ref, forceTransition, forceOpen;
+
+		const Portal = ({ children, open }) =>
+			open ? createPortal(children, scratch) : null;
+
 		const Wrapper = forwardRef((_props, ref) => <div ref={ref}>Wrapper</div>);
 		const Transition = ({ children }) => {
 			const state = useState(0);
-			set = state[1];
+			forceTransition = state[1];
 			expect(children.ref).to.not.be.undefined;
-			return <div>{children}</div>;
+			if (state[0] === 0) expect(children.props.ref).to.be.undefined;
+			return children;
 		};
 
 		const App = () => {
+			const openState = useState(false);
+			forceOpen = openState[1];
 			ref = useRef();
 			return (
-				<Transition>
-					<Wrapper ref={ref} />
-				</Transition>
+				<Portal open={openState[0]}>
+					<Transition>
+						<Wrapper ref={ref} />
+					</Transition>
+				</Portal>
 			);
 		};
 
 		render(<App />, scratch);
 
 		act(() => {
-			set(1);
+			forceOpen(true);
+		});
+
+		expect(ref.current.innerHTML).to.equal('Wrapper');
+
+		act(() => {
+			forceTransition(1);
 		});
 
 		expect(ref.current.innerHTML).to.equal('Wrapper');

--- a/demo/index.js
+++ b/demo/index.js
@@ -23,7 +23,6 @@ import TextFields from './textFields';
 import ReduxBug from './reduxUpdate';
 import SuspenseRouterBug from './suspense-router';
 import NestedSuspenseBug from './nested-suspense';
-import { Select, MenuItem } from '@material-ui/core';
 
 let isBenchmark = /(\/spiral|\/pythagoras|[#&]bench)/g.test(
 	window.location.href
@@ -41,11 +40,9 @@ window.setImmediate = setTimeout;
 class Home extends Component {
 	render() {
 		return (
-			<Select value={0}>
-				<MenuItem value="0">Test 0</MenuItem>
-				<MenuItem value="1">Test 1</MenuItem>
-				<MenuItem value="3">Test 3</MenuItem>
-			</Select>
+			<div>
+				<h1>Hello</h1>
+			</div>
 		);
 	}
 }

--- a/demo/index.js
+++ b/demo/index.js
@@ -23,6 +23,7 @@ import TextFields from './textFields';
 import ReduxBug from './reduxUpdate';
 import SuspenseRouterBug from './suspense-router';
 import NestedSuspenseBug from './nested-suspense';
+import { Select, MenuItem } from '@material-ui/core';
 
 let isBenchmark = /(\/spiral|\/pythagoras|[#&]bench)/g.test(
 	window.location.href
@@ -40,9 +41,11 @@ window.setImmediate = setTimeout;
 class Home extends Component {
 	render() {
 		return (
-			<div>
-				<h1>Hello</h1>
-			</div>
+			<Select value={0}>
+				<MenuItem value="0">Test 0</MenuItem>
+				<MenuItem value="1">Test 1</MenuItem>
+				<MenuItem value="3">Test 3</MenuItem>
+			</Select>
 		);
 	}
 }

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -907,9 +907,9 @@
       }
     },
     "@emotion/hash": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.2.tgz",
-      "integrity": "sha512-RMtr1i6E8MXaBWwhXL3yeOU8JXRnz8GNxHvaUfVvwxokvayUY0zoBeWbKw1S9XkufmGEEdQd228pSZXFkAln8Q=="
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.4.tgz",
+      "integrity": "sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A=="
     },
     "@emotion/is-prop-valid": {
       "version": "0.7.3",
@@ -930,93 +930,78 @@
       "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg=="
     },
     "@material-ui/core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.2.0.tgz",
-      "integrity": "sha512-kqwoCMpGaj3zJedihUuVZWjISh+T72KAXOwgk6VKNf+APMTB8yLByLSgSLDhXsliRBO/9Pda/0g/KzGY7R+irQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.9.5.tgz",
+      "integrity": "sha512-hVuUqw6847jcgRsUqzCiYCXcIJYhPUfM3gS9sNehTsbI0SF3tufLNO2B2Cgkuns8uOGy0nicD4p3L7JqhnEElg==",
       "requires": {
-        "@babel/runtime": "^7.2.0",
-        "@material-ui/styles": "^4.2.0",
-        "@material-ui/system": "^4.3.0",
-        "@material-ui/types": "^4.1.1",
-        "@material-ui/utils": "^4.1.0",
-        "@types/react-transition-group": "^2.0.16",
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/styles": "^4.9.0",
+        "@material-ui/system": "^4.9.3",
+        "@material-ui/types": "^5.0.0",
+        "@material-ui/utils": "^4.7.1",
+        "@types/react-transition-group": "^4.2.0",
         "clsx": "^1.0.2",
-        "convert-css-length": "^2.0.0",
-        "deepmerge": "^3.0.0",
-        "hoist-non-react-statics": "^3.2.1",
-        "is-plain-object": "^3.0.0",
-        "normalize-scroll-left": "^0.2.0",
+        "hoist-non-react-statics": "^3.3.2",
         "popper.js": "^1.14.1",
         "prop-types": "^15.7.2",
-        "react-transition-group": "^4.0.0",
-        "warning": "^4.0.1"
+        "react-is": "^16.8.0",
+        "react-transition-group": "^4.3.0"
       },
       "dependencies": {
-        "is-plain-object": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
           "requires": {
-            "isobject": "^4.0.0"
+            "react-is": "^16.7.0"
           }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
         }
       }
     },
     "@material-ui/styles": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.2.0.tgz",
-      "integrity": "sha512-VpPCNWYK1KjpurFh1gH02xpAmCqKZrC/rmiBosZcCRDl8AOcUkSxBMNU0rziHgSQ/jYTEh3MdKNs3Gq0vGCQ/w==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.9.0.tgz",
+      "integrity": "sha512-nJHum4RqYBPWsjL/9JET8Z02FZ9gSizlg/7LWVFpIthNzpK6OQ5OSRR4T4x9/p+wK3t1qNn3b1uI4XpnZaPxOA==",
       "requires": {
-        "@babel/runtime": "^7.2.0",
-        "@emotion/hash": "^0.7.1",
-        "@material-ui/types": "^4.1.1",
-        "@material-ui/utils": "^4.1.0",
+        "@babel/runtime": "^7.4.4",
+        "@emotion/hash": "^0.7.4",
+        "@material-ui/types": "^5.0.0",
+        "@material-ui/utils": "^4.7.1",
         "clsx": "^1.0.2",
         "csstype": "^2.5.2",
-        "deepmerge": "^3.0.0",
         "hoist-non-react-statics": "^3.2.1",
-        "jss": "10.0.0-alpha.17",
-        "jss-plugin-camel-case": "10.0.0-alpha.17",
-        "jss-plugin-default-unit": "10.0.0-alpha.17",
-        "jss-plugin-global": "10.0.0-alpha.17",
-        "jss-plugin-nested": "10.0.0-alpha.17",
-        "jss-plugin-props-sort": "10.0.0-alpha.17",
-        "jss-plugin-rule-value-function": "10.0.0-alpha.17",
-        "jss-plugin-vendor-prefixer": "10.0.0-alpha.17",
-        "prop-types": "^15.7.2",
-        "warning": "^4.0.1"
+        "jss": "^10.0.3",
+        "jss-plugin-camel-case": "^10.0.3",
+        "jss-plugin-default-unit": "^10.0.3",
+        "jss-plugin-global": "^10.0.3",
+        "jss-plugin-nested": "^10.0.3",
+        "jss-plugin-props-sort": "^10.0.3",
+        "jss-plugin-rule-value-function": "^10.0.3",
+        "jss-plugin-vendor-prefixer": "^10.0.3",
+        "prop-types": "^15.7.2"
       }
     },
     "@material-ui/system": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.3.0.tgz",
-      "integrity": "sha512-VQh3mWZSmzm1JR7Ci35AHKwOhhxHHMrBWCdP4mh7UAwSdjWBE6s2Y9Y0iJiqMoEsHP64vU3W1JpsW2AgkUeHsQ==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.9.3.tgz",
+      "integrity": "sha512-DBGsTKYrLlFpHG8BUp0X6ZpvaOzef+GhSwn/8DwVTXUdHitphaPQoL9xucrI8X9MTBo//El+7nylko7lo7eJIw==",
       "requires": {
-        "@babel/runtime": "^7.2.0",
-        "deepmerge": "^3.0.0",
-        "prop-types": "^15.7.2",
-        "warning": "^4.0.1"
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.7.1",
+        "prop-types": "^15.7.2"
       }
     },
     "@material-ui/types": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-4.1.1.tgz",
-      "integrity": "sha512-AN+GZNXytX9yxGi0JOfxHrRTbhFybjUJ05rnsBVjcB+16e466Z0Xe5IxawuOayVZgTBNDxmPKo5j4V6OnMtaSQ==",
-      "requires": {
-        "@types/react": "*"
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.0.0.tgz",
+      "integrity": "sha512-UeH2BuKkwDndtMSS0qgx1kCzSMw+ydtj0xx/XbFtxNSTlXydKwzs5gVW5ZKsFlAkwoOOQ9TIsyoCC8hq18tOwg=="
     },
     "@material-ui/utils": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.1.0.tgz",
-      "integrity": "sha512-muwmVU799tzPjzb+Q5E/CTDle0rXwkCAdvMVyU0BfbJhenkUsFmuYiCmbvMVOU1m6F1S5HWfXz8EP4pXwwAvrw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.7.1.tgz",
+      "integrity": "sha512-+ux0SlLdlehvzCk2zdQ3KiS3/ylWvuo/JwAGhvb8dFVvwR21K28z0PU9OQW2PGogrMEdvX3miEI5tGxTwwWiwQ==",
       "requires": {
-        "@babel/runtime": "^7.2.0",
+        "@babel/runtime": "^7.4.4",
         "prop-types": "^15.7.2",
         "react-is": "^16.8.0"
       }
@@ -1051,23 +1036,23 @@
       "dev": true
     },
     "@types/prop-types": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.1.tgz",
-      "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg=="
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
-      "version": "16.8.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.23.tgz",
-      "integrity": "sha512-abkEOIeljniUN9qB5onp++g0EY38h7atnDHxwKUFz1r3VH1+yG1OKi2sNPTyObL40goBmfKFpdii2lEzwLX1cA==",
+      "version": "16.9.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.23.tgz",
+      "integrity": "sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
       }
     },
     "@types/react-transition-group": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.9.2.tgz",
-      "integrity": "sha512-5Fv2DQNO+GpdPZcxp2x/OQG/H19A01WlmpjVD9cKvVFmoVLOZ9LvBgSWG6pSXIU4og5fgbvGPaCV5+VGkWAEHA==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.2.4.tgz",
+      "integrity": "sha512-8DMUaDqh0S70TjkqU0DxOu80tFUiiaS9rxkWip/nb7gtvAsbqOXm02UCmR8zdcjWujgeYPiPNTVpVpKzUDotwA==",
       "requires": {
         "@types/react": "*"
       }
@@ -2188,9 +2173,9 @@
       }
     },
     "clsx": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.0.4.tgz",
-      "integrity": "sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.0.tgz",
+      "integrity": "sha512-3avwM37fSK5oP6M5rQ9CNe99lwxhXDOeSWVPAOYF6OazUTgZCMb0yWlJpmdD74REy1gkEaFiub2ULv4fq9GUhA=="
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -2364,11 +2349,6 @@
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
-    "console-polyfill": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/console-polyfill/-/console-polyfill-0.1.2.tgz",
-      "integrity": "sha1-ls/tUcr3gYn2mVcubxgnHcN8DjA="
-    },
     "constants-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
@@ -2389,15 +2369,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
-    },
-    "convert-css-length": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-css-length/-/convert-css-length-2.0.0.tgz",
-      "integrity": "sha512-ygBgHNzImHJ/kjgqdzC0oaY2+EMID3s88/CZD2C9O1stM3PwsOwXzzlFTTkZy/bPZe0wjyt1UoYjilfunQGjlw==",
-      "requires": {
-        "console-polyfill": "^0.1.2",
-        "parse-unit": "^1.0.1"
-      }
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -2583,12 +2554,27 @@
       }
     },
     "css-vendor": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.5.tgz",
-      "integrity": "sha512-36w+4Cg0zqFIt5TAkaM3proB6XWh5kSGmbddRCPdrRLQiYNfHPTgaWPOlCrcuZIO0iAtrG+5wsHJZ6jj8AUULA==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.7.tgz",
+      "integrity": "sha512-VS9Rjt79+p7M0WkPqcAza4Yq1ZHrsHrwf7hPL/bjQB+c1lwmAI+1FXxYTYt818D/50fFVflw0XKleiBN5RITkg==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
+        "@babel/runtime": "^7.6.2",
         "is-in-browser": "^1.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
+          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.4",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
+          "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+        }
       }
     },
     "css-what": {
@@ -2604,9 +2590,9 @@
       "dev": true
     },
     "csstype": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.5.tgz",
-      "integrity": "sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA=="
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
+      "integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -2724,11 +2710,6 @@
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
-    },
-    "deepmerge": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
-      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA=="
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -2897,11 +2878,27 @@
       }
     },
     "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.3.tgz",
+      "integrity": "sha512-nZD1OtwfWGRBWlpANxacBEZrEuLa16o1nh7YopFWeoF68Zt8GGEmzHu6Xv4F3XaFIC+YXtTLrzgqKxFgLEe4jw==",
       "requires": {
-        "@babel/runtime": "^7.1.2"
+        "@babel/runtime": "^7.6.3",
+        "csstype": "^2.6.7"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
+          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.4",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
+          "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+        }
       }
     },
     "dom-serializer": {
@@ -5325,79 +5322,80 @@
       }
     },
     "jss": {
-      "version": "10.0.0-alpha.17",
-      "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
-      "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.4.tgz",
+      "integrity": "sha512-GqHmeDK83qbqMAVjxyPfN1qJVTKZne533a9bdCrllZukUM8npG/k+JumEPI86IIB5ifaZAHG2HAsUziyxOiooQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
+        "csstype": "^2.6.5",
         "is-in-browser": "^1.1.3",
         "tiny-warning": "^1.0.2"
       }
     },
     "jss-plugin-camel-case": {
-      "version": "10.0.0-alpha.17",
-      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.0-alpha.17.tgz",
-      "integrity": "sha512-aPY4kr6MwliH7KToLRzeSk1NxXUo9n7MQsAa0Hghwj01x9UnMkDkGAKENMKUtPjGkQZfiJpB9tTLFrSJ/6VrIQ==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.4.tgz",
+      "integrity": "sha512-+wnqxJsyfUnOn0LxVg3GgZBSjfBCrjxwx7LFxwVTUih0ceGaXKZoieheNOaTo5EM4w8bt1nbb8XonpQCj67C6A==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "hyphenate-style-name": "^1.0.3",
-        "jss": "10.0.0-alpha.17"
+        "jss": "10.0.4"
       }
     },
     "jss-plugin-default-unit": {
-      "version": "10.0.0-alpha.17",
-      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.0-alpha.17.tgz",
-      "integrity": "sha512-KQgiXczvzJ9AlFdD8NS7FZLub0NSctSrCA9Yi/GqdsfJg4ZCriU4DzIybCZBHCi/INFGJmLIESYWSxnuhAzgSQ==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.4.tgz",
+      "integrity": "sha512-T0mhL/Ogp/quvod/jAHEqKvptLDxq7Cj3a+7zRuqK8HxUYkftptN89wJElZC3rshhNKiogkEYhCWenpJdFvTBg==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.0.0-alpha.17"
+        "jss": "10.0.4"
       }
     },
     "jss-plugin-global": {
-      "version": "10.0.0-alpha.17",
-      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.0.0-alpha.17.tgz",
-      "integrity": "sha512-WYxiwwI+CLk0ozW8loeceqXBAZXBMsLBEZeRwVf9WX+FljdJkGwVZpRCk6LBX4aXnqAGyKqCxIAIJ3KP2yBdEg==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.0.4.tgz",
+      "integrity": "sha512-N8n9/GHENZce+sqE4UYiZiJtI+t+erT/BypHOrNYAfIoNEj7OYsOEKfIo2P0GpLB3QyDAYf5eo9XNdZ8veEkUA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.0.0-alpha.17"
+        "jss": "10.0.4"
       }
     },
     "jss-plugin-nested": {
-      "version": "10.0.0-alpha.17",
-      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.0.0-alpha.17.tgz",
-      "integrity": "sha512-onpFqv904KCujryf2t6IIV1/QoB7cSF7ojrd4UujcN5TPvYOvXF5bchi7jnHG5U0SLlRSDGMLJ9fhtoCknhEbw==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.0.4.tgz",
+      "integrity": "sha512-QM21BKVt8LDeoRfowvAMh/s+/89VYrreIIE6ch4pvw0oAXDWw1iorUPlqLZ7uCO3UL0uFtQhJq3QMLN6Lr1v0A==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.0.0-alpha.17",
+        "jss": "10.0.4",
         "tiny-warning": "^1.0.2"
       }
     },
     "jss-plugin-props-sort": {
-      "version": "10.0.0-alpha.17",
-      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.0-alpha.17.tgz",
-      "integrity": "sha512-KnbyrxCbtQTqpDx2mSZU/r/E5QnDPIVfIxRi8K+W/q4gZpomBvqWC+xgvAk9hbpmA6QBoQaOilV8o12w2IZ6fg==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.4.tgz",
+      "integrity": "sha512-WoETdOCjGskuin/OMt2uEdDPLZF3vfQuHXF+XUHGJrq0BAapoyGQDcv37SeReDlkRAbVXkEZPsIMvYrgHSHFiA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.0.0-alpha.17"
+        "jss": "10.0.4"
       }
     },
     "jss-plugin-rule-value-function": {
-      "version": "10.0.0-alpha.17",
-      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.0-alpha.17.tgz",
-      "integrity": "sha512-8AuJB44Q+ehfkWVRi2XlRbUf6SrLmrHTa5EXd6dgQRCCRuvGmqX8Dl4fZvNeKRFjTLPZgzg9+31rqeOMhKa2vA==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.4.tgz",
+      "integrity": "sha512-0hrzOSWRF5ABJGaHrlnHbYZjU877Ofzfh2id3uLtBvemGQLHI+ldoL8/+6iPSRa7M8z8Ngfg2vfYhKjUA5gA0g==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.0.0-alpha.17"
+        "jss": "10.0.4"
       }
     },
     "jss-plugin-vendor-prefixer": {
-      "version": "10.0.0-alpha.17",
-      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.0-alpha.17.tgz",
-      "integrity": "sha512-wDq9EL0QaoMGSGifPEBb+/SA9LBcqPEW0jpL9ht+Z2t+lV7NNz0j7uCEOuE6FvNWqHzUKTsiATs1rTHPkzNBEQ==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.4.tgz",
+      "integrity": "sha512-4JgEbcrdeMda1qvxTm1CnxFJAWVV++VLpP46HNTrfH7VhVlvUpihnUNs2gAlKuRT/XSBuiWeLAkrTqF4NVrPig==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "css-vendor": "^2.0.1",
-        "jss": "10.0.0-alpha.17"
+        "css-vendor": "^2.0.7",
+        "jss": "10.0.4"
       }
     },
     "killable": {
@@ -6139,11 +6137,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
-    "normalize-scroll-left": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.2.0.tgz",
-      "integrity": "sha512-t5oCENZJl8TGusJKoCJm7+asaSsPuNmK6+iEjrZ5TyBj2f02brCRsd4c83hwtu+e5d4LCSBZ0uoDlMjBo+A8yA=="
-    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -6479,11 +6472,6 @@
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
-    "parse-unit": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
-      "integrity": "sha1-fhu21b7zh0wo45JSaiVBFwKR7s8="
-    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -6613,9 +6601,9 @@
       }
     },
     "popper.js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
-      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "portfinder": {
       "version": "1.0.20",
@@ -7023,14 +7011,29 @@
       }
     },
     "react-transition-group": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.2.1.tgz",
-      "integrity": "sha512-IXrPr93VzCPupwm2O6n6C2kJIofJ/Rp5Ltihhm9UfE8lkuVX2ng/SUUl/oWjblybK9Fq2Io7LGa6maVqPB762Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.3.0.tgz",
+      "integrity": "sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==",
       "requires": {
-        "@babel/runtime": "^7.4.5",
-        "dom-helpers": "^3.4.0",
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
+          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.4",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
+          "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+        }
       }
     },
     "read-pkg": {
@@ -8873,14 +8876,6 @@
       "dev": true,
       "requires": {
         "indexof": "0.0.1"
-      }
-    },
-    "warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -26,7 +26,7 @@
     "webpack-dev-server": "^3.7.1"
   },
   "dependencies": {
-    "@material-ui/core": "4.2.0",
+    "@material-ui/core": "4.9.5",
     "d3-scale": "^1.0.7",
     "d3-selection": "^1.2.0",
     "htm": "2.1.1",


### PR DESCRIPTION
## The problem

In `mui` there's a concept of `forking` a ref, this means that we combine the passed ref from the top with the one used internally inside a component to manage presentation.

An example: https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Grow/Grow.js#L32

This becomes problematic in the following scenario

```
const Wrapper = forwardRef((props, ref) => <div ref={ref}>I am wrapped</div>);
const App = () => {
  const ref = useRef()
  return (
    <Grow>
       <Wrapper ref={ref} />
    </Grow>
  )
}
```

At this point we have evaluated `Wrapper` and moved the `vnode.ref` to `vnode.props.ref` due to `options.vnode` being called (`createVNode`). This makes the `forking` of the `Grow` ref fail since we talk to `children.ref` which in this case is `Wrapper.ref`. That's why we move the `forwarding` of refs to the point where we are going to diff the `forwarded` component.

Fixes: https://github.com/preactjs/preact/issues/2249