### PR TITLE
Disable normalization of string vnodes

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -104,62 +104,66 @@ options.vnode = vnode => {
 	let type = vnode.type;
 	let props = vnode.props;
 
-	// Alias `class` prop to `className` if available
-	if (props.class != props.className) {
-		classNameDescriptor.enumerable = 'className' in props;
-		if (props.className != null) props.class = props.className;
-		Object.defineProperty(props, 'className', classNameDescriptor);
-	}
-
-	// Apply DOM VNode compat
-	if (typeof type != 'function') {
-		// Apply defaultValue to value
-		if (props.defaultValue && props.value !== undefined) {
-			if (!props.value && props.value !== 0) {
-				props.value = props.defaultValue;
-			}
-			delete props.defaultValue;
+	if (type) {
+		// Alias `class` prop to `className` if available
+		if (props.class != props.className) {
+			classNameDescriptor.enumerable = 'className' in props;
+			if (props.className != null) props.class = props.className;
+			Object.defineProperty(props, 'className', classNameDescriptor);
 		}
 
-		// Add support for array select values: <select value={[]} />
-		if (Array.isArray(props.value) && props.multiple && type === 'select') {
-			toChildArray(props.children).forEach(child => {
-				if (props.value.indexOf(child.props.value) != -1) {
-					child.props.selected = true;
+		// Apply DOM VNode compat
+		if (typeof type != 'function') {
+			// Apply defaultValue to value
+			if (props.defaultValue && props.value !== undefined) {
+				if (!props.value && props.value !== 0) {
+					props.value = props.defaultValue;
 				}
-			});
-			delete props.value;
-		}
+				delete props.defaultValue;
+			}
 
-		// Normalize DOM vnode properties.
-		let shouldSanitize, attrs, i;
-		for (i in props) if ((shouldSanitize = CAMEL_PROPS.test(i))) break;
-		if (shouldSanitize) {
-			attrs = vnode.props = {};
-			for (i in props) {
-				attrs[
-					CAMEL_PROPS.test(i) ? i.replace(/([A-Z0-9])/, '-$1').toLowerCase() : i
-				] = props[i];
+			// Add support for array select values: <select value={[]} />
+			if (Array.isArray(props.value) && props.multiple && type === 'select') {
+				toChildArray(props.children).forEach(child => {
+					if (props.value.indexOf(child.props.value) != -1) {
+						child.props.selected = true;
+					}
+				});
+				delete props.value;
+			}
+
+			// Normalize DOM vnode properties.
+			let shouldSanitize, attrs, i;
+			for (i in props) if ((shouldSanitize = CAMEL_PROPS.test(i))) break;
+			if (shouldSanitize) {
+				attrs = vnode.props = {};
+				for (i in props) {
+					attrs[
+						CAMEL_PROPS.test(i)
+							? i.replace(/([A-Z0-9])/, '-$1').toLowerCase()
+							: i
+					] = props[i];
+				}
 			}
 		}
-	}
 
-	// Events
-	applyEventNormalization(vnode);
+		// Events
+		applyEventNormalization(vnode);
 
-	// Component base class compat
-	// We can't just patch the base component class, because components that use
-	// inheritance and are transpiled down to ES5 will overwrite our patched
-	// getters and setters. See #1941
-	if (
-		typeof type === 'function' &&
-		!type._patchedLifecycles &&
-		type.prototype
-	) {
-		setSafeDescriptor(type.prototype, 'componentWillMount');
-		setSafeDescriptor(type.prototype, 'componentWillReceiveProps');
-		setSafeDescriptor(type.prototype, 'componentWillUpdate');
-		type._patchedLifecycles = true;
+		// Component base class compat
+		// We can't just patch the base component class, because components that use
+		// inheritance and are transpiled down to ES5 will overwrite our patched
+		// getters and setters. See #1941
+		if (
+			typeof type === 'function' &&
+			!type._patchedLifecycles &&
+			type.prototype
+		) {
+			setSafeDescriptor(type.prototype, 'componentWillMount');
+			setSafeDescriptor(type.prototype, 'componentWillReceiveProps');
+			setSafeDescriptor(type.prototype, 'componentWillUpdate');
+			type._patchedLifecycles = true;
+		}
 	}
 
 	if (oldVNodeHook) oldVNodeHook(vnode);

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -139,9 +139,7 @@ options.vnode = vnode => {
 				attrs = vnode.props = {};
 				for (i in props) {
 					attrs[
-						CAMEL_PROPS.test(i)
-							? i.replace(/([A-Z0-9])/, '-$1').toLowerCase()
-							: i
+						CAMEL_PROPS.test(i) ? i.replace(/[A-Z0-9]/, '-$&').toLowerCase() : i
 					] = props[i];
 				}
 			}

--- a/compat/test/browser/createElement.test.js
+++ b/compat/test/browser/createElement.test.js
@@ -1,4 +1,4 @@
-import React, { createElement } from 'preact/compat';
+import React, { createElement, render } from 'preact/compat';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
 describe('compat createElement()', () => {
@@ -45,5 +45,17 @@ describe('compat createElement()', () => {
 			.to.have.property('props')
 			.that.is.an('object');
 		expect(vnode.props.children.props).to.eql({ children: 't' });
+	});
+
+	it('should not normalize text nodes', () => {
+		String.prototype.capFLetter = function() {
+			return this.charAt(0).toUpperCase() + this.slice(1);
+		};
+		let vnode = <div>hi buddy</div>;
+
+		render(vnode, scratch);
+
+		expect(scratch.innerHTML).to.equal('<div>hi buddy</div>');
+		console.log(scratch);
 	});
 });

--- a/compat/test/browser/createElement.test.js
+++ b/compat/test/browser/createElement.test.js
@@ -56,6 +56,5 @@ describe('compat createElement()', () => {
 		render(vnode, scratch);
 
 		expect(scratch.innerHTML).to.equal('<div>hi buddy</div>');
-		console.log(scratch);
 	});
 });


### PR DESCRIPTION
Fixes: https://github.com/preactjs/preact/issues/2387

What would happen is it would see the prototype and shift it through normalization, since string vnode.props is the actual string we don't want this. This adds a gaurd to avoid this check.