### PR TITLE
Add owner stack for invalid child warning

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -282,7 +282,8 @@ export function initDebug() {
 					delete child._depth;
 					const keys = Object.keys(child).join(',');
 					throw new Error(
-						`Objects are not valid as a child. Encountered an object with the keys {${keys}}.`
+						`Objects are not valid as a child. Encountered an object with the keys {${keys}}.` +
+							`\n\n${getOwnerStack(vnode)}`
 					);
 				}
 			});


### PR DESCRIPTION
We somehow missed to add the component stack to this error.

Before:

![Screenshot from 2020-03-14 07-10-07](https://user-images.githubusercontent.com/1062408/76676364-e481e400-65c2-11ea-9f0b-b23be8898ebc.png)

After:

![Screenshot from 2020-03-14 07-08-10](https://user-images.githubusercontent.com/1062408/76676355-ce742380-65c2-11ea-8048-2238f88e8061.png)

Fixes #2415 .