### PR TITLE
Ensure ref is mutable even if a dom node is inserted into it

### DIFF
--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -40,7 +40,7 @@ export function useReducer<S, A, I>(
 	init: (arg: I) => S
 ): [S, (action: A) => void];
 
-type PropRef<T> = { readonly current?: T };
+type PropRef<T> = { current?: T };
 type Ref<T> = { current: T };
 
 /**


### PR DESCRIPTION
After a conversation on Slack it turned out there was a discrepancy with the react-types, where we limit the ref to be readonly when it's a dom-node being inserted (no initial-value) react doesn't. This fixes that