### PR TITLE
Keep calling render until state isn't dirty

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -164,6 +164,12 @@ export function diff(
 			c._parentDom = parentDom;
 
 			tmp = c.render(c.props, c.state, c.context);
+			while (c._dirty) {
+				oldState = c.state;
+				c._dirty = false;
+				tmp = c.render(c.props, (c.state = c._nextState), c.context);
+			}
+
 			let isTopLevelFragment =
 				tmp != null && tmp.type == Fragment && tmp.key == null;
 			newVNode._children = isTopLevelFragment

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -2575,5 +2575,25 @@ describe('Components', () => {
 
 			expect(scratch.innerHTML).to.equal('<div>bar</div>');
 		});
+
+		it('should call render again when state got dirtied', () => {
+			class Persons extends Component {
+				constructor(props) {
+					super(props);
+					this.state = { x: false };
+				}
+
+				render() {
+					if (this.state.x === false) {
+						this.setState({ x: true });
+					}
+
+					return <p>{this.state.x === true ? 'hi' : 'bye'}</p>;
+				}
+			}
+
+			render(<Persons />, scratch);
+			expect(scratch.innerHTML).to.equal('<p>hi</p>');
+		});
 	});
 });


### PR DESCRIPTION
This will empty the render queue until it's empty for every single vnode, this prevents us from going down the diff too much.