### PR TITLE
Improve handling of exceptions thrown during `act` callback

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -258,10 +258,11 @@ export function useErrorBoundary(cb) {
 function flushAfterPaintEffects() {
 	afterPaintEffects.some(component => {
 		if (component._parentDom) {
+			const effects = component.__hooks._pendingEffects;
+			component.__hooks._pendingEffects = [];
 			try {
-				component.__hooks._pendingEffects.forEach(invokeCleanup);
-				component.__hooks._pendingEffects.forEach(invokeEffect);
-				component.__hooks._pendingEffects = [];
+				effects.forEach(invokeCleanup);
+				effects.forEach(invokeEffect);
 			} catch (e) {
 				options._catchError(e, component._vnode);
 				return true;

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -258,12 +258,12 @@ export function useErrorBoundary(cb) {
 function flushAfterPaintEffects() {
 	afterPaintEffects.some(component => {
 		if (component._parentDom) {
-			const effects = component.__hooks._pendingEffects;
-			component.__hooks._pendingEffects = [];
 			try {
-				effects.forEach(invokeCleanup);
-				effects.forEach(invokeEffect);
+				component.__hooks._pendingEffects.forEach(invokeCleanup);
+				component.__hooks._pendingEffects.forEach(invokeEffect);
+				component.__hooks._pendingEffects = [];
 			} catch (e) {
+				component.__hooks._pendingEffects = [];
 				options._catchError(e, component._vnode);
 				return true;
 			}

--- a/test-utils/src/index.js
+++ b/test-utils/src/index.js
@@ -65,16 +65,29 @@ export function act(cb) {
 		--actDepth;
 	};
 
-	const result = cb();
+	let err;
+	let result;
+
+	try {
+		result = cb();
+	} catch (e) {
+		err = e;
+	}
 
 	if (isThenable(result)) {
-		return result.then(finish);
+		return result.then(finish, err => {
+			finish();
+			throw err;
+		});
 	}
 
 	// nb. If the callback is synchronous, effects must be flushed before
 	// `act` returns, so that the caller does not have to await the result,
 	// even though React recommends this.
 	finish();
+	if (err) {
+		throw err;
+	}
 	return Promise.resolve();
 }
 

--- a/test-utils/src/index.js
+++ b/test-utils/src/index.js
@@ -30,6 +30,8 @@ export function act(cb) {
 		// outermost call returns. In the inner call, we just execute the
 		// callback and return since the infrastructure for flushing has already
 		// been set up.
+		//
+		// If an exception occurs, the outermost `act` will handle cleanup.
 		const result = cb();
 		if (isThenable(result)) {
 			return result.then(() => {
@@ -50,18 +52,23 @@ export function act(cb) {
 	options.requestAnimationFrame = fc => (flush = fc);
 
 	const finish = () => {
-		rerender();
-		while (flush) {
-			toFlush = flush;
-			flush = null;
-
-			toFlush();
+		try {
 			rerender();
+			while (flush) {
+				toFlush = flush;
+				flush = null;
+
+				toFlush();
+				rerender();
+			}
+			teardown();
+		} catch (e) {
+			if (!err) {
+				err = e;
+			}
 		}
 
-		teardown();
 		options.requestAnimationFrame = previousRequestAnimationFrame;
-
 		--actDepth;
 	};
 

--- a/test-utils/test/shared/act.test.js
+++ b/test-utils/test/shared/act.test.js
@@ -342,7 +342,7 @@ describe('act', () => {
 		});
 	});
 
-	context('when `act` callback throws an exception', () => {
+	describe('when `act` callback throws an exception', () => {
 		function BrokenWidget() {
 			throw new Error('BrokenWidget is broken');
 		}
@@ -385,7 +385,7 @@ describe('act', () => {
 			} catch (e) {}
 		};
 
-		context('synchronously', () => {
+		describe('synchronously', () => {
 			it('should rethrow the exception', () => {
 				expect(renderBroken).to.throw('BrokenWidget is broken');
 			});
@@ -403,7 +403,7 @@ describe('act', () => {
 			});
 		});
 
-		context('asynchronously', () => {
+		describe('asynchronously', () => {
 			const renderBrokenAsync = async () => {
 				await act(async () => {
 					render(<BrokenWidget />, scratch);
@@ -439,7 +439,7 @@ describe('act', () => {
 			});
 		});
 
-		context('in an effect', () => {
+		describe('in an effect', () => {
 			function BrokenEffect() {
 				useEffect(() => {
 					throw new Error('BrokenEffect effect');

--- a/test-utils/test/shared/act.test.js
+++ b/test-utils/test/shared/act.test.js
@@ -438,5 +438,42 @@ describe('act', () => {
 				expect(effectCount).to.equal(1);
 			});
 		});
+
+		context('in an effect', () => {
+			function BrokenEffect() {
+				useEffect(() => {
+					throw new Error('BrokenEffect effect');
+				}, []);
+				return null;
+			}
+
+			const renderBrokenEffect = () => {
+				act(() => {
+					render(<BrokenEffect />, scratch);
+				});
+			};
+
+			it('should rethrow the exception', () => {
+				expect(renderBrokenEffect).to.throw('BrokenEffect effect');
+			});
+
+			it('should not affect state updates in future renders', () => {
+				try {
+					renderBrokenEffect();
+				} catch (e) {}
+
+				renderWorking();
+				expect(scratch.textContent).to.equal('1');
+			});
+
+			it('should not affect effects in future renders', () => {
+				try {
+					renderBrokenEffect();
+				} catch (e) {}
+
+				renderWorking();
+				expect(effectCount).to.equal(1);
+			});
+		});
 	});
 });

--- a/test-utils/test/shared/act.test.js
+++ b/test-utils/test/shared/act.test.js
@@ -341,4 +341,102 @@ describe('act', () => {
 			expect(button.textContent).to.equal('1');
 		});
 	});
+
+	context('when `act` callback throws an exception', () => {
+		function BrokenWidget() {
+			throw new Error('BrokenWidget is broken');
+		}
+
+		let effectCount;
+
+		function WorkingWidget() {
+			const [count, setCount] = useState(0);
+
+			useEffect(() => {
+				++effectCount;
+			}, []);
+
+			if (count === 0) {
+				setCount(1);
+			}
+
+			return <div>{count}</div>;
+		}
+
+		beforeEach(() => {
+			effectCount = 0;
+		});
+
+		const renderBroken = () => {
+			act(() => {
+				render(<BrokenWidget />, scratch);
+			});
+		};
+
+		const renderWorking = () => {
+			act(() => {
+				render(<WorkingWidget />, scratch);
+			});
+		};
+
+		const tryRenderBroken = () => {
+			try {
+				renderBroken();
+			} catch (e) {}
+		};
+
+		context('synchronously', () => {
+			it('should rethrow the exception', () => {
+				expect(renderBroken).to.throw('BrokenWidget is broken');
+			});
+
+			it('should not affect state updates in future renders', () => {
+				tryRenderBroken();
+				renderWorking();
+				expect(scratch.textContent).to.equal('1');
+			});
+
+			it('should not affect effects in future renders', () => {
+				tryRenderBroken();
+				renderWorking();
+				expect(effectCount).to.equal(1);
+			});
+		});
+
+		context('asynchronously', () => {
+			const renderBrokenAsync = async () => {
+				await act(async () => {
+					render(<BrokenWidget />, scratch);
+				});
+			};
+
+			it('should rethrow the exception', async () => {
+				let err;
+				try {
+					await renderBrokenAsync();
+				} catch (e) {
+					err = e;
+				}
+				expect(err.message).to.equal('BrokenWidget is broken');
+			});
+
+			it('should not affect state updates in future renders', async () => {
+				try {
+					await renderBrokenAsync();
+				} catch (e) {}
+
+				renderWorking();
+				expect(scratch.textContent).to.equal('1');
+			});
+
+			it('should not affect effects in future renders', async () => {
+				try {
+					await renderBrokenAsync();
+				} catch (e) {}
+
+				renderWorking();
+				expect(effectCount).to.equal(1);
+			});
+		});
+	});
 });


### PR DESCRIPTION
This PR fixes https://github.com/preactjs/preact/issues/2432 by ensuring that effect and pending render queues are flushed if a callback passed to `act` throws an exception. Previously `useEffect` effects and state updates would stop working after a call to `act` aborted with an exception. The result was that a single failure in a test suite could trigger a cascade of failures in unrelated tests, which was pretty confusing.

In the process, I discovered an issue that if an effect threw an exception, the effect would remain in the component's effect queue and would end up running again the next time that component's effects were flushed.