### PR TITLE
Fix error messages logged by failed prop type checks

### DIFF
--- a/debug/src/check-props.js
+++ b/debug/src/check-props.js
@@ -2,6 +2,25 @@ const ReactPropTypesSecret = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
 
 let loggedTypeFailures = {};
 
+/**
+ * Reset the history of which prop type warnings have been logged.
+ */
+export function resetPropWarnings() {
+	loggedTypeFailures = {};
+}
+
+/**
+ * Assert that the values match with the type specs.
+ * Error messages are memorized and will only be shown once.
+ *
+ * Adapted from https://github.com/facebook/prop-types/blob/master/checkPropTypes.js
+ *
+ * @param {object} typeSpecs Map of name to a ReactPropType
+ * @param {object} values Runtime values that need to be type-checked
+ * @param {string} location e.g. "prop", "context", "child context"
+ * @param {string} componentName Name of the component for error messages.
+ * @param {?Function} getStack Returns the component stack.
+ */
 export function checkPropTypes(
 	typeSpecs,
 	values,

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -214,8 +214,8 @@ export function initDebug() {
 			checkPropTypes(
 				vnode.type.propTypes,
 				vnode.props,
-				getDisplayName(vnode),
-				serializeVNode(vnode)
+				'prop',
+				getDisplayName(vnode)
 			);
 		}
 

--- a/debug/src/index.js
+++ b/debug/src/index.js
@@ -2,3 +2,5 @@ import { initDebug } from './debug';
 import 'preact/devtools';
 
 initDebug();
+
+export { resetPropWarnings } from './check-props';


### PR DESCRIPTION
The error message logged when a value of an incorrect type is passed as
the prop `propName` for a component `Widget` should read:

```
Failed prop type: Invalid prop `propName` supplied to `Widget`
```

Instead it read:

```
Failed Widget type: Invalid Widget `propName` supplied to `Widget`
```

The issue was that the wrong parameters were passed to `checkPropType`.