### PR TITLE
POC for selective context option 2

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -212,14 +212,14 @@ export function useCallback(callback, args) {
 /**
  * @param {import('./internal').PreactContext} context
  */
-export function useContext(context) {
+export function useContext(context, shouldUpdate) {
 	const provider = currentComponent.context[context._id];
 	if (!provider) return context._defaultValue;
 	const state = getHookState(currentIndex++);
 	// This is probably not safe to convert to "!"
 	if (state._value == null) {
 		state._value = true;
-		provider.sub(currentComponent);
+		provider.sub(currentComponent, shouldUpdate);
 	}
 	return provider.props.value;
 }

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -212,16 +212,16 @@ export function useCallback(callback, args) {
 /**
  * @param {import('./internal').PreactContext} context
  */
-export function useContext(context, shouldUpdate) {
+export function useContext(context, selector) {
 	const provider = currentComponent.context[context._id];
 	if (!provider) return context._defaultValue;
 	const state = getHookState(currentIndex++);
 	// This is probably not safe to convert to "!"
 	if (state._value == null) {
 		state._value = true;
-		provider.sub(currentComponent, shouldUpdate);
+		provider.sub(currentComponent, selector);
 	}
-	return provider.props.value;
+	return selector ? selector(provider.props.value) : provider.props.value;
 }
 
 /**

--- a/hooks/test/browser/useContext.test.js
+++ b/hooks/test/browser/useContext.test.js
@@ -348,4 +348,89 @@ describe('useContext', () => {
 		});
 		expect(scratch.innerHTML).to.equal('<p>hi</p>');
 	});
+
+	it('should selectively rerender', () => {
+		let appRenders = 0,
+			providerRenders = 0,
+			layoutRenders = 0,
+			consumerFooRenders = 0,
+			consumerBarRenders = 0,
+			set;
+		const context = createContext();
+
+		const MyProvider = ({ children }) => {
+			providerRenders++;
+			const [state, setState] = useState({ foo: 'hello', bar: 'world' });
+			set = setState;
+			return <context.Provider value={state}>{children}</context.Provider>;
+		};
+
+		const Layout = ({ children }) => {
+			layoutRenders++;
+			return <div>{children}</div>;
+		};
+
+		const Foo = () => {
+			consumerFooRenders++;
+			const value = useContext(context, v => v.foo);
+			return <p>{value}</p>;
+		};
+
+		const Bar = () => {
+			consumerBarRenders++;
+			const value = useContext(context, v => v.bar);
+			return <p>{value}</p>;
+		};
+
+		const App = () => {
+			appRenders++;
+			return (
+				<MyProvider>
+					<Layout>
+						<Foo />
+						<Bar />
+					</Layout>
+				</MyProvider>
+			);
+		};
+
+		render(<App />, scratch);
+
+		expect(scratch.innerHTML).to.equal('<div><p>hello</p><p>world</p></div>');
+		expect(appRenders).to.equal(1);
+		expect(layoutRenders).to.equal(1);
+		expect(providerRenders).to.equal(1);
+		expect(consumerFooRenders).to.equal(1);
+		expect(consumerBarRenders).to.equal(1);
+
+		act(() => {
+			set({ foo: 'hello', bar: 'Earth' });
+		});
+		expect(scratch.innerHTML).to.equal('<div><p>hello</p><p>Earth</p></div>');
+		expect(appRenders).to.equal(1);
+		expect(layoutRenders).to.equal(1);
+		expect(providerRenders).to.equal(2);
+		expect(consumerFooRenders).to.equal(1);
+		expect(consumerBarRenders).to.equal(2);
+
+		act(() => {
+			set({ foo: 'hi', bar: 'Earth' });
+		});
+		expect(scratch.innerHTML).to.equal('<div><p>hi</p><p>Earth</p></div>');
+		expect(appRenders).to.equal(1);
+		expect(layoutRenders).to.equal(1);
+		expect(providerRenders).to.equal(3);
+		expect(consumerFooRenders).to.equal(2);
+		expect(consumerBarRenders).to.equal(2);
+
+		act(() => {
+			set({ foo: 'hello', bar: 'world' });
+		});
+		expect(scratch.innerHTML).to.equal('<div><p>hello</p><p>world</p></div>');
+		expect(appRenders).to.equal(1);
+		expect(layoutRenders).to.equal(1);
+		expect(providerRenders).to.equal(4);
+		expect(consumerFooRenders).to.equal(3);
+		expect(consumerBarRenders).to.equal(3);
+	});
 });

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -22,17 +22,20 @@ export function createContext(defaultValue) {
 				this.shouldComponentUpdate = _props => {
 					if (this.props.value !== _props.value) {
 						subs.some(c => {
-							c.context = _props.value;
-							enqueueRender(c);
+							if (!c[1] || c[1](_props.value, this.props.value)) {
+								c[0].context = _props.value;
+								enqueueRender(c[0]);
+							}
 						});
 					}
 				};
 
-				this.sub = c => {
-					subs.push(c);
+				this.sub = (c, cb) => {
+					const entry = [c, cb];
+					subs.push(entry);
 					let old = c.componentWillUnmount;
 					c.componentWillUnmount = () => {
-						subs.splice(subs.indexOf(c), 1);
+						subs.splice(subs.indexOf(entry), 1);
 						old && old.call(c);
 					};
 				};

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -9,7 +9,7 @@ export function createContext(defaultValue) {
 		_id: '__cC' + i++,
 		_defaultValue: defaultValue,
 		Consumer(props, context) {
-			return props.children(context);
+			return props.children(props.selector(context));
 		},
 		Provider(props) {
 			if (!this.getChildContext) {

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -9,7 +9,7 @@ export function createContext(defaultValue) {
 		_id: '__cC' + i++,
 		_defaultValue: defaultValue,
 		Consumer(props, context) {
-			return props.children(props.selector(context));
+			return props.children(props.selector ? props.selector(context) : context);
 		},
 		Provider(props) {
 			if (!this.getChildContext) {

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -22,7 +22,7 @@ export function createContext(defaultValue) {
 				this.shouldComponentUpdate = _props => {
 					if (this.props.value !== _props.value) {
 						subs.some(c => {
-							if (!c[1] || c[1](_props.value, this.props.value)) {
+							if (!c[1] || c[1](_props.value) !== c[1](this.props.value)) {
 								c[0].context = _props.value;
 								enqueueRender(c[0]);
 							}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -70,7 +70,7 @@ export function diff(
 					c.constructor = newType;
 					c.render = doRender;
 				}
-				if (provider) provider.sub(c);
+				if (provider) provider.sub(c, newProps.shouldUpdate);
 
 				c.props = newProps;
 				if (!c.state) c.state = {};

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -70,7 +70,7 @@ export function diff(
 					c.constructor = newType;
 					c.render = doRender;
 				}
-				if (provider) provider.sub(c, newProps.shouldUpdate);
+				if (provider) provider.sub(c, newProps.selector);
 
 				c.props = newProps;
 				if (!c.state) c.state = {};


### PR DESCRIPTION
This still relies on https://github.com/preactjs/preact/pull/2386 to bail out of Provider children
Implements a POC for option 2  https://github.com/preactjs/preact/issues/2425

This isn't aimed at `contextType` on class components since this can naturally benefit from `shouldComponentUpdate` instead. This is aimed at `Consumer` and `useContext`.

Will add tests for this when #2386 is merged since this is quite important.

Will make a second PR implementing option 1

TODO:
- types
- docs
- test Consumer