### PR TITLE
docs: Fix simple typo, stucture -> structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ render(<main><h1>Hello World!</h1></main>, document.body);
 // ^ this second invocation of render(...) will use a single DOM call to update the text of the <h1>
 ```
 
-Hooray! render() has taken our structure and output a User Interface! This approach demonstrates a simple case, but would be difficult to use as an application grows in complexity. Each change would be forced to calculate the difference between the current and updated stucture for the entire application. Components can help here – by dividing the User Interface into nested Components each can calculate their difference from their mounted point. Here's an example:
+Hooray! render() has taken our structure and output a User Interface! This approach demonstrates a simple case, but would be difficult to use as an application grows in complexity. Each change would be forced to calculate the difference between the current and updated structure for the entire application. Components can help here – by dividing the User Interface into nested Components each can calculate their difference from their mounted point. Here's an example:
 
 ```js
 import { render, h } from 'preact';


### PR DESCRIPTION
There is a small typo in README.md.

Should read `structure` rather than `stucture`.

