### PR TITLE
Update act type signature

### DIFF
--- a/test-utils/src/index.d.ts
+++ b/test-utils/src/index.d.ts
@@ -1,3 +1,3 @@
 export function setupRerender(): () => void;
-export function act(callback: () => void): void;
+export function act(callback: () => void | Promise<void>): Promise<void>;
 export function teardown(): void;


### PR DESCRIPTION
## What am I trying to achieve?
Resolves https://github.com/preactjs/preact/issues/2441

Updating `act`'s typings
1- Callback return type can still be function or explicitly, return a promise (if async ideally)
2- Return type to be `Promise<void>`

## What approach did I use?
🔍 Digging Preact's code base to learn

- TIL act supports async

📚 Mostly following Preact's [contribution guidelines](https://github.com/preactjs/preact/blob/master/CONTRIBUTING.md):