### PR TITLE
Support node13

### DIFF
--- a/config/node-13-exports.js
+++ b/config/node-13-exports.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+
+const subRepositories = ['compat', 'debug', 'devtools', 'hooks', 'test-utils'];
+
+const snakeCaseToCamelCase = str =>
+	str.replace(/([-_][a-z])/g, group => group.toUpperCase().replace('-', ''));
+
+const copyPreact = () => {
+	fs.writeFileSync(
+		`${process.cwd()}/dist/preact.mjs`,
+		fs.readFileSync(`${process.cwd()}/dist/preact.module.js`)
+	);
+	fs.writeFileSync(
+		`${process.cwd()}/dist/preact.mjs.map`,
+		fs.readFileSync(`${process.cwd()}/dist/preact.module.js.map`)
+	);
+};
+
+const copy = name => {
+	const filename = name.includes('-') ? snakeCaseToCamelCase(name) : name;
+	fs.writeFileSync(
+		`${process.cwd()}/${name}/dist/${filename}.mjs`,
+		fs.readFileSync(`${process.cwd()}/${name}/dist/${filename}.module.js`)
+	);
+	fs.writeFileSync(
+		`${process.cwd()}/${name}/dist/${filename}.mjs.map`,
+		fs.readFileSync(`${process.cwd()}/${name}/dist/${filename}.module.js.map`)
+	);
+};
+
+copyPreact();
+subRepositories.forEach(copy);

--- a/config/node-13-exports.js
+++ b/config/node-13-exports.js
@@ -1,30 +1,28 @@
 const fs = require('fs');
 
 const subRepositories = ['compat', 'debug', 'devtools', 'hooks', 'test-utils'];
-
 const snakeCaseToCamelCase = str =>
 	str.replace(/([-_][a-z])/g, group => group.toUpperCase().replace('-', ''));
 
 const copyPreact = () => {
+	// Copy .module.js --> .mjs for Node 13 compat.
 	fs.writeFileSync(
 		`${process.cwd()}/dist/preact.mjs`,
 		fs.readFileSync(`${process.cwd()}/dist/preact.module.js`)
 	);
+	// Copy over preact.cjs --> preact.min.js for Preact 8 compat.
 	fs.writeFileSync(
-		`${process.cwd()}/dist/preact.mjs.map`,
-		fs.readFileSync(`${process.cwd()}/dist/preact.module.js.map`)
+		`${process.cwd()}/dist/preact.min.js`,
+		fs.readFileSync(`${process.cwd()}/dist/preact.js`)
 	);
 };
 
 const copy = name => {
+	// Copy .module.js --> .mjs for Node 13 compat.
 	const filename = name.includes('-') ? snakeCaseToCamelCase(name) : name;
 	fs.writeFileSync(
 		`${process.cwd()}/${name}/dist/${filename}.mjs`,
 		fs.readFileSync(`${process.cwd()}/${name}/dist/${filename}.module.js`)
-	);
-	fs.writeFileSync(
-		`${process.cwd()}/${name}/dist/${filename}.mjs.map`,
-		fs.readFileSync(`${process.cwd()}/${name}/dist/${filename}.module.js.map`)
 	);
 };
 

--- a/package.json
+++ b/package.json
@@ -9,43 +9,42 @@
   "umd:main": "dist/preact.umd.js",
   "unpkg": "dist/preact.umd.js",
   "source": "src/index.js",
-  "type": "module",
   "exports": {
     ".": {
       "browser": "./dist/preact.module.js",
       "umd": "./dist/preact.umd.js",
-      "import": "./dist/preact.module.js",
+      "import": "./dist/preact.mjs",
       "require": "./dist/preact.js"
     },
     "./compat": {
       "browser": "./compat/dist/compat.module.js",
       "umd": "./compat/dist/compat.umd.js",
       "require": "./compat/dist/compat.js",
-      "import": "./compat/dist/compat.module.js"
+      "import": "./compat/dist/compat.mjs"
     },
     "./debug": {
       "browser": "./debug/dist/debug.module.js",
       "umd": "./debug/dist/debug.umd.js",
       "require": "./debug/dist/debug.js",
-      "import": "./debug/dist/debug.module.js"
+      "import": "./debug/dist/debug.mjs"
     },
     "./devtools": {
       "browser": "./devtools/dist/devtools.module.js",
       "umd": "./devtools/dist/devtools.umd.js",
       "require": "./devtools/dist/devtools.js",
-      "import": "./devtools/dist/devtools.module.js"
+      "import": "./devtools/dist/devtools.mjs"
     },
     "./hooks": {
       "browser": "./hooks/dist/hooks.module.js",
       "umd": "./hooks/dist/hooks.umd.js",
       "require": "./hooks/dist/hooks.js",
-      "import": "./hooks/dist/hooks.module.js"
+      "import": "./hooks/dist/hooks.mjs"
     },
     "./test-utils": {
       "browser": "./test-utils/dist/testUtils.module.js",
       "umd": "./test-utils/dist/testUtils.umd.js",
       "require": "./test-utils/dist/testUtils.js",
-      "import": "./test-utils/dist/testUtils.module.js"
+      "import": "./test-utils/dist/testUtils.mjs"
     },
     "./compat/server": {
       "require": "./compat/server.js"
@@ -67,6 +66,7 @@
     "build:hooks": "microbundle build --raw --cwd hooks",
     "build:test-utils": "microbundle build --raw --cwd test-utils",
     "build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks'",
+    "postbuild": "node ./config/node-13-exports.js",
     "dev": "microbundle watch --raw --format cjs",
     "dev:hooks": "microbundle watch --raw --format cjs --cwd hooks",
     "dev:compat": "microbundle watch --raw --format cjs --cwd compat --globals 'preact/hooks=preactHooks'",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "types": "src/index.d.ts",
   "scripts": {
-    "build": "npm-run-all --parallel build:* && cp dist/preact.js dist/preact.min.js",
+    "build": "npm-run-all --parallel build:*",
     "build:core": "microbundle build --raw",
     "build:debug": "microbundle build --raw --cwd debug",
     "build:devtools": "microbundle build --raw --cwd devtools",

--- a/package.json
+++ b/package.json
@@ -13,32 +13,38 @@
     ".": {
       "browser": "./dist/preact.module.js",
       "umd": "./dist/preact.umd.js",
-      "import": "./dist/preact.module.js",
+      "import": "./dist/preact.mjs",
       "require": "./dist/preact.js"
     },
     "./compat": {
       "browser": "./compat/dist/compat.module.js",
       "umd": "./compat/dist/compat.umd.js",
       "require": "./compat/dist/compat.js",
-      "import": "./compat/dist/compat.module.js"
+      "import": "./compat/dist/compat.mjs"
     },
     "./debug": {
       "browser": "./debug/dist/debug.module.js",
       "umd": "./debug/dist/debug.umd.js",
       "require": "./debug/dist/debug.js",
-      "import": "./debug/dist/debug.module.js"
+      "import": "./debug/dist/debug.mjs"
+    },
+    "./devtools": {
+      "browser": "./devtools/dist/devtools.module.js",
+      "umd": "./devtools/dist/devtools.umd.js",
+      "require": "./devtools/dist/devtools.js",
+      "import": "./devtools/dist/devtools.mjs"
     },
     "./hooks": {
       "browser": "./hooks/dist/hooks.module.js",
       "umd": "./hooks/dist/hooks.umd.js",
       "require": "./hooks/dist/hooks.js",
-      "import": "./hooks/dist/hooks.module.js"
+      "import": "./hooks/dist/hooks.mjs"
     },
     "./test-utils": {
       "browser": "./test-utils/dist/testUtils.module.js",
       "umd": "./test-utils/dist/testUtils.umd.js",
       "require": "./test-utils/dist/testUtils.js",
-      "import": "./test-utils/dist/testUtils.module.js"
+      "import": "./test-utils/dist/testUtils.mjs"
     },
     "./compat/server": {
       "require": "./compat/server.js"
@@ -54,12 +60,12 @@
   "types": "src/index.d.ts",
   "scripts": {
     "build": "npm-run-all --parallel build:* && cp dist/preact.js dist/preact.min.js",
-    "build:core": "microbundle build --raw",
-    "build:debug": "microbundle build --raw --cwd debug",
-    "build:devtools": "microbundle build --raw --cwd devtools",
-    "build:hooks": "microbundle build --raw --cwd hooks",
-    "build:test-utils": "microbundle build --raw --cwd test-utils",
-    "build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks'",
+    "build:core": "microbundle build --raw && cp ./dist/preact.module.js ./dist/preact.mjs",
+    "build:debug": "microbundle build --raw --cwd debug && cp ./debug/dist/debug.module.js ./debug/dist/debug.mjs",
+    "build:devtools": "microbundle build --raw --cwd devtools && cp ./devtools/dist/devtools.module.js ./devtools/dist/devtools.mjs",
+    "build:hooks": "microbundle build --raw --cwd hooks && cp ./hooks/dist/hooks.module.js ./hooks/dist/hooks.mjs",
+    "build:test-utils": "microbundle build --raw --cwd test-utils && cp ./test-utils/dist/testUtils.module.js ./test-utils/dist/testUtils.mjs",
+    "build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks && cp ./compat/dist/compat.module.js ./compat/dist/compat.mjs'",
     "dev": "microbundle watch --raw --format cjs",
     "dev:hooks": "microbundle watch --raw --format cjs --cwd hooks",
     "dev:compat": "microbundle watch --raw --format cjs --cwd compat --globals 'preact/hooks=preactHooks'",

--- a/package.json
+++ b/package.json
@@ -9,42 +9,43 @@
   "umd:main": "dist/preact.umd.js",
   "unpkg": "dist/preact.umd.js",
   "source": "src/index.js",
+  "type": "module",
   "exports": {
     ".": {
       "browser": "./dist/preact.module.js",
       "umd": "./dist/preact.umd.js",
-      "import": "./dist/preact.mjs",
+      "import": "./dist/preact.module.js",
       "require": "./dist/preact.js"
     },
     "./compat": {
       "browser": "./compat/dist/compat.module.js",
       "umd": "./compat/dist/compat.umd.js",
       "require": "./compat/dist/compat.js",
-      "import": "./compat/dist/compat.mjs"
+      "import": "./compat/dist/compat.module.js"
     },
     "./debug": {
       "browser": "./debug/dist/debug.module.js",
       "umd": "./debug/dist/debug.umd.js",
       "require": "./debug/dist/debug.js",
-      "import": "./debug/dist/debug.mjs"
+      "import": "./debug/dist/debug.module.js"
     },
     "./devtools": {
       "browser": "./devtools/dist/devtools.module.js",
       "umd": "./devtools/dist/devtools.umd.js",
       "require": "./devtools/dist/devtools.js",
-      "import": "./devtools/dist/devtools.mjs"
+      "import": "./devtools/dist/devtools.module.js"
     },
     "./hooks": {
       "browser": "./hooks/dist/hooks.module.js",
       "umd": "./hooks/dist/hooks.umd.js",
       "require": "./hooks/dist/hooks.js",
-      "import": "./hooks/dist/hooks.mjs"
+      "import": "./hooks/dist/hooks.module.js"
     },
     "./test-utils": {
       "browser": "./test-utils/dist/testUtils.module.js",
       "umd": "./test-utils/dist/testUtils.umd.js",
       "require": "./test-utils/dist/testUtils.js",
-      "import": "./test-utils/dist/testUtils.mjs"
+      "import": "./test-utils/dist/testUtils.module.js"
     },
     "./compat/server": {
       "require": "./compat/server.js"
@@ -60,12 +61,12 @@
   "types": "src/index.d.ts",
   "scripts": {
     "build": "npm-run-all --parallel build:* && cp dist/preact.js dist/preact.min.js",
-    "build:core": "microbundle build --raw && cp ./dist/preact.module.js ./dist/preact.mjs",
-    "build:debug": "microbundle build --raw --cwd debug && cp ./debug/dist/debug.module.js ./debug/dist/debug.mjs",
-    "build:devtools": "microbundle build --raw --cwd devtools && cp ./devtools/dist/devtools.module.js ./devtools/dist/devtools.mjs",
-    "build:hooks": "microbundle build --raw --cwd hooks && cp ./hooks/dist/hooks.module.js ./hooks/dist/hooks.mjs",
-    "build:test-utils": "microbundle build --raw --cwd test-utils && cp ./test-utils/dist/testUtils.module.js ./test-utils/dist/testUtils.mjs",
-    "build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks && cp ./compat/dist/compat.module.js ./compat/dist/compat.mjs'",
+    "build:core": "microbundle build --raw",
+    "build:debug": "microbundle build --raw --cwd debug",
+    "build:devtools": "microbundle build --raw --cwd devtools",
+    "build:hooks": "microbundle build --raw --cwd hooks",
+    "build:test-utils": "microbundle build --raw --cwd test-utils",
+    "build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks'",
     "dev": "microbundle watch --raw --format cjs",
     "dev:hooks": "microbundle watch --raw --format cjs --cwd hooks",
     "dev:compat": "microbundle watch --raw --format cjs --cwd compat --globals 'preact/hooks=preactHooks'",


### PR DESCRIPTION
In node v13 we either need to end our modular file in `.mjs` or have a `module: true` entry in our package json to resolve as a module