### PR TITLE
Add support for context displayName

### DIFF
--- a/mangle.json
+++ b/mangle.json
@@ -53,6 +53,7 @@
       "$_globalContext": "__n",
       "$_defaultValue": "__",
       "$_id": "__c",
+      "$_contextRef": "__",
       "$_parentDom": "__P",
       "$_prevState": "__u",
       "$_root": "__",

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -44,5 +44,12 @@ export function createContext(defaultValue) {
 
 	context.Consumer.contextType = context;
 
+	// Devtools needs access to the context object when it
+	// encounters a Provider. This is necessary to support
+	// setting `displayName` on the context object instead
+	// of on the component itself. See:
+	// https://reactjs.org/docs/context.html#contextdisplayname
+	context.Provider._contextRef = context;
+
 	return context;
 }


### PR DESCRIPTION
React supports setting a `displayName` directly on the context object instead of on the `Provider` or `Consumer` component.

It's best explained with the example from their docs:

```jsx
const MyContext = createContext(/* some value */);
MyContext.displayName = 'MyDisplayName';

<MyContext.Provider> // "MyDisplayName.Provider" in DevTools
<MyContext.Consumer> // "MyDisplayName.Consumer" in DevTools
```

I was able to make that work for `Consumer` components, because they have a reference to the context object via `contextType`. But `Provider`s don't have any way to retrieve the corresponding object, making this feature impossible. This PR adds a way for the Provider to get a hold of the original context object.

React docs: https://reactjs.org/docs/context.html#contextdisplayname
PR against devtools: https://github.com/preactjs/preact-devtools/pull/119