### PR TITLE
Root cause fix for #2455

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -362,10 +362,12 @@ function diffElementNodes(
 
 		diffProps(dom, newProps, oldProps, isSvg, isHydrating);
 
-		newVNode._children = newVNode.props.children;
-
 		// If the new vnode didn't have dangerouslySetInnerHTML, diff its children
-		if (!newHtml) {
+		if (newHtml) {
+			newVNode._children = [];
+		}
+		else {
+			newVNode._children = newVNode.props.children;
 			diffChildren(
 				dom,
 				newVNode,


### PR DESCRIPTION
Don't assign vnode._children to unnormalized value in the codepath for dangerouslySetInnerHTML.

@JoviDeCroock I targeted this at your PR so it has the same test.