### PR TITLE
fix strict-equality with forced updates

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -122,12 +122,15 @@ export function diff(
 				if (
 					(!c._force &&
 						c.shouldComponentUpdate != null &&
-						c.shouldComponentUpdate(
-							newProps,
-							c._nextState,
-							componentContext
-						) === false) ||
-					(newVNode._original === oldVNode._original && !c._processingException)
+							c.shouldComponentUpdate(
+								newProps,
+								c._nextState,
+								componentContext
+							) === false) ||
+					(newVNode._original === oldVNode._original &&
+						!c._processingException &&
+						(!oldVNode._parent._component ||
+							!oldVNode._parent._component._force))
 				) {
 					c.props = newProps;
 					c.state = c._nextState;
@@ -212,7 +215,8 @@ export function diff(
 			c._force = false;
 		} else if (
 			excessDomChildren == null &&
-			newVNode._original === oldVNode._original
+			newVNode._original === oldVNode._original &&
+			(!oldVNode._parent._component || !oldVNode._parent._component._force)
 		) {
 			newVNode._children = oldVNode._children;
 			newVNode._dom = oldVNode._dom;

--- a/test/browser/lifecycles/shouldComponentUpdate.test.js
+++ b/test/browser/lifecycles/shouldComponentUpdate.test.js
@@ -764,4 +764,36 @@ describe('Lifecycle methods', () => {
 		rerender();
 		expect(scratch.innerHTML).to.equal('<p>bar</p>');
 	});
+
+	it('should support nested update with strict-equal vnodes (forceUpdate)', () => {
+		let force,
+			setState,
+			i = 0;
+
+		class Wrapper extends Component {
+			render() {
+				force = this.forceUpdate.bind(this);
+				setState = this.setState.bind(this);
+				return this.props.children;
+			}
+		}
+
+		const Child = () => <p>{++i}</p>;
+		const App = () => (
+			<Wrapper>
+				<Child />
+			</Wrapper>
+		);
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal('<p>1</p>');
+
+		setState({ i: false });
+		rerender();
+		expect(scratch.innerHTML).to.equal('<p>1</p>');
+
+		force();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<p>2</p>');
+	});
 });


### PR DESCRIPTION
When we are doing a forced update we should force the children to rerender, this can be done by checking if the oldVNode._component has a force flag to true since we  reset this on the newVNode.component.