### PR TITLE
Account for defaultProps when wrapping components with memo [fixes #2443]

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -83,10 +83,13 @@ declare namespace React {
 		isPureReactComponent: boolean;
 	}
 
-	export function memo<P = {}>(
-		component: preact.FunctionalComponent<P>,
-		comparer?: (prev: P, next: P) => boolean
-	): preact.FunctionComponent<P>;
+	export function memo<C extends preact.FunctionalComponent<any>>(
+		component: C,
+		comparer?: (
+			prev: preact.ComponentProps<C>,
+			next: preact.ComponentProps<C>
+		) => boolean
+	): C;
 
 	export interface ForwardFn<P = {}, T = any> {
 		(props: P, ref: Ref<T>): preact.ComponentChild;

--- a/compat/test/ts/memo.tsx
+++ b/compat/test/ts/memo.tsx
@@ -1,0 +1,40 @@
+import * as React from '../../src';
+
+function ExpectType<T>(v: T) {} // type assertion helper
+
+interface MemoProps {
+	required: string;
+	optional?: string;
+	defaulted: string;
+}
+
+const ReadonlyBaseComponent = (props: Readonly<MemoProps>) => (
+	<div>{props.required + props.optional + props.defaulted}</div>
+);
+ReadonlyBaseComponent.defaultProps = { defaulted: '' };
+
+const BaseComponent = (props: MemoProps) => (
+	<div>{props.required + props.optional + props.defaulted}</div>
+);
+BaseComponent.defaultProps = { defaulted: '' };
+
+// memo for readonly component with default comparison
+const MemoedReadonlyComponent = React.memo(ReadonlyBaseComponent);
+ExpectType<React.FunctionComponent<MemoProps>>(MemoedReadonlyComponent);
+export const memoedReadonlyComponent = (
+	<MemoedReadonlyComponent required="hi" />
+);
+
+// memo for non-readonly component with default comparison
+const MemoedComponent = React.memo(BaseComponent);
+ExpectType<React.FunctionComponent<MemoProps>>(MemoedComponent);
+export const memoedComponent = <MemoedComponent required="hi" />;
+
+// memo with custom comparison
+const CustomMemoedComponent = React.memo(BaseComponent, (a, b) => {
+	ExpectType<MemoProps>(a);
+	ExpectType<MemoProps>(b);
+	return a.required === b.required;
+});
+ExpectType<React.FunctionComponent<MemoProps>>(CustomMemoedComponent);
+export const customMemoedComponent = <CustomMemoedComponent required="hi" />;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -69,12 +69,17 @@ declare namespace preact {
 		};
 	}
 
-	type RenderableProps<P, RefType = any> = Readonly<
-		P & Attributes & { children?: ComponentChildren; ref?: Ref<RefType> }
-	>;
+	type RenderableProps<P, RefType = any> = P &
+		Readonly<Attributes & { children?: ComponentChildren; ref?: Ref<RefType> }>;
 
 	type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
 	type ComponentFactory<P = {}> = ComponentType<P>;
+
+	type ComponentProps<C extends ComponentType<any>> = C extends ComponentType<
+		infer P
+	>
+		? P
+		: never;
 
 	interface FunctionComponent<P = {}> {
 		(props: RenderableProps<P>, context?: any): VNode<any> | null;


### PR DESCRIPTION
Implements the suggestions in #2443 and adds tests.

I didn't see any explicit patterns for type-based tests so I introduced `ExpectType` for this specific set of tests.