### PR TITLE
(fix) - circular vnode ref

### DIFF
--- a/src/create-element.js
+++ b/src/create-element.js
@@ -80,7 +80,6 @@ export function createVNode(type, props, key, ref, original) {
 
 	Object.defineProperty(vnode, '_original', {
 		value: original || vnode,
-		enumerable: false,
 		writable: true
 	});
 	if (options.vnode) options.vnode(vnode);

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -78,6 +78,10 @@ export function createVNode(type, props, key, ref, original) {
 		constructor: undefined
 	};
 
+	// We're setting this as non-enumberable (+writeable)
+	// because we need to overwrite this value sometimes and
+	// because this can induce circular references on _children and
+	// for testing frameworks traversing the vnodes.
 	Object.defineProperty(vnode, '_original', {
 		value: original || vnode,
 		writable: true

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -80,10 +80,8 @@ export function createVNode(type, props, key, ref, original) {
 
 	Object.defineProperty(vnode, '_original', {
 		value: original || vnode,
-		enumerable: false,
-		writable: true
+		enumerable: false
 	});
-
 	if (options.vnode) options.vnode(vnode);
 
 	return vnode;

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -80,7 +80,8 @@ export function createVNode(type, props, key, ref, original) {
 
 	Object.defineProperty(vnode, '_original', {
 		value: original || vnode,
-		enumerable: false
+		enumerable: false,
+		writable: true
 	});
 	if (options.vnode) options.vnode(vnode);
 

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -75,11 +75,15 @@ export function createVNode(type, props, key, ref, original) {
 		// a _nextDom that has been set to `null`
 		_nextDom: undefined,
 		_component: null,
-		constructor: undefined,
-		_original: original
+		constructor: undefined
 	};
 
-	if (original == null) vnode._original = vnode;
+	Object.defineProperty(vnode, '_original', {
+		value: original || vnode,
+		enumerable: false,
+		writable: true
+	});
+
 	if (options.vnode) options.vnode(vnode);
 
 	return vnode;

--- a/test/browser/createElement.production.test.js
+++ b/test/browser/createElement.production.test.js
@@ -1,0 +1,8 @@
+import { h } from 'preact';
+
+describe('createElement production build', () => {
+	it('should produce a correct structure', () => {
+		const el = h('div', null, h('span', null), h('br', null));
+		expect(() => JSON.stringify(el)).to.not.throw();
+	});
+});


### PR DESCRIPTION
We've been hearing some issues with circular refs from testing frameworks and `react-fast-compare`. This is an attempt to solving these