### PR TITLE
(fix) - normalize props on cloneElement

### DIFF
--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -12,9 +12,14 @@ import { createVNode } from './create-element';
 export function cloneElement(vnode, props) {
 	props = assign(assign({}, vnode.props), props);
 	if (arguments.length > 2) props.children = EMPTY_ARR.slice.call(arguments, 2);
+	let normalizedProps = {};
+	for (const i in props) {
+		if (i !== 'key' && i !== 'ref') normalizedProps[i] = props[i];
+	}
+
 	return createVNode(
 		vnode.type,
-		props,
+		normalizedProps,
 		props.key || vnode.key,
 		props.ref || vnode.ref,
 		null

--- a/test/browser/cloneElement.test.js
+++ b/test/browser/cloneElement.test.js
@@ -1,4 +1,4 @@
-import { createElement, cloneElement } from 'preact';
+import { createElement, cloneElement, createRef } from 'preact';
 
 /** @jsx createElement */
 
@@ -60,5 +60,11 @@ describe('cloneElement', () => {
 
 		clone = cloneElement(instance, { ref: b });
 		expect(clone.ref).to.equal(b);
+	});
+
+	it('should normalize props', () => {
+		const div = <div>hello</div>;
+		const clone = cloneElement(div, { ref: createRef() });
+		expect(clone.props.ref).to.equal(undefined);
 	});
 });

--- a/test/browser/cloneElement.test.js
+++ b/test/browser/cloneElement.test.js
@@ -62,9 +62,15 @@ describe('cloneElement', () => {
 		expect(clone.ref).to.equal(b);
 	});
 
-	it('should normalize props', () => {
+	it('should normalize props (ref)', () => {
 		const div = <div>hello</div>;
 		const clone = cloneElement(div, { ref: createRef() });
 		expect(clone.props.ref).to.equal(undefined);
+	});
+
+	it('should normalize props (key)', () => {
+		const div = <div>hello</div>;
+		const clone = cloneElement(div, { key: 'myKey' });
+		expect(clone.props.key).to.equal(undefined);
 	});
 });


### PR DESCRIPTION
Fixes: https://github.com/preactjs/preact/issues/2468

This normalizes the props object that can optionally be passed as a second argument to `cloneElement` just like we do on the regular `createElement`.

CC @vaneenige 