### PR TITLE
Upgrade devtools adapter

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -1,9 +1,10 @@
-import { options, Fragment } from 'preact';
+import { options, Fragment, Component } from 'preact';
 
 export function initDevTools() {
 	if (typeof window != 'undefined' && window.__PREACT_DEVTOOLS__) {
-		window.__PREACT_DEVTOOLS__.attachPreact('10.0.5', options, {
-			Fragment
+		window.__PREACT_DEVTOOLS__.attachPreact('10.4.1', options, {
+			Fragment,
+			Component
 		});
 	}
 }


### PR DESCRIPTION
The devtools needs to patch setState to be able to detect the previously rendered state. This is necessary to properly display why a node did render.

See: https://github.com/preactjs/preact-devtools/pull/138