### PR TITLE
Run benchmarks with v8, master, and local builds

### DIFF
--- a/benches/scripts/config.js
+++ b/benches/scripts/config.js
@@ -47,9 +47,9 @@ async function generateConfig(benchPath, options) {
 			name,
 			url,
 			packageVersions: {
-				label: 'preact-v10',
+				label: 'preact-master',
 				dependencies: {
-					preact: '^10.4.0'
+					preact: 'github:preactjs/preact#master'
 				}
 			}
 		},


### PR DESCRIPTION
Per feedback in #2462 updating benchmarks to run with v8, master, and local builds of Preact.