### PR TITLE
Reduce number of builds in actions

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -26,7 +26,6 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
     - run: npm ci
-    - run: npm run build
 
   test:
     name: Test

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -25,7 +25,6 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
     - run: npm ci
-    - run: npm run build
 
   test:
     name: Test

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "dev": "microbundle watch --raw --format cjs",
     "dev:hooks": "microbundle watch --raw --format cjs --cwd hooks",
     "dev:compat": "microbundle watch --raw --format cjs --cwd compat --globals 'preact/hooks=preactHooks'",
-    "test": "npm-run-all lint build test:unit",
+    "test": "npm-run-all build lint test:unit",
     "test:unit": "run-p test:mocha test:karma:minify test:ts",
     "test:ts": "run-p test:ts:*",
     "test:ts:core": "tsc -p test/ts/ && mocha --require \"@babel/register\" test/ts/**/*-test.js",


### PR DESCRIPTION
With the new `prepare` script, our current actions setup builds Preact 4 times:

Build Job:

1. The build job runs `npm ci` which builds as part of the `prepare` script
2. The build job then runs `npm run build`

Test Job:

3. The test job runs `npm ci` which builds as part of the `prepare` script
4. The test job then runs `npm test` which runs `npm run build`

Since this is redundant I've removed the `npm run build` step from the build jobs. However I left the extra build in test for now. I thought this might still be useful to support the development scenario where you make local changes and then run `npm test` to validate them. If `npm test` doesn't do a build, then developers need to update their habits to also do a build before running `npm test`, or else `npm test` will test the previous build without their changes.

Let me know what you think!