### PR TITLE
make warn effectively warn instead of throwing

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -232,10 +232,10 @@ export function initDebug() {
 
 	const warn = (property, err) => ({
 		get() {
-			throw new Error(`getting vnode.${property} is deprecated, ${err}`);
+			console.warn(`getting vnode.${property} is deprecated, ${err}`);
 		},
 		set() {
-			throw new Error(`setting vnode.${property} is not allowed, ${err}`);
+			console.warn(`setting vnode.${property} is not allowed, ${err}`);
 		}
 	});
 

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -119,15 +119,23 @@ describe('debug', () => {
 
 	it('should throw errors when accessing certain attributes', () => {
 		const vnode = h('div', null);
-		expect(() => vnode).to.not.throw();
-		expect(() => vnode.attributes).to.throw(/use vnode.props/);
-		expect(() => vnode.nodeName).to.throw(/use vnode.type/);
-		expect(() => vnode.children).to.throw(/use vnode.props.children/);
-		expect(() => (vnode.attributes = {})).to.throw(/use vnode.props/);
-		expect(() => (vnode.nodeName = 'test')).to.throw(/use vnode.type/);
-		expect(() => (vnode.children = [<div />])).to.throw(
-			/use vnode.props.children/
-		);
+		vnode;
+		vnode.attributes;
+		expect(console.warn).to.be.calledOnce;
+		expect(console.warn.args[0]).to.match(/use vnode.props/);
+		vnode.nodeName;
+		expect(console.warn).to.be.calledTwice;
+		expect(console.warn.args[1]).to.match(/use vnode.type/);
+		vnode.children;
+		expect(console.warn).to.be.calledThrice;
+		expect(console.warn.args[2]).to.match(/use vnode.props.children/);
+
+		vnode.attributes = {};
+		expect(console.warn.args[3]).to.match(/use vnode.props/);
+		vnode.nodeName = '';
+		expect(console.warn.args[4]).to.match(/use vnode.type/);
+		vnode.children = [];
+		expect(console.warn.args[5]).to.match(/use vnode.props.children/);
 	});
 
 	it('should warn when calling setState inside the constructor', () => {

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -117,7 +117,7 @@ describe('debug', () => {
 		expect(vnode.props.__self).to.be.undefined;
 	});
 
-	it('should throw errors when accessing certain attributes', () => {
+	it('should warn when accessing certain attributes', () => {
 		const vnode = h('div', null);
 		vnode;
 		vnode.attributes;


### PR DESCRIPTION
Relates to: https://github.com/preactjs/preact/issues/2445

Our factory function is called warn, let's warn instead of throw