### PR TITLE
Add support for hooks inspection via devtools

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -222,12 +222,12 @@ export function initDebug() {
 		if (oldBeforeDiff) oldBeforeDiff(vnode);
 	};
 
-	options._hook = comp => {
+	options._hook = (comp, index, type) => {
 		if (!comp) {
 			throw new Error('Hook can only be invoked from render methods.');
 		}
 
-		if (oldHook) oldHook(comp);
+		if (oldHook) oldHook(comp, index, type);
 	};
 
 	const warn = (property, err) => ({

--- a/hooks/mangle.json
+++ b/hooks/mangle.json
@@ -46,6 +46,7 @@
       "$_pendingError": "__E",
       "$_processingException": "__",
       "$_globalContext": "__n",
+      "$_context": "__c",
       "$_defaultValue": "__",
       "$_id": "__c",
       "$_parentDom": "__P",
@@ -57,7 +58,8 @@
       "$_hook": "__h",
       "$_catchError": "__e",
       "$_unmount": "_e",
-      "$_owner": "__o"
+      "$_owner": "__o",
+      "$_skipEffects": "__s"
     }
   }
 }

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -229,9 +229,13 @@ export function useCallback(callback, args) {
  */
 export function useContext(context) {
 	const provider = currentComponent.context[context._id];
-	// We could skip this, but we need to call getHookState here, make
-	// the devtools aware of the hook.
+	// We could skip this call here, but than we'd not call
+	// `options._hook`. We need to do that in order to make
+	// the devtools aware of this hook.
 	const state = getHookState(currentIndex++, 9);
+	// The devtools needs access to the context object to
+	// be able to pull of the default value when no provider
+	// is present in the tree.
 	state._context = context;
 	if (!provider) return context._defaultValue;
 	// This is probably not safe to convert to "!"

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -6,6 +6,9 @@ let currentIndex;
 /** @type {import('./internal').Component} */
 let currentComponent;
 
+/** @type {number} */
+let currentHook = 0;
+
 /** @type {Array<import('./internal').Component>} */
 let afterPaintEffects = [];
 
@@ -82,10 +85,15 @@ options.unmount = vnode => {
 /**
  * Get a hook's state from the currentComponent
  * @param {number} index The index of the hook to get
+ * @param {number} type The index of the hook to get
  * @returns {import('./internal').HookState}
  */
-function getHookState(index) {
-	if (options._hook) options._hook(currentComponent);
+function getHookState(index, type) {
+	if (options._hook) {
+		options._hook(currentComponent, index, currentHook || type);
+	}
+	currentHook = 0;
+
 	// Largely inspired by:
 	// * https://github.com/michael-klein/funcy.js/blob/f6be73468e6ec46b0ff5aa3cc4c9baf72a29025a/src/hooks/core_hooks.mjs
 	// * https://github.com/michael-klein/funcy.js/blob/650beaa58c43c33a74820a3c98b3c7079cf2e333/src/renderer.mjs
@@ -93,7 +101,10 @@ function getHookState(index) {
 	// * https://codesandbox.io/s/mnox05qp8
 	const hooks =
 		currentComponent.__hooks ||
-		(currentComponent.__hooks = { _list: [], _pendingEffects: [] });
+		(currentComponent.__hooks = {
+			_list: [],
+			_pendingEffects: []
+		});
 
 	if (index >= hooks._list.length) {
 		hooks._list.push({});
@@ -105,6 +116,7 @@ function getHookState(index) {
  * @param {import('./index').StateUpdater<any>} initialState
  */
 export function useState(initialState) {
+	currentHook = 1;
 	return useReducer(invokeOrReturn, initialState);
 }
 
@@ -116,7 +128,7 @@ export function useState(initialState) {
  */
 export function useReducer(reducer, initialState, init) {
 	/** @type {import('./internal').ReducerHookState} */
-	const hookState = getHookState(currentIndex++);
+	const hookState = getHookState(currentIndex++, 2);
 	if (!hookState._component) {
 		hookState._component = currentComponent;
 
@@ -142,8 +154,8 @@ export function useReducer(reducer, initialState, init) {
  */
 export function useEffect(callback, args) {
 	/** @type {import('./internal').EffectHookState} */
-	const state = getHookState(currentIndex++);
-	if (argsChanged(state._args, args)) {
+	const state = getHookState(currentIndex++, 3);
+	if (!options._skipEffects && argsChanged(state._args, args)) {
 		state._value = callback;
 		state._args = args;
 
@@ -157,8 +169,8 @@ export function useEffect(callback, args) {
  */
 export function useLayoutEffect(callback, args) {
 	/** @type {import('./internal').EffectHookState} */
-	const state = getHookState(currentIndex++);
-	if (argsChanged(state._args, args)) {
+	const state = getHookState(currentIndex++, 4);
+	if (!options._skipEffects && argsChanged(state._args, args)) {
 		state._value = callback;
 		state._args = args;
 
@@ -167,6 +179,7 @@ export function useLayoutEffect(callback, args) {
 }
 
 export function useRef(initialValue) {
+	currentHook = 5;
 	return useMemo(() => ({ current: initialValue }), []);
 }
 
@@ -176,6 +189,7 @@ export function useRef(initialValue) {
  * @param {any[]} args
  */
 export function useImperativeHandle(ref, createHandle, args) {
+	currentHook = 6;
 	useLayoutEffect(
 		() => {
 			if (typeof ref == 'function') ref(createHandle());
@@ -191,7 +205,7 @@ export function useImperativeHandle(ref, createHandle, args) {
  */
 export function useMemo(factory, args) {
 	/** @type {import('./internal').MemoHookState} */
-	const state = getHookState(currentIndex++);
+	const state = getHookState(currentIndex++, 7);
 	if (argsChanged(state._args, args)) {
 		state._args = args;
 		state._factory = factory;
@@ -206,6 +220,7 @@ export function useMemo(factory, args) {
  * @param {any[]} args
  */
 export function useCallback(callback, args) {
+	currentHook = 8;
 	return useMemo(() => callback, args);
 }
 
@@ -214,8 +229,11 @@ export function useCallback(callback, args) {
  */
 export function useContext(context) {
 	const provider = currentComponent.context[context._id];
+	// We could skip this, but we need to call getHookState here, make
+	// the devtools aware of the hook.
+	const state = getHookState(currentIndex++, 9);
+	state._context = context;
 	if (!provider) return context._defaultValue;
-	const state = getHookState(currentIndex++);
 	// This is probably not safe to convert to "!"
 	if (state._value == null) {
 		state._value = true;
@@ -235,7 +253,7 @@ export function useDebugValue(value, formatter) {
 }
 
 export function useErrorBoundary(cb) {
-	const state = getHookState(currentIndex++);
+	const state = getHookState(currentIndex++, 10);
 	const errState = useState();
 	state._value = cb;
 	if (!currentComponent.componentDidCatch) {

--- a/hooks/test/browser/hooks.options.test.js
+++ b/hooks/test/browser/hooks.options.test.js
@@ -1,13 +1,25 @@
 import {
 	afterDiffSpy,
 	beforeRenderSpy,
-	unmountSpy
+	unmountSpy,
+	hookSpy
 } from '../../../test/_util/optionSpies';
 
-import { setupRerender } from 'preact/test-utils';
-import { createElement, render } from 'preact';
+import { setupRerender, act } from 'preact/test-utils';
+import { createElement, render, createContext, options } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { useState } from 'preact/hooks';
+import {
+	useState,
+	useReducer,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useImperativeHandle,
+	useMemo,
+	useCallback,
+	useContext,
+	useErrorBoundary
+} from 'preact/hooks';
 
 /** @jsx createElement */
 
@@ -28,6 +40,7 @@ describe('hook options', () => {
 		afterDiffSpy.resetHistory();
 		unmountSpy.resetHistory();
 		beforeRenderSpy.resetHistory();
+		hookSpy.resetHistory();
 	});
 
 	afterEach(() => {
@@ -62,5 +75,73 @@ describe('hook options', () => {
 		render(null, scratch);
 
 		expect(unmountSpy).to.have.been.called;
+	});
+
+	it('should detect hooks', () => {
+		const USE_STATE = 1;
+		const USE_REDUCER = 2;
+		const USE_EFFECT = 3;
+		const USE_LAYOUT_EFFECT = 4;
+		const USE_REF = 5;
+		const USE_IMPERATIVE_HANDLE = 6;
+		const USE_MEMO = 7;
+		const USE_CALLBACK = 8;
+		const USE_CONTEXT = 9;
+		const USE_ERROR_BOUNDARY = 10;
+
+		const Ctx = createContext(null);
+
+		function App() {
+			useState(0);
+			useReducer(x => x, 0);
+			useEffect(() => null, []);
+			useLayoutEffect(() => null, []);
+			const ref = useRef(null);
+			useImperativeHandle(ref, () => null);
+			useMemo(() => null, []);
+			useCallback(() => null, []);
+			useContext(Ctx);
+			useErrorBoundary(() => null);
+		}
+
+		render(
+			<Ctx.Provider value="a">
+				<App />
+			</Ctx.Provider>,
+			scratch
+		);
+
+		expect(hookSpy.args.map(arg => [arg[1], arg[2]])).to.deep.equal([
+			[0, USE_STATE],
+			[1, USE_REDUCER],
+			[2, USE_EFFECT],
+			[3, USE_LAYOUT_EFFECT],
+			[4, USE_REF],
+			[5, USE_IMPERATIVE_HANDLE],
+			[6, USE_MEMO],
+			[7, USE_CALLBACK],
+			[8, USE_CONTEXT],
+			[9, USE_ERROR_BOUNDARY],
+			// Belongs to useErrorBoundary that uses multiple native hooks.
+			[10, USE_STATE]
+		]);
+	});
+
+	it('should skip effect hooks', () => {
+		options._skipEffects = true;
+		const spy = sinon.spy();
+		function App() {
+			useEffect(spy, []);
+			useLayoutEffect(spy, []);
+			return null;
+		}
+
+		act(() => {
+			render(<App />, scratch);
+		});
+
+		expect(spy.callCount).to.equal(0);
+
+		options._skipEffects = false;
 	});
 });

--- a/hooks/test/browser/hooks.options.test.js
+++ b/hooks/test/browser/hooks.options.test.js
@@ -127,21 +127,28 @@ describe('hook options', () => {
 		]);
 	});
 
-	it('should skip effect hooks', () => {
-		options._skipEffects = true;
-		const spy = sinon.spy();
-		function App() {
-			useEffect(spy, []);
-			useLayoutEffect(spy, []);
-			return null;
-		}
-
-		act(() => {
-			render(<App />, scratch);
+	describe('Effects', () => {
+		beforeEach(() => {
+			options._skipEffects = options.__s = true;
 		});
 
-		expect(spy.callCount).to.equal(0);
+		afterEach(() => {
+			options._skipEffects = options.__s = false;
+		});
 
-		options._skipEffects = false;
+		it('should skip effect hooks', () => {
+			const spy = sinon.spy();
+			function App() {
+				useEffect(spy, []);
+				useLayoutEffect(spy, []);
+				return null;
+			}
+
+			act(() => {
+				render(<App />, scratch);
+			});
+
+			expect(spy.callCount).to.equal(0);
+		});
 	});
 });

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -1,5 +1,18 @@
 import * as preact from './index';
 
+export enum HookType {
+	useState = 1,
+	useReducer = 2,
+	useEffect = 3,
+	useLayoutEffect = 4,
+	useRef = 5,
+	useImperativeHandle = 6,
+	useMemo = 7,
+	useCallback = 8,
+	useContext = 9,
+	useErrorBoundary = 10
+}
+
 export interface Options extends preact.Options {
 	/** Attach a hook that is invoked before render, mainly to check the arguments. */
 	_root?(
@@ -13,7 +26,9 @@ export interface Options extends preact.Options {
 	/** Attach a hook that is invoked before a vnode has rendered. */
 	_render?(vnode: VNode): void;
 	/** Attach a hook that is invoked before a hook's state is queried. */
-	_hook?(component: Component): void;
+	_hook?(component: Component, index: number, type: HookType): void;
+	/** Bypass effect execution. Currenty only used in devtools for hooks inspection */
+	_skipEffects?: boolean;
 	/** Attach a hook that is invoked after an error is caught in a component but before calling lifecycle hooks */
 	_catchError(error: any, vnode: VNode, oldVNode: VNode | undefined): void;
 }

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -10,7 +10,9 @@ export enum HookType {
 	useMemo = 7,
 	useCallback = 8,
 	useContext = 9,
-	useErrorBoundary = 10
+	useErrorBoundary = 10,
+	// Not a real hook, but the devtools treat is as such
+	useDebugvalue = 11
 }
 
 export interface Options extends preact.Options {


### PR DESCRIPTION
This PR makes it possible to inspect a components hook state which is needed for the devtools (https://github.com/preactjs/preact-devtools/pull/143).

The way the devtools work is that they inspect a node lazily when the user selects it in the elements panel and not during rendering. So we need to guess which piece of state belongs to which hook at a later point. To do that I've introduced numbers as unique ids for each hook function.

Some of our hooks leverage other hooks to keep our size small and this PR will detect that and will pick the topmost "native" hook. So if `useState` calls `useReducer` internally, the hook will be identified as `useState` no matter what.

Originally I played around with storing that information on the `_hooks` property of a component, but that turns out to be a lot bigger than just passing it as an additional argument to `options._hook`. Besides the type, the callsite index of the current hooks is very relevant for the devtools to display them in the correct order.

To retrieve any custom hooks we need to do some awkward re-rendering of the inspected component. Custom hooks are just plain JavaScript function and we can be only made aware of those by inspecting the stack trace via the `Error` object.

But simply re-rendering poses another issue in that we need to make sure that it doesn't change the state of the current app in any way. We assume that the render function is pure and leverage a new `options._skipEffects` flag to bypass all scheduled effects.

For a longer description of the approach used in the devtools check this comment out: https://github.com/preactjs/preact-devtools/issues/52#issuecomment-615066128

![Screenshot from 2020-04-19 09-33-13](https://user-images.githubusercontent.com/1062408/79682247-dc9c0c00-8220-11ea-9d5d-164e1dbe11dc.png)
