### PR TITLE
Correctly handle child insertions

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -34,7 +34,13 @@ export function diffChildren(
 	oldDom,
 	isHydrating
 ) {
-	let i, j, oldVNode, newDom, sibDom, firstChildDom, refs;
+	let i,
+		j = 0,
+		oldVNode,
+		newDom,
+		sibDom,
+		firstChildDom,
+		refs;
 
 	// This is a compression of oldParentVNode!=null && oldParentVNode != EMPTY_OBJ && oldParentVNode._children || EMPTY_ARR
 	// as EMPTY_OBJ._children should be `undefined`.
@@ -64,12 +70,11 @@ export function diffChildren(
 		for (i = 0; i < newParentVNode._children.length; i++) {
 			if (
 				newParentVNode._children[i] &&
-				oldChildren[i - insertedIndices.length] &&
-				(oldChildren[i - insertedIndices.length].type !==
-					newParentVNode._children[i].type ||
-					oldChildren[i - insertedIndices.length].key !==
-						newParentVNode._children[i].key)
+				oldChildren[i - j] &&
+				(oldChildren[i - j].type !== newParentVNode._children[i].type ||
+					oldChildren[i - j].key !== newParentVNode._children[i].key)
 			) {
+				j++;
 				insertedIndices.push(i);
 			}
 		}

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -62,12 +62,13 @@ export function diffChildren(
 		newParentVNode._children.length > oldChildrenLength
 	) {
 		for (i = 0; i < newParentVNode._children.length; i++) {
-			const child = newParentVNode._children[i];
 			if (
-				child &&
+				newParentVNode._children[i] &&
 				oldChildren[i - insertedIndices.length] &&
-				(oldChildren[i - insertedIndices.length].type !== child.type ||
-					oldChildren[i - insertedIndices.length].key !== child.key)
+				(oldChildren[i - insertedIndices.length].type !==
+					newParentVNode._children[i].type ||
+					oldChildren[i - insertedIndices.length].key !==
+						newParentVNode._children[i].key)
 			) {
 				insertedIndices.push(i);
 			}

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -56,6 +56,24 @@ export function diffChildren(
 		}
 	}
 
+	const insertedIndices = [];
+	if (
+		Array.isArray(newParentVNode._children) &&
+		newParentVNode._children.length > oldChildrenLength
+	) {
+		for (i = 0; i < newParentVNode._children.length; i++) {
+			const child = newParentVNode._children[i];
+			if (
+				child &&
+				oldChildren[i - insertedIndices.length] &&
+				(oldChildren[i - insertedIndices.length].type !== child.type ||
+					oldChildren[i - insertedIndices.length].key !== child.key)
+			) {
+				insertedIndices.push(i);
+			}
+		}
+	}
+
 	i = 0;
 	newParentVNode._children = toChildArray(
 		newParentVNode._children,
@@ -77,6 +95,9 @@ export function diffChildren(
 						childVNode.type === oldVNode.type)
 				) {
 					oldChildren[i] = undefined;
+				} else if (insertedIndices.indexOf(i) !== -1) {
+					console.log('in inserted index clause');
+					oldVNode = null;
 				} else {
 					// Either oldVNode === undefined or oldChildrenLength > 0,
 					// so after this loop oldVNode == null or oldVNode is a valid value.

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -96,7 +96,6 @@ export function diffChildren(
 				) {
 					oldChildren[i] = undefined;
 				} else if (insertedIndices.indexOf(i) !== -1) {
-					console.log('in inserted index clause');
 					oldVNode = null;
 				} else {
 					// Either oldVNode === undefined or oldChildrenLength > 0,

--- a/test/browser/focus.test.js
+++ b/test/browser/focus.test.js
@@ -134,7 +134,69 @@ describe('focus', () => {
 		validateFocus(input, 'move from end to middle');
 	});
 
-	it('should maintain focus when adding children around input', () => {
+	it('should maintain focus when adding children around input (unkeyed)', () => {
+		render(
+			<div>
+				<input type="text" />
+			</div>,
+			scratch
+		);
+
+		let input = focusInput();
+		expect(scratch.innerHTML).to.equal(getListHtml([], []));
+
+		render(
+			<div>
+				<span>1</span>
+				<input type="text" />
+			</div>,
+			scratch
+		);
+
+		expect(scratch.innerHTML).to.equal(getListHtml([1], []));
+		validateFocus(input, 'insert sibling before');
+
+		render(
+			<div>
+				<span>1</span>
+				<input type="text" />
+				<span>2</span>
+			</div>,
+			scratch
+		);
+
+		expect(scratch.innerHTML).to.equal(getListHtml([1], [2]));
+		validateFocus(input, 'insert sibling after');
+
+		render(
+			<div>
+				<span>1</span>
+				<input type="text" />
+				<span>2</span>
+				<span>3</span>
+			</div>,
+			scratch
+		);
+
+		expect(scratch.innerHTML).to.equal(getListHtml([1], [2, 3]));
+		validateFocus(input, 'insert sibling after again');
+
+		render(
+			<div>
+				<span>0</span>
+				<span>1</span>
+				<input type="text" />
+				<span>2</span>
+				<span>3</span>
+			</div>,
+			scratch
+		);
+
+		expect(scratch.innerHTML).to.equal(getListHtml([0, 1], [2, 3]));
+		validateFocus(input, 'insert sibling before again');
+	});
+
+	it('should maintain focus when adding children around input (keyed)', () => {
 		render(
 			<List>
 				<Input />

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -1503,7 +1503,7 @@ describe('Fragment', () => {
 		clearLog();
 		render(<Foo condition={true} />, scratch);
 
-		expect(ops).to.deep.equal(['Update Stateful', 'Update Stateful']);
+		expect(ops).to.deep.equal(['Update Stateful']);
 		expect(scratch.innerHTML).to.equal(
 			htmlForTrue,
 			'rendering from false to true'


### PR DESCRIPTION
There is atm one failing test since we removeone "stateful update" so one dom mutation less, this does handle some of the bugs we've been facing with focus loss and too much dom insertions.

Linearly this could check if we are dealing with a removed index, .... I  think this opens the possibility to remove some code.

Improves perf more than https://github.com/preactjs/preact/pull/2478