### PR TITLE
Remove processingException check

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -127,7 +127,7 @@ export function diff(
 							c._nextState,
 							componentContext
 						) === false) ||
-					(newVNode._original === oldVNode._original && !c._processingException)
+					newVNode._original === oldVNode._original
 				) {
 					c.props = newProps;
 					c.state = c._nextState;


### PR DESCRIPTION
Due to the addition of

```
// More info about this here: https://gist.github.com/JoviDeCroock/bec5f2ce93544d2e6070ef8e0036e4e8
if (newVNode._original !== oldVNode._original) c._dirty = false;
```

We can safely ignore `processingException` since we won't stop diffing if the children are still potentially dirty