### PR TITLE
Reduce unnecessary DOM attribute reads

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -345,7 +345,9 @@ function diffElementNodes(
 		// During hydration, props are not diffed at all (including dangerouslySetInnerHTML)
 		// @TODO we should warn in debug mode when props don't match here.
 		if (!isHydrating) {
-			if (oldProps === EMPTY_OBJ) {
+			// But, if we are in a situation where we are using existing DOM (e.g. replaceNode)
+			// we should read the existing DOM attributes to diff them
+			if (excessDomChildren != null) {
 				oldProps = {};
 				for (let i = 0; i < dom.attributes.length; i++) {
 					oldProps[dom.attributes[i].name] = dom.attributes[i].value;

--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -220,6 +220,8 @@ export function teardown(scratch) {
 	if (getLog().length > 0) {
 		clearLog();
 	}
+
+	restoreElementAttributes();
 }
 
 const Foo = () => 'd';
@@ -262,3 +264,29 @@ export const resetAllSpies = obj =>
 			obj[key].resetHistory();
 		}
 	});
+
+let attributesSpy, originalAttributesPropDescriptor;
+
+export function spyOnElementAttributes() {
+	if (!attributesSpy) {
+		originalAttributesPropDescriptor = Object.getOwnPropertyDescriptor(
+			Element.prototype,
+			'attributes'
+		);
+		attributesSpy = sinon.spy(Element.prototype, 'attributes', ['get']);
+	}
+
+	return attributesSpy;
+}
+
+function restoreElementAttributes() {
+	if (originalAttributesPropDescriptor) {
+		// Workaround bug in Sinon where getter/setter spies don't get auto-restored
+		Object.defineProperty(
+			Element.prototype,
+			'attributes',
+			originalAttributesPropDescriptor
+		);
+		attributesSpy = null;
+	}
+}

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -3,7 +3,8 @@ import {
 	setupScratch,
 	teardown,
 	sortAttributes,
-	serializeHtml
+	serializeHtml,
+	spyOnElementAttributes
 } from '../_util/helpers';
 import { ul, li, div } from '../_util/dom';
 import { logCall, clearLog, getLog } from '../_util/logCall';
@@ -11,7 +12,7 @@ import { logCall, clearLog, getLog } from '../_util/logCall';
 /** @jsx createElement */
 
 describe('hydrate()', () => {
-	let scratch;
+	let scratch, attributesSpy;
 
 	const List = ({ children }) => <ul>{children}</ul>;
 	const ListItem = ({ children }) => <li>{children}</li>;
@@ -27,6 +28,7 @@ describe('hydrate()', () => {
 
 	beforeEach(() => {
 		scratch = setupScratch();
+		attributesSpy = spyOnElementAttributes();
 	});
 
 	afterEach(() => {
@@ -129,6 +131,7 @@ describe('hydrate()', () => {
 		clearLog();
 		hydrate(vnode, scratch);
 
+		expect(attributesSpy.get).to.not.have.been.called;
 		expect(serializeHtml(scratch)).to.equal(
 			sortAttributes(
 				'<div><span before-hydrate="test" different-value="a" same-value="foo">Test</span></div>'
@@ -250,6 +253,7 @@ describe('hydrate()', () => {
 		);
 
 		hydrate(preactElement, scratch);
+		expect(attributesSpy.get).to.not.have.been.called;
 		expect(scratch).to.have.property(
 			'innerHTML',
 			'<div><a foo="bar"></a></div>'

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -582,42 +582,6 @@ describe('render()', () => {
 			expect(style.zIndex.toString()).to.equal('');
 		});
 
-		it('should remove existing attributes', () => {
-			const div = document.createElement('div');
-			div.setAttribute('class', 'red');
-			const span = document.createElement('span');
-			const text = document.createTextNode('Hi');
-
-			span.appendChild(text);
-			div.appendChild(span);
-			scratch.appendChild(div);
-
-			const App = () => (
-				<div>
-					<span>Bye</span>
-				</div>
-			);
-
-			render(<App />, scratch);
-			expect(serializeHtml(scratch)).to.equal('<div><span>Bye</span></div>');
-		});
-
-		it('should remove class attributes', () => {
-			const App = props => (
-				<div className={props.class}>
-					<span>Bye</span>
-				</div>
-			);
-
-			render(<App class="hi" />, scratch);
-			expect(scratch.innerHTML).to.equal(
-				'<div class="hi"><span>Bye</span></div>'
-			);
-
-			render(<App />, scratch);
-			expect(serializeHtml(scratch)).to.equal('<div><span>Bye</span></div>');
-		});
-
 		it('should remove old styles', () => {
 			render(<div style={{ color: 'red' }} />, scratch);
 			render(<div style={{ backgroundColor: 'blue' }} />, scratch);
@@ -1562,5 +1526,41 @@ describe('render()', () => {
 		set({ show: false });
 		rerender();
 		expect(scratch.innerHTML).to.equal('');
+	});
+
+	it('should remove existing attributes', () => {
+		const div = document.createElement('div');
+		div.setAttribute('class', 'red');
+		const span = document.createElement('span');
+		const text = document.createTextNode('Hi');
+
+		span.appendChild(text);
+		div.appendChild(span);
+		scratch.appendChild(div);
+
+		const App = () => (
+			<div>
+				<span>Bye</span>
+			</div>
+		);
+
+		render(<App />, scratch);
+		expect(serializeHtml(scratch)).to.equal('<div><span>Bye</span></div>');
+	});
+
+	it('should remove class attributes', () => {
+		const App = props => (
+			<div className={props.class}>
+				<span>Bye</span>
+			</div>
+		);
+
+		render(<App class="hi" />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<div class="hi"><span>Bye</span></div>'
+		);
+
+		render(<App />, scratch);
+		expect(serializeHtml(scratch)).to.equal('<div><span>Bye</span></div>');
 	});
 });

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -8,7 +8,8 @@ import {
 	sortCss,
 	serializeHtml,
 	supportsPassiveEvents,
-	supportsDataList
+	supportsDataList,
+	spyOnElementAttributes
 } from '../_util/helpers';
 import { clearLog, getLog, logCall } from '../_util/logCall';
 
@@ -1528,7 +1529,7 @@ describe('render()', () => {
 		expect(scratch.innerHTML).to.equal('');
 	});
 
-	it('should remove existing attributes', () => {
+	it('should remove attributes on pre-existing DOM', () => {
 		const div = document.createElement('div');
 		div.setAttribute('class', 'red');
 		const span = document.createElement('span');
@@ -1562,5 +1563,31 @@ describe('render()', () => {
 
 		render(<App />, scratch);
 		expect(serializeHtml(scratch)).to.equal('<div><span>Bye</span></div>');
+	});
+
+	it('should not read DOM attributes on render without existing DOM', () => {
+		const attributesSpy = spyOnElementAttributes();
+
+		render(
+			<div id="wrapper">
+				<div id="page1">Page 1</div>
+			</div>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal(
+			'<div id="wrapper"><div id="page1">Page 1</div></div>'
+		);
+		expect(attributesSpy.get).to.not.have.been.called;
+
+		render(
+			<div id="wrapper">
+				<div id="page2">Page 2</div>
+			</div>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal(
+			'<div id="wrapper"><div id="page2">Page 2</div></div>'
+		);
+		expect(attributesSpy.get).to.not.have.been.called;
 	});
 });


### PR DESCRIPTION
I think there are 4 different "modes" of diffing that Preact can be in (ignoring things like suspense for now).

1. **Hydration with existing DOM**: We skip all attribute diffing. Already handled by `!isHydrating` check
2. **Render with existing DOM**: Currently we support calling `render` when the container contains existing DOM. This behavior compares the existing DOM with the specified VNodes including attributes.
3. **ReplaceNode**: Basically the same the number 2, but the user specifies which node in the container to begin the diff with.
4. **Render without existing DOM**: For example, using `preact-router` and rendering an entirely new route client side. Preact creates the DOM from scratch. Because the DOM is created entirely from scratch, there are no attributes to be read.

This PR fixes a bug where the `attributes` property was being read in case 4. Since this is a fairly common situation, I figured skipping the `attributes` read would be beneficial.