### PR TITLE
Remove unnecessary excessDomChildren creation

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -45,7 +45,9 @@ export function render(vnode, parentDom, replaceNode) {
 			? [replaceNode]
 			: oldVNode
 			? null
-			: EMPTY_ARR.slice.call(parentDom.childNodes),
+			: parentDom.childNodes.length
+			? EMPTY_ARR.slice.call(parentDom.childNodes)
+			: null,
 		commitQueue,
 		replaceNode || EMPTY_OBJ,
 		isHydrating


### PR DESCRIPTION
Only create the `excessDomChildren` array if there are no `childNodes` in the `parentDom`. If there aren't children, then skip creating array. This change will allow the diff algorithm to skip a lot of empty `for` loops when `excessDomChildren` would be an empty array.