### PR TITLE
Fix creating multiple roots from useEffect

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -336,7 +336,9 @@ function afterPaint(newQueueLength) {
  * @param {import('./internal').EffectHookState} hook
  */
 function invokeCleanup(hook) {
+	const comp = currentComponent;
 	if (hook._cleanup) hook._cleanup();
+	currentComponent = comp;
 }
 
 /**
@@ -344,8 +346,10 @@ function invokeCleanup(hook) {
  * @param {import('./internal').EffectHookState} hook
  */
 function invokeEffect(hook) {
+	const comp = currentComponent;
 	const result = hook._value();
 	if (typeof result == 'function') hook._cleanup = result;
+	currentComponent = comp;
 }
 
 /**

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -66,12 +66,9 @@ options.unmount = vnode => {
 	if (oldBeforeUnmount) oldBeforeUnmount(vnode);
 
 	const c = vnode._component;
-	if (!c) return;
-
-	const hooks = c.__hooks;
-	if (hooks) {
+	if (c && c.__hooks) {
 		try {
-			hooks._list.forEach(hook => hook._cleanup && hook._cleanup());
+			c.__hooks._list.forEach(hook => hook._cleanup && hook._cleanup());
 		} catch (e) {
 			options._catchError(e, c._vnode);
 		}

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -27,9 +27,10 @@ options._render = vnode => {
 	currentIndex = 0;
 
 	if (currentComponent.__hooks) {
-		currentComponent.__hooks._pendingEffects.forEach(invokeCleanup);
-		currentComponent.__hooks._pendingEffects.forEach(invokeEffect);
-		currentComponent.__hooks._pendingEffects = [];
+		const c = currentComponent;
+		c.__hooks._pendingEffects.forEach(invokeCleanup);
+		c.__hooks._pendingEffects.forEach(invokeEffect);
+		c.__hooks._pendingEffects = [];
 	}
 };
 
@@ -336,9 +337,7 @@ function afterPaint(newQueueLength) {
  * @param {import('./internal').EffectHookState} hook
  */
 function invokeCleanup(hook) {
-	const comp = currentComponent;
 	if (hook._cleanup) hook._cleanup();
-	currentComponent = comp;
 }
 
 /**
@@ -346,10 +345,8 @@ function invokeCleanup(hook) {
  * @param {import('./internal').EffectHookState} hook
  */
 function invokeEffect(hook) {
-	const comp = currentComponent;
 	const result = hook._value();
 	if (typeof result == 'function') hook._cleanup = result;
-	currentComponent = comp;
 }
 
 /**

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -26,11 +26,11 @@ options._render = vnode => {
 	currentComponent = vnode._component;
 	currentIndex = 0;
 
-	if (currentComponent.__hooks) {
-		const c = currentComponent;
-		c.__hooks._pendingEffects.forEach(invokeCleanup);
-		c.__hooks._pendingEffects.forEach(invokeEffect);
-		c.__hooks._pendingEffects = [];
+	const hooks = currentComponent.__hooks;
+	if (hooks) {
+		hooks._pendingEffects.forEach(invokeCleanup);
+		hooks._pendingEffects.forEach(invokeEffect);
+		hooks._pendingEffects = [];
 	}
 };
 
@@ -38,13 +38,8 @@ options.diffed = vnode => {
 	if (oldAfterDiff) oldAfterDiff(vnode);
 
 	const c = vnode._component;
-	if (!c) return;
-
-	const hooks = c.__hooks;
-	if (hooks) {
-		if (hooks._pendingEffects.length) {
-			afterPaint(afterPaintEffects.push(c));
-		}
+	if (c && c.__hooks && c.__hooks._pendingEffects.length) {
+		afterPaint(afterPaintEffects.push(c));
 	}
 };
 

--- a/hooks/test/browser/useEffect.test.js
+++ b/hooks/test/browser/useEffect.test.js
@@ -1,7 +1,7 @@
 import { act } from 'preact/test-utils';
 import { createElement, render, Fragment, Component } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { useEffect, useState, useRef } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 import { useEffectAssertions } from './useEffectAssertions.test';
 import { scheduleEffectAssert } from '../_util/useEffectUtil';
 


### PR DESCRIPTION
Fixes: https://github.com/preactjs/preact/issues/2175

When we dispatch a new `render` from within an effect we have to restore our `currentComponent`.