### PR TITLE
Devtools: Check if hook is present in parent window

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -1,8 +1,12 @@
 import { options, Fragment, Component } from 'preact';
 
 export function initDevTools() {
-	if (typeof window != 'undefined' && window.__PREACT_DEVTOOLS__) {
-		window.__PREACT_DEVTOOLS__.attachPreact('10.4.1', options, {
+	const hook =
+		typeof window != 'undefined' &&
+		(window.__PREACT_DEVTOOLS__ || window.parent.__PREACT_DEVTOOLS__);
+
+	if (hook) {
+		hook.attachPreact('10.4.1', options, {
 			Fragment,
 			Component
 		});


### PR DESCRIPTION
This PR completes support for debugging Preact apps that are rendered inside an `iframe`. If we don't find the devtools hook in the current frame, we check for it on the parent window. If a window does not have a parent, its parent property is a reference to itself.

![Screenshot from 2020-04-25 09-59-51](https://user-images.githubusercontent.com/1062408/80274612-04391b80-86dc-11ea-9d68-69ebcf73b3fd.png)
 