### PR TITLE
Iteratively diff children and convert array children to Fragments

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -63,6 +63,18 @@ export function diffChildren(
 		// in a `if (childVNode) { ... } condition
 		if (childVNode == null) continue;
 
+		// If this newVNode is being reused (e.g. <div>{reuse}{reuse}</div>) in the same diff,
+		// copy it so it can have it's own DOM & etc. pointers
+		if (childVNode._dom != null || childVNode._component != null) {
+			childVNode = newParentVNode._children[i] = createVNode(
+				childVNode.type,
+				childVNode.props,
+				childVNode.key,
+				null,
+				childVNode._original
+			);
+		}
+
 		childVNode._parent = newParentVNode;
 		childVNode._depth = newParentVNode._depth + 1;
 
@@ -253,16 +265,6 @@ export function toChildArray(children, internal, flattened) {
 		flattened.push(children);
 	} else if (typeof children == 'string' || typeof children == 'number') {
 		flattened.push(createVNode(null, children, null, null, children));
-	} else if (children._dom != null || children._component != null) {
-		flattened.push(
-			createVNode(
-				children.type,
-				children.props,
-				children.key,
-				null,
-				children._original
-			)
-		);
 	} else {
 		flattened.push(children);
 	}

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -275,7 +275,6 @@ export function diffChildren(
  * Flatten and loop through the children of a virtual node
  * @param {import('../index').ComponentChildren} children The unflattened
  * children of a virtual node
- * @param {Array<import('../internal').VNode | string | number>} [flattened] An flat array of children to modify
  * @returns {import('../internal').VNode[]}
  */
 export function toChildArray(children) {
@@ -283,7 +282,7 @@ export function toChildArray(children) {
 		return [];
 	} else if (Array.isArray(children)) {
 		return EMPTY_ARR.concat.apply([], children.map(toChildArray));
-	} else {
-		return [children];
 	}
+
+	return [children];
 }

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -62,13 +62,12 @@ export function diffChildren(
 	for (i = 0; i < renderResult.length; i++) {
 		childVNode = renderResult[i];
 
-		// Terser removes the `continue` here and wraps the loop body
-		// in a `if (childVNode) { ... } condition
 		if (childVNode == null || typeof childVNode == 'boolean') {
 			childVNode = newParentVNode._children[i] = null;
 		}
 		// If this newVNode is being reused (e.g. <div>{reuse}{reuse}</div>) in the same diff,
-		// copy it so it can have it's own DOM & etc. pointers
+		// or we are rendering a component (e.g. setState) copy the oldVNodes so it can have
+		// it's own DOM & etc. pointers
 		else if (typeof childVNode == 'string' || typeof childVNode == 'number') {
 			childVNode = newParentVNode._children[i] = createVNode(
 				null,
@@ -97,6 +96,8 @@ export function diffChildren(
 			childVNode = newParentVNode._children[i] = childVNode;
 		}
 
+		// Terser removes the `continue` here and wraps the loop body
+		// in a `if (childVNode) { ... } condition
 		if (childVNode == null) {
 			continue;
 		}

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -34,7 +34,7 @@ export function diffChildren(
 	oldDom,
 	isHydrating
 ) {
-	let i, j, oldVNode, newDom, sibDom, firstChildDom, refs;
+	let i, j, oldVNode, childVNode, newDom, sibDom, firstChildDom, refs;
 
 	// This is a compression of oldParentVNode!=null && oldParentVNode != EMPTY_OBJ && oldParentVNode._children || EMPTY_ARR
 	// as EMPTY_OBJ._children should be `undefined`.
@@ -56,162 +56,157 @@ export function diffChildren(
 		}
 	}
 
-	i = 0;
-	newParentVNode._children = toChildArray(
-		newParentVNode._children,
-		childVNode => {
-			if (childVNode != null) {
-				childVNode._parent = newParentVNode;
-				childVNode._depth = newParentVNode._depth + 1;
+	for (i = 0; i < newParentVNode._children.length; i++) {
+		childVNode = newParentVNode._children[i];
 
-				// Check if we find a corresponding element in oldChildren.
-				// If found, delete the array item by setting to `undefined`.
-				// We use `undefined`, as `null` is reserved for empty placeholders
-				// (holes).
-				oldVNode = oldChildren[i];
+		if (childVNode != null) {
+			childVNode._parent = newParentVNode;
+			childVNode._depth = newParentVNode._depth + 1;
 
-				if (
-					oldVNode === null ||
-					(oldVNode &&
+			// Check if we find a corresponding element in oldChildren.
+			// If found, delete the array item by setting to `undefined`.
+			// We use `undefined`, as `null` is reserved for empty placeholders
+			// (holes).
+			oldVNode = oldChildren[i];
+
+			if (
+				oldVNode === null ||
+				(oldVNode &&
+					childVNode.key == oldVNode.key &&
+					childVNode.type === oldVNode.type)
+			) {
+				oldChildren[i] = undefined;
+			} else {
+				// Either oldVNode === undefined or oldChildrenLength > 0,
+				// so after this loop oldVNode == null or oldVNode is a valid value.
+				for (j = 0; j < oldChildrenLength; j++) {
+					oldVNode = oldChildren[j];
+					// If childVNode is unkeyed, we only match similarly unkeyed nodes, otherwise we match by key.
+					// We always match by type (in either case).
+					if (
+						oldVNode &&
 						childVNode.key == oldVNode.key &&
-						childVNode.type === oldVNode.type)
-				) {
-					oldChildren[i] = undefined;
-				} else {
-					// Either oldVNode === undefined or oldChildrenLength > 0,
-					// so after this loop oldVNode == null or oldVNode is a valid value.
-					for (j = 0; j < oldChildrenLength; j++) {
-						oldVNode = oldChildren[j];
-						// If childVNode is unkeyed, we only match similarly unkeyed nodes, otherwise we match by key.
-						// We always match by type (in either case).
-						if (
-							oldVNode &&
-							childVNode.key == oldVNode.key &&
-							childVNode.type === oldVNode.type
-						) {
-							oldChildren[j] = undefined;
-							break;
-						}
-						oldVNode = null;
-					}
-				}
-
-				oldVNode = oldVNode || EMPTY_OBJ;
-
-				// Morph the old element into the new one, but don't append it to the dom yet
-				newDom = diff(
-					parentDom,
-					childVNode,
-					oldVNode,
-					globalContext,
-					isSvg,
-					excessDomChildren,
-					commitQueue,
-					oldDom,
-					isHydrating
-				);
-
-				if ((j = childVNode.ref) && oldVNode.ref != j) {
-					if (!refs) refs = [];
-					if (oldVNode.ref) refs.push(oldVNode.ref, null, childVNode);
-					refs.push(j, childVNode._component || newDom, childVNode);
-				}
-
-				// Only proceed if the vnode has not been unmounted by `diff()` above.
-				if (newDom != null) {
-					if (firstChildDom == null) {
-						firstChildDom = newDom;
-					}
-
-					let nextDom;
-					if (childVNode._nextDom !== undefined) {
-						// Only Fragments or components that return Fragment like VNodes will
-						// have a non-undefined _nextDom. Continue the diff from the sibling
-						// of last DOM child of this child VNode
-						nextDom = childVNode._nextDom;
-
-						// Eagerly cleanup _nextDom. We don't need to persist the value because
-						// it is only used by `diffChildren` to determine where to resume the diff after
-						// diffing Components and Fragments. Once we store it the nextDOM local var, we
-						// can clean up the property
-						childVNode._nextDom = undefined;
-					} else if (
-						excessDomChildren == oldVNode ||
-						newDom != oldDom ||
-						newDom.parentNode == null
+						childVNode.type === oldVNode.type
 					) {
-						// NOTE: excessDomChildren==oldVNode above:
-						// This is a compression of excessDomChildren==null && oldVNode==null!
-						// The values only have the same type when `null`.
-
-						outer: if (oldDom == null || oldDom.parentNode !== parentDom) {
-							parentDom.appendChild(newDom);
-							nextDom = null;
-						} else {
-							// `j<oldChildrenLength; j+=2` is an alternative to `j++<oldChildrenLength/2`
-							for (
-								sibDom = oldDom, j = 0;
-								(sibDom = sibDom.nextSibling) && j < oldChildrenLength;
-								j += 2
-							) {
-								if (sibDom == newDom) {
-									break outer;
-								}
-							}
-							parentDom.insertBefore(newDom, oldDom);
-							nextDom = oldDom;
-						}
-
-						// Browsers will infer an option's `value` from `textContent` when
-						// no value is present. This essentially bypasses our code to set it
-						// later in `diff()`. It works fine in all browsers except for IE11
-						// where it breaks setting `select.value`. There it will be always set
-						// to an empty string. Re-applying an options value will fix that, so
-						// there are probably some internal data structures that aren't
-						// updated properly.
-						//
-						// To fix it we make sure to reset the inferred value, so that our own
-						// value check in `diff()` won't be skipped.
-						if (newParentVNode.type == 'option') {
-							parentDom.value = '';
-						}
+						oldChildren[j] = undefined;
+						break;
 					}
-
-					// If we have pre-calculated the nextDOM node, use it. Else calculate it now
-					// Strictly check for `undefined` here cuz `null` is a valid value of `nextDom`.
-					// See more detail in create-element.js:createVNode
-					if (nextDom !== undefined) {
-						oldDom = nextDom;
-					} else {
-						oldDom = newDom.nextSibling;
-					}
-
-					if (typeof newParentVNode.type == 'function') {
-						// Because the newParentVNode is Fragment-like, we need to set it's
-						// _nextDom property to the nextSibling of its last child DOM node.
-						//
-						// `oldDom` contains the correct value here because if the last child
-						// is a Fragment-like, then oldDom has already been set to that child's _nextDom.
-						// If the last child is a DOM VNode, then oldDom will be set to that DOM
-						// node's nextSibling.
-
-						newParentVNode._nextDom = oldDom;
-					}
-				} else if (
-					oldDom &&
-					oldVNode._dom == oldDom &&
-					oldDom.parentNode != parentDom
-				) {
-					// The above condition is to handle null placeholders. See test in placeholder.test.js:
-					// `efficiently replace null placeholders in parent rerenders`
-					oldDom = getDomSibling(oldVNode);
+					oldVNode = null;
 				}
 			}
 
-			i++;
-			return childVNode;
+			oldVNode = oldVNode || EMPTY_OBJ;
+
+			// Morph the old element into the new one, but don't append it to the dom yet
+			newDom = diff(
+				parentDom,
+				childVNode,
+				oldVNode,
+				globalContext,
+				isSvg,
+				excessDomChildren,
+				commitQueue,
+				oldDom,
+				isHydrating
+			);
+
+			if ((j = childVNode.ref) && oldVNode.ref != j) {
+				if (!refs) refs = [];
+				if (oldVNode.ref) refs.push(oldVNode.ref, null, childVNode);
+				refs.push(j, childVNode._component || newDom, childVNode);
+			}
+
+			// Only proceed if the vnode has not been unmounted by `diff()` above.
+			if (newDom != null) {
+				if (firstChildDom == null) {
+					firstChildDom = newDom;
+				}
+
+				let nextDom;
+				if (childVNode._nextDom !== undefined) {
+					// Only Fragments or components that return Fragment like VNodes will
+					// have a non-undefined _nextDom. Continue the diff from the sibling
+					// of last DOM child of this child VNode
+					nextDom = childVNode._nextDom;
+
+					// Eagerly cleanup _nextDom. We don't need to persist the value because
+					// it is only used by `diffChildren` to determine where to resume the diff after
+					// diffing Components and Fragments. Once we store it the nextDOM local var, we
+					// can clean up the property
+					childVNode._nextDom = undefined;
+				} else if (
+					excessDomChildren == oldVNode ||
+					newDom != oldDom ||
+					newDom.parentNode == null
+				) {
+					// NOTE: excessDomChildren==oldVNode above:
+					// This is a compression of excessDomChildren==null && oldVNode==null!
+					// The values only have the same type when `null`.
+
+					outer: if (oldDom == null || oldDom.parentNode !== parentDom) {
+						parentDom.appendChild(newDom);
+						nextDom = null;
+					} else {
+						// `j<oldChildrenLength; j+=2` is an alternative to `j++<oldChildrenLength/2`
+						for (
+							sibDom = oldDom, j = 0;
+							(sibDom = sibDom.nextSibling) && j < oldChildrenLength;
+							j += 2
+						) {
+							if (sibDom == newDom) {
+								break outer;
+							}
+						}
+						parentDom.insertBefore(newDom, oldDom);
+						nextDom = oldDom;
+					}
+
+					// Browsers will infer an option's `value` from `textContent` when
+					// no value is present. This essentially bypasses our code to set it
+					// later in `diff()`. It works fine in all browsers except for IE11
+					// where it breaks setting `select.value`. There it will be always set
+					// to an empty string. Re-applying an options value will fix that, so
+					// there are probably some internal data structures that aren't
+					// updated properly.
+					//
+					// To fix it we make sure to reset the inferred value, so that our own
+					// value check in `diff()` won't be skipped.
+					if (newParentVNode.type == 'option') {
+						parentDom.value = '';
+					}
+				}
+
+				// If we have pre-calculated the nextDOM node, use it. Else calculate it now
+				// Strictly check for `undefined` here cuz `null` is a valid value of `nextDom`.
+				// See more detail in create-element.js:createVNode
+				if (nextDom !== undefined) {
+					oldDom = nextDom;
+				} else {
+					oldDom = newDom.nextSibling;
+				}
+
+				if (typeof newParentVNode.type == 'function') {
+					// Because the newParentVNode is Fragment-like, we need to set it's
+					// _nextDom property to the nextSibling of its last child DOM node.
+					//
+					// `oldDom` contains the correct value here because if the last child
+					// is a Fragment-like, then oldDom has already been set to that child's _nextDom.
+					// If the last child is a DOM VNode, then oldDom will be set to that DOM
+					// node's nextSibling.
+
+					newParentVNode._nextDom = oldDom;
+				}
+			} else if (
+				oldDom &&
+				oldVNode._dom == oldDom &&
+				oldDom.parentNode != parentDom
+			) {
+				// The above condition is to handle null placeholders. See test in placeholder.test.js:
+				// `efficiently replace null placeholders in parent rerenders`
+				oldDom = getDomSibling(oldVNode);
+			}
 		}
-	);
+	}
 
 	newParentVNode._dom = firstChildDom;
 
@@ -239,38 +234,35 @@ export function diffChildren(
  * Flatten and loop through the children of a virtual node
  * @param {import('../index').ComponentChildren} children The unflattened
  * children of a virtual node
- * @param {(vnode: import('../internal').VNode) => import('../internal').VNode} [callback]
- * A function to invoke for each child before it is added to the flattened list.
+ * @param {boolean} [internal]
  * @param {Array<import('../internal').VNode | string | number>} [flattened] An flat array of children to modify
  * @returns {import('../internal').VNode[]}
  */
-export function toChildArray(children, callback, flattened) {
+export function toChildArray(children, internal, flattened) {
 	if (flattened == null) flattened = [];
 
 	if (children == null || typeof children == 'boolean') {
-		if (callback) flattened.push(callback(null));
+		if (internal) flattened.push(null);
 	} else if (Array.isArray(children)) {
 		for (let i = 0; i < children.length; i++) {
-			toChildArray(children[i], callback, flattened);
+			toChildArray(children[i], internal, flattened);
 		}
-	} else if (!callback) {
+	} else if (!internal) {
 		flattened.push(children);
 	} else if (typeof children == 'string' || typeof children == 'number') {
-		flattened.push(callback(createVNode(null, children, null, null, children)));
+		flattened.push(createVNode(null, children, null, null, children));
 	} else if (children._dom != null || children._component != null) {
 		flattened.push(
-			callback(
-				createVNode(
-					children.type,
-					children.props,
-					children.key,
-					null,
-					children._original
-				)
+			createVNode(
+				children.type,
+				children.props,
+				children.key,
+				null,
+				children._original
 			)
 		);
 	} else {
-		flattened.push(callback(children));
+		flattened.push(children);
 	}
 
 	return flattened;

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -274,28 +274,39 @@ export function diffChildren(
  * Flatten and loop through the children of a virtual node
  * @param {import('../index').ComponentChildren} children The unflattened
  * children of a virtual node
- * @param {boolean} [internal]
  * @param {Array<import('../internal').VNode | string | number>} [flattened] An flat array of children to modify
  * @returns {import('../internal').VNode[]}
  */
-export function toChildArray(children, internal, flattened) {
-	if (flattened == null) flattened = [];
-
-	// TODO: REMOVE INTERNAL OPTION
-
+// export function toChildArray(children, flattened) {
+// if (flattened == null) flattened = [];
+// if (Array.isArray(children)) {
+// 	for (let i = 0; i < children.length; i++) {
+// 		toChildArray(children[i], flattened);
+// 	}
+// } else if (children != null && typeof children != 'boolean') {
+// 	flattened.push(children);
+// }
+// return flattened;
+// }
+export function toChildArray(children) {
 	if (children == null || typeof children == 'boolean') {
-		if (internal) flattened.push(null);
+		return [];
 	} else if (Array.isArray(children)) {
-		for (let i = 0; i < children.length; i++) {
-			toChildArray(children[i], internal, flattened);
-		}
-	} else if (!internal) {
-		flattened.push(children);
-	} else if (typeof children == 'string' || typeof children == 'number') {
-		flattened.push(createVNode(null, children, null, null, children));
+		// let flattened = [];
+		// for (let i = 0; i < children.length; i++) {
+		// 	flattened = flattened.concat(toChildArray(children[i]));
+		// }
+		// return flattened;
+		// return Array.prototype.concat.apply([], children.map(toChildArray));
+		return [].concat.apply([], children.map(toChildArray));
 	} else {
-		flattened.push(children);
+		return [children];
 	}
 
-	return flattened;
+	// if (children != null && typeof children != 'boolean') {
+	// 	return [children];
+	// }
+	// else if (Array.isArray(children)) {
+	// 	return [].concat.apply([], children.map(toChildArray).filter(Boolean));
+	// }
 }

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -277,36 +277,12 @@ export function diffChildren(
  * @param {Array<import('../internal').VNode | string | number>} [flattened] An flat array of children to modify
  * @returns {import('../internal').VNode[]}
  */
-// export function toChildArray(children, flattened) {
-// if (flattened == null) flattened = [];
-// if (Array.isArray(children)) {
-// 	for (let i = 0; i < children.length; i++) {
-// 		toChildArray(children[i], flattened);
-// 	}
-// } else if (children != null && typeof children != 'boolean') {
-// 	flattened.push(children);
-// }
-// return flattened;
-// }
 export function toChildArray(children) {
 	if (children == null || typeof children == 'boolean') {
 		return [];
 	} else if (Array.isArray(children)) {
-		// let flattened = [];
-		// for (let i = 0; i < children.length; i++) {
-		// 	flattened = flattened.concat(toChildArray(children[i]));
-		// }
-		// return flattened;
-		// return Array.prototype.concat.apply([], children.map(toChildArray));
-		return [].concat.apply([], children.map(toChildArray));
+		return EMPTY_ARR.concat.apply([], children.map(toChildArray));
 	} else {
 		return [children];
 	}
-
-	// if (children != null && typeof children != 'boolean') {
-	// 	return [children];
-	// }
-	// else if (Array.isArray(children)) {
-	// 	return [].concat.apply([], children.map(toChildArray).filter(Boolean));
-	// }
 }

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -59,152 +59,154 @@ export function diffChildren(
 	for (i = 0; i < newParentVNode._children.length; i++) {
 		childVNode = newParentVNode._children[i];
 
-		if (childVNode != null) {
-			childVNode._parent = newParentVNode;
-			childVNode._depth = newParentVNode._depth + 1;
+		// Terser removes the `continue` here and wraps the loop body
+		// in a `if (childVNode) { ... } condition
+		if (childVNode == null) continue;
 
-			// Check if we find a corresponding element in oldChildren.
-			// If found, delete the array item by setting to `undefined`.
-			// We use `undefined`, as `null` is reserved for empty placeholders
-			// (holes).
-			oldVNode = oldChildren[i];
+		childVNode._parent = newParentVNode;
+		childVNode._depth = newParentVNode._depth + 1;
 
-			if (
-				oldVNode === null ||
-				(oldVNode &&
+		// Check if we find a corresponding element in oldChildren.
+		// If found, delete the array item by setting to `undefined`.
+		// We use `undefined`, as `null` is reserved for empty placeholders
+		// (holes).
+		oldVNode = oldChildren[i];
+
+		if (
+			oldVNode === null ||
+			(oldVNode &&
+				childVNode.key == oldVNode.key &&
+				childVNode.type === oldVNode.type)
+		) {
+			oldChildren[i] = undefined;
+		} else {
+			// Either oldVNode === undefined or oldChildrenLength > 0,
+			// so after this loop oldVNode == null or oldVNode is a valid value.
+			for (j = 0; j < oldChildrenLength; j++) {
+				oldVNode = oldChildren[j];
+				// If childVNode is unkeyed, we only match similarly unkeyed nodes, otherwise we match by key.
+				// We always match by type (in either case).
+				if (
+					oldVNode &&
 					childVNode.key == oldVNode.key &&
-					childVNode.type === oldVNode.type)
-			) {
-				oldChildren[i] = undefined;
-			} else {
-				// Either oldVNode === undefined or oldChildrenLength > 0,
-				// so after this loop oldVNode == null or oldVNode is a valid value.
-				for (j = 0; j < oldChildrenLength; j++) {
-					oldVNode = oldChildren[j];
-					// If childVNode is unkeyed, we only match similarly unkeyed nodes, otherwise we match by key.
-					// We always match by type (in either case).
-					if (
-						oldVNode &&
-						childVNode.key == oldVNode.key &&
-						childVNode.type === oldVNode.type
-					) {
-						oldChildren[j] = undefined;
-						break;
-					}
-					oldVNode = null;
-				}
-			}
-
-			oldVNode = oldVNode || EMPTY_OBJ;
-
-			// Morph the old element into the new one, but don't append it to the dom yet
-			newDom = diff(
-				parentDom,
-				childVNode,
-				oldVNode,
-				globalContext,
-				isSvg,
-				excessDomChildren,
-				commitQueue,
-				oldDom,
-				isHydrating
-			);
-
-			if ((j = childVNode.ref) && oldVNode.ref != j) {
-				if (!refs) refs = [];
-				if (oldVNode.ref) refs.push(oldVNode.ref, null, childVNode);
-				refs.push(j, childVNode._component || newDom, childVNode);
-			}
-
-			// Only proceed if the vnode has not been unmounted by `diff()` above.
-			if (newDom != null) {
-				if (firstChildDom == null) {
-					firstChildDom = newDom;
-				}
-
-				let nextDom;
-				if (childVNode._nextDom !== undefined) {
-					// Only Fragments or components that return Fragment like VNodes will
-					// have a non-undefined _nextDom. Continue the diff from the sibling
-					// of last DOM child of this child VNode
-					nextDom = childVNode._nextDom;
-
-					// Eagerly cleanup _nextDom. We don't need to persist the value because
-					// it is only used by `diffChildren` to determine where to resume the diff after
-					// diffing Components and Fragments. Once we store it the nextDOM local var, we
-					// can clean up the property
-					childVNode._nextDom = undefined;
-				} else if (
-					excessDomChildren == oldVNode ||
-					newDom != oldDom ||
-					newDom.parentNode == null
+					childVNode.type === oldVNode.type
 				) {
-					// NOTE: excessDomChildren==oldVNode above:
-					// This is a compression of excessDomChildren==null && oldVNode==null!
-					// The values only have the same type when `null`.
-
-					outer: if (oldDom == null || oldDom.parentNode !== parentDom) {
-						parentDom.appendChild(newDom);
-						nextDom = null;
-					} else {
-						// `j<oldChildrenLength; j+=2` is an alternative to `j++<oldChildrenLength/2`
-						for (
-							sibDom = oldDom, j = 0;
-							(sibDom = sibDom.nextSibling) && j < oldChildrenLength;
-							j += 2
-						) {
-							if (sibDom == newDom) {
-								break outer;
-							}
-						}
-						parentDom.insertBefore(newDom, oldDom);
-						nextDom = oldDom;
-					}
-
-					// Browsers will infer an option's `value` from `textContent` when
-					// no value is present. This essentially bypasses our code to set it
-					// later in `diff()`. It works fine in all browsers except for IE11
-					// where it breaks setting `select.value`. There it will be always set
-					// to an empty string. Re-applying an options value will fix that, so
-					// there are probably some internal data structures that aren't
-					// updated properly.
-					//
-					// To fix it we make sure to reset the inferred value, so that our own
-					// value check in `diff()` won't be skipped.
-					if (newParentVNode.type == 'option') {
-						parentDom.value = '';
-					}
+					oldChildren[j] = undefined;
+					break;
 				}
-
-				// If we have pre-calculated the nextDOM node, use it. Else calculate it now
-				// Strictly check for `undefined` here cuz `null` is a valid value of `nextDom`.
-				// See more detail in create-element.js:createVNode
-				if (nextDom !== undefined) {
-					oldDom = nextDom;
-				} else {
-					oldDom = newDom.nextSibling;
-				}
-
-				if (typeof newParentVNode.type == 'function') {
-					// Because the newParentVNode is Fragment-like, we need to set it's
-					// _nextDom property to the nextSibling of its last child DOM node.
-					//
-					// `oldDom` contains the correct value here because if the last child
-					// is a Fragment-like, then oldDom has already been set to that child's _nextDom.
-					// If the last child is a DOM VNode, then oldDom will be set to that DOM
-					// node's nextSibling.
-
-					newParentVNode._nextDom = oldDom;
-				}
-			} else if (
-				oldDom &&
-				oldVNode._dom == oldDom &&
-				oldDom.parentNode != parentDom
-			) {
-				// The above condition is to handle null placeholders. See test in placeholder.test.js:
-				// `efficiently replace null placeholders in parent rerenders`
-				oldDom = getDomSibling(oldVNode);
+				oldVNode = null;
 			}
+		}
+
+		oldVNode = oldVNode || EMPTY_OBJ;
+
+		// Morph the old element into the new one, but don't append it to the dom yet
+		newDom = diff(
+			parentDom,
+			childVNode,
+			oldVNode,
+			globalContext,
+			isSvg,
+			excessDomChildren,
+			commitQueue,
+			oldDom,
+			isHydrating
+		);
+
+		if ((j = childVNode.ref) && oldVNode.ref != j) {
+			if (!refs) refs = [];
+			if (oldVNode.ref) refs.push(oldVNode.ref, null, childVNode);
+			refs.push(j, childVNode._component || newDom, childVNode);
+		}
+
+		// Only proceed if the vnode has not been unmounted by `diff()` above.
+		if (newDom != null) {
+			if (firstChildDom == null) {
+				firstChildDom = newDom;
+			}
+
+			let nextDom;
+			if (childVNode._nextDom !== undefined) {
+				// Only Fragments or components that return Fragment like VNodes will
+				// have a non-undefined _nextDom. Continue the diff from the sibling
+				// of last DOM child of this child VNode
+				nextDom = childVNode._nextDom;
+
+				// Eagerly cleanup _nextDom. We don't need to persist the value because
+				// it is only used by `diffChildren` to determine where to resume the diff after
+				// diffing Components and Fragments. Once we store it the nextDOM local var, we
+				// can clean up the property
+				childVNode._nextDom = undefined;
+			} else if (
+				excessDomChildren == oldVNode ||
+				newDom != oldDom ||
+				newDom.parentNode == null
+			) {
+				// NOTE: excessDomChildren==oldVNode above:
+				// This is a compression of excessDomChildren==null && oldVNode==null!
+				// The values only have the same type when `null`.
+
+				outer: if (oldDom == null || oldDom.parentNode !== parentDom) {
+					parentDom.appendChild(newDom);
+					nextDom = null;
+				} else {
+					// `j<oldChildrenLength; j+=2` is an alternative to `j++<oldChildrenLength/2`
+					for (
+						sibDom = oldDom, j = 0;
+						(sibDom = sibDom.nextSibling) && j < oldChildrenLength;
+						j += 2
+					) {
+						if (sibDom == newDom) {
+							break outer;
+						}
+					}
+					parentDom.insertBefore(newDom, oldDom);
+					nextDom = oldDom;
+				}
+
+				// Browsers will infer an option's `value` from `textContent` when
+				// no value is present. This essentially bypasses our code to set it
+				// later in `diff()`. It works fine in all browsers except for IE11
+				// where it breaks setting `select.value`. There it will be always set
+				// to an empty string. Re-applying an options value will fix that, so
+				// there are probably some internal data structures that aren't
+				// updated properly.
+				//
+				// To fix it we make sure to reset the inferred value, so that our own
+				// value check in `diff()` won't be skipped.
+				if (newParentVNode.type == 'option') {
+					parentDom.value = '';
+				}
+			}
+
+			// If we have pre-calculated the nextDOM node, use it. Else calculate it now
+			// Strictly check for `undefined` here cuz `null` is a valid value of `nextDom`.
+			// See more detail in create-element.js:createVNode
+			if (nextDom !== undefined) {
+				oldDom = nextDom;
+			} else {
+				oldDom = newDom.nextSibling;
+			}
+
+			if (typeof newParentVNode.type == 'function') {
+				// Because the newParentVNode is Fragment-like, we need to set it's
+				// _nextDom property to the nextSibling of its last child DOM node.
+				//
+				// `oldDom` contains the correct value here because if the last child
+				// is a Fragment-like, then oldDom has already been set to that child's _nextDom.
+				// If the last child is a DOM VNode, then oldDom will be set to that DOM
+				// node's nextSibling.
+
+				newParentVNode._nextDom = oldDom;
+			}
+		} else if (
+			oldDom &&
+			oldVNode._dom == oldDom &&
+			oldDom.parentNode != parentDom
+		) {
+			// The above condition is to handle null placeholders. See test in placeholder.test.js:
+			// `efficiently replace null placeholders in parent rerenders`
+			oldDom = getDomSibling(oldVNode);
 		}
 	}
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -8,6 +8,7 @@ import { getDomSibling } from '../component';
  * Diff the children of a virtual node
  * @param {import('../internal').PreactElement} parentDom The DOM element whose
  * children are being diffed
+ * @param {import('../index').ComponentChildren[]} renderResult
  * @param {import('../internal').VNode} newParentVNode The new virtual
  * node whose children should be diff'ed against oldParentVNode
  * @param {import('../internal').VNode} oldParentVNode The old virtual
@@ -25,6 +26,7 @@ import { getDomSibling } from '../component';
  */
 export function diffChildren(
 	parentDom,
+	renderResult,
 	newParentVNode,
 	oldParentVNode,
 	globalContext,
@@ -56,8 +58,9 @@ export function diffChildren(
 		}
 	}
 
-	for (i = 0; i < newParentVNode._children.length; i++) {
-		childVNode = newParentVNode._children[i];
+	newParentVNode._children = [];
+	for (i = 0; i < renderResult.length; i++) {
+		childVNode = renderResult[i];
 
 		// Terser removes the `continue` here and wraps the loop body
 		// in a `if (childVNode) { ... } condition
@@ -90,6 +93,8 @@ export function diffChildren(
 				null,
 				childVNode._original
 			);
+		} else {
+			childVNode = newParentVNode._children[i] = childVNode;
 		}
 
 		if (childVNode == null) {

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -1,7 +1,7 @@
 import { EMPTY_OBJ, EMPTY_ARR } from '../constants';
 import { Component } from '../component';
 import { Fragment } from '../create-element';
-import { diffChildren } from './children';
+import { diffChildren, toChildArray } from './children';
 import { diffProps, setProperty } from './props';
 import { assign, removeNode } from '../util';
 import options from '../options';
@@ -173,11 +173,10 @@ export function diff(
 			tmp = c.render(c.props, c.state, c.context);
 			let isTopLevelFragment =
 				tmp != null && tmp.type == Fragment && tmp.key == null;
-			newVNode._children = isTopLevelFragment
-				? tmp.props.children
-				: Array.isArray(tmp)
-				? tmp
-				: [tmp];
+			newVNode._children = toChildArray(
+				isTopLevelFragment ? tmp.props.children : tmp,
+				true
+			);
 
 			if (c.getChildContext != null) {
 				globalContext = assign(assign({}, globalContext), c.getChildContext());
@@ -368,7 +367,7 @@ function diffElementNodes(
 		if (newHtml) {
 			newVNode._children = [];
 		} else {
-			newVNode._children = newVNode.props.children;
+			newVNode._children = toChildArray(newVNode.props.children, true);
 			diffChildren(
 				dom,
 				newVNode,

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -171,18 +171,6 @@ export function diff(
 			c._parentDom = parentDom;
 
 			tmp = c.render(c.props, c.state, c.context);
-			let isTopLevelFragment =
-				tmp != null && tmp.type == Fragment && tmp.key == null;
-
-			// NOTE: Reusing _children here leads to VNode shape changes since _children
-			// isn't always an array
-			// TODO: Could we fast path renderResult not being an array? Would probably need to happen
-			// in diffChildren, and might make it hard for diffChildren to be optimized if one of its
-			// argument's type changes a lot
-			let renderResult = isTopLevelFragment ? tmp.props.children : tmp;
-			renderResult = Array.isArray(renderResult)
-				? renderResult
-				: [renderResult];
 
 			if (c.getChildContext != null) {
 				globalContext = assign(assign({}, globalContext), c.getChildContext());
@@ -192,9 +180,19 @@ export function diff(
 				snapshot = c.getSnapshotBeforeUpdate(oldProps, oldState);
 			}
 
+			let isTopLevelFragment =
+				tmp != null && tmp.type == Fragment && tmp.key == null;
+
+			// NOTE: Reusing _children here leads to VNode shape changes since _children
+			// isn't always an array
+			// TODO: Could we fast path renderResult not being an array? Would probably need to happen
+			// in diffChildren, and might make it hard for diffChildren to be optimized if one of its
+			// argument's type changes a lot
+			let renderResult = isTopLevelFragment ? tmp.props.children : tmp;
+
 			diffChildren(
 				parentDom,
-				renderResult,
+				Array.isArray(renderResult) ? renderResult : [renderResult],
 				newVNode,
 				oldVNode,
 				globalContext,

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -175,7 +175,7 @@ export function diff(
 				tmp != null && tmp.type == Fragment && tmp.key == null;
 			newVNode._children = isTopLevelFragment ? tmp.props.children : tmp;
 			newVNode._children = Array.isArray(newVNode._children)
-				? newVNode._children
+				? newVNode._children.slice()
 				: [newVNode._children];
 
 			if (c.getChildContext != null) {
@@ -369,7 +369,7 @@ function diffElementNodes(
 		} else {
 			newVNode._children = newVNode.props.children;
 			newVNode._children = Array.isArray(newVNode._children)
-				? newVNode._children
+				? newVNode._children.slice()
 				: [newVNode._children];
 			diffChildren(
 				dom,

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -374,13 +374,10 @@ function diffElementNodes(
 		if (newHtml) {
 			newVNode._children = [];
 		} else {
-			let renderResult = newVNode.props.children;
-			renderResult = Array.isArray(renderResult)
-				? renderResult
-				: [renderResult];
+			i = newVNode.props.children;
 			diffChildren(
 				dom,
-				renderResult,
+				Array.isArray(i) ? i : [i],
 				newVNode,
 				oldVNode,
 				globalContext,

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -1,7 +1,7 @@
 import { EMPTY_OBJ, EMPTY_ARR } from '../constants';
 import { Component } from '../component';
 import { Fragment } from '../create-element';
-import { diffChildren, toChildArray } from './children';
+import { diffChildren } from './children';
 import { diffProps, setProperty } from './props';
 import { assign, removeNode } from '../util';
 import options from '../options';
@@ -173,10 +173,10 @@ export function diff(
 			tmp = c.render(c.props, c.state, c.context);
 			let isTopLevelFragment =
 				tmp != null && tmp.type == Fragment && tmp.key == null;
-			newVNode._children = toChildArray(
-				isTopLevelFragment ? tmp.props.children : tmp,
-				true
-			);
+			newVNode._children = isTopLevelFragment ? tmp.props.children : tmp;
+			newVNode._children = Array.isArray(newVNode._children)
+				? newVNode._children
+				: [newVNode._children];
 
 			if (c.getChildContext != null) {
 				globalContext = assign(assign({}, globalContext), c.getChildContext());
@@ -367,7 +367,10 @@ function diffElementNodes(
 		if (newHtml) {
 			newVNode._children = [];
 		} else {
-			newVNode._children = toChildArray(newVNode.props.children, true);
+			newVNode._children = newVNode.props.children;
+			newVNode._children = Array.isArray(newVNode._children)
+				? newVNode._children
+				: [newVNode._children];
 			diffChildren(
 				dom,
 				newVNode,

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -182,12 +182,6 @@ export function diff(
 
 			let isTopLevelFragment =
 				tmp != null && tmp.type == Fragment && tmp.key == null;
-
-			// NOTE: Reusing _children here leads to VNode shape changes since _children
-			// isn't always an array
-			// TODO: Could we fast path renderResult not being an array? Would probably need to happen
-			// in diffChildren, and might make it hard for diffChildren to be optimized if one of its
-			// argument's type changes a lot
 			let renderResult = isTopLevelFragment ? tmp.props.children : tmp;
 
 			diffChildren(

--- a/test/browser/focus.test.js
+++ b/test/browser/focus.test.js
@@ -238,7 +238,7 @@ describe('focus', () => {
 		validateFocus(input, 'insert sibling before again');
 	});
 
-	it.skip('should maintain focus when adding children around input (unkeyed)', () => {
+	it('should maintain focus when adding children around input (unkeyed)', () => {
 		// Related preactjs/preact#2446
 
 		render(<DynamicList unkeyed />, scratch);

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -119,24 +119,24 @@ describe('render()', () => {
 		render(
 			<div>
 				{reused}
-				<span />
+				<hr />
 				{reused}
 			</div>,
 			scratch
 		);
-		expect(scratch.innerHTML).to.eql(
-			`<div><div class="reuse">Hello World!</div><span></span><div class="reuse">Hello World!</div></div>`
+		expect(serializeHtml(scratch)).to.eql(
+			`<div><div class="reuse">Hello World!</div><hr><div class="reuse">Hello World!</div></div>`
 		);
 
 		render(
 			<div>
-				<span />
+				<hr />
 				{reused}
 			</div>,
 			scratch
 		);
-		expect(scratch.innerHTML).to.eql(
-			`<div><span></span><div class="reuse">Hello World!</div></div>`
+		expect(serializeHtml(scratch)).to.eql(
+			`<div><hr><div class="reuse">Hello World!</div></div>`
 		);
 	});
 


### PR DESCRIPTION
At the suggestion from @developit from forever ago, this PR no longer uses `toChildArray` in diffChildren to convert `props.children` to an array. It also no longer flattens nested arrays when diffing children. It now converts them to Fragments.

I think this change will help us improve diff perf in the future and it also fixes #2446.