### PR TITLE
Fix compat export

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -137,7 +137,7 @@ export default {
 	version,
 	Children,
 	render,
-	hydrate: render,
+	hydrate,
 	unmountComponentAtNode,
 	createPortal,
 	createElement,


### PR DESCRIPTION
Removes the aliasing of hydrate to render.

Looks like separate hydrate was added in #2206 and default export was missed.