### PR TITLE
Remove unnecessary cloning of props

### DIFF
--- a/compat/src/memo.js
+++ b/compat/src/memo.js
@@ -1,5 +1,5 @@
 import { createElement } from 'preact';
-import { shallowDiffers, assign } from './util';
+import { shallowDiffers } from './util';
 
 /**
  * Memoize a component, so that it only updates when the props actually have
@@ -25,7 +25,7 @@ export function memo(c, comparer) {
 
 	function Memoed(props) {
 		this.shouldComponentUpdate = shouldUpdate;
-		return createElement(c, assign({}, props));
+		return createElement(c, props);
 	}
 	Memoed.prototype.isReactComponent = true;
 	Memoed.displayName = 'Memo(' + (c.displayName || c.name) + ')';

--- a/compat/test/browser/memo.test.js
+++ b/compat/test/browser/memo.test.js
@@ -155,4 +155,21 @@ describe('memo()', () => {
 			render(<App />, scratch);
 		}).to.not.throw();
 	});
+
+	it('should pass ref through nested memos', () => {
+		class Foo extends Component {
+			render() {
+				return <h1>Hello World</h1>;
+			}
+		}
+
+		const App = memo(memo(Foo));
+
+		const ref = {};
+
+		render(<App ref={ref} />, scratch);
+
+		expect(ref.current).not.to.be.undefined;
+		expect(ref.current).to.be.instanceOf(Foo);
+	});
 });


### PR DESCRIPTION
This clone seems unnecessary as `createElement` is going to clone the props anyway.

ref forwarding is the only case I could think of that might break with this change.