### PR TITLE
Add "loading" attribute to HTMLAttributes TypeScript interface

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -666,6 +666,7 @@ export namespace JSXInternal {
 		label?: string;
 		lang?: string;
 		list?: string;
+		loading?: 'eager' | 'lazy';
 		loop?: boolean;
 		low?: number;
 		manifest?: string;


### PR DESCRIPTION
# Summary

This PR proposes adding the `loading` attribute to the `HTMLAttributes` TypeScript interface.

See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-loading

# Why?

I wanted to write the following JSX in a Preact component:
```html
<img
  alt={alt}
  src={src}
  loading="lazy"
/>
```
But I would get the following error when adding the `loading="lazy"` attribute/value:

<img width="737" alt="Screen Shot 2020-05-03 at 12 02 11 PM" src="https://user-images.githubusercontent.com/459757/80924696-4b0fbc80-8d3f-11ea-9395-c84f1dc60d05.png">

```
(JSX attribute) loading: string
Type '{ alt: string; class: string; itemProp: string; src: string; loading: string; }' is not assignable to type 'HTMLAttributes<HTMLImageElement>'.
  Property 'loading' does not exist on type 'HTMLAttributes<HTMLImageElement>'.ts(2322)
```

Please let me know if there is anything I should modify. I'm _pretty_ sure this is the only change that's needed. I don't know if I need to write a test or anything like that. Thank you! 🙂  