### PR TITLE
Improve IS_NON_DIMENSIONAL for compatibility with animation-iteration-count

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,3 @@
 export const EMPTY_OBJ = {};
 export const EMPTY_ARR = [];
-export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord/i;
+export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i;

--- a/test/browser/style.test.js
+++ b/test/browser/style.test.js
@@ -90,6 +90,20 @@ describe('style attribute', () => {
 			.that.equals('0');
 	});
 
+	it('should support animation-iteration-count as number', () => {
+		render(<div style={{ animationIterationCount: 1 }}>Test</div>, scratch);
+		let style = scratch.firstChild.style;
+		expect(style)
+			.to.have.property('animationIterationCount')
+			.that.equals('1');
+
+		render(<div style={{ animationIterationCount: 2.5 }}>Test</div>, scratch);
+		style = scratch.firstChild.style;
+		expect(style)
+			.to.have.property('animationIterationCount')
+			.that.equals('2.5');
+	});
+
 	it('should replace previous style objects', () => {
 		render(<div style={{ display: 'inline' }}>test</div>, scratch);
 


### PR DESCRIPTION
```jsx
<div style={{ animationIterationCount: 1 }}>text</div>
```

It can be a number in the syntax but does not take effect in preact@latest

CodeSandbox:
https://codesandbox.io/s/animationiterationcount-as-number-p7i07?file=/src/index.js

