### PR TITLE
useReducer: use latest reducer

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -122,6 +122,7 @@ export function useState(initialState) {
 export function useReducer(reducer, initialState, init) {
 	/** @type {import('./internal').ReducerHookState} */
 	const hookState = getHookState(currentIndex++, 2);
+	hookState._reducer = reducer;
 	if (!hookState._component) {
 		hookState._component = currentComponent;
 
@@ -129,7 +130,7 @@ export function useReducer(reducer, initialState, init) {
 			!init ? invokeOrReturn(undefined, initialState) : init(initialState),
 
 			action => {
-				const nextValue = reducer(hookState._value[0], action);
+				const nextValue = hookState._reducer(hookState._value[0], action);
 				if (hookState._value[0] !== nextValue) {
 					hookState._value[0] = nextValue;
 					hookState._component.setState({});

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -1,4 +1,5 @@
 import { Component as PreactComponent } from '../../src/internal';
+import { Reducer } from '.';
 
 export { PreactContext } from '../../src/internal';
 
@@ -52,4 +53,5 @@ export interface MemoHookState {
 export interface ReducerHookState {
 	_value?: any;
 	_component?: Component;
+	_reducer?: Reducer<any, any>;
 }

--- a/hooks/test/browser/useReducer.test.js
+++ b/hooks/test/browser/useReducer.test.js
@@ -116,4 +116,60 @@ describe('useReducer', () => {
 
 		expect(states).to.deep.equal([{ count: 10 }, { count: 20 }]);
 	});
+
+	it('provides a stable reference for dispatch', () => {
+		const dispatches = [];
+		let _dispatch;
+
+		const initState = { count: 0 };
+
+		function reducer(state, action) {
+			switch (action.type) {
+				case 'increment':
+					return { count: state.count + action.by };
+			}
+		}
+
+		function Comp() {
+			const [, dispatch] = useReducer(reducer, initState);
+			_dispatch = dispatch;
+			dispatches.push(dispatch);
+			return null;
+		}
+
+		render(<Comp />, scratch);
+
+		_dispatch({ type: 'increment', by: 10 });
+		rerender();
+
+		expect(dispatches[0]).to.equal(dispatches[1]);
+	});
+
+	it('uses latest reducer', () => {
+		const states = [];
+		let _dispatch;
+
+		const initState = { count: 0 };
+
+		function Comp({ increment }) {
+			const [state, dispatch] = useReducer(function(state, action) {
+				switch (action.type) {
+					case 'increment':
+						return { count: state.count + increment };
+				}
+			}, initState);
+			_dispatch = dispatch;
+			states.push(state);
+			return null;
+		}
+
+		render(<Comp increment={10} />, scratch);
+
+		render(<Comp increment={20} />, scratch);
+
+		_dispatch({ type: 'increment' });
+		rerender();
+
+		expect(states).to.deep.equal([{ count: 0 }, { count: 0 }, { count: 20 }]);
+	});
 });


### PR DESCRIPTION
Matches useReducer's behaviour to React's useReducer.
React [demo](https://codesandbox.io/s/jolly-meitner-iiggh)
Preact [demo](https://codesandbox.io/s/nifty-villani-chci3)

Not sure about performance implications of assigning reducer on every render.