### PR TITLE
Allow cloneElement to create copies of `ComponentChild`

### DIFF
--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -7,9 +7,13 @@ import { createVNode } from './create-element';
  * @param {import('./internal').VNode} vnode The virtual DOM element to clone
  * @param {object} props Attributes/props to add when cloning
  * @param {Array<import('./index').ComponentChildren>} rest Any additional arguments will be used as replacement children.
- * @returns {import('./internal').VNode}
+ * @returns {import('./internal').VNode|import('./index').ComponentChildren}
  */
 export function cloneElement(vnode, props) {
+	if (!vnode.type && !vnode._children) {
+		const clone = vnode;
+		return clone;
+	}
 	props = assign(assign({}, vnode.props), props);
 	if (arguments.length > 2) props.children = EMPTY_ARR.slice.call(arguments, 2);
 	let normalizedProps = {};

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -228,6 +228,11 @@ declare namespace preact {
 		parent: Element | Document | ShadowRoot | DocumentFragment
 	): void;
 	function cloneElement(
+		vnode: preact.ComponentChild,
+		props?: any,
+		...children: ComponentChildren[]
+	): VNode<any>;
+	function cloneElement(
 		vnode: VNode<any>,
 		props?: any,
 		...children: ComponentChildren[]

--- a/test/ts/VNode-test.tsx
+++ b/test/ts/VNode-test.tsx
@@ -9,6 +9,7 @@ import {
 	ComponentFactory,
 	VNode,
 	ComponentChildren,
+	ComponentChild,
 	cloneElement
 } from '../../src';
 
@@ -32,6 +33,43 @@ const SimpleFunctionalComponent = () => <div />;
 
 const a: ComponentFactory = SimpleComponent;
 const b: ComponentFactory = SimpleFunctionalComponent;
+
+describe('ComponentChild TS types', () => {
+	it('vnode should work with cloneElement', () => {
+		const comp: VNode = (
+			<SimpleComponent>
+				<div>child 1</div>
+			</SimpleComponent>
+		);
+		const clone: ComponentChild = cloneElement(comp.props.children);
+		expect(comp.props.children).to.deep.equal(clone);
+	});
+
+	it('number should work with cloneElement', () => {
+		const comp: VNode = <SimpleComponent>123124</SimpleComponent>;
+		const clone: ComponentChild = cloneElement(comp.props.children);
+		expect(comp.props.children).to.equal(clone);
+	});
+
+	it('string should work with cloneElement', () => {
+		const comp: VNode = <SimpleComponent>'hello'</SimpleComponent>;
+		const clone: ComponentChild = cloneElement(comp.props.children);
+		expect(comp.props.children).to.equal(clone);
+	});
+
+	it('object should work with cloneElement', () => {
+		const foo = { bar: 'baz' };
+		const comp: VNode = <SimpleComponent>{foo}</SimpleComponent>;
+		const clone: ComponentChild = cloneElement(comp.props.children);
+		expect(comp.props.children).to.equal(clone);
+	});
+
+	it('boolean should work with cloneElement', () => {
+		const comp: VNode = <SimpleComponent>false</SimpleComponent>;
+		const clone: ComponentChild = cloneElement(comp.props.children);
+		expect(comp.props.children).to.equal(clone);
+	});
+});
 
 describe('VNode TS types', () => {
 	it('is returned by h', () => {


### PR DESCRIPTION
## What am I trying to achieve?
Fixes https://github.com/preactjs/preact/issues/2428

Update typings for `cloneElement` to create copies of `ComponentChild`, namely `VNode` and primitives.

## What approach did I use?

Most of these changes involve type definitions. Given `ComponentChild` can be:

```typescript
type ComponentChild = VNode<any> | object | string | number | boolean | null | undefined;
```

- We overload `cloneElement`'s function signature in accept `ComponentChild`
- If the child is singular and not a VNode, we simple return create and return its copy.

On a side note, React's [ReactChild](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L237) is defined as follows:
`type ReactChild = ReactElement | ReactText;`. `cloneElement` should work with `string` and `number` at the very least.

Also, I think this still feels a bit weird — I'm wondering if using type inference / casting [as mentioned](https://github.com/preactjs/preact/issues/2428#issuecomment-606556737) in the issue should be enough to fix this issue.