### PR TITLE
chore: Add preact-render-to-string as peerdep

### DIFF
--- a/compat/package.json
+++ b/compat/package.json
@@ -14,6 +14,7 @@
     "regex": "^_"
   },
   "peerDependencies": {
-    "preact": "^10.0.0"
+    "preact": "^10.0.0",
+    "preact-render-to-string": "^5.1.8"
   }
 }


### PR DESCRIPTION
I might have missed something but `preact-render-to-string` is used in `preact/compat/server.js` it should be added to interdependencies if it can't be a direct dependency.

https://github.com/preactjs/preact/blob/da382e13d9377a53056e4cb0fd741f6e0aadf1c1/compat/server.js#L3-L9