### PR TITLE
fix useEffect regression by using invokeCleanup in unmount

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -68,7 +68,7 @@ options.unmount = vnode => {
 	const c = vnode._component;
 	if (c && c.__hooks) {
 		try {
-			c.__hooks._list.forEach(hook => hook._cleanup && hook._cleanup());
+			c.__hooks._list.forEach(invokeCleanup);
 		} catch (e) {
 			options._catchError(e, c._vnode);
 		}

--- a/hooks/test/browser/useEffect.test.js
+++ b/hooks/test/browser/useEffect.test.js
@@ -251,4 +251,19 @@ describe('useEffect', () => {
 			'<div><div><div>Inner</div></div></div><div><div>global</div></div>'
 		);
 	});
+
+	it('should not crash when effect returns truthy non-function value', () => {
+		const callback = sinon.spy(() => 'truthy');
+		function Comp() {
+			useEffect(callback);
+			return null;
+		}
+
+		render(<Comp />, scratch);
+		render(<Comp />, scratch);
+
+		expect(callback).to.have.been.calledOnce;
+
+		render(<div>Replacement</div>, scratch);
+	});
 });


### PR DESCRIPTION
This fixes a regression caused by #2494 

The unmount hook cleanup wasn't using `invokeCleanup` so it was relying on non functions never being assigned to `_cleanup` in the first place. 

In my project upgrading to `10.4.2` caused a `useEffect` like this to crash:
```js
useEffect(async () => {
  await apiCall()
}, [])
```
Perhaps not a recommended usage since the typescript types would disallow it.. but still.

The promise ends up as the `_cleanup` and it is of course truthy causing the component to crash when unmounted.

I wrote a quick test to validate this, but not sure if I did in the best way 🤔 advice would be appreciated there.