### PR TITLE
Use "babel-plugin-transform-rename-properties" to consistently mangle properties

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -30,19 +30,11 @@ module.exports = function(api) {
 		plugins: [
 			'@babel/plugin-proposal-object-rest-spread',
 			'@babel/plugin-transform-react-jsx',
-			'babel-plugin-transform-async-to-promises'
+			'babel-plugin-transform-async-to-promises',
+			['babel-plugin-transform-rename-properties', { rename }]
 		],
 		include: ['**/src/**/*.js', '**/test/**/*.js'],
 		overrides: [
-			{
-				test(filename) {
-					const isOptionsTestFile =
-						filename.endsWith('optionSpies.js') ||
-						filename.endsWith('.options.test.js');
-					return minify && isOptionsTestFile;
-				},
-				plugins: [['babel-plugin-transform-rename-properties', { rename }]]
-			},
 			{
 				test: /(component-stack|debug)\.test\.js$/,
 				plugins: ['@babel/plugin-transform-react-jsx-source']

--- a/compat/mangle.json
+++ b/compat/mangle.json
@@ -6,7 +6,7 @@
   "minify": {
     "mangle": {
       "properties": {
-        "regex": "^_",
+        "regex": "^_[^_]",
         "reserved": [
           "__REACT_DEVTOOLS_GLOBAL_HOOK__",
           "__PREACT_DEVTOOLS__",
@@ -15,50 +15,6 @@
           "__self"
         ]
       }
-    }
-  },
-  "props": {
-    "cname": 6,
-    "props": {
-      "$_afterPaintQueued": "__a",
-      "$__hooks": "__H",
-      "$_list": "__",
-      "$_pendingEffects": "__h",
-      "$_value": "__",
-      "$_original": "__v",
-      "$_args": "__H",
-      "$_factory": "__h",
-      "$_depth": "__b",
-      "$_nextDom": "__d",
-      "$_dirty": "__d",
-      "$_detachOnNextRender": "__b",
-      "$_force": "__e",
-      "$_nextState": "__s",
-      "$_renderCallbacks": "__h",
-      "$_vnode": "__v",
-      "$_children": "__k",
-      "$_pendingSuspensionCount": "__u",
-      "$_childDidSuspend": "__c",
-      "$_suspendedComponentWillUnmount": "__c",
-      "$_dom": "__e",
-      "$_component": "__c",
-      "$__html": "__html",
-      "$_parent": "__",
-      "$_pendingError": "__E",
-      "$_processingException": "__",
-      "$_globalContext": "__n",
-      "$_defaultValue": "__",
-      "$_id": "__c",
-      "$_parentDom": "__P",
-      "$_prevState": "__u",
-      "$_root": "__",
-      "$_diff": "__b",
-      "$_commit": "__c",
-      "$_render": "__r",
-      "$_hook": "__h",
-      "$_catchError": "__e",
-      "$_unmount": "_e",
-      "$_owner": "__o"
     }
   }
 }

--- a/compat/src/portals.js
+++ b/compat/src/portals.js
@@ -1,4 +1,4 @@
-import { createElement, hydrate, render, _unmount } from 'preact';
+import { createElement, hydrate, render, __u as _unmount } from 'preact';
 
 class ContextProvider {
 	getChildContext() {

--- a/debug/mangle.json
+++ b/debug/mangle.json
@@ -6,7 +6,7 @@
   "minify": {
     "mangle": {
       "properties": {
-        "regex": "^_",
+        "regex": "^_[^_]",
         "reserved": [
           "__REACT_DEVTOOLS_GLOBAL_HOOK__",
           "__PREACT_DEVTOOLS__",
@@ -15,49 +15,6 @@
           "__self"
         ]
       }
-    }
-  },
-  "props": {
-    "cname": 6,
-    "props": {
-      "$_afterPaintQueued": "__a",
-      "$__hooks": "__H",
-      "$_list": "__",
-      "$_pendingEffects": "__h",
-      "$_value": "__",
-      "$_args": "__H",
-      "$_factory": "__h",
-      "$_depth": "__b",
-      "$_nextDom": "__d",
-      "$_dirty": "__d",
-      "$_detachOnNextRender": "__b",
-      "$_force": "__e",
-      "$_nextState": "__s",
-      "$_renderCallbacks": "__h",
-      "$_vnode": "__v",
-      "$_children": "__k",
-      "$_pendingSuspensionCount": "__u",
-      "$_childDidSuspend": "__c",
-      "$_suspendedComponentWillUnmount": "__c",
-      "$_dom": "__e",
-      "$_component": "__c",
-      "$__html": "__html",
-      "$_parent": "__",
-      "$_pendingError": "__E",
-      "$_processingException": "__",
-      "$_globalContext": "__n",
-      "$_defaultValue": "__",
-      "$_id": "__c",
-      "$_parentDom": "__P",
-      "$_prevState": "__u",
-      "$_root": "__",
-      "$_diff": "__b",
-      "$_commit": "__c",
-      "$_render": "__r",
-      "$_hook": "__h",
-      "$_catchError": "__e",
-      "$_unmount": "_e",
-      "$_owner": "__o"
     }
   }
 }

--- a/devtools/mangle.json
+++ b/devtools/mangle.json
@@ -6,7 +6,7 @@
   "minify": {
     "mangle": {
       "properties": {
-        "regex": "^_",
+        "regex": "^_[^_]",
         "reserved": [
           "__REACT_DEVTOOLS_GLOBAL_HOOK__",
           "__PREACT_DEVTOOLS__",
@@ -15,49 +15,6 @@
           "__self"
         ]
       }
-    }
-  },
-  "props": {
-    "cname": 6,
-    "props": {
-      "$_afterPaintQueued": "__a",
-      "$__hooks": "__H",
-      "$_list": "__",
-      "$_pendingEffects": "__h",
-      "$_value": "__",
-      "$_args": "__H",
-      "$_factory": "__h",
-      "$_depth": "__b",
-      "$_nextDom": "__d",
-      "$_dirty": "__d",
-      "$_detachOnNextRender": "__b",
-      "$_force": "__e",
-      "$_nextState": "__s",
-      "$_renderCallbacks": "__h",
-      "$_vnode": "__v",
-      "$_children": "__k",
-      "$_suspensions": "__u",
-      "$_childDidSuspend": "__c",
-      "$_suspendedComponentWillUnmount": "__c",
-      "$_dom": "__e",
-      "$_component": "__c",
-      "$__html": "__html",
-      "$_parent": "__",
-      "$_pendingError": "__E",
-      "$_processingException": "__",
-      "$_globalContext": "__n",
-      "$_defaultValue": "__",
-      "$_id": "__c",
-      "$_parentDom": "__P",
-      "$_prevState": "__u",
-      "$_root": "__",
-      "$_diff": "__b",
-      "$_commit": "__c",
-      "$_render": "__r",
-      "$_hook": "__h",
-      "$_catchError": "__e",
-      "$_unmount": "_e",
-      "$_owner": "__o"
     }
   }
 }

--- a/hooks/mangle.json
+++ b/hooks/mangle.json
@@ -6,7 +6,7 @@
   "minify": {
     "mangle": {
       "properties": {
-        "regex": "^_",
+        "regex": "^_[^_]",
         "reserved": [
           "__REACT_DEVTOOLS_GLOBAL_HOOK__",
           "__PREACT_DEVTOOLS__",
@@ -15,51 +15,6 @@
           "__self"
         ]
       }
-    }
-  },
-  "props": {
-    "cname": 6,
-    "props": {
-      "$_afterPaintQueued": "__a",
-      "$__hooks": "__H",
-      "$_list": "__",
-      "$_pendingEffects": "__h",
-      "$_value": "__",
-      "$_args": "__H",
-      "$_factory": "__h",
-      "$_depth": "__b",
-      "$_nextDom": "__d",
-      "$_dirty": "__d",
-      "$_detachOnNextRender": "__b",
-      "$_force": "__e",
-      "$_nextState": "__s",
-      "$_renderCallbacks": "__h",
-      "$_vnode": "__v",
-      "$_children": "__k",
-      "$_pendingSuspensionCount": "__u",
-      "$_childDidSuspend": "__c",
-      "$_suspendedComponentWillUnmount": "__c",
-      "$_dom": "__e",
-      "$_component": "__c",
-      "$__html": "__html",
-      "$_parent": "__",
-      "$_pendingError": "__E",
-      "$_processingException": "__",
-      "$_globalContext": "__n",
-      "$_context": "__c",
-      "$_defaultValue": "__",
-      "$_id": "__c",
-      "$_parentDom": "__P",
-      "$_prevState": "__u",
-      "$_root": "__",
-      "$_diff": "__b",
-      "$_commit": "__c",
-      "$_render": "__r",
-      "$_hook": "__h",
-      "$_catchError": "__e",
-      "$_unmount": "_e",
-      "$_owner": "__o",
-      "$_skipEffects": "__s"
     }
   }
 }

--- a/mangle.json
+++ b/mangle.json
@@ -6,7 +6,7 @@
   "minify": {
     "mangle": {
       "properties": {
-        "regex": "^_",
+        "regex": "^_[^_]",
         "reserved": [
           "__REACT_DEVTOOLS_GLOBAL_HOOK__",
           "__PREACT_DEVTOOLS__",
@@ -51,6 +51,7 @@
       "$_pendingError": "__E",
       "$_processingException": "__",
       "$_globalContext": "__n",
+      "$_context": "__c",
       "$_defaultValue": "__",
       "$_id": "__c",
       "$_contextRef": "__",
@@ -62,8 +63,9 @@
       "$_render": "__r",
       "$_hook": "__h",
       "$_catchError": "__e",
-      "$_unmount": "_e",
-      "$_owner": "__o"
+      "$_unmount": "__u",
+      "$_owner": "__o",
+      "$_skipEffects": "__s"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "build:devtools": "microbundle build --raw --cwd devtools",
     "build:hooks": "microbundle build --raw --cwd hooks",
     "build:test-utils": "microbundle build --raw --cwd test-utils",
-    "build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks' --no-compress",
+    "build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks'",
     "postbuild": "node ./config/node-13-exports.js",
     "dev": "microbundle watch --raw --format cjs",
     "dev:hooks": "microbundle watch --raw --format cjs --cwd hooks",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "build:devtools": "microbundle build --raw --cwd devtools",
     "build:hooks": "microbundle build --raw --cwd hooks",
     "build:test-utils": "microbundle build --raw --cwd test-utils",
-    "build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks'",
+    "build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks' --no-compress",
     "postbuild": "node ./config/node-13-exports.js",
     "dev": "microbundle watch --raw --format cjs",
     "dev:hooks": "microbundle watch --raw --format cjs --cwd hooks",

--- a/src/index.js
+++ b/src/index.js
@@ -10,5 +10,5 @@ export { Component } from './component';
 export { cloneElement } from './clone-element';
 export { createContext } from './create-context';
 export { toChildArray } from './diff/children';
-export { unmount as _unmount } from './diff';
+export { unmount as __u } from './diff';
 export { default as options } from './options';


### PR DESCRIPTION
Use @jviide's `babel-plugin-transform-rename-properties` plugin to consistently mangle property names instead of terser. The benefit of doings this is that it enables us to produce unminified builds whose mangled properties are consistent with the minified builds. Another benefit is that now all builds share one mapping of property names to mangle names.

I manually compared the CommonJS (CJS) output of the builds of master and this branch to verify no properties changed. Only local variables and local function names changed for core and hooks. This check actually lead me to find a bug (as well as the test failing):

The babel plugin only mangles property names, not import/export names. At the time babel runs, the import/export statements are still import/export statements so the babel plugin does not change them. However when terser runs, the import/export statements become `exports._unmount = ...` and `preact._unmount(...)` and so terser could mangle these. This difference tripped up the one mangled export we have, `_unmount` in core which `compat` consumes for portals. To fix this, I manually exported and imported the desired mangled name.