### PR TITLE
🏌️‍♂️ rAF check

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -307,7 +307,7 @@ function afterNextFrame(callback) {
 	const timeout = setTimeout(done, RAF_TIMEOUT);
 
 	let raf;
-	if (typeof window != 'undefined') {
+	if (typeof requestAnimationFrame == 'function') {
 		raf = requestAnimationFrame(done);
 	}
 }


### PR DESCRIPTION
There were no other `window` references in `preact/hooks`, so checking for `requestAnimationFrame` directly yeilds some nice savings.