### PR TITLE
Normalize value prop on textareas in compat

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -130,6 +130,12 @@ options.vnode = vnode => {
 				delete props.value;
 			}
 
+			// Normalize textarea by setting children to value
+			if (props.value != null && type === 'textarea') {
+				props.children = props.value;
+				delete props.value;
+			}
+
 			// Normalize DOM vnode properties.
 			let shouldSanitize, attrs, i;
 			for (i in props) if ((shouldSanitize = CAMEL_PROPS.test(i))) break;

--- a/compat/test/browser/textarea.test.js
+++ b/compat/test/browser/textarea.test.js
@@ -17,4 +17,10 @@ describe('Textarea', () => {
 
 		expect(scratch.innerHTML).to.equal('<textarea>foo</textarea>');
 	});
+
+	it('should alias defaultValue to children', () => {
+		render(<textarea defaultValue="foo" />, scratch);
+
+		expect(scratch.innerHTML).to.equal('<textarea>foo</textarea>');
+	});
 });

--- a/compat/test/browser/textarea.test.js
+++ b/compat/test/browser/textarea.test.js
@@ -1,0 +1,20 @@
+import React, { render } from 'preact/compat';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+
+describe('Textarea', () => {
+	let scratch;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('should alias value to children', () => {
+		render(<textarea value="foo" />, scratch);
+
+		expect(scratch.innerHTML).to.equal('<textarea>foo</textarea>');
+	});
+});


### PR DESCRIPTION
Fixes #2556. This PR implements [the textarea normalization that React performs](https://reactjs.org/docs/forms.html#the-textarea-tag) in `preact/compat`.

Thanks @marvinhagemeister for pointing out where to make this change, it's been super helpful for getting to understand the codebase better! 🙌 