### PR TITLE
support css-variables by diffing 'style' during hydration

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -21,7 +21,7 @@ export function diffProps(dom, newProps, oldProps, isSvg, hydrate) {
 
 	for (i in newProps) {
 		if (
-			(!hydrate || typeof newProps[i] == 'function') &&
+			(!hydrate || typeof newProps[i] == 'function' || i === 'style') &&
 			i !== 'children' &&
 			i !== 'key' &&
 			i !== 'value' &&


### PR DESCRIPTION
Fixes: https://github.com/preactjs/preact/issues/2562

CSS-variables still need to be hydrated on the client-side

We could make this have less runtime effect by only including the css-variables I assume https://github.com/preactjs/preact/blob/master/src/diff/props.js#L37