### PR TITLE
Fix forwardRef passing object instead of null

### DIFF
--- a/compat/src/forwardRef.js
+++ b/compat/src/forwardRef.js
@@ -30,7 +30,11 @@ export function forwardRef(fn) {
 	function Forwarded(props, ref) {
 		let clone = assign({}, props);
 		delete clone.ref;
-		return fn(clone, props.ref || ref);
+		ref = props.ref || ref;
+		return fn(
+			clone,
+			typeof ref === 'object' && !('current' in ref) ? null : ref
+		);
 	}
 
 	// mobx-react checks for this being present

--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -432,4 +432,16 @@ describe('forwardRef', () => {
 
 		expect(ref.current.innerHTML).to.equal('Wrapper');
 	});
+
+	// Issue #2566
+	it('should pass null as ref when no ref is present', () => {
+		let actual;
+		const App = forwardRef((_, ref) => {
+			actual = ref;
+			return <div />;
+		});
+
+		render(<App />, scratch);
+		expect(actual).to.equal(null);
+	});
 });

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -86,7 +86,7 @@ export function createVNode(type, props, key, ref, original) {
 }
 
 export function createRef() {
-	return {};
+	return { current: null };
 }
 
 export function Fragment(props) {

--- a/test/browser/refs.test.js
+++ b/test/browser/refs.test.js
@@ -47,7 +47,7 @@ describe('refs', () => {
 
 	it('should support createRef', () => {
 		const r = createRef();
-		expect(r.current).to.equal(undefined);
+		expect(r.current).to.equal(null);
 
 		render(<div ref={r} />, scratch);
 		expect(r.current).to.equalNode(scratch.firstChild);


### PR DESCRIPTION
Previously we'd always pass an empty `object` as the second parameter. To be able to differentiate a missing `ref` vs an unset `ref` we need to expand our `createRef` function unfortunately. I kinda loved that it did nothing before :see_no_evil: 

Fixes #2566 .