### PR TITLE
Share build output between action jobs

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -6,29 +6,8 @@ on:
       - master
 
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: Cache node modules
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - run: npm ci
-
-  test:
-    name: Test
+  build_test:
+    name: Build & Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -57,41 +36,45 @@ jobs:
           FLAKEY: false
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        run: npm run test
+        # Not using `npm test` since it rebuilds source which npm ci has already done
+        run: |
+          npm run lint
+          npm run test:unit
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@v1.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Package
+        # Use --ignore-scripts here to avoid re-building again before pack
+        run: |
+          npm pack --ignore-scripts
+          tar -xzf preact-*.tgz
+      - name: Upload build output
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-output
+          path: package/
 
   bench_text_update:
     name: Bench text_update
     runs-on: windows-latest
+    needs: build_test
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
+      - uses: actions/download-artifact@v2
+        with:
+          name: build-output
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - name: Cache node modules
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          # This uses the same name as the build-action so we can share the caches.
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
       - name: install & build
         env:
           # Skip downloading Firefox driver until we bench against it
           GECKODRIVER_SKIP_DOWNLOAD: 'true'
         run: |
           $env:CHROMEDRIVER_FILEPATH=(Join-Path $env:CHROMEWEBDRIVER chromedriver.exe)
-          npm ci
           cd benches
           npm ci
       - name: bench
@@ -102,32 +85,23 @@ jobs:
   bench_02_replace1k:
     name: Bench 02_replace1k
     runs-on: windows-latest
+    needs: build_test
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
+      - uses: actions/download-artifact@v2
+        with:
+          name: build-output
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - name: Cache node modules
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          # This uses the same name as the build-action so we can share the caches.
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
       - name: install & build
         env:
           # Skip downloading Firefox driver until we bench against it
           GECKODRIVER_SKIP_DOWNLOAD: 'true'
         run: |
           $env:CHROMEDRIVER_FILEPATH=(Join-Path $env:CHROMEWEBDRIVER chromedriver.exe)
-          npm ci
           cd benches
           npm ci
       - name: bench
@@ -138,32 +112,23 @@ jobs:
   bench_03_update10th1k_x16:
     name: Bench 03_update10th1k_x16
     runs-on: windows-latest
+    needs: build_test
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
+      - uses: actions/download-artifact@v2
+        with:
+          name: build-output
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - name: Cache node modules
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          # This uses the same name as the build-action so we can share the caches.
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
       - name: install & build
         env:
           # Skip downloading Firefox driver until we bench against it
           GECKODRIVER_SKIP_DOWNLOAD: 'true'
         run: |
           $env:CHROMEDRIVER_FILEPATH=(Join-Path $env:CHROMEWEBDRIVER chromedriver.exe)
-          npm ci
           cd benches
           npm ci
       - name: bench

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -43,11 +43,6 @@ jobs:
         run: |
           npm pack --ignore-scripts
           tar -xzf preact-*.tgz
-      - name: Upload NPM tarball
-        uses: actions/upload-artifact@v2
-        with:
-          name: npm-tarball
-          path: preact-*.tgz
       - name: Upload build output
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -57,10 +57,15 @@ jobs:
   bench_text_update:
     name: Bench text_update
     runs-on: windows-latest
+    needs: build_test
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
+      - uses: actions/download-artifact@v2
+        with:
+          name: build-output
+      - run: ls -alR
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
@@ -82,7 +87,6 @@ jobs:
           GECKODRIVER_SKIP_DOWNLOAD: 'true'
         run: |
           $env:CHROMEDRIVER_FILEPATH=(Join-Path $env:CHROMEWEBDRIVER chromedriver.exe)
-          npm ci
           cd benches
           npm ci
       - name: bench
@@ -93,10 +97,14 @@ jobs:
   bench_02_replace1k:
     name: Bench 02_replace1k
     runs-on: windows-latest
+    needs: build_test
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
+      - uses: actions/download-artifact@v2
+        with:
+          name: build-output
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
@@ -118,7 +126,6 @@ jobs:
           GECKODRIVER_SKIP_DOWNLOAD: 'true'
         run: |
           $env:CHROMEDRIVER_FILEPATH=(Join-Path $env:CHROMEWEBDRIVER chromedriver.exe)
-          npm ci
           cd benches
           npm ci
       - name: bench
@@ -129,10 +136,14 @@ jobs:
   bench_03_update10th1k_x16:
     name: Bench 03_update10th1k_x16
     runs-on: windows-latest
+    needs: build_test
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
+      - uses: actions/download-artifact@v2
+        with:
+          name: build-output
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
@@ -154,7 +165,6 @@ jobs:
           GECKODRIVER_SKIP_DOWNLOAD: 'true'
         run: |
           $env:CHROMEDRIVER_FILEPATH=(Join-Path $env:CHROMEWEBDRIVER chromedriver.exe)
-          npm ci
           cd benches
           npm ci
       - name: bench

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: build-output
-      - run: ls -alR
+      - run: ls; ls hooks
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
@@ -89,10 +89,12 @@ jobs:
           $env:CHROMEDRIVER_FILEPATH=(Join-Path $env:CHROMEWEBDRIVER chromedriver.exe)
           cd benches
           npm ci
+      - run: ls; ls hooks
       - name: bench
         run: |
           cd benches
           npm run bench text_update.html
+      - run: ls; ls hooks
 
   bench_02_replace1k:
     name: Bench 02_replace1k

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -19,6 +19,7 @@ jobs:
           cache-name: cache-node-modules
         with:
           path: ~/.npm
+          # This uses the same name as the build-action so we can share the caches.
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -3,8 +3,8 @@ name: CI-PR
 on: [pull_request]
 
 jobs:
-  build:
-    name: Build
+  build_test:
+    name: Build & Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -19,30 +19,6 @@ jobs:
           cache-name: cache-node-modules
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - run: npm ci
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: Cache node modules
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          # This uses the same name as the build-action so we can share the caches.
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
@@ -54,7 +30,10 @@ jobs:
           CI: true
           COVERAGE: true
           FLAKEY: false
-        run: npm run test
+        # Not using `npm test` since it rebuilds source which npm ci has already done
+        run: |
+          npm run lint
+          npm run test:unit
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@v1.0.1
         with:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -38,6 +38,21 @@ jobs:
         uses: coverallsapp/github-action@v1.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Package
+        # Use --ignore-scripts here to avoid re-building again before pack
+        run: |
+          npm pack --ignore-scripts
+          tar -xzf preact-*.tgz
+      - name: Upload NPM tarball
+        uses: actions/upload-artifact@v2
+        with:
+          name: npm-tarball
+          path: preact-*.tgz
+      - name: Upload build output
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-output
+          path: package/
 
   bench_text_update:
     name: Bench text_update

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -65,22 +65,9 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: build-output
-      - run: ls; ls hooks
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - name: Cache node modules
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          # This uses the same name as the build-action so we can share the caches.
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
       - name: install & build
         env:
           # Skip downloading Firefox driver until we bench against it
@@ -89,12 +76,10 @@ jobs:
           $env:CHROMEDRIVER_FILEPATH=(Join-Path $env:CHROMEWEBDRIVER chromedriver.exe)
           cd benches
           npm ci
-      - run: ls; ls hooks
       - name: bench
         run: |
           cd benches
           npm run bench text_update.html
-      - run: ls; ls hooks
 
   bench_02_replace1k:
     name: Bench 02_replace1k
@@ -110,18 +95,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - name: Cache node modules
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          # This uses the same name as the build-action so we can share the caches.
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
       - name: install & build
         env:
           # Skip downloading Firefox driver until we bench against it
@@ -149,18 +122,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - name: Cache node modules
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          # This uses the same name as the build-action so we can share the caches.
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
       - name: install & build
         env:
           # Skip downloading Firefox driver until we bench against it

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ test/ts/**/*.js
 coverage
 *.sw[op]
 *.log
+package/
+preact-*.tgz


### PR DESCRIPTION
Install and build the main repo once, and share that build output with other jobs (in the same workflow) that need it.

* I've combined the previous "build" and "test" jobs so that we only install our dev dependencies once. If the build and tests pass then the build output is uploaded as an artifact which other jobs can download. This change means that no other job (i.e. benchmarks) will run unless tests pass. Depending on what you want that could be a feature or a bug 😅 Let me know what you think!

* I determine what the build output is by running npm pack to generate our npm tarball. Then the build untars that file and uploads it's contents. I wanted to use `npm pack` to reuse the declaration of our build output from our package.json's `files` property.

* I don't upload the tarball directly cuz then each job that needed the output would have to download the artifact, untar it, and then shuffle the files around into their correct position in the repo. The approach done here means that other jobs that want to re-use the build output just download the artifact into the working directory (which is a clone of the preact repo) and the build files are already correctly placed for them. We could also upload the tarball if that's useful but I figured we just do that once we had a use for it.

* I removed the node_modules cache from the benchmarks jobs cuz it was consistently failing and just added a lot of duplication between the benchmarks. The `npm ci` command usually takes between 20s - 40s so I'm not going to sweat it now. We can look at the cache issue later if that becomes important/if there is interest.