### PR TITLE
Add TypeScript for extending JSX types with custom elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8359,6 +8359,12 @@
           "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.2.tgz",
           "integrity": "sha512-eO6vFm0JvqGzjWIQA6QVKjxpmELfhWbDUWHm1rPfIbn55mhKPiAa5xpLmQWJrNa629ZIeQ8ZvMAi13kvrjK6Mg==",
           "dev": true
+        },
+        "typescript": {
+          "version": "3.9.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
+          "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
+          "dev": true
         }
       }
     },
@@ -14738,9 +14744,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
-      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
     "prop-types": "^15.7.2",
     "sinon": "^6.1.3",
     "sinon-chai": "^3.0.0",
-    "typescript": "^3.0.1",
+    "typescript": "3.5.3",
     "webpack": "^4.3.0"
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,7 +15,7 @@ declare namespace preact {
 		props: P & { children: ComponentChildren };
 		key: Key;
 		/**
-		 * ref is not guaranteed by React.ReactElement, for compatiblity reasons
+		 * ref is not guaranteed by React.ReactElement, for compatibility reasons
 		 * with popular react libs we define it as optional too
 		 */
 		ref?: Ref<any> | null;

--- a/test/ts/Component-test.tsx
+++ b/test/ts/Component-test.tsx
@@ -1,11 +1,6 @@
 import 'mocha';
 import { expect } from 'chai';
-import {
-	createElement,
-	Component,
-	RenderableProps,
-	Fragment
-} from '../../src/';
+import { createElement, Component, RenderableProps, Fragment } from '../../';
 
 // Test `this` binding on event handlers
 function onHandler(this: HTMLInputElement, event: any) {

--- a/test/ts/VNode-test.tsx
+++ b/test/ts/VNode-test.tsx
@@ -10,7 +10,7 @@ import {
 	VNode,
 	ComponentChildren,
 	cloneElement
-} from '../../src';
+} from '../../';
 
 function getDisplayType(vnode: VNode | string | number) {
 	if (typeof vnode === 'string' || typeof vnode == 'number') {

--- a/test/ts/custom-elements.tsx
+++ b/test/ts/custom-elements.tsx
@@ -5,6 +5,7 @@ declare module '../../' {
 		interface IntrinsicElements {
 			// Custom element can use JSX EventHandler definitions
 			'clickable-ce': {
+				optionalAttr?: string;
 				onClick?: MouseEventHandler<HTMLElement>;
 			};
 
@@ -45,17 +46,28 @@ const { Provider, Consumer } = createContext({ contextValue: '' });
 // Sample component that uses custom elements
 
 class SimpleComponent extends Component {
+	componentProp = 'componentProp';
 	render() {
 		// Render inside div to ensure standard JSX elements still work
 		return (
 			<Provider value={{ contextValue: 'value' }}>
 				<div>
 					<clickable-ce
-						onClick={e => console.log('clicked ', e.target)}
+						onClick={e => {
+							// `this` should be instance of SimpleComponent since this is an
+							// arrow function
+							console.log(this.componentProp);
+
+							// Validate `currentTarget` is HTMLElement
+							console.log('clicked ', e.currentTarget.style.display);
+						}}
 					></clickable-ce>
-					<color-picker space="rgb"></color-picker>
+					<color-picker space="rgb" dir="rtl"></color-picker>
 					<custom-whatever
+						dir="auto" // Inherited prop from HTMLAttributes
+						someattribute="string"
 						onsomeevent={function(e) {
+							// Validate `this` and `e` are the right type
 							console.log('clicked', this.instanceProp, e.eventProp);
 						}}
 					></custom-whatever>

--- a/test/ts/custom-elements.tsx
+++ b/test/ts/custom-elements.tsx
@@ -1,0 +1,73 @@
+import { createElement, Component, createContext } from '../../';
+
+declare module '../../' {
+	namespace createElement.JSX {
+		interface IntrinsicElements {
+			// Custom element can use JSX EventHandler definitions
+			'clickable-ce': {
+				onClick?: MouseEventHandler<HTMLElement>;
+			};
+
+			// Custom Element that extends HTML attributes
+			'color-picker': HTMLAttributes & {
+				// Required attribute
+				space: 'rgb' | 'hsl' | 'hsv';
+				// Optional attribute
+				alpha?: boolean;
+			};
+
+			// Custom Element with custom interface definition
+			'custom-whatever': WhateveElAttributes;
+		}
+	}
+}
+
+// Whatever Element definition
+
+interface WhateverElement {
+	instanceProp: string;
+}
+
+interface WhateverElementEvent {
+	eventProp: number;
+}
+
+// preact.JSX.HTMLAttributes also appears to work here but for consistency,
+// let's use createElement.JSX
+interface WhateveElAttributes extends createElement.JSX.HTMLAttributes {
+	someattribute?: string;
+	onsomeevent?: (this: WhateverElement, ev: WhateverElementEvent) => void;
+}
+
+// Ensure context still works
+const { Provider, Consumer } = createContext({ contextValue: '' });
+
+// Sample component that uses custom elements
+
+class SimpleComponent extends Component {
+	render() {
+		// Render inside div to ensure standard JSX elements still work
+		return (
+			<Provider value={{ contextValue: 'value' }}>
+				<div>
+					<clickable-ce
+						onClick={e => console.log('clicked ', e.target)}
+					></clickable-ce>
+					<color-picker space="rgb"></color-picker>
+					<custom-whatever
+						onsomeevent={function(e) {
+							console.log('clicked', this.instanceProp, e.eventProp);
+						}}
+					></custom-whatever>
+
+					{/* Ensure context still works */}
+					<Consumer>
+						{({ contextValue }) => contextValue.toLowerCase()}
+					</Consumer>
+				</div>
+			</Provider>
+		);
+	}
+}
+
+const component = <SimpleComponent />;

--- a/test/ts/hoc-test.tsx
+++ b/test/ts/hoc-test.tsx
@@ -4,7 +4,7 @@ import {
 	ComponentFactory,
 	ComponentConstructor,
 	Component
-} from '../../src';
+} from '../../';
 import { SimpleComponent, SimpleComponentProps } from './Component-test';
 
 export interface highlightedProps {

--- a/test/ts/jsx-namespacce-test.tsx
+++ b/test/ts/jsx-namespacce-test.tsx
@@ -1,4 +1,4 @@
-import { createElement, Component } from '../../src';
+import { createElement, Component } from '../../';
 
 // declare global JSX types that should not be mixed with preact's internal types
 declare global {

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -5,7 +5,7 @@ import {
 	FunctionalComponent,
 	AnyComponent,
 	h
-} from '../../src';
+} from '../../';
 
 interface DummyProps {
 	initialInput: string;
@@ -207,7 +207,8 @@ class DefaultPropsWithUnion extends Component<
 		| {
 				type: 'number';
 				num: number;
-		  })
+		  }
+	)
 > {
 	static defaultProps = {
 		default: true

--- a/test/ts/refs.tsx
+++ b/test/ts/refs.tsx
@@ -6,7 +6,7 @@ import {
 	Fragment,
 	RefObject,
 	RefCallback
-} from '../../src';
+} from '../../';
 
 // Test Fixtures
 const Foo: FunctionalComponent = () => <span>Foo</span>;


### PR DESCRIPTION
Add a new custom element TypeScript test that validates it is possible to extend Preact's JSX types with custom elements.

This PR also locks our TypeScript to 3.5.3. I've done this to ensure that future updates we make to our types are backwards compatible with our current min TS version. If we want to take advantage of a bugfix or feature in a future version of TS, we should bump this to the new min version of TypeScript and mention the new min version in the release notes for the next Preact release.

Resolves #1180 