### PR TITLE
fix(compat): don't leak class prop when using className

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -104,7 +104,8 @@ options.vnode = vnode => {
 
 	if (type) {
 		// Alias `class` prop to `className` if available
-		if (props.class != props.className) {
+		// only alias on dom elements
+		if (typeof type === 'string' && props.class != props.className) {
 			classNameDescriptor.enumerable = 'className' in props;
 			if (props.className != null) props.class = props.className;
 			Object.defineProperty(props, 'className', classNameDescriptor);

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -88,10 +88,16 @@ function setSafeDescriptor(proto, key) {
 	}
 }
 
-let classNameDescriptor = {
+const classNameDescriptor = {
 	configurable: true,
 	get() {
 		return this.class;
+	}
+};
+const classDescriptor = {
+	configurable: true,
+	get() {
+		return this.className;
 	}
 };
 
@@ -105,10 +111,16 @@ options.vnode = vnode => {
 	if (type) {
 		// Alias `class` prop to `className` if available
 		// only alias on dom elements
-		if (typeof type === 'string' && props.class != props.className) {
+		if (props.class) {
 			classNameDescriptor.enumerable = 'className' in props;
-			if (props.className != null) props.class = props.className;
+			if (props.className != null) {
+				props.class = props.className;
+			}
 			Object.defineProperty(props, 'className', classNameDescriptor);
+		}
+		if (props.className && !props.class) {
+			classDescriptor.enumerable = false;
+			Object.defineProperty(props, 'class', classDescriptor);
 		}
 
 		// Apply DOM VNode compat

--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -242,6 +242,37 @@ describe('compat render', () => {
 		);
 	});
 
+	// Issue #2582
+	it('should not leak class/className normalisation into props', () => {
+		function Foo({ className, ...props }) {
+			return (
+				<ul className={className}>
+					<li {...props}>hi</li>
+				</ul>
+			);
+		}
+		function Bar({ class: className, ...props }) {
+			return (
+				<ul class={className}>
+					<li {...props}>hi</li>
+				</ul>
+			);
+		}
+
+		render(
+			<>
+				<Foo className="foo" />
+				<Bar class="bar" />
+			</>,
+			scratch
+		);
+		expect(scratch.firstChild.className).to.equal('foo');
+		expect(scratch.firstChild.children[0].className).to.equal('');
+
+		expect(scratch.lastChild.className).to.equal('bar');
+		expect(scratch.lastChild.children[0].className).to.equal('');
+	});
+
 	it('should support static content', () => {
 		const updateSpy = sinon.spy();
 		const mountSpy = sinon.spy();

--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -243,17 +243,17 @@ describe('compat render', () => {
 	});
 
 	// Issue #2582
-	it('should not leak class/className normalisation into props', () => {
-		function Foo({ className, ...props }) {
+	it.only('should not leak class/className normalisation into props', () => {
+		function Foo({ className, class: cl, ...props }) {
 			return (
-				<ul className={className}>
+				<ul className={className} data-class={cl}>
 					<li {...props}>hi</li>
 				</ul>
 			);
 		}
-		function Bar({ class: className, ...props }) {
+		function Bar({ class: className, className: cl, ...props }) {
 			return (
-				<ul class={className}>
+				<ul className={className} data-class={cl}>
 					<li {...props}>hi</li>
 				</ul>
 			);
@@ -267,9 +267,11 @@ describe('compat render', () => {
 			scratch
 		);
 		expect(scratch.firstChild.className).to.equal('foo');
+		expect(scratch.firstChild.dataset.class).to.equal('foo');
 		expect(scratch.firstChild.children[0].className).to.equal('');
 
 		expect(scratch.lastChild.className).to.equal('bar');
+		expect(scratch.lastChild.dataset.class).to.equal('bar');
 		expect(scratch.lastChild.children[0].className).to.equal('');
 	});
 

--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -243,7 +243,7 @@ describe('compat render', () => {
 	});
 
 	// Issue #2582
-	it.only('should not leak class/className normalisation into props', () => {
+	it('should not leak class/className normalisation into props', () => {
 		function Foo({ className, class: cl, ...props }) {
 			return (
 				<ul className={className} data-class={cl}>


### PR DESCRIPTION
When using preact-compat with className it leaks the class prop into a react component and breaks spreading props.

I might be missing some context here so this fix might not be 100% accurate.

Fixes #2582