### PR TITLE
fix hydration issue by unmounting the excessChildren

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -232,6 +232,9 @@ export function diff(
 
 		if ((tmp = options.diffed)) tmp(newVNode);
 	} catch (e) {
+		// When we are hydrating and have excessDomChildren we don't know the _children this VNode
+		// should receive so it's safer to unmount them. Else on the subsequent error-boundary diff,
+		// we won't know the oldDom and insert an additional node instead of replace the prerendered one. (#2539)
 		if (isHydrating && excessDomChildren != null) {
 			for (tmp = excessDomChildren.length; tmp--; ) {
 				if (excessDomChildren[tmp] != null) removeNode(excessDomChildren[tmp]);

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -232,6 +232,12 @@ export function diff(
 
 		if ((tmp = options.diffed)) tmp(newVNode);
 	} catch (e) {
+		if (isHydrating && excessDomChildren != null) {
+			for (tmp = excessDomChildren.length; tmp--; ) {
+				if (excessDomChildren[tmp] != null) removeNode(excessDomChildren[tmp]);
+			}
+		}
+
 		newVNode._original = null;
 		options._catchError(e, newVNode, oldVNode);
 	}

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -1,4 +1,5 @@
-import { createElement, hydrate, Fragment } from 'preact';
+import { setupRerender } from 'preact/test-utils';
+import { createElement, hydrate, Fragment, Component } from 'preact';
 import {
 	setupScratch,
 	teardown,
@@ -311,5 +312,35 @@ describe('hydrate()', () => {
 		expect(element.innerHTML).to.equal(
 			'<p class="hi">hello baz</p><p class="hi">hello bar</p>'
 		);
+	});
+
+	it('should handle errors during hydration', () => {
+		let rerender = setupRerender();
+		scratch.innerHTML = '<div id="test"><div>Hello World!</div></div>';
+
+		function App() {
+			throw Error();
+		}
+
+		class Root extends Component {
+			constructor() {
+				super();
+				this.state = {};
+			}
+			componentDidCatch(error) {
+				this.setState({ error });
+			}
+			render() {
+				if (!this.state.error) {
+					return <App />;
+				}
+				return <div>Error!</div>;
+			}
+		}
+
+		const element = document.getElementById('test');
+		hydrate(<Root />, element);
+		rerender();
+		expect(element.innerHTML).to.equal('<div>Error!</div>');
 	});
 });


### PR DESCRIPTION
Since we can't assess what would've been returned from the `render`, it's safer to unmount the remaining result and default to the regular render process which is achieved by the error boundary.

Fixes https://github.com/preactjs/preact/issues/2539