### PR TITLE
Improve code coverage

### DIFF
--- a/compat/test/browser/hydrate.test.js
+++ b/compat/test/browser/hydrate.test.js
@@ -22,4 +22,13 @@ describe('compat hydrate', () => {
 		hydrate(<input />, scratch);
 		expect(document.activeElement).to.equal(input);
 	});
+
+	it('should call the callback', () => {
+		scratch.innerHTML = '<div></div>';
+
+		let spy = sinon.spy();
+		hydrate(<div />, scratch, spy);
+		expect(spy).to.be.calledOnce;
+		expect(spy).to.be.calledWithExactly();
+	});
 });

--- a/test/browser/isValidElement.test.js
+++ b/test/browser/isValidElement.test.js
@@ -1,0 +1,4 @@
+import { createElement, isValidElement, Component } from 'preact';
+import { isValidElementTests } from '../shared/isValidElementTests';
+
+isValidElementTests(expect, isValidElement, createElement, Component);

--- a/test/shared/isValidElement.test.js
+++ b/test/shared/isValidElement.test.js
@@ -1,33 +1,5 @@
 import { createElement, isValidElement, Component } from '../../';
 import { expect } from 'chai';
+import { isValidElementTests } from './isValidElementTests';
 
-/** @jsx createElement */
-
-describe('isValidElement', () => {
-	it('should check if the argument is a valid vnode', () => {
-		// Failure cases
-		expect(isValidElement(123)).to.equal(false);
-		expect(isValidElement(0)).to.equal(false);
-		expect(isValidElement('')).to.equal(false);
-		expect(isValidElement('abc')).to.equal(false);
-		expect(isValidElement(null)).to.equal(false);
-		expect(isValidElement(undefined)).to.equal(false);
-		expect(isValidElement(true)).to.equal(false);
-		expect(isValidElement(false)).to.equal(false);
-		expect(isValidElement([])).to.equal(false);
-		expect(isValidElement([123])).to.equal(false);
-		expect(isValidElement([null])).to.equal(false);
-
-		// Success cases
-		expect(isValidElement(<div />)).to.equal(true);
-
-		const Foo = () => 123;
-		expect(isValidElement(<Foo />)).to.equal(true);
-		class Bar extends Component {
-			render() {
-				return <div />;
-			}
-		}
-		expect(isValidElement(<Bar />)).to.equal(true);
-	});
-});
+isValidElementTests(expect, isValidElement, createElement, Component);

--- a/test/shared/isValidElementTests.js
+++ b/test/shared/isValidElementTests.js
@@ -1,0 +1,37 @@
+/** @jsx createElement */
+
+export function isValidElementTests(
+	expect,
+	isValidElement,
+	createElement,
+	Component
+) {
+	describe('isValidElement', () => {
+		it('should check if the argument is a valid vnode', () => {
+			// Failure cases
+			expect(isValidElement(123)).to.equal(false);
+			expect(isValidElement(0)).to.equal(false);
+			expect(isValidElement('')).to.equal(false);
+			expect(isValidElement('abc')).to.equal(false);
+			expect(isValidElement(null)).to.equal(false);
+			expect(isValidElement(undefined)).to.equal(false);
+			expect(isValidElement(true)).to.equal(false);
+			expect(isValidElement(false)).to.equal(false);
+			expect(isValidElement([])).to.equal(false);
+			expect(isValidElement([123])).to.equal(false);
+			expect(isValidElement([null])).to.equal(false);
+
+			// Success cases
+			expect(isValidElement(<div />)).to.equal(true);
+
+			const Foo = () => 123;
+			expect(isValidElement(<Foo />)).to.equal(true);
+			class Bar extends Component {
+				render() {
+					return <div />;
+				}
+			}
+			expect(isValidElement(<Bar />)).to.equal(true);
+		});
+	});
+}


### PR DESCRIPTION
Re-worked `isValidElement` tests so that they count in our code coverage. And actually, this pattern may be a better way to share tests between node and browser since how we import `preact`, etc. differs between node and browser tests.