### PR TITLE
Simplify compat defaultValue handling

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -112,14 +112,6 @@ options.vnode = vnode => {
 
 		// Apply DOM VNode compat
 		if (typeof type != 'function') {
-			// Apply defaultValue to value
-			if (props.defaultValue && props.value !== undefined) {
-				if (!props.value && props.value !== 0) {
-					props.value = props.defaultValue;
-				}
-				delete props.defaultValue;
-			}
-
 			// Add support for array select values: <select value={[]} />
 			if (Array.isArray(props.value) && props.multiple && type === 'select') {
 				toChildArray(props.children).forEach(child => {
@@ -133,6 +125,7 @@ options.vnode = vnode => {
 			// Normalize textarea by setting children to value
 			if (props.value != null && type === 'textarea') {
 				props.children = props.value;
+				delete props.defaultValue;
 				delete props.value;
 			}
 

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -123,8 +123,13 @@ options.vnode = vnode => {
 			}
 
 			// Normalize textarea by setting children to value
-			if (props.value != null && type === 'textarea') {
-				props.children = props.value;
+			if (type === 'textarea') {
+				if (props.value != null) {
+					props.children = props.value;
+				} else if (props.defaultValue != null) {
+					props.children = props.defaultValue; // IE 11 fix
+				}
+
 				delete props.defaultValue;
 				delete props.value;
 			}

--- a/compat/test/browser/select.test.js
+++ b/compat/test/browser/select.test.js
@@ -31,4 +31,24 @@ describe('Select', () => {
 		});
 		expect(scratch.firstChild.value).to.equal('B');
 	});
+
+	it('should work with multiple selected defaultValues (array of values)', () => {
+		function App() {
+			return (
+				<select multiple defaultValue={['B', 'C']}>
+					<option value="A">A</option>
+					<option value="B">B</option>
+					<option value="C">C</option>
+				</select>
+			);
+		}
+
+		render(<App />, scratch);
+		Array.prototype.slice.call(scratch.firstChild.childNodes).forEach(node => {
+			if (node.value === 'B' || node.value === 'C') {
+				expect(node.selected).to.equal(true);
+			}
+		});
+		expect(scratch.firstChild.value).to.equal('B');
+	});
 });

--- a/compat/test/browser/textarea.test.js
+++ b/compat/test/browser/textarea.test.js
@@ -2,6 +2,8 @@ import React, { render } from 'preact/compat';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
 describe('Textarea', () => {
+	// React textarea: https://codesandbox.io/s/react-textarea-py5c6
+
 	let scratch;
 
 	beforeEach(() => {
@@ -22,5 +24,28 @@ describe('Textarea', () => {
 		render(<textarea defaultValue="foo" />, scratch);
 
 		expect(scratch.innerHTML).to.equal('<textarea>foo</textarea>');
+	});
+
+	it('should allow using children text if no value or defaultValue is provided', () => {
+		render(<textarea>Children text</textarea>, scratch);
+		expect(scratch.innerHTML).to.equal('<textarea>Children text</textarea>');
+	});
+
+	it('should prioritize value over defaultValue', () => {
+		render(
+			<textarea value="Value prop" defaultValue="defaultValue prop" />,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal('<textarea>Value prop</textarea>');
+	});
+
+	it('should prioritize value prop over defaultValue and children', () => {
+		render(
+			<textarea value="Value prop" defaultValue="defaultValue prop">
+				Children text
+			</textarea>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal('<textarea>Value prop</textarea>');
 	});
 });

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -96,7 +96,8 @@ export function initDebug() {
 
 	options._diff = vnode => {
 		let { type, _parent: parent } = vnode;
-		let parentVNode = getClosestDomNodeParent(parent);
+		const parentType = getClosestDomNodeParent(parent).type;
+		const isVNodeCompatInstalled = '$$typeof' in vnode;
 
 		if (type === undefined) {
 			throw new Error(
@@ -125,7 +126,7 @@ export function initDebug() {
 
 		if (
 			(type === 'thead' || type === 'tfoot' || type === 'tbody') &&
-			parentVNode.type !== 'table'
+			parentType !== 'table'
 		) {
 			console.error(
 				'Improper nesting of table. Your <thead/tbody/tfoot> should have a <table> parent.' +
@@ -134,23 +135,23 @@ export function initDebug() {
 			);
 		} else if (
 			type === 'tr' &&
-			parentVNode.type !== 'thead' &&
-			parentVNode.type !== 'tfoot' &&
-			parentVNode.type !== 'tbody' &&
-			parentVNode.type !== 'table'
+			parentType !== 'thead' &&
+			parentType !== 'tfoot' &&
+			parentType !== 'tbody' &&
+			parentType !== 'table'
 		) {
 			console.error(
 				'Improper nesting of table. Your <tr> should have a <thead/tbody/tfoot/table> parent.' +
 					serializeVNode(vnode) +
 					`\n\n${getOwnerStack(vnode)}`
 			);
-		} else if (type === 'td' && parentVNode.type !== 'tr') {
+		} else if (type === 'td' && parentType !== 'tr') {
 			console.error(
 				'Improper nesting of table. Your <td> should have a <tr> parent.' +
 					serializeVNode(vnode) +
 					`\n\n${getOwnerStack(vnode)}`
 			);
-		} else if (type === 'th' && parentVNode.type !== 'tr') {
+		} else if (type === 'th' && parentType !== 'tr') {
 			console.error(
 				'Improper nesting of table. Your <th> should have a <tr>.' +
 					serializeVNode(vnode) +
@@ -162,7 +163,7 @@ export function initDebug() {
 			vnode.ref !== undefined &&
 			typeof vnode.ref != 'function' &&
 			typeof vnode.ref != 'object' &&
-			!('$$typeof' in vnode) // allow string refs when preact-compat is installed
+			!isVNodeCompatInstalled // allow string refs when preact-compat is installed
 		) {
 			throw new Error(
 				`Component's "ref" property should be a function, or an object created ` +
@@ -172,7 +173,7 @@ export function initDebug() {
 			);
 		}
 
-		if (typeof vnode.type == 'string') {
+		if (typeof type == 'string') {
 			for (const key in vnode.props) {
 				if (
 					key[0] === 'o' &&
@@ -191,17 +192,17 @@ export function initDebug() {
 		}
 
 		// Check prop-types if available
-		if (typeof vnode.type == 'function' && vnode.type.propTypes) {
+		if (typeof type == 'function' && type.propTypes) {
 			if (
-				vnode.type.displayName === 'Lazy' &&
+				type.displayName === 'Lazy' &&
 				warnedComponents &&
-				!warnedComponents.lazyPropTypes.has(vnode.type)
+				!warnedComponents.lazyPropTypes.has(type)
 			) {
 				const m =
 					'PropTypes are not supported on lazy(). Use propTypes on the wrapped component itself. ';
 				try {
-					const lazyVNode = vnode.type();
-					warnedComponents.lazyPropTypes.set(vnode.type, true);
+					const lazyVNode = type();
+					warnedComponents.lazyPropTypes.set(type, true);
 					console.warn(
 						m + `Component wrapped in lazy() is ${getDisplayName(lazyVNode)}`
 					);
@@ -212,7 +213,7 @@ export function initDebug() {
 				}
 			}
 			checkPropTypes(
-				vnode.type.propTypes,
+				type.propTypes,
 				vnode.props,
 				'prop',
 				getDisplayName(vnode)

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -189,6 +189,18 @@ export function initDebug() {
 					);
 				}
 			}
+
+			if (isVNodeCompatInstalled && type == 'input') {
+				if ('value' in vnode.props && 'defaultValue' in vnode.props) {
+					console.warn(
+						`An input of type "${vnode.props.type}" includes both "value" and ` +
+							`"defaultValue" props. Input elements should either specify a ` +
+							`value prop or a defaultValue prop.\n` +
+							serializeVNode(vnode) +
+							`\n\n${getOwnerStack(vnode)}`
+					);
+				}
+			}
 		}
 
 		// Check prop-types if available

--- a/debug/test/browser/debug-compat.test.js
+++ b/debug/test/browser/debug-compat.test.js
@@ -1,0 +1,41 @@
+import { createElement, render, lazy, Suspense } from 'preact/compat';
+import 'preact/debug';
+import { setupRerender } from 'preact/test-utils';
+import {
+	setupScratch,
+	teardown,
+	serializeHtml
+} from '../../../test/_util/helpers';
+
+/** @jsx createElement */
+
+describe('debug with suspense', () => {
+	/** @type {HTMLDivElement} */
+	let scratch;
+	let rerender;
+	let errors = [];
+	let warnings = [];
+
+	beforeEach(() => {
+		errors = [];
+		warnings = [];
+		scratch = setupScratch();
+		rerender = setupRerender();
+		sinon.stub(console, 'error').callsFake(e => errors.push(e));
+		sinon.stub(console, 'warn').callsFake(w => warnings.push(w));
+	});
+
+	afterEach(() => {
+		console.error.restore();
+		console.warn.restore();
+		teardown(scratch);
+	});
+
+	it('should warn for an input with both value & defaultValue', () => {
+		render(<input value="a" defaultValue="b" />, scratch);
+		expect(console.warn).to.be.called;
+		expect(warnings[1]).to.match(
+			/includes both "value" and "defaultValue" props/
+		);
+	});
+});

--- a/debug/test/browser/debug-compat.test.js
+++ b/debug/test/browser/debug-compat.test.js
@@ -1,18 +1,12 @@
-import { createElement, render, lazy, Suspense } from 'preact/compat';
+import { createElement, render } from 'preact/compat';
 import 'preact/debug';
-import { setupRerender } from 'preact/test-utils';
-import {
-	setupScratch,
-	teardown,
-	serializeHtml
-} from '../../../test/_util/helpers';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
 
 /** @jsx createElement */
 
 describe('debug with suspense', () => {
 	/** @type {HTMLDivElement} */
 	let scratch;
-	let rerender;
 	let errors = [];
 	let warnings = [];
 
@@ -20,7 +14,6 @@ describe('debug with suspense', () => {
 		errors = [];
 		warnings = [];
 		scratch = setupScratch();
-		rerender = setupRerender();
 		sinon.stub(console, 'error').callsFake(e => errors.push(e));
 		sinon.stub(console, 'warn').callsFake(w => warnings.push(w));
 	});

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -271,6 +271,12 @@ describe('debug', () => {
 		expect(console.error).to.not.be.called;
 	});
 
+	it('should not warn on input with value and defaultValue', () => {
+		// Only when using preact/compat should this warn
+		render(<input value="a" defaultValue="b" />, scratch);
+		expect(console.warn).to.not.be.called;
+	});
+
 	describe('duplicate keys', () => {
 		const List = props => <ul>{props.children}</ul>;
 		const ListItem = props => <li>{props.children}</li>;


### PR DESCRIPTION
The code removed below was originally added back in preactjs/preact-compat#280. However, in a recent change (maybe #2392?) the `props.value = props.defaultValue` stopped being covered by our tests (see attached). So I wondered if this code was even necessary anymore. I added some additional tests to try and push the boundary of whether this code is needed. Seems like it isn't and we can rely on native defaultValue handling. MDN seems to imply [defaultValue works going back a while](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement) (though I did find one bug with textarea and defaultValue in IE11)

I also adding a warning when using preact/compat and `value` and `defaultValue` on an `input` tag. React warns about this and figured it would be good if we did too. The benefit is to push people to use preact/compat with only React-approved patterns to limit the scope of what preact/compat needs to support. I don't want to support unsupported React behaviors in preact/compat too lol.

[coverage.zip](https://github.com/preactjs/preact/files/4856070/coverage.zip)