### PR TITLE
[docs] HTTPS fix for readme image

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ MIT
 
 
 
-[![Preact](http://i.imgur.com/YqCHvEW.gif)](https://preactjs.com)
+[![Preact](https://i.imgur.com/YqCHvEW.gif)](https://preactjs.com)
 
 
 [preact/compat]: https://github.com/preactjs/preact/tree/master/compat


### PR DESCRIPTION
GitHub auto-fixes this when rendering, but npm doesn't.