### PR TITLE
fix case where textarea doesn't reset state

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -133,7 +133,7 @@ options.vnode = vnode => {
 			// Normalize textarea by setting children to value
 			if (props.value != null && type === 'textarea') {
 				props.children = props.value;
-				delete props.value;
+				// delete props.value;
 			}
 
 			// Normalize DOM vnode properties.

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -130,12 +130,6 @@ options.vnode = vnode => {
 				delete props.value;
 			}
 
-			// Normalize textarea by setting children to value
-			if (props.value != null && type === 'textarea') {
-				props.children = props.value;
-				// delete props.value;
-			}
-
 			// Normalize DOM vnode properties.
 			let shouldSanitize, attrs, i;
 			for (i in props) if ((shouldSanitize = CAMEL_PROPS.test(i))) break;

--- a/compat/test/browser/textarea.test.js
+++ b/compat/test/browser/textarea.test.js
@@ -16,13 +16,13 @@ describe('Textarea', () => {
 	it('should alias value to children', () => {
 		render(<textarea value="foo" />, scratch);
 
-		expect(scratch.innerHTML).to.equal('<textarea>foo</textarea>');
+		expect(scratch.firstElementChild.value).to.equal('foo');
 	});
 
 	it('should alias defaultValue to children', () => {
 		render(<textarea defaultValue="foo" />, scratch);
 
-		expect(scratch.innerHTML).to.equal('<textarea>foo</textarea>');
+		expect(scratch.firstElementChild.value).to.equal('foo');
 	});
 
 	it('should support resetting the value', () => {
@@ -39,12 +39,15 @@ describe('Textarea', () => {
 		act(() => {
 			set('hello');
 		});
+		// Note: this looks super counterintuitive. The value is not present because
+		// innerHTML doesn't serialize form field values. See https://jsfiddle.net/4had2Lu8
+		expect(scratch.innerHTML).to.equal('<textarea></textarea>');
 		expect(scratch.firstElementChild.value).to.equal('hello');
-		expect(scratch.innerHTML).to.equal('<textarea>hello</textarea>');
 
 		act(() => {
 			set('');
 		});
 		expect(scratch.innerHTML).to.equal('<textarea></textarea>');
+		expect(scratch.firstElementChild.value).to.equal('');
 	});
 });

--- a/compat/test/browser/textarea.test.js
+++ b/compat/test/browser/textarea.test.js
@@ -1,5 +1,6 @@
-import React, { render } from 'preact/compat';
+import React, { render, useState } from 'preact/compat';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { act } from 'preact/test-utils';
 
 describe('Textarea', () => {
 	let scratch;
@@ -22,5 +23,27 @@ describe('Textarea', () => {
 		render(<textarea defaultValue="foo" />, scratch);
 
 		expect(scratch.innerHTML).to.equal('<textarea>foo</textarea>');
+	});
+
+	it('should support resetting the value', () => {
+		let set;
+		const App = () => {
+			const [state, setState] = useState('');
+			set = setState;
+			return <textarea value={state} />;
+		};
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal('<textarea></textarea>');
+
+		act(() => {
+			set('hello');
+		});
+		expect(scratch.innerHTML).to.equal('<textarea>hello</textarea>');
+
+		act(() => {
+			set('');
+		});
+		expect(scratch.innerHTML).to.equal('<textarea></textarea>');
 	});
 });

--- a/compat/test/browser/textarea.test.js
+++ b/compat/test/browser/textarea.test.js
@@ -39,6 +39,7 @@ describe('Textarea', () => {
 		act(() => {
 			set('hello');
 		});
+		expect(scratch.firstElementChild.value).to.equal('hello');
 		expect(scratch.innerHTML).to.equal('<textarea>hello</textarea>');
 
 		act(() => {

--- a/compat/test/browser/textarea.test.js
+++ b/compat/test/browser/textarea.test.js
@@ -39,8 +39,10 @@ describe('Textarea', () => {
 		act(() => {
 			set('hello');
 		});
-		// Note: this looks super counterintuitive. The value is not present because
-		// innerHTML doesn't serialize form field values. See https://jsfiddle.net/4had2Lu8
+		// Note: This looks counterintuitive, but it's working correctly - the value
+		// missing from HTML because innerHTML doesn't serialize form field values.
+		// See demo: https://jsfiddle.net/4had2Lu8
+		// Related renderToString PR: preactjs/preact-render-to-string#161
 		expect(scratch.innerHTML).to.equal('<textarea></textarea>');
 		expect(scratch.firstElementChild.value).to.equal('hello');
 


### PR DESCRIPTION
Fixes: https://github.com/preactjs/preact/issues/2604

The test doesn't reproduce this yet I think it's related to uncontrolled/controlled which isn't emulated correctly in jsdom, I tried it out in demo and this fixes the issue.