### PR TITLE
strokeMiterlimit accept a number as well

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -222,7 +222,7 @@ export namespace JSXInternal {
 		strokeDashoffset?: string | number;
 		strokeLinecap?: 'butt' | 'round' | 'square' | 'inherit';
 		strokeLinejoin?: 'miter' | 'round' | 'bevel' | 'inherit';
-		strokeMiterlimit?: string;
+		strokeMiterlimit?: string | number;
 		strokeOpacity?: number | string;
 		strokeWidth?: number | string;
 		surfaceScale?: number | string;


### PR DESCRIPTION
React and SVGR accepts and convert strokeMiterlimit to number. To ensure compatibility I made this little change.