### PR TITLE
Remove useErrorBoundary in compat/src/index.d.ts

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -29,7 +29,6 @@ declare namespace React {
 	export import useReducer = _hooks.useReducer;
 	export import useRef = _hooks.useRef;
 	export import useState = _hooks.useState;
-	export import useErrorBoundary = _hooks.useErrorBoundary
 
 	// Preact Defaults
 	export import Component = preact.Component;

--- a/compat/test/ts/suspense.tsx
+++ b/compat/test/ts/suspense.tsx
@@ -36,17 +36,12 @@ class SuspensefulFunc extends React.Component {
 
 //SuspenseList using lazy components
 function SuspenseListTester(props: any) {
-  const [error] = React.useErrorBoundary((msg) => {
-    console.log(msg)
-  })
-  const _fallback = error ? <div>{JSON.stringify(error)}</div> : <FallBack />
-
   return (
     <React.SuspenseList revealOrder="together">
-      <React.Suspense fallback={_fallback}>
+      <React.Suspense fallback={<FallBack />}>
         <IsLazyFunc isProp={false} />
       </React.Suspense>
-      <React.Suspense fallback={_fallback}>
+      <React.Suspense fallback={<FallBack />}>
         <IsLazyFunc isProp={false} />
       </React.Suspense>
     </React.SuspenseList>


### PR DESCRIPTION
`useErrorBoundary` is not exported from `preact/compat`.
https://github.com/preactjs/preact/blob/5a9c453d78fd885fa3db40b21a5ec4b9a6f7da48/compat/src/index.js#L10-L21