### PR TITLE
resolving type conflict with ReactComponents

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -197,7 +197,7 @@ declare namespace preact {
 	}
 
 	function h(
-		type: string,
+		type: string | ReactComponent,
 		props:
 			| (JSXInternal.HTMLAttributes &
 					JSXInternal.SVGAttributes &


### PR DESCRIPTION
using h(ReactComponent, {element: (<></>)}), exist a type error, but this work!