### PR TITLE
Updated capture defination.

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -611,7 +611,7 @@ export namespace JSXInternal {
 		autofocus?: boolean;
 		autoFocus?: boolean;
 		autoPlay?: boolean;
-		capture?: boolean;
+		capture?: boolean | string;
 		cellPadding?: number | string;
 		cellSpacing?: number | string;
 		charSet?: string;


### PR DESCRIPTION
The spec has changed go allow strings. Please see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/capture