### PR TITLE
allow component to be suspended multiple times

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -27,6 +27,14 @@ function detachedClone(vnode) {
 	return vnode;
 }
 
+function removeOriginal(vnode) {
+	if (vnode) {
+		vnode._original = null;
+		vnode._children = vnode._children && vnode._children.map(removeOriginal);
+	}
+	return vnode;
+}
+
 // having custom inheritance instead of a class here saves a lot of bytes
 export function Suspense() {
 	// we do not call super here to golf some bytes...
@@ -80,7 +88,7 @@ Suspense.prototype._childDidSuspend = function(promise, suspendingComponent) {
 
 	const onSuspensionComplete = () => {
 		if (!--c._pendingSuspensionCount) {
-			c._vnode._children[0] = c.state._suspended;
+			c._vnode._children[0] = removeOriginal(c.state._suspended);
 			c.setState({ _suspended: (c._detachOnNextRender = null) });
 
 			let suspended;

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -787,8 +787,8 @@ describe('suspense', () => {
 				expect(scratch.innerHTML).to.eql(
 					`<div>Hello first 2</div><div>Hello second 2</div>`
 				);
-				expect(Suspender1.prototype.render).to.have.been.calledTwice;
-				expect(Suspender2.prototype.render).to.have.been.calledTwice;
+				expect(Suspender1.prototype.render).to.have.been.calledThrice;
+				expect(Suspender2.prototype.render).to.have.been.calledThrice;
 			});
 		});
 	});
@@ -841,8 +841,8 @@ describe('suspense', () => {
 				expect(scratch.innerHTML).to.eql(
 					`<div>Hello first 2</div><div><div>Hello second 2</div></div>`
 				);
-				expect(Suspender1.prototype.render).to.have.been.calledTwice;
-				expect(Suspender2.prototype.render).to.have.been.calledTwice;
+				expect(Suspender1.prototype.render).to.have.been.calledThrice;
+				expect(Suspender2.prototype.render).to.have.been.calledThrice;
 			});
 		});
 	});
@@ -1314,6 +1314,71 @@ describe('suspense', () => {
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(`<div>conditional hide</div>`);
+	});
+
+	it('should allow suspended multiple times', async () => {
+		const [Suspender1, suspend1] = createSuspender(() => (
+			<div>Suspender 1</div>
+		));
+		const [Suspender2, suspend2] = createSuspender(() => (
+			<div>Suspender 2</div>
+		));
+
+		let hide, resolve;
+
+		class Conditional extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { show: true };
+
+				hide = () => {
+					this.setState({ show: false });
+				};
+			}
+
+			render(props, { show }) {
+				return (
+					<div>
+						conditional {show ? 'show' : 'hide'}
+						{show && (
+							<Suspense fallback="Suspended">
+								<Suspender1 />
+								<Suspender2 />
+							</Suspense>
+						)}
+					</div>
+				);
+			}
+		}
+
+		render(<Conditional />, scratch);
+		expect(scratch.innerHTML).to.eql(
+			'<div>conditional show<div>Suspender 1</div><div>Suspender 2</div></div>'
+		);
+
+		resolve = suspend1()[0];
+		rerender();
+		expect(scratch.innerHTML).to.eql('<div>conditional showSuspended</div>');
+
+		await resolve(() => <div>Done 1</div>);
+		rerender();
+		expect(scratch.innerHTML).to.eql(
+			'<div>conditional show<div>Done 1</div><div>Suspender 2</div></div>'
+		);
+
+		resolve = suspend2()[0];
+		rerender();
+		expect(scratch.innerHTML).to.eql('<div>conditional showSuspended</div>');
+
+		await resolve(() => <div>Done 2</div>);
+		rerender();
+		expect(scratch.innerHTML).to.eql(
+			'<div>conditional show<div>Done 1</div><div>Done 2</div></div>'
+		);
+
+		hide();
+		rerender();
+		expect(scratch.innerHTML).to.eql('<div>conditional hide</div>');
 	});
 
 	it('should call componentWillUnmount on a suspended component', () => {


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/2660

there's a `shouldComponentUpdate` or `newVNode._original === oldVNode._original` optimisation to skip diffing the vnode, but suspended vnode is in a weird state where it is the original node, but the `_dom` is null, (because the DOM element is unmounted from DOM when the component is suspended).

setting the `_original = null` can skip this optimisation, and therefore recreate the dom nodes.