### PR TITLE
fix (#2657) diffElementNodes-bug

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -354,7 +354,7 @@ function diffElementNodes(
 	}
 
 	if (newVNode.type === null) {
-		if (oldProps !== newProps && dom.data != newProps) {
+		if (oldProps !== newProps && dom.data !== newProps) {
 			dom.data = newProps;
 		}
 	} else {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -41,6 +41,14 @@ describe('render()', () => {
 		logCall(Element.prototype, 'remove');
 	});
 
+	it('should rerender when value from "" to 0', () => {
+		render('', scratch);
+		expect(scratch.innerHTML).to.equal('');
+
+		render(0, scratch);
+		expect(scratch.innerHTML).to.equal('0');
+	});
+
 	it('should render an empty text node given an empty string', () => {
 		render('', scratch);
 		let c = scratch.childNodes;


### PR DESCRIPTION
fix #2657 

https://codesandbox.io/s/runtime-wind-bp75k?file=/src/index.js

When setState "state.a" from '' to 0, dom.data is '', newProps is 0,  ('' == 0) is true. so the dom will not change.