### PR TITLE
Fix incorrect download attribute handling

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -130,6 +130,15 @@ options.vnode = vnode => {
 				delete props.value;
 			}
 
+			// Calling `setAttribute` with a truthy value will lead to it being
+			// passed as a stringified value, e.g. `download="true"`. React
+			// converts it to an empty string instead, otherwise the attribute
+			// value will be used as the file name and the file will be called
+			// "true" upon downloading it.
+			if (props.download === true) {
+				props.download = '';
+			}
+
 			// Normalize DOM vnode properties.
 			let shouldSanitize, attrs, i;
 			for (i in props) if ((shouldSanitize = CAMEL_PROPS.test(i))) break;

--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -242,6 +242,14 @@ describe('compat render', () => {
 		);
 	});
 
+	it('should cast boolean "download" values', () => {
+		render(<a download />, scratch);
+		expect(scratch.firstChild.getAttribute('download')).to.equal('');
+
+		render(<a download={false} />, scratch);
+		expect(scratch.firstChild.getAttribute('download')).to.equal(null);
+	});
+
 	it('should support static content', () => {
 		const updateSpy = sinon.spy();
 		const mountSpy = sinon.spy();

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -115,6 +115,7 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 		name !== 'form' &&
 		name !== 'type' &&
 		name !== 'size' &&
+		name !== 'download' &&
 		!isSvg &&
 		name in dom
 	) {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -370,6 +370,14 @@ describe('render()', () => {
 		expect(scratch.firstChild.spellcheck).to.equal(false);
 	});
 
+	it('should render download attribute', () => {
+		render(<a download="" />, scratch);
+		expect(scratch.firstChild.getAttribute('download')).to.equal('');
+
+		render(<a download={null} />, scratch);
+		expect(scratch.firstChild.getAttribute('download')).to.equal(null);
+	});
+
 	it('should not set tagName', () => {
 		expect(() => render(<input tagName="div" />, scratch)).not.to.throw();
 	});


### PR DESCRIPTION
This PR fixes incorrect handling of the `download` attribute on `<a>`-tags. When the value is non-empty it will be used as the name for the file to download. Interestingly it is impossible to remove that attribute via the DOM property directly. Setting it to either `undefined` or `null` will just stringify the value. Only `removeAttribute` correctly removes it.

I've moved the boolean handling over to compat as that is not spec compliant, but rather some special React behavior.

Fixes #2673 .