### PR TITLE
avoid touching dom-attributes during hydration

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -183,7 +183,7 @@ export function diffChildren(
 			//
 			// To fix it we make sure to reset the inferred value, so that our own
 			// value check in `diff()` won't be skipped.
-			if (newParentVNode.type == 'option' && !isHydrating) {
+			if (!isHydrating && newParentVNode.type == 'option') {
 				parentDom.value = '';
 			} else if (typeof newParentVNode.type == 'function') {
 				// Because the newParentVNode is Fragment-like, we need to set it's

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -183,7 +183,7 @@ export function diffChildren(
 			//
 			// To fix it we make sure to reset the inferred value, so that our own
 			// value check in `diff()` won't be skipped.
-			if (newParentVNode.type == 'option') {
+			if (newParentVNode.type == 'option' && !isHydrating) {
 				parentDom.value = '';
 			} else if (typeof newParentVNode.type == 'function') {
 				// Because the newParentVNode is Fragment-like, we need to set it's

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -281,6 +281,38 @@ describe('hydrate()', () => {
 		expect(element.innerHTML).to.equal('<p>hello bar</p>');
 	});
 
+	it('should not remove values', () => {
+		scratch.innerHTML =
+			'<select><option value="0">Zero</option><option selected value="2">Two</option></select>';
+		const App = () => {
+			const options = [
+				{
+					value: '0',
+					label: 'Zero'
+				},
+				{
+					value: '2',
+					label: 'Two'
+				}
+			];
+
+			return (
+				<select value="2">
+					{options.map(({ disabled, label, value }) => (
+						<option key={label} disabled={disabled} value={value}>
+							{label}
+						</option>
+					))}
+				</select>
+			);
+		};
+
+		hydrate(<App />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<select><option value="0">Zero</option><option selected="" value="2">Two</option></select>'
+		);
+	});
+
 	it('should deopt for trees introduced in hydrate (append)', () => {
 		scratch.innerHTML = '<div id="test"><p class="hi">hello bar</p></div>';
 		const Component = props => <p class="hi">hello {props.foo}</p>;


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/2678

I broke this in https://github.com/preactjs/preact/pull/2551/files#diff-a04f8653407a342eac2cd2ea6a5c3ff6R186

`render-to-string` already sets these values correctly and we shouldn't double touch it