### PR TITLE
Add support for IntrinsicElements in ComponentProps

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -75,10 +75,12 @@ declare namespace preact {
 	type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
 	type ComponentFactory<P = {}> = ComponentType<P>;
 
-	type ComponentProps<C extends ComponentType<any>> = C extends ComponentType<
-		infer P
-	>
+	type ComponentProps<
+		C extends ComponentType<any> | keyof JSXInternal.IntrinsicElements
+	> = C extends ComponentType<infer P>
 		? P
+		: C extends keyof JSXInternal.IntrinsicElements
+		? JSXInternal.IntrinsicElements[C]
 		: never;
 
 	interface FunctionComponent<P = {}> {

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -2,6 +2,7 @@ import {
 	createElement,
 	render,
 	Component,
+	ComponentProps,
 	FunctionalComponent,
 	AnyComponent,
 	h
@@ -277,3 +278,16 @@ class ComponentWithPartialSetState extends Component<{}, PartialState> {
 }
 
 const withPartialSetState = <ComponentWithPartialSetState />;
+
+let functionalProps: ComponentProps<typeof DummerComponent> = {
+	initialInput: '',
+	input: ''
+};
+
+let classProps: ComponentProps<typeof DummyComponent> = {
+	initialInput: ''
+};
+
+let elementProps: ComponentProps<'button'> = {
+	type: 'button'
+};


### PR DESCRIPTION
This means users can use for example `ComponentProps<'button'>` or `ComponentProps<'div'>` the same way it can be used with `@types/react`.