### PR TITLE
preact/debug: Add component stack to prop type validation error, do not pass ref to prop-types validation (fixes mui incompatbility)

### DIFF
--- a/debug/src/check-props.js
+++ b/debug/src/check-props.js
@@ -45,7 +45,8 @@ export function checkPropTypes(
 		if (error && !(error.message in loggedTypeFailures)) {
 			loggedTypeFailures[error.message] = true;
 			console.error(
-				`Failed ${location} type: ${error.message}${(getStack && getStack()) ||
+				`Failed ${location} type: ${error.message}${(getStack &&
+					`\n${getStack()}`) ||
 					''}`
 			);
 		}

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -11,6 +11,7 @@ import {
 	getCurrentVNode,
 	getDisplayName
 } from './component-stack';
+import { assign } from './util';
 
 const isWeakMapSupported = typeof WeakMap == 'function';
 
@@ -218,7 +219,7 @@ export function initDebug() {
 
 			let values = vnode.props;
 			if (vnode.type._forwarded) {
-				values = { ...values };
+				values = assign({}, values);
 				delete values.ref;
 			}
 

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -219,7 +219,8 @@ export function initDebug() {
 				vnode.type.propTypes,
 				vnode.props,
 				'prop',
-				getDisplayName(vnode)
+				getDisplayName(vnode),
+				() => getOwnerStack(vnode)
 			);
 		}
 

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -215,9 +215,16 @@ export function initDebug() {
 					);
 				}
 			}
+
+			let values = vnode.props;
+			if (vnode.type._forwarded) {
+				values = { ...values };
+				delete values.ref;
+			}
+
 			checkPropTypes(
 				vnode.type.propTypes,
-				vnode.props,
+				values,
 				'prop',
 				getDisplayName(vnode),
 				() => getOwnerStack(vnode)

--- a/debug/src/util.js
+++ b/debug/src/util.js
@@ -1,0 +1,11 @@
+/**
+ * Assign properties from `props` to `obj`
+ * @template O, P The obj and props types
+ * @param {O} obj The object to copy properties to
+ * @param {P} props The object to copy properties from
+ * @returns {O & P}
+ */
+export function assign(obj, props) {
+	for (let i in props) obj[i] = props[i];
+	return /** @type {O & P} */ (obj);
+}

--- a/debug/test/browser/debug-compat.test.js
+++ b/debug/test/browser/debug-compat.test.js
@@ -1,0 +1,66 @@
+import { createElement, render, createRef } from 'preact';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+import './fakeDevTools';
+import 'preact/debug';
+import * as PropTypes from 'prop-types';
+
+// eslint-disable-next-line no-duplicate-imports
+import { resetPropWarnings } from 'preact/debug';
+import { forwardRef } from 'preact/compat';
+
+const h = createElement;
+/** @jsx createElement */
+
+describe('debug compat', () => {
+	let scratch;
+	let errors = [];
+	let warnings = [];
+
+	beforeEach(() => {
+		errors = [];
+		warnings = [];
+		scratch = setupScratch();
+		sinon.stub(console, 'error').callsFake(e => errors.push(e));
+		sinon.stub(console, 'warn').callsFake(w => warnings.push(w));
+	});
+
+	afterEach(() => {
+		/** @type {*} */
+		(console.error).restore();
+		console.warn.restore();
+		teardown(scratch);
+	});
+
+	describe('PropTypes', () => {
+		beforeEach(() => {
+			resetPropWarnings();
+		});
+
+		it('should not fail if ref is passed to comp wrapped in forwardRef', () => {
+			// This test ensures compat with airbnb/prop-types-exact, mui exact prop types util, etc.
+
+			const Foo = forwardRef(function Foo(props, ref) {
+				return <h1 ref={ref}>{props.text}</h1>;
+			});
+
+			Foo.propTypes = {
+				text: PropTypes.string.isRequired,
+				ref(props) {
+					if ('ref' in props) {
+						throw new Error(
+							'ref should not be passed to prop-types valiation!'
+						);
+					}
+				}
+			};
+
+			const ref = createRef();
+
+			render(<Foo ref={ref} text="123" />, scratch);
+
+			expect(console.error).not.been.called;
+
+			expect(ref.current).to.not.be.undefined;
+		});
+	});
+});

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -10,7 +10,6 @@ import * as PropTypes from 'prop-types';
 
 // eslint-disable-next-line no-duplicate-imports
 import { resetPropWarnings } from 'preact/debug';
-import { forwardRef } from 'preact/compat';
 
 const h = createElement;
 /** @jsx createElement */
@@ -543,33 +542,6 @@ describe('debug', () => {
 					/^Failed prop type: Invalid prop `text` of type `number` supplied to `Foo`, expected `string`\.\n {2}in Foo \(at (.*)\/debug\/test\/browser\/debug\.test\.js:[0-9]+\)$/m
 				)
 			);
-		});
-
-		it('should not fail if ref is passed to comp wrapped in forwardRef', () => {
-			// This test ensures compat with airbnb/prop-types-exact, mui exact prop types util, etc.
-
-			const Foo = forwardRef(function Foo(props, ref) {
-				return <h1 ref={ref}>{props.text}</h1>;
-			});
-
-			Foo.propTypes = {
-				text: PropTypes.string.isRequired,
-				ref(props) {
-					if ('ref' in props) {
-						throw new Error(
-							'ref should not be passed to prop-types valiation!'
-						);
-					}
-				}
-			};
-
-			const ref = createRef();
-
-			render(<Foo ref={ref} text="123" />, scratch);
-
-			expect(console.error).not.been.called;
-
-			expect(ref.current).to.not.be.undefined;
 		});
 
 		it('should only log a given prop type error once', () => {

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -538,7 +538,9 @@ describe('debug', () => {
 			// but we check it exactly to make sure all parameters were supplied
 			// correctly.
 			expect(console.error).to.be.calledWith(
-				'Failed prop type: Invalid prop `text` of type `number` supplied to `Foo`, expected `string`.'
+				sinon.match(
+					/^Failed prop type: Invalid prop `text` of type `number` supplied to `Foo`, expected `string`\.\n {2}in Foo \(at (.*)\/debug\/test\/browser\/debug\.test\.js:[0-9]+\)$/m
+				)
 			);
 		});
 

--- a/mangle.json
+++ b/mangle.json
@@ -66,7 +66,8 @@
       "$_unmount": "__u",
       "$_owner": "__o",
       "$_skipEffects": "__s",
-      "$_rerenderCount": "__r"
+      "$_rerenderCount": "__r",
+      "$_forwarded": "__f"
     }
   }
 }


### PR DESCRIPTION
Add the component stack to the prop types validation error message to help debug #2682 

Not sure that inline arrow function is the best solution but I guess it is preferable over `.bind(null, vnode)`