### PR TITLE
Go back to undefined as default value for useRef

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -174,10 +174,7 @@ export function useLayoutEffect(callback, args) {
 
 export function useRef(initialValue) {
 	currentHook = 5;
-	return useMemo(
-		() => ({ current: initialValue === undefined ? null : initialValue }),
-		[]
-	);
+	return useMemo(() => ({ current: initialValue }), []);
 }
 
 /**

--- a/hooks/test/browser/useRef.test.js
+++ b/hooks/test/browser/useRef.test.js
@@ -32,7 +32,7 @@ describe('useRef', () => {
 		expect(values).to.deep.equal([1, 2]);
 	});
 
-	it('defaults to null', () => {
+	it('defaults to undefined', () => {
 		const values = [];
 
 		function Comp() {
@@ -45,6 +45,6 @@ describe('useRef', () => {
 		render(<Comp />, scratch);
 		render(<Comp />, scratch);
 
-		expect(values).to.deep.equal([null, 2]);
+		expect(values).to.deep.equal([undefined, 2]);
 	});
 });


### PR DESCRIPTION
Turns out that library from #2647 (`react-use`) has a bug and prints out the error with React, too. Double checked and React uses `undefined` as the default value instead of `null`.

This partially reverts #2648 .

Fixes #2688 .
