### PR TITLE
fix(#2677): replace null to undefined on normalizing props

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -140,15 +140,12 @@ options.vnode = vnode => {
 			}
 
 			// Normalize DOM vnode properties.
-			let shouldSanitize, attrs, i;
-			for (i in props) if ((shouldSanitize = CAMEL_PROPS.test(i))) break;
-			if (shouldSanitize) {
-				attrs = vnode.props = {};
-				for (i in props) {
-					attrs[
-						CAMEL_PROPS.test(i) ? i.replace(/[A-Z0-9]/, '-$&').toLowerCase() : i
-					] = props[i];
-				}
+			let i;
+			for (i in props) {
+				let shouldSanitize = CAMEL_PROPS.test(i);
+				if (shouldSanitize)
+					vnode.props[i.replace(/[A-Z0-9]/, '-$&').toLowerCase()] = props[i];
+				if (shouldSanitize || props[i] === null) props[i] = undefined;
 			}
 		}
 

--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -99,6 +99,12 @@ describe('compat render', () => {
 			.that.equals('dynamic content');
 	});
 
+	it('should ignore maxLength / minLength when is null', () => {
+		render(<input maxLength={null} minLength={null} />, scratch);
+		expect(scratch.firstElementChild.getAttribute('maxlength')).to.equal(null);
+		expect(scratch.firstElementChild.getAttribute('minlength')).to.equal(null);
+	});
+
 	it('should support defaultValue', () => {
 		render(<input defaultValue="foo" />, scratch);
 		expect(scratch.firstElementChild).to.have.property('value', 'foo');


### PR DESCRIPTION
Closes https://github.com/preactjs/preact/issues/2677

Very good initiative about the "beginner-friendly" label, I will be more encouraged to contribute. 😊

The issue here was about `maxLength={null}`, this  was converted to `maxlength="0"`. In React, however, it was the same as `undefined`. This PR fixes this. 