### PR TITLE
Fix useDebugValue typings to align w/ react

### DIFF
--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -125,7 +125,7 @@ export function useContext<T>(context: PreactContext<T>): T;
  */
 export function useDebugValue<T>(
 	value: T,
-	formatter?: (value: T) => string | number
+	formatter?: (value: T) => any
 ): void;
 
 export function useErrorBoundary(


### PR DESCRIPTION
> function useDebugValue<T>(value: T, format?: (value: T) => any): void;
> https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L1126

Return type of `format` function is `any` in React.

I found this gap when rewriting a certain lib for `react` into `preact` one.

Is this reasonable? 👀 