### PR TITLE
Remove errorInfo type from componentDidCatch

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -127,7 +127,7 @@ declare namespace preact {
 			previousState: Readonly<S>,
 			snapshot: any
 		): void;
-		componentDidCatch?(error: any, errorInfo: any): void;
+		componentDidCatch?(error: any): void;
 	}
 
 	abstract class Component<P, S> {


### PR DESCRIPTION
This parameter exists in the React equivalent, but not in Preact.