### PR TITLE
Fix state turned readonly in update fn

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -33,7 +33,9 @@ Component.prototype.setState = function(update, callback) {
 	}
 
 	if (typeof update == 'function') {
-		update = update(s, this.props);
+		// Some libraries like `immer` mark the current state as readonly,
+		// preventing us from mutating it, so we need to clone it. See #2716
+		update = update(assign({}, s), this.props);
 	}
 
 	if (update) {

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -2572,6 +2572,35 @@ describe('Components', () => {
 			expect(scratch.innerHTML).to.equal('baz');
 			expect(callbackState).to.deep.equal({ foo: 'baz' });
 		});
+
+		// #2716
+		it('should work with readonly state', () => {
+			let update;
+			class Foo extends Component {
+				constructor(props) {
+					super(props);
+					this.state = { foo: 'bar' };
+					update = () =>
+						this.setState(prev => {
+							Object.defineProperty(prev, 'foo', {
+								writable: false
+							});
+
+							return prev;
+						});
+				}
+
+				render() {
+					return <div />;
+				}
+			}
+
+			render(<Foo />, scratch);
+			expect(() => {
+				update();
+				rerender();
+			}).to.not.throw();
+		});
 	});
 
 	describe('forceUpdate', () => {


### PR DESCRIPTION
Some libraries like `immer` mutate the current state object and mark all properties as `readonly`. This broke our update function.

Fixes #2716.