### PR TITLE
fix rendering children as zero number

### DIFF
--- a/compat/src/Children.js
+++ b/compat/src/Children.js
@@ -1,11 +1,11 @@
 import { toChildArray } from 'preact';
 
 const mapFn = (children, fn) => {
-	if (typeof children === 'undefined' || children === null) return null;
+	if (children === undefined || children === null) return null;
 	return toChildArray(toChildArray(children).map(fn));
 };
 
-// This API is completely unnecessary for Preact, so it's basically passthrough.
+// This API is completely unne`cessary for Preact, so it's basically passthrough.
 export const Children = {
 	map: mapFn,
 	forEach: mapFn,

--- a/compat/src/Children.js
+++ b/compat/src/Children.js
@@ -1,7 +1,7 @@
 import { toChildArray } from 'preact';
 
 const mapFn = (children, fn) => {
-	if (children === undefined || children === null) return null;
+	if (children == null) return null;
 	return toChildArray(toChildArray(children).map(fn));
 };
 

--- a/compat/src/Children.js
+++ b/compat/src/Children.js
@@ -1,7 +1,7 @@
 import { toChildArray } from 'preact';
 
 const mapFn = (children, fn) => {
-	if (!children) return null;
+	if (typeof children === 'undefined' || children === null) return null;
 	return toChildArray(toChildArray(children).map(fn));
 };
 

--- a/compat/src/Children.js
+++ b/compat/src/Children.js
@@ -5,7 +5,7 @@ const mapFn = (children, fn) => {
 	return toChildArray(toChildArray(children).map(fn));
 };
 
-// This API is completely unne`cessary for Preact, so it's basically passthrough.
+// This API is completely unnecessary for Preact, so it's basically passthrough.
 export const Children = {
 	map: mapFn,
 	forEach: mapFn,

--- a/compat/test/browser/Children.test.js
+++ b/compat/test/browser/Children.test.js
@@ -99,6 +99,13 @@ describe('Children', () => {
 			expect(serializeHtml(scratch)).to.equal('<div></div>');
 		});
 
+		it('should work with children as zero number', () => {
+			const testNumber = 0;
+
+			render(<Foo>{testNumber}</Foo>, scratch);
+			expect(serializeHtml(scratch)).to.equal('<div><span>0</span></div>');
+		});
+
 		it('should flatten result', () => {
 			const ProblemChild = ({ children }) => {
 				return React.Children.map(children, child => {


### PR DESCRIPTION
React allows pass `0` (number, not string) as children prop and properly render it
React sandbox example
https://codesandbox.io/s/cranky-dust-7tjqw