### PR TITLE
Add version check to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,6 +2,8 @@
 👋 Hi there! Thanks for taking the time to open an issue.
 ׁ
 Here's a guide to getting your issue resolved quickly:
+
+❓ Did you check that you're on the latest version of Preact?
 🗣 For help with Preact, ask on Slack: https://preact-slack.now.sh
 ✨ Check for existing StackOverflow solutions: https://stackoverflow.com/search?q=preact
 📚 Check out our docs - for Preact 10: https://preactjs.com/guide/v10/getting-started

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@
 Here's a guide to getting your issue resolved quickly:
 
 ❓ Did you check that you're on the latest version of Preact?
-🗣 For help with Preact, ask on Slack: https://preact-slack.now.sh
+🗣 For help with Preact, ask on Slack: https://chat.preactjs.com/
 ✨ Check for existing StackOverflow solutions: https://stackoverflow.com/search?q=preact
 📚 Check out our docs - for Preact 10: https://preactjs.com/guide/v10/getting-started
 🔎 Check if there's already an issue for your problem


### PR DESCRIPTION
We've got a few issues where the issue was already fixed, but the reporter was on an older version of Preact. I'm hoping that this added sentence will make them double check that.

Also noticed that the chat link was wrong.