### PR TITLE
Debug: Print error on changing dependency array length between renders

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -23,6 +23,23 @@ function getClosestDomNodeParent(parent) {
 	return parent;
 }
 
+/**
+ * Get the name of a hook with arguments by type
+ * @param {import('../../src/internal').HookType} type
+ */
+function getArgsHookName(type) {
+	switch (type) {
+		case 3:
+			return 'useEffect';
+		case 4:
+			return 'useLayoutEffect';
+		case 7:
+			return 'useMemo';
+		default:
+			return 'unknown';
+	}
+}
+
 export function initDebug() {
 	setupComponentStack();
 
@@ -35,6 +52,7 @@ export function initDebug() {
 	let oldCatchError = options._catchError;
 	let oldRoot = options._root;
 	let oldHook = options._hook;
+	let oldArgsChanged = options._argsChanged;
 	const warnedComponents = !isWeakMapSupported
 		? null
 		: {
@@ -236,12 +254,27 @@ export function initDebug() {
 		if (oldBeforeDiff) oldBeforeDiff(vnode);
 	};
 
+	let lastHookType = -1;
 	options._hook = (comp, index, type) => {
+		lastHookType = type;
 		if (!comp || !hooksAllowed) {
 			throw new Error('Hook can only be invoked from render methods.');
 		}
 
 		if (oldHook) oldHook(comp, index, type);
+	};
+
+	options._argsChanged = (oldArgs, newArgs, currentComponent) => {
+		if (oldArgs && newArgs && oldArgs.length !== newArgs.length) {
+			const name = getArgsHookName(lastHookType);
+			console.error(
+				`Error: The dependency Array (last argument) passed to ${name} ` +
+					`changed size between renders. The order of the items and the size ` +
+					`of this Array must remain the same.` +
+					`\n\n${getOwnerStack(currentComponent._vnode)}`
+			);
+		}
+		if (oldArgsChanged) oldArgsChanged(oldArgs, newArgs, currentComponent);
 	};
 
 	// Ideally we'd want to print a warning once per component, but we

--- a/debug/test/browser/debug-hooks.test.js
+++ b/debug/test/browser/debug-hooks.test.js
@@ -135,19 +135,19 @@ describe('debug with hooks', () => {
 			return <p>{foo}</p>;
 		};
 
-		render(<App useMemo={true} />, scratch);
+		render(<App useMemo />, scratch);
 		render(<App useMemo={false} />, scratch);
 		expect(errors[0]).to.match(/changed size/);
 		expect(errors[0]).to.match(/useMemo/);
 
 		errors = [];
-		render(<App useEffect={true} />, scratch);
+		render(<App useEffect />, scratch);
 		render(<App useEffect={false} />, scratch);
 		expect(errors[0]).to.match(/changed size/);
 		expect(errors[0]).to.match(/useEffect/);
 
 		errors = [];
-		render(<App useLayoutEffect={true} />, scratch);
+		render(<App useLayoutEffect />, scratch);
 		render(<App useLayoutEffect={false} />, scratch);
 		expect(errors[0]).to.match(/changed size/);
 		expect(errors[0]).to.match(/useLayoutEffect/);

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -149,7 +149,10 @@ export function useReducer(reducer, initialState, init) {
 export function useEffect(callback, args) {
 	/** @type {import('./internal').EffectHookState} */
 	const state = getHookState(currentIndex++, 3);
-	if (!options._skipEffects && argsChanged(state._args, args)) {
+	if (
+		!options._skipEffects &&
+		argsChanged(state._args, args, currentComponent)
+	) {
 		state._value = callback;
 		state._args = args;
 
@@ -164,7 +167,10 @@ export function useEffect(callback, args) {
 export function useLayoutEffect(callback, args) {
 	/** @type {import('./internal').EffectHookState} */
 	const state = getHookState(currentIndex++, 4);
-	if (!options._skipEffects && argsChanged(state._args, args)) {
+	if (
+		!options._skipEffects &&
+		argsChanged(state._args, args, currentComponent)
+	) {
 		state._value = callback;
 		state._args = args;
 
@@ -200,7 +206,7 @@ export function useImperativeHandle(ref, createHandle, args) {
 export function useMemo(factory, args) {
 	/** @type {import('./internal').MemoHookState} */
 	const state = getHookState(currentIndex++, 7);
-	if (argsChanged(state._args, args)) {
+	if (argsChanged(state._args, args, currentComponent)) {
 		state._value = factory();
 		state._args = args;
 		state._factory = factory;
@@ -346,8 +352,12 @@ function invokeEffect(hook) {
 /**
  * @param {any[]} oldArgs
  * @param {any[]} newArgs
+ * @param {import('./internal').Component} currentComponent
  */
-function argsChanged(oldArgs, newArgs) {
+function argsChanged(oldArgs, newArgs, currentComponent) {
+	if (options._argsChanged) {
+		options._argsChanged(oldArgs, newArgs, currentComponent);
+	}
 	return (
 		!oldArgs ||
 		oldArgs.length !== newArgs.length ||

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -266,6 +266,11 @@ declare namespace preact {
 		debounceRendering?(cb: () => void): void;
 		useDebugValue?(value: string | number): void;
 		__suspenseDidResolve?(vnode: VNode, cb: () => void): void;
+		_argsChanged?(
+			oldArgs: any[],
+			newArgs: any[],
+			currentComponent: Component
+		): void;
 		// __canSuspenseResolve?(vnode: VNode, cb: () => void): void;
 	}
 


### PR DESCRIPTION
This PR adds a new error log to `preact/debug` that comes into play when the dependency array length of a hook changes between renders.

Fixes #2728 .