### PR TITLE
[wip] optimizations for compat

### DIFF
--- a/compat/src/Children.js
+++ b/compat/src/Children.js
@@ -1,11 +1,8 @@
 import { toChildArray } from 'preact';
 
 const mapFn = (children, fn) => {
-	if (!children) return null;
-	return toChildArray(children).reduce(
-		(acc, value, index) => acc.concat(fn(value, index)),
-		[]
-	);
+	if (children == null) return null;
+	return toChildArray(toChildArray(children).map(fn));
 };
 
 // This API is completely unnecessary for Preact, so it's basically passthrough.
@@ -16,11 +13,9 @@ export const Children = {
 		return children ? toChildArray(children).length : 0;
 	},
 	only(children) {
-		children = toChildArray(children);
-		if (children.length !== 1) {
-			throw new Error('Children.only() expects only one child.');
-		}
-		return children[0];
+		const normalized = toChildArray(children);
+		if (normalized.length !== 1) throw 'Children.only';
+		return normalized[0];
 	},
 	toArray: toChildArray
 };

--- a/compat/src/PureComponent.js
+++ b/compat/src/PureComponent.js
@@ -4,16 +4,12 @@ import { shallowDiffers } from './util';
 /**
  * Component class with a predefined `shouldComponentUpdate` implementation
  */
-export class PureComponent extends Component {
-	constructor(props) {
-		super(props);
-		// Some third-party libraries check if this property is present
-		this.isPureReactComponent = true;
-	}
-
-	shouldComponentUpdate(props, state) {
-		return (
-			shallowDiffers(this.props, props) || shallowDiffers(this.state, state)
-		);
-	}
+export function PureComponent(p) {
+	this.props = p;
 }
+PureComponent.prototype = new Component();
+// Some third-party libraries check if this property is present
+PureComponent.prototype.isPureReactComponent = true;
+PureComponent.prototype.shouldComponentUpdate = function(props, state) {
+	return shallowDiffers(this.props, props) || shallowDiffers(this.state, state);
+};

--- a/compat/src/portals.js
+++ b/compat/src/portals.js
@@ -1,12 +1,8 @@
 import { createElement, hydrate, render, __u as _unmount } from 'preact';
 
-class ContextProvider {
-	getChildContext() {
-		return this.props.context;
-	}
-	render(props) {
-		return props.children;
-	}
+function ContextProvider(props) {
+	this.getChildContext = () => props.context;
+	return props.children;
 }
 
 /**

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -120,11 +120,9 @@ options.vnode = vnode => {
 		Object.defineProperty(props, 'className', classNameDescriptor);
 	} else if (type) {
 		let normalizedProps = {};
-		let value, valueProp, multiple;
 
 		for (let i in props) {
-			value = props[i];
-			if (i === 'multiple') multiple = true;
+			let value = props[i];
 
 			// Alias `class` prop to `className` if available
 			if (i === 'className') {
@@ -140,16 +138,10 @@ options.vnode = vnode => {
 				}
 			}
 
-			if (i === 'defaultValue' && valueProp == null) {
-				if ('value' in props) {
-					i = 'value';
-				} else {
-					valueProp = value;
-				}
-			}
-
-			if (i === 'value') {
-				valueProp = value;
+			if (i === 'defaultValue' && 'value' in props && props.value == null) {
+				// `defaultValue` is treated as a fallback `value` when a value prop is present but null/undefined.
+				// `defaultValue` for Elements with no value prop is the same as the DOM defaultValue property.
+				i = 'value';
 			} else if (
 				/^onchange(textarea|input)/i.test(i + type) &&
 				!ONCHANGE_INPUT_TYPES.test(props.type)
@@ -165,6 +157,7 @@ options.vnode = vnode => {
 
 			normalizedProps[i] = value;
 		}
+
 		Object.defineProperty(normalizedProps, 'className', classNameDescriptor);
 
 		if (valueProp != null) {

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -104,7 +104,9 @@ options.vnode = vnode => {
 
 	const isComponent = typeof type == 'function';
 	if (isComponent) {
-		classNameDescriptor.enumerable = 'className' in props;
+		if ((classNameDescriptor.enumerable = 'className' in props)) {
+			props.class = props.className;
+		}
 		Object.defineProperty(props, 'className', classNameDescriptor);
 	} else if (type) {
 		let normalizedProps = {};

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -83,7 +83,11 @@ function isDefaultPrevented() {
 			return this[mapped];
 		},
 		set(v) {
-			this[mapped] = v;
+			Object.defineProperty(this, key, {
+				configurable: true,
+				writable: true,
+				value: v
+			});
 		}
 	});
 });

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -134,33 +134,30 @@ options.vnode = vnode => {
 				}
 			}
 
-			/*if (isComponent) {
-				normalizedProps[i] = value;
-			} else*/
-			if (i === 'defaultValue') {
-				if (valueProp == null) {
+			if (i === 'defaultValue' && valueProp == null) {
+				if ('value' in props) {
+					i = 'value';
+				} else {
 					valueProp = value;
 				}
-			} else if (i === 'value') {
-				if (value != null) {
-					valueProp = value;
-				}
-			} else {
-				if (
-					/^onchange(textarea|input)/i.test(i + type) &&
-					!/fil|che|rad/i.test(props.type)
-				) {
-					i = 'oninput';
-				} else if (/ondoubleclick/i.test(i)) {
-					i = 'ondblclick';
-				} else if (/^on(Ani|Tra|Tou|BeforeInp)/.test(i)) {
-					i = i.toLowerCase();
-				} else if (CAMEL_PROPS.test(i)) {
-					i = i.replace(/[A-Z0-9]/, '-$&').toLowerCase();
-				}
-
-				normalizedProps[i] = value;
 			}
+
+			if (i === 'value') {
+				valueProp = value;
+			} else if (
+				/^onchange(textarea|input)/i.test(i + type) &&
+				!/fil|che|rad/i.test(props.type)
+			) {
+				i = 'oninput';
+			} else if (/ondoubleclick/i.test(i)) {
+				i = 'ondblclick';
+			} else if (/^on(Ani|Tra|Tou|BeforeInp)/.test(i)) {
+				i = i.toLowerCase();
+			} else if (CAMEL_PROPS.test(i)) {
+				i = i.replace(/[A-Z0-9]/, '-$&').toLowerCase();
+			}
+
+			normalizedProps[i] = value;
 		}
 		Object.defineProperty(normalizedProps, 'className', classNameDescriptor);
 
@@ -170,8 +167,6 @@ options.vnode = vnode => {
 				toChildArray(props.children).forEach(child => {
 					child.props.selected = valueProp.indexOf(child.props.value) != -1;
 				});
-			} else {
-				normalizedProps.value = valueProp;
 			}
 		}
 

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -144,12 +144,13 @@ options.vnode = vnode => {
 				}
 			} else {
 				if (
-					/onchange(textarea|input(fil|che|ra))/i.test(i + type + props.type)
+					/^onchange(textarea|input)/i.test(i + type) &&
+					!/fil|che|rad/i.test(props.type)
 				) {
 					i = 'oninput';
-				} else if (/ondoubleclick/.test(i)) {
+				} else if (/ondoubleclick/i.test(i)) {
 					i = 'ondblclick';
-				} else if (/^on(Ani|Tra|Tou|BeforeInp|Cha)/.test(i)) {
+				} else if (/^on(Ani|Tra|Tou|BeforeInp)/.test(i)) {
 					i = i.toLowerCase();
 				} else if (CAMEL_PROPS.test(i)) {
 					i = i.replace(/[A-Z0-9]/, '-$&').toLowerCase();

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -142,11 +142,10 @@ options.vnode = vnode => {
 				}
 			} else {
 				if (
-					i === 'onchange' &&
-					/textarea|input(fil|che|ra)/i.test(type + props.type)
+					/onchange(textarea|input(fil|che|ra))/i.test(i + type + props.type)
 				) {
 					i = 'oninput';
-				} else if (i === 'ondoubleclick') {
+				} else if (/ondoubleclick/.test(i)) {
 					i = 'ondblclick';
 				} else if (/^on(Ani|Tra|Tou|BeforeInp|Cha)/.test(i)) {
 					i = i.toLowerCase();
@@ -169,6 +168,8 @@ options.vnode = vnode => {
 				normalizedProps.value = valueProp;
 			}
 		}
+
+		vnode.props = normalizedProps;
 	}
 
 	if (oldVNodeHook) oldVNodeHook(vnode);

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -9,6 +9,12 @@ import { IS_NON_DIMENSIONAL } from './util';
 
 const CAMEL_PROPS = /^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|fill|flood|font|glyph(?!R)|horiz|marker(?!H|W|U)|overline|paint|stop|strikethrough|stroke|text(?!L)|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/;
 
+// Input types for which onchange should not be converted to oninput.
+// type="file|checkbox|radio", plus "range" in IE11.
+// (IE11 doesn't support Symbol, which we use here to turn `rad` into `ra` which matches "range")
+const ONCHANGE_INPUT_TYPES =
+	typeof Symbol != 'undefined' ? /fil|che|rad/i : /fil|che|ra/i;
+
 // Some libraries like `react-virtualized` explicitly check for this.
 Component.prototype.isReactComponent = {};
 
@@ -114,7 +120,7 @@ options.vnode = vnode => {
 		Object.defineProperty(props, 'className', classNameDescriptor);
 	} else if (type) {
 		let normalizedProps = {};
-		let value, hasClass, valueProp, multiple;
+		let value, valueProp, multiple;
 
 		for (let i in props) {
 			value = props[i];
@@ -146,7 +152,7 @@ options.vnode = vnode => {
 				valueProp = value;
 			} else if (
 				/^onchange(textarea|input)/i.test(i + type) &&
-				!/fil|che|rad/i.test(props.type)
+				!ONCHANGE_INPUT_TYPES.test(props.type)
 			) {
 				i = 'oninput';
 			} else if (/ondoubleclick/i.test(i)) {

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -5,7 +5,6 @@ import {
 	toChildArray,
 	Component
 } from 'preact';
-// import { applyEventNormalization } from './events';
 import { IS_NON_DIMENSIONAL } from './util';
 
 const CAMEL_PROPS = /^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|fill|flood|font|glyph(?!R)|horiz|marker(?!H|W|U)|overline|paint|stop|strikethrough|stroke|text(?!L)|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/;
@@ -49,26 +48,21 @@ export function hydrate(vnode, parent, callback) {
 let oldEventHook = options.event;
 options.event = e => {
 	if (oldEventHook) e = oldEventHook(e);
-	e.persist = () => {};
-	let stoppedPropagating = false,
-		defaultPrevented = false;
-
-	const origStopPropagation = e.stopPropagation;
-	e.stopPropagation = () => {
-		origStopPropagation.call(e);
-		stoppedPropagating = true;
-	};
-
-	const origPreventDefault = e.preventDefault;
-	e.preventDefault = () => {
-		origPreventDefault.call(e);
-		defaultPrevented = true;
-	};
-
-	e.isPropagationStopped = () => stoppedPropagating;
-	e.isDefaultPrevented = () => defaultPrevented;
+	e.persist = empty;
+	e.isPropagationStopped = isPropagationStopped;
+	e.isDefaultPrevented = isDefaultPrevented;
 	return (e.nativeEvent = e);
 };
+
+function empty() {}
+
+function isPropagationStopped() {
+	return this.cancelBubble;
+}
+
+function isDefaultPrevented() {
+	return this.defaultPrevented;
+}
 
 // Patch in `UNSAFE_*` lifecycle hooks
 function setSafeDescriptor(proto, key) {

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -45,7 +45,6 @@ Component.prototype.isReactComponent = {};
 				writable: true,
 				value: v
 			});
-			// this[mapped] = v;
 		}
 	});
 });
@@ -61,9 +60,7 @@ export function render(vnode, parent, callback) {
 	// React destroys any existing DOM nodes, see #1727
 	// ...but only on the first render, see #1828
 	if (parent._children == null) {
-		while (parent.firstChild) {
-			parent.removeChild(parent.firstChild);
-		}
+		parent.textContent = '';
 	}
 
 	preactRender(vnode, parent);

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -160,13 +160,17 @@ options.vnode = vnode => {
 
 		Object.defineProperty(normalizedProps, 'className', classNameDescriptor);
 
-		if (valueProp != null) {
-			// Add support for array select values: <select value={[]} />
-			if (type === 'select' && multiple && Array.isArray(valueProp)) {
-				toChildArray(props.children).forEach(child => {
-					child.props.selected = valueProp.indexOf(child.props.value) != -1;
-				});
-			}
+		// Add support for array select values: <select multiple value={[]} />
+		if (
+			type == 'select' &&
+			normalizedProps.multiple &&
+			Array.isArray(normalizedProps.value)
+		) {
+			// forEach() always returns undefined, which we abuse here to unset the value prop.
+			normalizedProps.value = toChildArray(props.children).forEach(child => {
+				child.props.selected =
+					normalizedProps.value.indexOf(child.props.value) != -1;
+			});
 		}
 
 		vnode.props = normalizedProps;

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -118,12 +118,11 @@ options.vnode = vnode => {
 
 		for (let i in props) {
 			value = props[i];
-			if (i === 'class') hasClass = true;
 			if (i === 'multiple') multiple = true;
 
 			// Alias `class` prop to `className` if available
 			if (i === 'className') {
-				if (!hasClass) normalizedProps.class = value;
+				normalizedProps.class = value;
 				classNameDescriptor.enumerable = true;
 			}
 

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -164,7 +164,7 @@ options.vnode = vnode => {
 			// Add support for array select values: <select value={[]} />
 			if (type === 'select' && multiple && Array.isArray(valueProp)) {
 				toChildArray(props.children).forEach(child => {
-					child.props.selected = valueProp.indexOf(child.props.value);
+					child.props.selected = valueProp.indexOf(child.props.value) != -1;
 				});
 			} else {
 				normalizedProps.value = valueProp;

--- a/compat/test/browser/events.test.js
+++ b/compat/test/browser/events.test.js
@@ -70,15 +70,18 @@ describe('preact/compat events', () => {
 		expect(vnode.props).to.not.haveOwnProperty('onchange');
 	});
 
-	it('should not normalize onChange for range', () => {
+	it('should normalize onChange for range, except in IE11', () => {
+		// NOTE: we don't normalize `onchange` for range inputs in IE11.
+		const eventType = /Trident\//.test(navigator.userAgent)
+			? 'change'
+			: 'input';
 		render(<input type="range" onChange={() => null} />, scratch);
 		expect(proto.addEventListener).to.have.been.calledOnce;
 		expect(proto.addEventListener).to.have.been.calledWithExactly(
-			'change',
+			eventType,
 			sinon.match.func,
 			false
 		);
-		expect(proto.addEventListener).not.to.have.been.calledWith('input');
 	});
 
 	it('should support onAnimationEnd', () => {

--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -195,11 +195,19 @@ describe('compat render', () => {
 	// Issue #2275
 	it('should normalize class+className + DOM properties', () => {
 		function Foo(props) {
-			return <ul {...props} class="old" />;
+			return <ul class="old" {...props} />;
 		}
 
 		render(<Foo fontSize="xlarge" className="new" />, scratch);
 		expect(scratch.firstChild.className).to.equal('new');
+	});
+
+	it('should give precedence to last-applied class/className prop', () => {
+		render(<ul className="from className" class="from class" />, scratch);
+		expect(scratch.firstChild.className).to.equal('from class');
+
+		render(<ul class="from class" className="from className" />, scratch);
+		expect(scratch.firstChild.className).to.equal('from className');
 	});
 
 	// Issue #2224

--- a/compat/test/browser/select.test.js
+++ b/compat/test/browser/select.test.js
@@ -24,11 +24,10 @@ describe('Select', () => {
 		}
 
 		render(<App />, scratch);
-		Array.prototype.slice.call(scratch.firstChild.childNodes).forEach(node => {
-			if (node.value === 'B' || node.value === 'C') {
-				expect(node.selected).to.equal(true);
-			}
-		});
+		const options = scratch.firstChild.children;
+		expect(options[0]).to.have.property('selected', false);
+		expect(options[1]).to.have.property('selected', true);
+		expect(options[2]).to.have.property('selected', true);
 		expect(scratch.firstChild.value).to.equal('B');
 	});
 });


### PR DESCRIPTION
This reduces vnode normalization to a single loop over `props` with no megamorphic property access and no shape mutations caused by `delete`. These don't show up in our CI benchmarks because they're only in compat.

Here's the demo+details for the `UNSAFE_` prefix change any why it works:
https://codesandbox.io/s/preact-x-react-table-6103-forked-4q3l8?file=/src/patch.js:185-307

This PR also fixes #1989 - instead of using `onchange` as-is for `<input type=range>`, it uses `oninput` in all browsers except IE11 (which fires continuous `onchange` for range inputs, the original bug).

I've incorporated the relevant bits from #2665 as well (everything outside of `src/render.js`).

It might be worth backporting the prop+event normalization stuff from this into v10 - it's pretty safe, and around 150b savings along with the performance boost.