### PR TITLE
Hydration Suspend & Resume

### DIFF
--- a/compat/src/internal.d.ts
+++ b/compat/src/internal.d.ts
@@ -16,7 +16,8 @@ export interface Component<P = {}, S = {}> extends PreactComponent<P, S> {
 
 	_childDidSuspend?(
 		error: Promise<void>,
-		suspendingComponent: Component<any, any>
+		suspendingComponent: Component<any, any>,
+		oldVNode?: VNode
 	): void;
 	_suspendedComponentWillUnmount?(): void;
 }

--- a/hooks/test/browser/useEffect.test.js
+++ b/hooks/test/browser/useEffect.test.js
@@ -107,6 +107,7 @@ describe('useEffect', () => {
 			componentDidCatch(err) {
 				spy();
 				errored = err;
+				this.forceUpdate();
 			}
 
 			render(props, state) {
@@ -157,6 +158,7 @@ describe('useEffect', () => {
 			componentDidCatch(err) {
 				spy();
 				errored = err;
+				this.forceUpdate();
 			}
 
 			render(props, state) {
@@ -191,6 +193,7 @@ describe('useEffect', () => {
 			componentDidCatch(err) {
 				spy();
 				errored = err;
+				this.forceUpdate();
 			}
 
 			render(props, state) {
@@ -207,6 +210,9 @@ describe('useEffect', () => {
 			render(<App />, scratch);
 		});
 		expect(spy).to.be.calledOnce;
+		expect(errored)
+			.to.be.an('Error')
+			.with.property('message', 'hi');
 		expect(scratch.innerHTML).to.equal('<p>Error</p>');
 	});
 

--- a/hooks/test/browser/useLayoutEffect.test.js
+++ b/hooks/test/browser/useLayoutEffect.test.js
@@ -253,6 +253,7 @@ describe('useLayoutEffect', () => {
 			componentDidCatch(err) {
 				spy();
 				errored = err;
+				this.forceUpdate();
 			}
 
 			render(props, state) {
@@ -303,6 +304,7 @@ describe('useLayoutEffect', () => {
 			componentDidCatch(err) {
 				spy();
 				errored = err;
+				this.forceUpdate();
 			}
 
 			render(props, state) {

--- a/mangle.json
+++ b/mangle.json
@@ -46,6 +46,7 @@
       "$_childDidSuspend": "__c",
       "$_suspendedComponentWillUnmount": "__c",
       "$_dom": "__e",
+      "$_hydrating": "__h",
       "$_component": "__c",
       "$__html": "__html",
       "$_parent": "__",

--- a/src/component.js
+++ b/src/component.js
@@ -190,6 +190,8 @@ const defer =
 
 let prevDebounce;
 
+let rerenderCount = 0;
+
 /**
  * Enqueue a rerender of a component
  * @param {import('./internal').Component} c The component to rerender
@@ -199,7 +201,7 @@ export function enqueueRender(c) {
 		(!c._dirty &&
 			(c._dirty = true) &&
 			rerenderQueue.push(c) &&
-			!process._rerenderCount++) ||
+			!rerenderCount++) ||
 		prevDebounce !== options.debounceRendering
 	) {
 		prevDebounce = options.debounceRendering;
@@ -210,7 +212,7 @@ export function enqueueRender(c) {
 /** Flush the render queue by rerendering all queued components */
 function process() {
 	let queue;
-	while ((process._rerenderCount = rerenderQueue.length)) {
+	while ((rerenderCount = rerenderQueue.length)) {
 		queue = rerenderQueue.sort((a, b) => a._vnode._depth - b._vnode._depth);
 		rerenderQueue = [];
 		// Don't update `renderCount` yet. Keep its value non-zero to prevent unnecessary
@@ -220,4 +222,3 @@ function process() {
 		});
 	}
 }
-process._rerenderCount = 0;

--- a/src/component.js
+++ b/src/component.js
@@ -190,8 +190,6 @@ const defer =
 
 let prevDebounce;
 
-let rerenderCount = 0;
-
 /**
  * Enqueue a rerender of a component
  * @param {import('./internal').Component} c The component to rerender
@@ -201,7 +199,7 @@ export function enqueueRender(c) {
 		(!c._dirty &&
 			(c._dirty = true) &&
 			rerenderQueue.push(c) &&
-			!rerenderCount++) ||
+			!process._rerenderCount++) ||
 		prevDebounce !== options.debounceRendering
 	) {
 		prevDebounce = options.debounceRendering;
@@ -212,7 +210,7 @@ export function enqueueRender(c) {
 /** Flush the render queue by rerendering all queued components */
 function process() {
 	let queue;
-	while ((rerenderCount = rerenderQueue.length)) {
+	while ((process._rerenderCount = rerenderQueue.length)) {
 		queue = rerenderQueue.sort((a, b) => a._vnode._depth - b._vnode._depth);
 		rerenderQueue = [];
 		// Don't update `renderCount` yet. Keep its value non-zero to prevent unnecessary
@@ -222,3 +220,4 @@ function process() {
 		});
 	}
 }
+process._rerenderCount = 0;

--- a/src/component.js
+++ b/src/component.js
@@ -131,9 +131,10 @@ function renderComponent(component) {
 			oldVNode,
 			component._globalContext,
 			parentDom.ownerSVGElement !== undefined,
-			null,
+			vnode._hydrating != null ? [oldDom] : null,
 			commitQueue,
-			oldDom == null ? getDomSibling(vnode) : oldDom
+			oldDom == null ? getDomSibling(vnode) : oldDom,
+			vnode._hydrating
 		);
 		commitRoot(commitQueue, vnode);
 

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -73,6 +73,7 @@ export function createVNode(type, props, key, ref, original) {
 		// a _nextDom that has been set to `null`
 		_nextDom: undefined,
 		_component: null,
+		_hydrating: null,
 		constructor: undefined,
 		_original: original
 	};

--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -9,32 +9,29 @@
  */
 export function _catchError(error, vnode) {
 	/** @type {import('../internal').Component} */
-	let component, hasCaught;
+	let component, ctor, handled;
+
 	const wasHydrating = vnode._hydrating;
 
 	for (; (vnode = vnode._parent); ) {
 		if ((component = vnode._component) && !component._processingException) {
 			try {
-				if (
-					component.constructor &&
-					component.constructor.getDerivedStateFromError != null
-				) {
-					hasCaught = true;
-					component.setState(
-						component.constructor.getDerivedStateFromError(error)
-					);
+				ctor = component.constructor;
+
+				if (ctor && ctor.getDerivedStateFromError != null) {
+					component.setState(ctor.getDerivedStateFromError(error));
+					handled = component._dirty;
 				}
 
 				if (component.componentDidCatch != null) {
-					hasCaught = true;
 					component.componentDidCatch(error);
+					handled = component._dirty;
 				}
 
-				if (hasCaught) {
-					// This is an error boundary. Mark it as having bailed out, and whether it was mid-hydration.
+				// This is an error boundary. Mark it as having bailed out, and whether it was mid-hydration.
+				if (handled) {
 					vnode._hydrating = wasHydrating;
-					component._pendingError = component;
-					return;
+					return (component._pendingError = component);
 				}
 			} catch (e) {
 				error = e;

--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -1,4 +1,4 @@
-import { enqueueRender } from '../component';
+// import { enqueueRender } from '../component';
 
 /**
  * Find the closest error boundary to a thrown error and call it
@@ -10,6 +10,7 @@ import { enqueueRender } from '../component';
 export function _catchError(error, vnode) {
 	/** @type {import('../internal').Component} */
 	let component, hasCaught;
+	const wasHydrating = vnode._hydrating;
 
 	for (; (vnode = vnode._parent); ) {
 		if ((component = vnode._component) && !component._processingException) {
@@ -29,8 +30,12 @@ export function _catchError(error, vnode) {
 					component.componentDidCatch(error);
 				}
 
-				if (hasCaught)
-					return enqueueRender((component._pendingError = component));
+				if (hasCaught) {
+					// This is an error boundary. Mark it as having bailed out, and whether it was mid-hydration.
+					vnode._hydrating = wasHydrating;
+					component._pendingError = component;
+					return;
+				}
 			} catch (e) {
 				error = e;
 			}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -69,6 +69,15 @@ export function diff(
 	// constructor as undefined. This to prevent JSON-injection.
 	if (newVNode.constructor !== undefined) return null;
 
+	// If the previous diff bailed out, resume creating/hydrating.
+	if (oldVNode._hydrating != null) {
+		isHydrating = oldVNode._hydrating;
+		oldDom = newVNode._dom = oldVNode._dom;
+		// if we resume, we want the tree to be "unlocked"
+		newVNode._hydrating = null;
+		excessDomChildren = [oldDom];
+	}
+
 	if ((tmp = options._diff)) tmp(newVNode);
 
 	try {
@@ -226,6 +235,9 @@ export function diff(
 
 			c.base = newVNode._dom;
 
+			// We successfully rendered this VNode, unset any stored hydration/bailout state:
+			newVNode._hydrating = null;
+
 			if (c._renderCallbacks.length) {
 				commitQueue.push(c);
 			}
@@ -257,6 +269,14 @@ export function diff(
 		if ((tmp = options.diffed)) tmp(newVNode);
 	} catch (e) {
 		newVNode._original = null;
+		// if hydrating or creating initial tree, bailout preserves DOM:
+		if (isHydrating || excessDomChildren != null) {
+			newVNode._dom = oldDom;
+			newVNode._hydrating = !!isHydrating;
+			excessDomChildren[excessDomChildren.indexOf(oldDom)] = null;
+			// ^ could possibly be simplified to:
+			// excessDomChildren.length = 0;
+		}
 		options._catchError(e, newVNode, oldVNode);
 	}
 
@@ -354,7 +374,8 @@ function diffElementNodes(
 	}
 
 	if (newVNode.type === null) {
-		if (oldProps !== newProps && dom.data !== newProps) {
+		// During hydration, we still have to split merged text from SSR'd HTML.
+		if (oldProps !== newProps && (!isHydrating || dom.data !== newProps)) {
 			dom.data = newProps;
 		}
 	} else {

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -47,7 +47,7 @@ export type ComponentFactory<P> =
 	| preact.ComponentClass<P>
 	| FunctionalComponent<P>;
 
-export interface PreactElement extends HTMLElement {
+export interface PreactElement extends HTMLElement, Text {
 	_children?: VNode<any> | null;
 	/** Event listeners to support event delegation */
 	_listeners: Record<string, (e: Event) => void>;
@@ -70,12 +70,13 @@ export interface VNode<P = {}> extends preact.VNode<P> {
 	/**
 	 * The [first (for Fragments)] DOM child of a VNode
 	 */
-	_dom: PreactElement | Text | null;
+	_dom: PreactElement | null;
 	/**
 	 * The last dom child of a Fragment, or components that return a Fragment
 	 */
-	_nextDom: PreactElement | Text | null;
+	_nextDom: PreactElement | null;
 	_component: Component | null;
+	_hydrating: boolean | null;
 	constructor: undefined;
 	_original?: VNode | null;
 }

--- a/test/browser/lifecycles/componentDidCatch.test.js
+++ b/test/browser/lifecycles/componentDidCatch.test.js
@@ -570,8 +570,10 @@ describe('Lifecycle methods', () => {
 			);
 			rerender();
 
-			expect(Adapter.prototype.componentDidCatch).to.have.been.called;
-			expect(Receiver.prototype.componentDidCatch).to.have.been.called;
+			expect(Adapter.prototype.componentDidCatch, 'Adapter').to.have.been
+				.called;
+			expect(Receiver.prototype.componentDidCatch, 'Receiver').to.have.been
+				.called;
 			expect(scratch).to.have.property('textContent', 'Error: Error!');
 		});
 


### PR DESCRIPTION
This PR implements suspend & resume for both hydration and new tree construction. If rendering throws during hydration or new tree construction (first render of a component or tree), catching the error up the tree in something like an "Error Boundary" will attach the hydration state and available DOM tree to the boundary's VNode. Triggering a render on this node (via any mechanism) attempts to resume from this state. The throw/catch process can be repeated and will continue to preserve DOM state. Once rendering completes, affected VNodes are un-marked and the behavior no longer occurs.