### PR TITLE
Fix unable to set progress value to 0

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -438,7 +438,11 @@ function diffElementNodes(
 			if (
 				'value' in newProps &&
 				(i = newProps.value) !== undefined &&
-				i !== dom.value
+				// #2756 For the <progress>-element the initial value is 0,
+				// despite the attribute not being present. When the attribute
+				// is missing the progress bar is treated as indeterminate.
+				// To fix that we'll always update it when it is 0 for progress elements
+				(i !== dom.value || (newVNode.type === 'progress' && !i))
 			) {
 				setProperty(dom, 'value', i, oldProps.value, false);
 			}

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -758,6 +758,13 @@ describe('render()', () => {
 		expect(scratch.firstChild.checked).to.equal(true);
 	});
 
+	// #2756
+	it('should set progress value to 0', () => {
+		render(<progress value={0} max="100" />, scratch);
+		expect(scratch.firstChild.value).to.equal(0);
+		expect(scratch.firstChild.getAttribute('value')).to.equal('0');
+	});
+
 	it('should always diff `checked` and `value` properties against the DOM', () => {
 		// See https://github.com/preactjs/preact/issues/1324
 


### PR DESCRIPTION
Due to a weird oddity in the DOM interface the value `0` is only treated as `0` when the `value` attribute is present. When the value is not present the progress bar is treated as being indeterminate. But the problem is that the DOM interface will always have all properties and the initial value for `value` is 0. This mismatch caused us to never set the progress bar value to `0`

Fixes #2756 .