### PR TITLE
Add mangle key for _suspended

### DIFF
--- a/mangle.json
+++ b/mangle.json
@@ -45,6 +45,7 @@
       "$_pendingSuspensionCount": "__u",
       "$_childDidSuspend": "__c",
       "$_suspendedComponentWillUnmount": "__c",
+      "$_suspended": "__e",
       "$_dom": "__e",
       "$_hydrating": "__h",
       "$_component": "__c",


### PR DESCRIPTION
This is needed for the Suspense devtools integration to be able to toggle the suspended state. See https://github.com/preactjs/preact-devtools/pull/266