### PR TITLE
Fix jsx-runtime not published

### DIFF
--- a/config/node-13-exports.js
+++ b/config/node-13-exports.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 
-const subRepositories = ['compat', 'debug', 'devtools', 'hooks', 'test-utils'];
+const subRepositories = ['compat', 'debug', 'devtools', 'hooks', 'jsx-runtime', 'test-utils'];
 const snakeCaseToCamelCase = str =>
 	str.replace(/([-_][a-z])/g, group => group.toUpperCase().replace('-', ''));
 


### PR DESCRIPTION
`Module not found: Error: Can't resolve 'preact/jsx-runtime'`

I don't know if this is the only / right place this needs to be fixed, though.