### PR TITLE
Fix incorrect package export for jsx-runtime

### DIFF
--- a/config/check-export-map.js
+++ b/config/check-export-map.js
@@ -1,0 +1,32 @@
+/* eslint-disable no-console */
+const fs = require('fs');
+const path = require('path');
+const pkg = JSON.parse(
+	fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')
+);
+
+console.log('Checking export maps...');
+for (const pkgName in pkg.exports) {
+	const entry = pkg.exports[pkgName];
+
+	if (typeof entry === 'string') {
+		if (!fs.existsSync(path.join(__dirname, '..', entry))) {
+			throw new Error(
+				`Could not find export map file for "${pkgName}" ${entry}`
+			);
+		}
+	} else {
+		for (const type in entry) {
+			if (pkgName === './') continue;
+
+			const fileName = entry[type];
+			if (!fs.existsSync(path.join(__dirname, '..', fileName))) {
+				throw new Error(
+					`Could not find export map file for "${pkgName}" ${type}: ${fileName}`
+				);
+			}
+		}
+	}
+}
+
+console.log('Checking export maps... DONE');

--- a/package.json
+++ b/package.json
@@ -47,16 +47,16 @@
       "import": "./test-utils/dist/testUtils.mjs"
     },
     "./jsx-runtime": {
-      "browser": "./jsx-runtime/dist/jsx-runtime.module.js",
-      "umd": "./jsx-runtime/dist/jsx-runtime.umd.js",
-      "require": "./jsx-runtime/dist/jsx-runtime.js",
-      "import": "./jsx-runtime/dist/jsx-runtime.mjs"
+      "browser": "./jsx-runtime/dist/jsxRuntime.module.js",
+      "umd": "./jsx-runtime/dist/jsxRuntime.umd.js",
+      "require": "./jsx-runtime/dist/jsxRuntime.js",
+      "import": "./jsx-runtime/dist/jsxRuntime.mjs"
     },
     "./jsx-dev-runtime": {
-      "browser": "./jsx-runtime/dist/jsx-runtime.module.js",
-      "umd": "./jsx-runtime/dist/jsx-runtime.umd.js",
-      "require": "./jsx-runtime/dist/jsx-runtime.js",
-      "import": "./jsx-runtime/dist/jsx-runtime.mjs"
+      "browser": "./jsx-runtime/dist/jsxRuntime.module.js",
+      "umd": "./jsx-runtime/dist/jsxRuntime.umd.js",
+      "require": "./jsx-runtime/dist/jsxRuntime.js",
+      "import": "./jsx-runtime/dist/jsxRuntime.mjs"
     },
     "./compat/server": {
       "require": "./compat/server.js"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "types": "src/index.d.ts",
   "scripts": {
-    "prepare": "run-s build",
+    "prepare": "run-s build && node ./config/check-export-map.js",
     "build": "npm-run-all --parallel build:*",
     "build:core": "microbundle build --raw",
     "build:core-min": "microbundle build --raw -f iife src/cjs.js -o dist/preact.min.js",


### PR DESCRIPTION
Also add a check before publishing that asserts if every file defined in the export map exists. Hopefully this will prevent any future publishing errors related to that.