### PR TITLE
Optimizations for preact/jsx-runtime

### DIFF
--- a/jsx-runtime/src/index.js
+++ b/jsx-runtime/src/index.js
@@ -3,24 +3,25 @@ import { options, Fragment } from 'preact';
 /** @typedef {import('preact').VNode} VNode */
 
 /**
- * jsx(type, props, key)
- * jsxs(type, props, key)
- * jsxDEV(type, props, key, __source, __self)
+ * @fileoverview
+ * This file exports various methods that implement Babel's "automatic" JSX runtime API:
+ * - jsx(type, props, key)
+ * - jsxs(type, props, key)
+ * - jsxDEV(type, props, key, __source, __self)
+ *
+ * The implementation of createVNode here is optimized for performance.
+ * Benchmarks: https://esbench.com/bench/5f6b54a0b4632100a7dcd2b3
+ */
+
+/**
+ * JSX.Element factory used by Babel's {runtime:"automatic"} JSX transform
  * @param {VNode['type']} type
  * @param {VNode['props']} props
  * @param {VNode['key']} [key]
  * @param {string} [__source]
  * @param {string} [__self]
- * @param {string} [_i]
- * @param {*} [_x]
  */
-function createVNode(type, props, key, __source, __self, _i, _x) {
-	// If a Component VNode, check for and apply defaultProps
-	// Note: type may be undefined in development, must never error here.
-	if ((_x = type && type.defaultProps)) {
-		for (_i in _x) if (props[_i] === undefined) props[_i] = _x[_i];
-	}
-
+function createVNode(type, props, key, __source, __self) {
 	const vnode = {
 		type,
 		props,
@@ -39,7 +40,15 @@ function createVNode(type, props, key, __source, __self, _i, _x) {
 		__self
 	};
 	vnode._original = vnode;
-	if (options.vnode != null) options.vnode(vnode);
+
+	// If a Component VNode, check for and apply defaultProps.
+	// Note: `type` is often a String, and can be `undefined` in development.
+	let defaults, i;
+	if (typeof type === 'function' && (defaults = type.defaultProps)) {
+		for (i in defaults) if (props[i] === undefined) props[i] = defaults[i];
+	}
+
+	if (options.vnode) options.vnode(vnode);
 	return vnode;
 }
 


### PR DESCRIPTION
This improves VNode creation performance by [7%](https://esbench.com/bench/5f6b54a0b4632100a7dcd2b3), at the expense of a small size increase for the `jsx-runtime` entry that should compress away in bundled applications.