### PR TITLE
Reset hooks state when suspense triggers

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -24,6 +24,9 @@ options._catchError = function(error, newVNode, oldVNode) {
 
 function detachedClone(vnode) {
 	if (vnode) {
+		if (vnode._component) {
+			vnode._component.__hooks = null;
+		}
 		vnode = assign({}, vnode);
 		vnode._component = null;
 		vnode._children = vnode._children && vnode._children.map(detachedClone);

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -25,16 +25,11 @@ options._catchError = function(error, newVNode, oldVNode) {
 function detachedClone(vnode) {
 	if (vnode) {
 		if (vnode._component && vnode._component.__hooks) {
-			if (vnode._component.__hooks._list.length) {
-				vnode._component.__hooks._list.forEach(effect => {
-					if (typeof effect._cleanup == 'function') effect._cleanup();
-				});
-			}
+			vnode._component.__hooks._list.forEach(effect => {
+				if (typeof effect._cleanup == 'function') effect._cleanup();
+			});
 
-			vnode._component.__hooks = {
-				_list: [],
-				_pendingEffects: []
-			};
+			vnode._component.__hooks = null;
 		}
 
 		vnode = assign({}, vnode);

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -24,19 +24,24 @@ options._catchError = function(error, newVNode, oldVNode) {
 
 function detachedClone(vnode) {
 	if (vnode) {
-		if (vnode._component) {
-			if (vnode._component.__hooks._pendingEffects.length) {
-				vnode._component.__hooks._pendingEffects.forEach(effect => {
+		if (vnode._component && vnode._component.__hooks) {
+			if (vnode._component.__hooks._list.length) {
+				vnode._component.__hooks._list.forEach(effect => {
 					if (typeof effect._cleanup == 'function') effect._cleanup();
 				});
 			}
 
-			vnode._component.__hooks = null;
+			vnode._component.__hooks = {
+				_list: [],
+				_pendingEffects: []
+			};
 		}
+
 		vnode = assign({}, vnode);
 		vnode._component = null;
 		vnode._children = vnode._children && vnode._children.map(detachedClone);
 	}
+
 	return vnode;
 }
 

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -25,6 +25,12 @@ options._catchError = function(error, newVNode, oldVNode) {
 function detachedClone(vnode) {
 	if (vnode) {
 		if (vnode._component) {
+			if (vnode._component.__hooks._pendingEffects.length) {
+				vnode._component.__hooks._pendingEffects.forEach(effect => {
+					if (typeof effect._cleanup == 'function') effect._cleanup();
+				});
+			}
+
 			vnode._component.__hooks = null;
 		}
 		vnode = assign({}, vnode);

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -6,7 +6,8 @@ import React, {
 	Suspense,
 	lazy,
 	Fragment,
-	createContext
+	createContext,
+	useState
 } from 'preact/compat';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
@@ -158,6 +159,56 @@ describe('suspense', () => {
 		return resolve().then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(`<div>Hello from LazyComp</div>`);
+		});
+	});
+
+	it('should reset hooks of components', () => {
+		let set;
+		const LazyComp = ({ name }) => <div>Hello from {name}</div>;
+
+		/** @type {() => Promise<void>} */
+		let resolve;
+		const Lazy = lazy(() => {
+			const p = new Promise(res => {
+				resolve = () => {
+					res({ default: LazyComp });
+					return p;
+				};
+			});
+
+			return p;
+		});
+
+		const Parent = ({ children }) => {
+			const [state, setState] = useState(false);
+			set = setState;
+
+			return (
+				<div>
+					<p>hi</p>
+					{state && children}
+				</div>
+			);
+		};
+
+		render(
+			<Suspense fallback={<div>Suspended...</div>}>
+				<Parent>
+					<Lazy name="LazyComp" />
+				</Parent>
+			</Suspense>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.eql(`<div><p>hi</p></div>`);
+
+		set(true);
+		rerender();
+
+		expect(scratch.innerHTML).to.eql('<div>Suspended...</div>');
+
+		return resolve().then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.eql(`<div><p>hi</p></div>`);
 		});
 	});
 

--- a/mangle.json
+++ b/mangle.json
@@ -25,6 +25,7 @@
   "props": {
     "cname": 6,
     "props": {
+      "$_cleanup": "__c",
       "$_afterPaintQueued": "__a",
       "$__hooks": "__H",
       "$_list": "__",


### PR DESCRIPTION
In React when a component suspends it resets all hooks that are being processed, it also runs cleanups of active effects.

Fixes: https://github.com/preactjs/preact/issues/2795

I also used this opportunity to move `_cleanup` to a reserved property name so I can use it in prefresh https://github.com/JoviDeCroock/prefresh/pull/206/files