### PR TITLE
Fix jsx import by moving it to the root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ coverage
 *.log
 package/
 preact-*.tgz
+./jsxRuntime.js
+./jsxRuntime.mjs

--- a/package.json
+++ b/package.json
@@ -53,10 +53,9 @@
       "import": "./jsx-runtime/dist/jsxRuntime.mjs"
     },
     "./jsx-dev-runtime": {
-      "browser": "./jsx-runtime/dist/jsxRuntime.module.js",
-      "umd": "./jsx-runtime/dist/jsxRuntime.umd.js",
-      "require": "./jsx-runtime/dist/jsxRuntime.js",
-      "import": "./jsx-runtime/dist/jsxRuntime.mjs"
+      "browser": "./jsxRuntime.mjs",
+      "require": "./jsxRuntime.js",
+      "import": "./jsxRuntime.mjs"
     },
     "./compat/server": {
       "require": "./compat/server.js"
@@ -80,7 +79,7 @@
     "build:hooks": "microbundle build --raw --cwd hooks",
     "build:test-utils": "microbundle build --raw --cwd test-utils",
     "build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks'",
-    "build:jsx": "microbundle build --raw --cwd jsx-runtime",
+    "build:jsx": "microbundle build --raw --cwd jsx-runtime && cp ./jsx-runtime/dist/jsxRuntime.module.js ./jsxRuntime.mjs && cp ./jsx-runtime/dist/jsxRuntime.js ./jsxRuntime.js",
     "postbuild": "node ./config/node-13-exports.js",
     "dev": "microbundle watch --raw --format cjs",
     "dev:hooks": "microbundle watch --raw --format cjs --cwd hooks",


### PR DESCRIPTION
Fixes: https://github.com/preactjs/preact/issues/2801

Babel requires the two files to be available at the root.