### PR TITLE
Make ref types' current property non-optional

### DIFF
--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -40,7 +40,7 @@ export function useReducer<S, A, I>(
 	init: (arg: I) => S
 ): [S, (action: A) => void];
 
-type PropRef<T> = { current?: T };
+type PropRef<T> = { current: T };
 type Ref<T> = { current: T };
 
 /**
@@ -123,10 +123,7 @@ export function useContext<T>(context: PreactContext<T>): T;
  * @param value Custom hook name or object that is passed to formatter
  * @param formatter Formatter to modify value before sending it to the devtools
  */
-export function useDebugValue<T>(
-	value: T,
-	formatter?: (value: T) => any
-): void;
+export function useDebugValue<T>(value: T, formatter?: (value: T) => any): void;
 
 export function useErrorBoundary(
 	callback?: (error: any) => Promise<void> | void

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -39,7 +39,7 @@ declare namespace preact {
 
 	type Key = string | number | any;
 
-	type RefObject<T> = { current?: T | null };
+	type RefObject<T> = { current: T | null };
 	type RefCallback<T> = (instance: T | null) => void;
 	type Ref<T> = RefObject<T> | RefCallback<T>;
 


### PR DESCRIPTION
This change aligns Preact's ref types with [those of React](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e47aff8a3a1331d0c540550db79dd5065ab735e5/types/react/index.d.ts#L88-L90), where the `current` property is not optional.