### PR TITLE
TypeScript: General JSX types export for jsx-runtime, fixes TS4.1 compatibility

### DIFF
--- a/jsx-runtime/src/index.d.ts
+++ b/jsx-runtime/src/index.d.ts
@@ -20,9 +20,6 @@ export function jsx<P>(
 	props: Attributes & P & { children?: ComponentChild },
 	key?: string
 ): VNode<any>;
-export namespace jsx {
-	export import JSX = JSXInternal;
-}
 
 export function jsxs(
 	type: string,
@@ -36,9 +33,6 @@ export function jsxs<P>(
 	props: Attributes & P & { children?: ComponentChild[] },
 	key?: string
 ): VNode<any>;
-export namespace jsxs {
-	export import JSX = JSXInternal;
-}
 
 export function jsxDEV(
 	type: string,
@@ -52,6 +46,5 @@ export function jsxDEV<P>(
 	props: Attributes & P & { children?: ComponentChildren },
 	key?: string
 ): VNode<any>;
-export namespace jsxDEV {
-	export import JSX = JSXInternal;
-}
+
+export { JSXInternal as JSX };


### PR DESCRIPTION
This is Re: microsoft/TypeScript#41330 - @weswigham's Pull Request makes sure to pick up the right types when using the new JSX transforms, looking for a general JSX namespace export. This also gets rid of the JSX namespace exports within each factory.

*However*, what I've seen is that TypeScript compiles to the React "convention" for `jsx-runtime`, which is with a configuration like that:

```json
{
  "compilerOptions": {
    ...
    "jsx": "react-jsx", 
    "jsxImportSource": "preact",
  }
}
```

The imports become e.g.

```js
var jsx_runtime_js_1 = require("preact/jsx-runtime.js");
```

I think setting the configuration to 

```json
{
  "compilerOptions": {
    ...
    "jsx": "react-jsx", 
    "jsxImportSource": "preact/compat",
  }
}
```

should do the trick with #2805 being merged. This would require another `jsx-dev-runtime.js` in `compat` to make it fully compatible with all compiler options.