### PR TITLE
Throw when hook is invoked outside of render

### DIFF
--- a/debug/test/browser/debug-hooks.test.js
+++ b/debug/test/browser/debug-hooks.test.js
@@ -25,19 +25,18 @@ describe('debug with hooks', () => {
 		teardown(scratch);
 	});
 
-	// TODO: Fix this test. It only passed before because App was the first component
-	// into render so currentComponent in hooks/index.js wasn't set yet. However,
-	// any children under App wouldn't have thrown the error if they did what App
-	// did because currentComponent would be set to App.
-	// In other words, hooks never clear currentComponent so once it is set, it won't
-	// be unset
-	it.skip('should throw an error when using a hook outside a render', () => {
-		const Foo = props => props.children;
-		class App extends Component {
+	it('should throw an error when using a hook outside a render', () => {
+		class Foo extends Component {
 			componentWillMount() {
 				useState();
 			}
 
+			render() {
+				return this.props.children;
+			}
+		}
+
+		class App extends Component {
 			render() {
 				return <p>test</p>;
 			}
@@ -77,6 +76,20 @@ describe('debug with hooks', () => {
 			act(() => {
 				useState();
 				render(<Foo>Hello!</Foo>, scratch);
+			});
+		expect(fn).to.throw(/Hook can only be invoked from render/);
+	});
+
+	it('should throw an error when invoked outside of a component after render', () => {
+		function Foo(props) {
+			useEffect(() => {}); // Pretend to use a hook
+			return props.children;
+		}
+
+		const fn = () =>
+			act(() => {
+				render(<Foo>Hello!</Foo>, scratch);
+				useState();
 			});
 		expect(fn).to.throw(/Hook can only be invoked from render/);
 	});


### PR DESCRIPTION
Looks like we only threw when a hook was called from outside of a component for the very first component that was rendered. This was caused by `currentComponent` already being set at that point. See the previous code comment in the changeset.

This PR corrects that so that we keep track of valid hook positions and always throw if it's invalid.

Fixes #2574 