### PR TITLE
Ensure preact/compat is not converting onchange to oninput for input type="range" in IE11

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -16,7 +16,9 @@ const CAMEL_PROPS = /^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|colo
 // type="file|checkbox|radio", plus "range" in IE11.
 // (IE11 doesn't support Symbol, which we use here to turn `rad` into `ra` which matches "range")
 const ONCHANGE_INPUT_TYPES =
-	typeof Symbol != 'undefined' ? /fil|che|rad/i : /fil|che|ra/i;
+	typeof Symbol != 'undefined' && typeof Symbol() == 'symbol'
+		? /fil|che|rad/i
+		: /fil|che|ra/i;
 
 // Some libraries like `react-virtualized` explicitly check for this.
 Component.prototype.isReactComponent = {};

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -15,10 +15,11 @@ const CAMEL_PROPS = /^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|colo
 // Input types for which onchange should not be converted to oninput.
 // type="file|checkbox|radio", plus "range" in IE11.
 // (IE11 doesn't support Symbol, which we use here to turn `rad` into `ra` which matches "range")
-const ONCHANGE_INPUT_TYPES =
-	typeof Symbol != 'undefined' && typeof Symbol() == 'symbol'
+const onChangeInputType = type =>
+	(typeof Symbol != 'undefined' && typeof Symbol() == 'symbol'
 		? /fil|che|rad/i
-		: /fil|che|ra/i;
+		: /fil|che|ra/i
+	).test(type);
 
 // Some libraries like `react-virtualized` explicitly check for this.
 Component.prototype.isReactComponent = {};
@@ -131,7 +132,7 @@ options.vnode = vnode => {
 				i = 'ondblclick';
 			} else if (
 				/^onchange(textarea|input)/i.test(i + type) &&
-				!ONCHANGE_INPUT_TYPES.test(props.type)
+				!onChangeInputType(props.type)
 			) {
 				i = 'oninput';
 			} else if (/^on(Ani|Tra|Tou|BeforeInp)/.test(i)) {

--- a/compat/test/browser/events.test.js
+++ b/compat/test/browser/events.test.js
@@ -75,6 +75,7 @@ describe('preact/compat events', () => {
 		const eventType = /Trident\//.test(navigator.userAgent)
 			? 'change'
 			: 'input';
+
 		render(<input type="range" onChange={() => null} />, scratch);
 		expect(proto.addEventListener).to.have.been.calledOnce;
 		expect(proto.addEventListener).to.have.been.calledWithExactly(
@@ -82,6 +83,34 @@ describe('preact/compat events', () => {
 			sinon.match.func,
 			false
 		);
+	});
+
+	it('should normalize onChange for range, except in IE11, including when IE11 has Symbol polyfill', () => {
+		// NOTE: we don't normalize `onchange` for range inputs in IE11.
+		// This test mimics a specific scenario when a Symbol polyfill may
+		// be present, in which case onChange should still not be normalized
+
+		const isIE11 = /Trident\//.test(navigator.userAgent);
+		const eventType = isIE11 ? 'change' : 'input';
+
+		if (isIE11) {
+			window.Symbol = () => 'mockSymbolPolyfill';
+		}
+		sinon.spy(window, 'Symbol');
+
+		render(<input type="range" onChange={() => null} />, scratch);
+		expect(window.Symbol).to.have.been.calledOnce;
+		expect(proto.addEventListener).to.have.been.calledOnce;
+		expect(proto.addEventListener).to.have.been.calledWithExactly(
+			eventType,
+			sinon.match.func,
+			false
+		);
+
+		window.Symbol.restore();
+		if (isIE11) {
+			window.Symbol = undefined;
+		}
 	});
 
 	it('should support onAnimationEnd', () => {


### PR DESCRIPTION
When using preact/compat, an input of `type="range"` converts an `onchange` to `oninput` except in IE11. This mimics react's implementation as `oninput` will not fire on an `<input type="range" />` in IE11.

I came across a situation where I was not seeing the `onChange` prop firing in IE11. Looking at it closer, preact/compat detects IE11 by checking `typeof Symbol != 'undefined'`. This works well as long as `Symbol` is not being polyfilled, for instance in a NextJS app with preact.

This PR is adding an additional check to verify that `Symbol` is native to the browser and not polyfilled, allowing for `<input type="range" />` to behave as expected.

