### PR TITLE
Add displayName to context

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -299,6 +299,7 @@ declare namespace preact {
 	interface Context<T> {
 		Consumer: Consumer<T>;
 		Provider: Provider<T>;
+		displayName?: string;
 	}
 	interface PreactContext<T> extends Context<T> {}
 


### PR DESCRIPTION
#2454 added support for context displayName.

The type definition is lacking the `displayName` property too.
