### PR TITLE
Fix prototype spies not being reset in tests

### DIFF
--- a/test/_util/logCall.js
+++ b/test/_util/logCall.js
@@ -37,6 +37,8 @@ export function logCall(obj, method) {
 		log.push(operation);
 		return old.apply(this, args);
 	};
+
+	return () => (obj[method] = old);
 }
 
 /**

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -33,10 +33,14 @@ describe('Fragment', () => {
 		}
 	}
 
+	let resetInsertBefore;
+	let resetAppendChild;
+	let resetRemoveChild;
+
 	before(() => {
-		logCall(Node.prototype, 'insertBefore');
-		logCall(Node.prototype, 'appendChild');
-		logCall(Node.prototype, 'removeChild');
+		resetInsertBefore = logCall(Node.prototype, 'insertBefore');
+		resetAppendChild = logCall(Node.prototype, 'appendChild');
+		resetRemoveChild = logCall(Node.prototype, 'removeChild');
 		// logCall(CharacterData.prototype, 'remove');
 		// TODO: Consider logging setting set data
 		// ```
@@ -47,6 +51,12 @@ describe('Fragment', () => {
 		// 	set(value) { console.log('setData', value); orgData.set.call(this, value); }
 		// });
 		// ```
+	});
+
+	after(() => {
+		resetInsertBefore();
+		resetAppendChild();
+		resetRemoveChild();
 	});
 
 	beforeEach(() => {
@@ -541,7 +551,7 @@ describe('Fragment', () => {
 		expect(scratch.innerHTML).to.equal('<div>Hello</div>');
 	});
 
-	it.skip('should not preserve state between array nested in fragment and double nested array', () => {
+	it('should not preserve state between array nested in fragment and double nested array', () => {
 		function Foo({ condition }) {
 			return condition ? (
 				<Fragment>{[<Stateful key="a" />]}</Fragment>

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -17,13 +17,29 @@ describe('hydrate()', () => {
 	const List = ({ children }) => <ul>{children}</ul>;
 	const ListItem = ({ children }) => <li>{children}</li>;
 
+	let resetAppendChild;
+	let resetInsertBefore;
+	let resetRemoveChild;
+	let resetRemove;
+	let resetSetAttribute;
+	let resetRemoveAttribute;
+
 	before(() => {
-		logCall(Element.prototype, 'appendChild');
-		logCall(Element.prototype, 'insertBefore');
-		logCall(Element.prototype, 'removeChild');
-		logCall(Element.prototype, 'remove');
-		logCall(Element.prototype, 'setAttribute');
-		logCall(Element.prototype, 'removeAttribute');
+		resetAppendChild = logCall(Element.prototype, 'appendChild');
+		resetInsertBefore = logCall(Element.prototype, 'insertBefore');
+		resetRemoveChild = logCall(Element.prototype, 'removeChild');
+		resetRemove = logCall(Element.prototype, 'remove');
+		resetSetAttribute = logCall(Element.prototype, 'setAttribute');
+		resetRemoveAttribute = logCall(Element.prototype, 'removeAttribute');
+	});
+
+	after(() => {
+		resetAppendChild();
+		resetInsertBefore();
+		resetRemoveChild();
+		resetRemove();
+		resetSetAttribute();
+		resetRemoveAttribute();
 	});
 
 	beforeEach(() => {

--- a/test/browser/keys.test.js
+++ b/test/browser/keys.test.js
@@ -50,11 +50,23 @@ describe('keys', () => {
 		values.splice(to, 0, value);
 	}
 
+	let resetAppendChild;
+	let resetInsertBefore;
+	let resetRemoveChild;
+	let resetRemove;
+
 	before(() => {
-		logCall(Element.prototype, 'appendChild');
-		logCall(Element.prototype, 'insertBefore');
-		logCall(Element.prototype, 'removeChild');
-		logCall(Element.prototype, 'remove');
+		resetAppendChild = logCall(Element.prototype, 'appendChild');
+		resetInsertBefore = logCall(Element.prototype, 'insertBefore');
+		resetRemoveChild = logCall(Element.prototype, 'removeChild');
+		resetRemove = logCall(Element.prototype, 'remove');
+	});
+
+	after(() => {
+		resetAppendChild();
+		resetInsertBefore();
+		resetRemoveChild();
+		resetRemove();
 	});
 
 	beforeEach(() => {

--- a/test/browser/lifecycles/shouldComponentUpdate.test.js
+++ b/test/browser/lifecycles/shouldComponentUpdate.test.js
@@ -15,11 +15,20 @@ describe('Lifecycle methods', () => {
 	// function expectDomLogToBe(expectedOperations, message) {
 	// 	expect(getLog()).to.deep.equal(expectedOperations, message);
 	// }
+	let resetInsertBefore;
+	let resetRemoveChild;
+	let resetRemove;
 
 	before(() => {
-		logCall(Node.prototype, 'insertBefore');
-		logCall(Node.prototype, 'appendChild');
-		logCall(Node.prototype, 'removeChild');
+		resetInsertBefore = logCall(Node.prototype, 'insertBefore');
+		resetRemoveChild = logCall(Node.prototype, 'appendChild');
+		resetRemove = logCall(Node.prototype, 'removeChild');
+	});
+
+	after(() => {
+		resetInsertBefore();
+		resetRemoveChild();
+		resetRemove();
 	});
 
 	beforeEach(() => {

--- a/test/browser/placeholders.test.js
+++ b/test/browser/placeholders.test.js
@@ -54,11 +54,23 @@ describe('null placeholders', () => {
 		return [Nullable, ref];
 	}
 
+	let resetAppendChild;
+	let resetInsertBefore;
+	let resetRemoveChild;
+	let resetRemove;
+
 	before(() => {
-		logCall(Element.prototype, 'appendChild');
-		logCall(Element.prototype, 'insertBefore');
-		logCall(Element.prototype, 'removeChild');
-		logCall(Element.prototype, 'remove');
+		resetAppendChild = logCall(Element.prototype, 'appendChild');
+		resetInsertBefore = logCall(Element.prototype, 'insertBefore');
+		resetRemoveChild = logCall(Element.prototype, 'removeChild');
+		resetRemove = logCall(Element.prototype, 'remove');
+	});
+
+	after(() => {
+		resetAppendChild();
+		resetInsertBefore();
+		resetRemoveChild();
+		resetRemove();
 	});
 
 	beforeEach(() => {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -27,6 +27,11 @@ function getAttributes(node) {
 describe('render()', () => {
 	let scratch, rerender;
 
+	let resetAppendChild;
+	let resetInsertBefore;
+	let resetRemoveChild;
+	let resetRemove;
+
 	beforeEach(() => {
 		scratch = setupScratch();
 		rerender = setupRerender();
@@ -37,10 +42,17 @@ describe('render()', () => {
 	});
 
 	before(() => {
-		logCall(Element.prototype, 'appendChild');
-		logCall(Element.prototype, 'insertBefore');
-		logCall(Element.prototype, 'removeChild');
-		logCall(Element.prototype, 'remove');
+		resetAppendChild = logCall(Element.prototype, 'appendChild');
+		resetInsertBefore = logCall(Element.prototype, 'insertBefore');
+		resetRemoveChild = logCall(Element.prototype, 'removeChild');
+		resetRemove = logCall(Element.prototype, 'remove');
+	});
+
+	after(() => {
+		resetAppendChild();
+		resetInsertBefore();
+		resetRemoveChild();
+		resetRemove();
 	});
 
 	it('should rerender when value from "" to 0', () => {


### PR DESCRIPTION
Looks like we never reset previous spies which lead to the failures experienced in #2755 .