### PR TITLE
Fix compat/jsx-runtime missing in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,8 @@
 		"compat/dist",
 		"compat/src",
 		"compat/server.js",
+		"compat/jsx-runtime.js",
+		"compat/jsx-runtime.mjs",
 		"compat/package.json",
 		"debug/dist",
 		"debug/src",


### PR DESCRIPTION
This is a follow-up to #2805. Those new entries weren't in the npm "files" array, so they weren't included in the published package.
