### PR TITLE
Update csstype from version 2 to version 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3548,9 +3548,9 @@
 			}
 		},
 		"csstype": {
-			"version": "2.6.13",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
-			"integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+			"integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==",
 			"dev": true
 		},
 		"currently-unhandled": {

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
 		"check-export-map": "^1.0.1",
 		"coveralls": "^3.0.0",
 		"cross-env": "^5.2.0",
-		"csstype": "^2.6.6",
+		"csstype": "^3.0.5",
 		"diff": "^3.5.0",
 		"eslint": "5.15.1",
 		"eslint-config-developit": "^1.1.1",

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -33,7 +33,10 @@ export namespace JSXInternal {
 		children: any;
 	}
 
-	interface CSSProperties extends CSS.Properties<string | number> {
+	interface CSSProperties<
+		TLength = (string & {}) | number,
+		TTime = string & {}
+	> extends CSS.Properties<TLength, TTime> {
 		/**
 		 * The index signature was removed to enable closed typing for style
 		 * using CSSType. You're able to use type assertion or module augmentation


### PR DESCRIPTION
Improved typing, and smaller type file with fewer internals exposed.

There are changes to the re-exported types but this feature exposing csstype has only just been released in preact. (https://github.com/preactjs/preact/pull/1797)

Expose TLength and TTime generics, and adapt length only to accept numbers of any kind, to match the 'px' appending logic in preact.

[Version 3 differences](https://github.com/frenic/csstype#version-30).

Now sure how type definitions should be tested ideally?

Have tested locally, including using [tsuquyomi](https://github.com/Quramy/tsuquyomi) for completions (which is the [reason](https://github.com/frenic/csstype#generics) for the `& {}` hack).

![style completions](https://user-images.githubusercontent.com/1188565/99131196-6884e380-260a-11eb-9fc2-6dacffc7bfd5.png)

Have also replaced the usage in one of my projects, which was using version 3 before:

```diff
-export type {Properties as CSSProperties} from 'csstype';
-
+export type CSSProperties = preact.JSX.CSSProperties<string | 0>;
```

Which works fine with my (limited) use of the `style` attribute.