### PR TITLE
Add errorInfo parameter to componentDidCatch

### DIFF
--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -24,7 +24,9 @@ export function _catchError(error, vnode) {
 				}
 
 				if (component.componentDidCatch != null) {
-					component.componentDidCatch(error);
+					component.componentDidCatch(error, {
+						componentStack: '' // TODO: Capture proper component stack
+					});
 					handled = component._dirty;
 				}
 

--- a/test/browser/lifecycles/componentDidCatch.test.js
+++ b/test/browser/lifecycles/componentDidCatch.test.js
@@ -670,5 +670,20 @@ describe('Lifecycle methods', () => {
 
 			expect(scratch.innerHTML).to.equal('<div>Error: Error!</div>');
 		});
+
+		// #2835
+		it('should pass errorInfo object as second parameter', () => {
+			ThrowErr.prototype.render = throwExpectedError;
+
+			render(
+				<Receiver>
+					<ThrowErr />
+				</Receiver>,
+				scratch
+			);
+			expect(
+				Receiver.prototype.componentDidCatch
+			).to.have.been.calledWith(expectedError, { componentStack: '' });
+		});
 	});
 });


### PR DESCRIPTION
We currently capture component stacks only in `preact/debug`. Not sure how to best combine that with `componentDidCatch` but this PR makes `@sentry/react` not crash for now.

Fixes #2835