### PR TITLE
Adding defaultValue support in select tag

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -162,8 +162,13 @@ options.vnode = vnode => {
 		// Adding support for defaultValue in select tag
 		if (type == 'select' && normalizedProps.defaultValue != null) {
 			normalizedProps.value = toChildArray(props.children).forEach(child => {
-				child.props.selected =
-					normalizedProps.defaultValue == child.props.value;
+				if (normalizedProps.multiple) {
+					child.props.selected =
+						normalizedProps.defaultValue.indexOf(child.props.value) != -1;
+				} else {
+					child.props.selected =
+						normalizedProps.defaultValue == child.props.value;
+				}
 			});
 		}
 

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -159,6 +159,14 @@ options.vnode = vnode => {
 			});
 		}
 
+		// Adding support for defaultValue in select tag
+		if (type == 'select' && normalizedProps.defaultValue) {
+			normalizedProps.value = toChildArray(props.children).forEach(child => {
+				child.props.selected =
+					normalizedProps.defaultValue.indexOf(child.props.value) != -1;
+			});
+		}
+
 		vnode.props = normalizedProps;
 	}
 

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -163,7 +163,7 @@ options.vnode = vnode => {
 		if (type == 'select' && normalizedProps.defaultValue != null) {
 			normalizedProps.value = toChildArray(props.children).forEach(child => {
 				child.props.selected =
-					normalizedProps.defaultValue.indexOf(child.props.value) != -1;
+					normalizedProps.defaultValue == child.props.value;
 			});
 		}
 

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -160,7 +160,7 @@ options.vnode = vnode => {
 		}
 
 		// Adding support for defaultValue in select tag
-		if (type == 'select' && normalizedProps.defaultValue) {
+		if (type == 'select' && normalizedProps.defaultValue != null) {
 			normalizedProps.value = toChildArray(props.children).forEach(child => {
 				child.props.selected =
 					normalizedProps.defaultValue.indexOf(child.props.value) != -1;

--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -110,6 +110,22 @@ describe('compat render', () => {
 		expect(scratch.firstElementChild).to.have.property('value', 'foo');
 	});
 
+	it('should support defaultValue for select tag', () => {
+		function App() {
+			return (
+				<select defaultValue="2">
+					<option value="1">Picked 1</option>
+					<option value="2">Picked 2</option>
+				</select>
+			);
+		}
+
+		render(<App />, scratch);
+		const options = scratch.firstChild.children;
+		expect(options[0]).to.have.property('selected', false);
+		expect(options[1]).to.have.property('selected', true);
+	});
+
 	it('should ignore defaultValue when value is 0', () => {
 		render(<input defaultValue={2} value={0} />, scratch);
 		expect(scratch.firstElementChild.value).to.equal('0');

--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -116,6 +116,7 @@ describe('compat render', () => {
 				<select defaultValue="2">
 					<option value="1">Picked 1</option>
 					<option value="2">Picked 2</option>
+					<option value="3">Picked 3</option>
 				</select>
 			);
 		}
@@ -124,6 +125,24 @@ describe('compat render', () => {
 		const options = scratch.firstChild.children;
 		expect(options[0]).to.have.property('selected', false);
 		expect(options[1]).to.have.property('selected', true);
+	});
+
+	it('should support defaultValue for select tag when using multi selection', () => {
+		function App() {
+			return (
+				<select multiple defaultValue={['1', '3']}>
+					<option value="1">Picked 1</option>
+					<option value="2">Picked 2</option>
+					<option value="3">Picked 3</option>
+				</select>
+			);
+		}
+
+		render(<App />, scratch);
+		const options = scratch.firstChild.children;
+		expect(options[0]).to.have.property('selected', true);
+		expect(options[1]).to.have.property('selected', false);
+		expect(options[2]).to.have.property('selected', true);
 	});
 
 	it('should ignore defaultValue when value is 0', () => {


### PR DESCRIPTION
## Description

`defaultValue` for `select` tag is supported by react even though it is not part of the html spec. This PR adds `defaultValue` attribute support for select tag

## Related Ticket
closes https://github.com/preactjs/preact/issues/2646