### PR TITLE
Adding support for defaultValue in typings

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -126,3 +126,11 @@ declare namespace React {
 		toArray: (children: preact.ComponentChildren) => preact.VNode<{}>[];
 	};
 }
+
+declare module 'preact/src/jsx' {
+	namespace JSXInternal {
+		interface HTMLAttributes<RefType extends EventTarget = EventTarget> {
+			defaultValue?: string;
+		}
+	}
+}


### PR DESCRIPTION
## What does it do?
Adds support for **defaultValue** in typescript for HTMLElement

## Related issue

Closes https://github.com/preactjs/preact/issues/2668

## QA Instructions, Screenshots, Recordings

1. Create a typescript preact typescript project with preact cli
2. create input element with attribute defaultValue
3. It should not have typescript error

## Added tests?

- [ ] yes
- [x] no