### PR TITLE
Simplify vnode re-use detection (-2 B)

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -84,7 +84,11 @@ export function diffChildren(
 				null,
 				null
 			);
-		} else if (childVNode._dom != null || childVNode._component != null) {
+		} else if (childVNode._depth > 0) {
+			// VNode is already in use, clone it. This can happen in the following
+			// scenario:
+			//   const reuse = <div />
+			//   <div>{reuse}<span />{reuse}</div>
 			childVNode = newParentVNode._children[i] = createVNode(
 				childVNode.type,
 				childVNode.props,


### PR DESCRIPTION
This PR simplifies our check to detect if a `vnode` is already in use and if we need to clone it. Noticed that while exploring alternative algorithms in `diffChildren`. Saves `2 B`.