### PR TITLE
types: Adding 'readonly' attribute to TS typings

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -709,6 +709,7 @@ export namespace JSXInternal {
 		poster?: string;
 		preload?: string;
 		radioGroup?: string;
+		readonly?: boolean;
 		readOnly?: boolean;
 		rel?: string;
 		required?: boolean;


### PR DESCRIPTION
## Summary

This PR adds `readonly` as a valid DOM attribute to the TS typings

## Explanation

I was using TS with the WMR template and noticed that the template comes with an input in the header that has the attribute `readonly`. Once this file is switched to be TSX, this attribute becomes invalid as the existing TS typings only recognize `readOnly`.

Both usages do create an output that is read-only ([reproduction/example](https://esm.codes/#Ly8gcmVhZG9ubHkgdnMgcmVhZE9ubHkgcmVwcm8gYnkgQHJzY2hyaXN0aWFuCi8vIC0tLS0tLS0tLS0tLS0tLS0KICAgIAppbXBvcnQgeyByZW5kZXIsIGh0bWwgfSBmcm9tICdodHRwczovL25wbS5yZXZlcnNlaHR0cC5jb20vcHJlYWN0LGh0bS9wcmVhY3QnOwoKcmVuZGVyKAogIGh0bWxgCiAgICA8aW5wdXQgcmVhZG9ubHkgcGxhY2Vob2xkZXI9InJlYWRvbmx5Ii8+CiAgICA8aW5wdXQgcmVhZE9ubHkgcGxhY2Vob2xkZXI9InJlYWRPbmx5Ii8+CiAgYCwKICBkb2N1bWVudC5ib2R5Cik7)) though the `readOnly` output is a bit questionable.

`readonly` => `<input readonly="true">`
`readOnly` => `<input readonly="">`.

Seeing as how both outcomes do have the desired effect, I decided to add the attribute, rather than replace. I notice there's a few other attributes given similar treatment (`autocomplete`/`autoComplete`, etc) and figure this stops the change from being breaking for any users. Probably better for migrating React users as well, as [`readOnly` is the syntax they use](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a46cca4cede33b3f9578adcf87f487c57667f1bc/types/react/v16/index.d.ts#L1892).