### PR TITLE
Improve JSDoc comments

### DIFF
--- a/compat/src/forwardRef.js
+++ b/compat/src/forwardRef.js
@@ -21,7 +21,7 @@ export const REACT_FORWARD_SYMBOL =
  * wrap components. Using `forwardRef` there is an easy way to get a reference
  * of the wrapped component instead of one of the wrapper itself.
  * @param {import('./index').ForwardFn} fn
- * @returns {import('./internal').FunctionalComponent}
+ * @returns {import('./internal').FunctionComponent}
  */
 export function forwardRef(fn) {
 	// We always have ref in props.ref, except for

--- a/compat/src/internal.d.ts
+++ b/compat/src/internal.d.ts
@@ -1,7 +1,7 @@
 import {
 	Component as PreactComponent,
 	VNode as PreactVNode,
-	FunctionalComponent as PreactFunctionalComponent
+	FunctionComponent as PreactFunctionComponent
 } from '../../src/internal';
 import { SuspenseProps } from './suspense';
 
@@ -19,8 +19,7 @@ export interface Component<P = {}, S = {}> extends PreactComponent<P, S> {
 	_suspendedComponentWillUnmount?(): void;
 }
 
-export interface FunctionalComponent<P = {}>
-	extends PreactFunctionalComponent<P> {
+export interface FunctionComponent<P = {}> extends PreactFunctionComponent<P> {
 	shouldComponentUpdate?(nextProps: Readonly<P>): boolean;
 	_forwarded?: boolean;
 	_patchedLifecycles?: true;

--- a/compat/src/memo.js
+++ b/compat/src/memo.js
@@ -4,9 +4,9 @@ import { shallowDiffers } from './util';
 /**
  * Memoize a component, so that it only updates when the props actually have
  * changed. This was previously known as `React.pure`.
- * @param {import('./internal').FunctionalComponent} c functional component
+ * @param {import('./internal').FunctionComponent} c functional component
  * @param {(prev: object, next: object) => boolean} [comparer] Custom equality function
- * @returns {import('./internal').FunctionalComponent}
+ * @returns {import('./internal').FunctionComponent}
  */
 export function memo(c, comparer) {
 	function shouldUpdate(nextProps) {

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -93,7 +93,7 @@ options.unmount = vnode => {
  * Get a hook's state from the currentComponent
  * @param {number} index The index of the hook to get
  * @param {number} type The index of the hook to get
- * @returns {import('./internal').HookState}
+ * @returns {any}
  */
 function getHookState(index, type) {
 	if (options._hook) {
@@ -120,7 +120,7 @@ function getHookState(index, type) {
 }
 
 /**
- * @param {import('./index').StateUpdater<any>} initialState
+ * @param {import('./index').StateUpdater<any>} [initialState]
  */
 export function useState(initialState) {
 	currentHook = 1;
@@ -240,6 +240,7 @@ export function useContext(context) {
 	// We could skip this call here, but than we'd not call
 	// `options._hook`. We need to do that in order to make
 	// the devtools aware of this hook.
+	/** @type {import('./internal').ContextHookState} */
 	const state = getHookState(currentIndex++, 9);
 	// The devtools needs access to the context object to
 	// be able to pull of the default value when no provider

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -265,7 +265,11 @@ export function useDebugValue(value, formatter) {
 	}
 }
 
+/**
+ * @param {(error: any) => void} cb
+ */
 export function useErrorBoundary(cb) {
+	/** @type {import('./internal').ErrorBoundaryHookState} */
 	const state = getHookState(currentIndex++, 10);
 	const errState = useState();
 	state._value = cb;

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -40,7 +40,8 @@ export type HookState =
 	| EffectHookState
 	| MemoHookState
 	| ReducerHookState
-	| ContextHookState;
+	| ContextHookState
+	| ErrorBoundaryHookState;
 
 export type Effect = () => void | Cleanup;
 export type Cleanup = () => void;
@@ -67,4 +68,8 @@ export interface ContextHookState {
 	/** Whether this hooks as subscribed to updates yet */
 	_value?: boolean;
 	_context?: PreactContext;
+}
+
+export interface ErrorBoundaryHookState {
+	_value?: (error: any) => void;
 }

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -1,7 +1,10 @@
-import { Component as PreactComponent } from '../../src/internal';
+import {
+	Component as PreactComponent,
+	PreactContext
+} from '../../src/internal';
 import { Reducer } from '.';
 
-export { PreactContext } from '../../src/internal';
+export { PreactContext };
 
 /**
  * The type of arguments passed to a Hook function. While this type is not
@@ -33,7 +36,11 @@ export interface Component extends PreactComponent<any, any> {
 	__hooks?: ComponentHooks;
 }
 
-export type HookState = EffectHookState | MemoHookState | ReducerHookState;
+export type HookState =
+	| EffectHookState
+	| MemoHookState
+	| ReducerHookState
+	| ContextHookState;
 
 export type Effect = () => void | Cleanup;
 export type Cleanup = () => void;
@@ -41,7 +48,7 @@ export type Cleanup = () => void;
 export interface EffectHookState {
 	_value?: Effect;
 	_args?: any[];
-	_cleanup?: Cleanup;
+	_cleanup?: Cleanup | void;
 }
 
 export interface MemoHookState {
@@ -54,4 +61,10 @@ export interface ReducerHookState {
 	_value?: any;
 	_component?: Component;
 	_reducer?: Reducer<any, any>;
+}
+
+export interface ContextHookState {
+	/** Whether this hooks as subscribed to updates yet */
+	_value?: boolean;
+	_context?: PreactContext;
 }

--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -5,7 +5,7 @@ import { createVNode } from './create-element';
  * Clones the given VNode, optionally adding attributes/props and replacing its children.
  * @param {import('./internal').VNode} vnode The virtual DOM element to clone
  * @param {object} props Attributes/props to add when cloning
- * @param {Array<import('./index').ComponentChildren>} rest Any additional arguments will be used as replacement children.
+ * @param {Array<import('./internal').ComponentChildren>} rest Any additional arguments will be used as replacement children.
  * @returns {import('./internal').VNode}
  */
 export function cloneElement(vnode, props, children) {

--- a/src/component.js
+++ b/src/component.js
@@ -17,6 +17,7 @@ export function Component(props, context) {
 
 /**
  * Update component state and schedule a re-render.
+ * @this {import('./internal').Component}
  * @param {object | ((s: object, p: object) => object)} update A hash of state
  * properties to update with new values or a function that given the current
  * state and props returns a new partial state
@@ -53,6 +54,7 @@ Component.prototype.setState = function(update, callback) {
 
 /**
  * Immediately perform a synchronous re-render of the component
+ * @this {import('./internal').Component}
  * @param {() => void} [callback] A function to be called after component is
  * re-rendered
  */

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -8,6 +8,7 @@ export function createContext(defaultValue, contextId) {
 	const context = {
 		_id: contextId,
 		_defaultValue: defaultValue,
+		/** @type {import('./internal').FunctionComponent} */
 		Consumer(props, contextValue) {
 			// return props.children(
 			// 	context[contextId] ? context[contextId].props.value : defaultValue

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -15,10 +15,11 @@ export function createContext(defaultValue, contextId) {
 			// );
 			return props.children(contextValue);
 		},
-		Provider(props, subs, ctx) {
+		/** @type {import('./internal').FunctionComponent} */
+		Provider(props) {
 			if (!this.getChildContext) {
-				subs = [];
-				ctx = {};
+				let subs = [];
+				let ctx = {};
 				ctx[contextId] = this;
 
 				this.getChildContext = () => ctx;

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -8,7 +8,7 @@ import { getDomSibling } from '../component';
  * Diff the children of a virtual node
  * @param {import('../internal').PreactElement} parentDom The DOM element whose
  * children are being diffed
- * @param {import('../index').ComponentChildren[]} renderResult
+ * @param {import('../internal').ComponentChildren[]} renderResult
  * @param {import('../internal').VNode} newParentVNode The new virtual
  * node whose children should be diff'ed against oldParentVNode
  * @param {import('../internal').VNode} oldParentVNode The old virtual
@@ -18,7 +18,7 @@ import { getDomSibling } from '../component';
  * @param {Array<import('../internal').PreactElement>} excessDomChildren
  * @param {Array<import('../internal').Component>} commitQueue List of components
  * which have callbacks to invoke in commitRoot
- * @param {Node | Text} oldDom The current attached DOM
+ * @param {import('../internal').PreactElement} oldDom The current attached DOM
  * element any new dom elements should be placed around. Likely `null` on first
  * render (except when hydrating). Can be a sibling DOM element when diffing
  * Fragments that have siblings. In most cases, it starts out as `oldChildren[0]._dom`.
@@ -201,6 +201,8 @@ export function diffChildren(
 			// To fix it we make sure to reset the inferred value, so that our own
 			// value check in `diff()` won't be skipped.
 			if (!isHydrating && newParentVNode.type === 'option') {
+				// @ts-ignore We have validated that the type of parentDOM is 'option'
+				// in the above check
 				parentDom.value = '';
 			} else if (typeof newParentVNode.type == 'function') {
 				// Because the newParentVNode is Fragment-like, we need to set it's

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -73,8 +73,10 @@ export function diff(
 			} else {
 				// Instantiate the new component
 				if ('prototype' in newType && newType.prototype.render) {
+					// @ts-ignore The check above verifies that newType is suppose to be constructed
 					newVNode._component = c = new newType(newProps, componentContext); // eslint-disable-line new-cap
 				} else {
+					// @ts-ignore Trust me, Component implements the interface we want
 					newVNode._component = c = new Component(newProps, componentContext);
 					c.constructor = newType;
 					c.render = doRender;
@@ -261,9 +263,11 @@ export function commitRoot(commitQueue, root) {
 
 	commitQueue.some(c => {
 		try {
+			// @ts-ignore Reuse the commitQueue variable here so the type changes
 			commitQueue = c._renderCallbacks;
 			c._renderCallbacks = [];
 			commitQueue.some(cb => {
+				// @ts-ignore See above ts-ignore on commitQueue
 				cb.call(c);
 			});
 		} catch (e) {
@@ -326,15 +330,24 @@ function diffElementNodes(
 
 	if (dom == null) {
 		if (newVNode.type === null) {
+			// @ts-ignore createTextNode returns Text, we expect PreactElement
 			return document.createTextNode(newProps);
 		}
 
-		dom = isSvg
-			? document.createElementNS('http://www.w3.org/2000/svg', newVNode.type)
-			: document.createElement(
-					newVNode.type,
-					newProps.is && { is: newProps.is }
-			  );
+		if (isSvg) {
+			dom = document.createElementNS(
+				'http://www.w3.org/2000/svg',
+				// @ts-ignore We know `newVNode.type` is a string
+				newVNode.type
+			);
+		} else {
+			dom = document.createElement(
+				// @ts-ignore We know `newVNode.type` is a string
+				newVNode.type,
+				newProps.is && { is: newProps.is }
+			);
+		}
+
 		// we created a new parent, so none of the previously attached children can be reused:
 		excessDomChildren = null;
 		// we are creating a new node, so we can assume this is a new subtree (in case we are hydrating), this deopts the hydrate

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -16,7 +16,7 @@ import options from '../options';
  * @param {Array<import('../internal').PreactElement>} excessDomChildren
  * @param {Array<import('../internal').Component>} commitQueue List of components
  * which have callbacks to invoke in commitRoot
- * @param {Element | Text} oldDom The current attached DOM
+ * @param {import('../internal').PreactElement} oldDom The current attached DOM
  * element any new dom elements should be placed around. Likely `null` on first
  * render (except when hydrating). Can be a sibling DOM element when diffing
  * Fragments that have siblings. In most cases, it starts out as `oldChildren[0]._dom`.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -94,6 +94,7 @@ declare namespace preact {
 		new (props: P, context?: any): Component<P, S>;
 		displayName?: string;
 		defaultProps?: Partial<P>;
+		contextType?: Context<any>;
 		getDerivedStateFromProps?(
 			props: Readonly<P>,
 			state: Readonly<S>

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -24,7 +24,7 @@ export interface Options extends preact.Options {
 	_vnodeId: number;
 	/** Attach a hook that is invoked before render, mainly to check the arguments. */
 	_root?(
-		vnode: preact.ComponentChild,
+		vnode: ComponentChild,
 		parent: Element | Document | ShadowRoot | DocumentFragment
 	): void;
 	/** Attach a hook that is invoked before a vnode is diffed. */
@@ -38,25 +38,40 @@ export interface Options extends preact.Options {
 	/** Bypass effect execution. Currenty only used in devtools for hooks inspection */
 	_skipEffects?: boolean;
 	/** Attach a hook that is invoked after an error is caught in a component but before calling lifecycle hooks */
-	_catchError(error: any, vnode: VNode, oldVNode: VNode | undefined): void;
+	_catchError(error: any, vnode: VNode, oldVNode?: VNode | undefined): void;
 }
 
-export interface FunctionalComponent<P = {}>
-	extends preact.FunctionComponent<P> {
-	// Define getDerivedStateFromProps as undefined on FunctionalComponent
-	// to get rid of some errors in `diff()`
+export type ComponentChild =
+	| VNode<any>
+	| string
+	| number
+	| boolean
+	| null
+	| undefined;
+export type ComponentChildren = ComponentChild[] | ComponentChild;
+
+export interface FunctionComponent<P = {}> extends preact.FunctionComponent<P> {
+	// Internally, createContext uses `contextType` on a Function component to
+	// implement the Consumer component
+	contextType?: any;
+
+	// Define these properties as undefined on FunctionComponent to get rid of
+	// some errors in `diff()`
 	getDerivedStateFromProps?: undefined;
+	getDerivedStateFromError?: undefined;
 }
 
-// Redefine ComponentFactory using our new internal FunctionalComponent interface above
-export type ComponentFactory<P> =
-	| preact.ComponentClass<P>
-	| FunctionalComponent<P>;
+export interface ComponentClass<P = {}> extends preact.ComponentClass<P> {
+	_contextRef?: any;
+}
 
-export interface PreactElement extends HTMLElement, Text {
+// Redefine ComponentType using our new internal FunctionComponent interface above
+export type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
+
+export interface PreactElement extends HTMLElement {
 	_children?: VNode<any> | null;
 	/** Event listeners to support event delegation */
-	_listeners: Record<string, (e: Event) => void>;
+	_listeners?: Record<string, (e: Event) => void>;
 
 	// Preact uses this attribute to detect SVG nodes
 	ownerSVGElement?: SVGElement | null;
@@ -67,9 +82,9 @@ export interface PreactElement extends HTMLElement, Text {
 }
 
 export interface VNode<P = {}> extends preact.VNode<P> {
-	// Redefine type here using our internal ComponentFactory type
-	type: string | ComponentFactory<P>;
-	props: P & { children: preact.ComponentChildren };
+	// Redefine type here using our internal ComponentType type
+	type: string | ComponentType<P>;
+	props: P & { children: ComponentChildren };
 	_children: Array<VNode<any>> | null;
 	_parent: VNode | null;
 	_depth: number | null;
@@ -89,7 +104,7 @@ export interface VNode<P = {}> extends preact.VNode<P> {
 
 export interface Component<P = {}, S = {}> extends preact.Component<P, S> {
 	// When component is functional component, this is reset to functional component
-	constructor: preact.ComponentType<P>;
+	constructor: ComponentType<P>;
 	state: S; // Override Component["state"] to not be readonly for internal use, specifically Hooks
 	base?: PreactElement;
 

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -53,7 +53,11 @@ export type ComponentChildren = ComponentChild[] | ComponentChild;
 export interface FunctionComponent<P = {}> extends preact.FunctionComponent<P> {
 	// Internally, createContext uses `contextType` on a Function component to
 	// implement the Consumer component
-	contextType?: any;
+	contextType?: PreactContext;
+
+	// Internally, createContext stores a ref to the context object on the Provider
+	// Function component to help devtools
+	_contextRef?: PreactContext;
 
 	// Define these properties as undefined on FunctionComponent to get rid of
 	// some errors in `diff()`

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -67,6 +67,9 @@ export interface FunctionComponent<P = {}> extends preact.FunctionComponent<P> {
 
 export interface ComponentClass<P = {}> extends preact.ComponentClass<P> {
 	_contextRef?: any;
+
+	// Override public contextType with internal PreactContext type
+	contextType?: PreactContext;
 }
 
 // Redefine ComponentType using our new internal FunctionComponent interface above
@@ -85,10 +88,17 @@ export interface PreactElement extends HTMLElement {
 	data?: string | number; // From Text node
 }
 
+// We use the `current` property to differentiate between the two kinds of Refs so
+// internally we'll define `current` on both to make TypeScript happy
+type RefObject<T> = { current: T | null };
+type RefCallback<T> = { (instance: T | null): void; current: undefined };
+type Ref<T> = RefObject<T> | RefCallback<T>;
+
 export interface VNode<P = {}> extends preact.VNode<P> {
 	// Redefine type here using our internal ComponentType type
 	type: string | ComponentType<P>;
 	props: P & { children: ComponentChildren };
+	ref?: Ref<any> | null;
 	_children: Array<VNode<any>> | null;
 	_parent: VNode | null;
 	_depth: number | null;

--- a/src/render.js
+++ b/src/render.js
@@ -7,10 +7,10 @@ const IS_HYDRATE = EMPTY_OBJ;
 
 /**
  * Render a Preact virtual node into a DOM element
- * @param {import('./index').ComponentChild} vnode The virtual node to render
+ * @param {import('./internal').ComponentChild} vnode The virtual node to render
  * @param {import('./internal').PreactElement} parentDom The DOM element to
  * render into
- * @param {Element | Text} [replaceNode] Optional: Attempt to re-use an
+ * @param {import('./internal').PreactElement | object} [replaceNode] Optional: Attempt to re-use an
  * existing DOM tree rooted at `replaceNode`
  */
 export function render(vnode, parentDom, replaceNode) {
@@ -59,7 +59,7 @@ export function render(vnode, parentDom, replaceNode) {
 
 /**
  * Update an existing DOM element with data from a Preact virtual node
- * @param {import('./index').ComponentChild} vnode The virtual node to render
+ * @param {import('./internal').ComponentChild} vnode The virtual node to render
  * @param {import('./internal').PreactElement} parentDom The DOM element to
  * update
  */

--- a/src/util.js
+++ b/src/util.js
@@ -6,6 +6,7 @@
  * @returns {O & P}
  */
 export function assign(obj, props) {
+	// @ts-ignore We change the type of `obj` to be `O & P`
 	for (let i in props) obj[i] = props[i];
 	return /** @type {O & P} */ (obj);
 }


### PR DESCRIPTION
This PR improves our JSDoc comments in the core rendered source to the point where there are only 3 (!) tsc --checkJS errors. Those remaining ones will go away with the work being done in the restructure branch.

Let me know your thoughts!

![image](https://user-images.githubusercontent.com/459878/102948307-88fe5400-447a-11eb-9e0f-08fc97aa99d0.png)
