### PR TITLE
Correct `_nextDom` pointer if it is being unmounted

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -236,7 +236,20 @@ export function diffChildren(
 
 	// Remove remaining oldChildren if there are any.
 	for (i = oldChildrenLength; i--; ) {
-		if (oldChildren[i] != null) unmount(oldChildren[i], oldChildren[i]);
+		if (oldChildren[i] != null) {
+			if (
+				typeof newParentVNode.type == 'function' &&
+				oldChildren[i]._dom != null &&
+				oldChildren[i]._dom == newParentVNode._nextDom
+			) {
+				// If the newParentVNode.__nextDom points to a dom node that is about to
+				// be unmounted, then get the next sibling of that vnode and set
+				// _nextDom to it
+				newParentVNode._nextDom = getDomSibling(oldParentVNode, i + 1);
+			}
+
+			unmount(oldChildren[i], oldChildren[i]);
+		}
 	}
 
 	// Set refs only after unmount

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -8,8 +8,6 @@ import { logCall, clearLog, getLog } from '../_util/logCall';
 /* eslint-disable react/jsx-boolean-value */
 
 describe('Fragment', () => {
-	let expectDomLog = false;
-
 	/** @type {HTMLDivElement} */
 	let scratch;
 
@@ -19,9 +17,7 @@ describe('Fragment', () => {
 	let ops = [];
 
 	function expectDomLogToBe(expectedOperations, message) {
-		if (expectDomLog) {
-			expect(getLog()).to.deep.equal(expectedOperations, message);
-		}
+		expect(getLog()).to.deep.equal(expectedOperations, message);
 	}
 
 	class Stateful extends Component {
@@ -711,7 +707,7 @@ describe('Fragment', () => {
 		);
 	});
 
-	it('should not preserve state when switching to a keyed fragment to an array', () => {
+	it('should not preserve state when switching between a keyed fragment and an array', () => {
 		function Foo({ condition }) {
 			return condition ? (
 				<div>
@@ -739,14 +735,14 @@ describe('Fragment', () => {
 		clearLog();
 		render(<Foo condition={false} />, scratch);
 
-		expect(ops).to.deep.equal([]);
+		expect(ops).to.deep.equal([]); // Component should not have updated (empty op log)
 		expect(scratch.innerHTML).to.equal(html);
 		expectDomLogToBe([
-			'<div>1Hello1.insertBefore(<span>1, <span>1)',
-			'<div>.appendChild(#text)',
-			'<div>11Hello.insertBefore(<div>Hello, <span>1)',
 			'<span>.appendChild(#text)',
-			'<div>1Hello1Hello.insertBefore(<span>2, <span>1)',
+			'<div>1Hello2.insertBefore(<span>1, <span>1)',
+			'<div>.appendChild(#text)',
+			'<div>11Hello2.insertBefore(<div>Hello, <span>1)',
+			'<div>1Hello1Hello2.insertBefore(<span>2, <span>1)',
 			'<span>1.remove()',
 			'<div>Hello.remove()'
 		]);
@@ -754,14 +750,15 @@ describe('Fragment', () => {
 		clearLog();
 		render(<Foo condition={true} />, scratch);
 
-		expect(ops).to.deep.equal([]);
+		expect(ops).to.deep.equal([]); // Component should not have updated (empty op log)
 		expect(scratch.innerHTML).to.equal(html);
 		expectDomLogToBe([
 			'<span>.appendChild(#text)',
 			'<div>1Hello2.insertBefore(<span>1, <span>1)',
 			'<div>.appendChild(#text)',
 			'<div>11Hello2.insertBefore(<div>Hello, <span>1)',
-			'<span>2.remove()',
+			'<div>1Hello1Hello2.insertBefore(<span>2, <span>1)',
+			'<span>1.remove()',
 			'<div>Hello.remove()'
 		]);
 	});
@@ -1150,32 +1147,12 @@ describe('Fragment', () => {
 		clearLog();
 		render(<Foo condition={false} />, scratch);
 		expect(scratch.innerHTML).to.equal(html, 'rendering from true to false');
-		expectDomLogToBe(
-			[
-				'<li>.appendChild(#text)',
-				'<ol>0121.appendChild(<li>2)',
-				'<li>.appendChild(#text)',
-				'<ol>01212.appendChild(<li>3)',
-				'<li>1.remove()',
-				'<li>2.remove()'
-			],
-			'rendering from true to false'
-		);
+		expectDomLogToBe([], 'rendering from true to false');
 
 		clearLog();
 		render(<Foo condition={true} />, scratch);
 		expect(scratch.innerHTML).to.equal(html, 'rendering from false to true');
-		expectDomLogToBe(
-			[
-				'<li>.appendChild(#text)',
-				'<ol>0123.insertBefore(<li>1, <li>1)',
-				'<li>.appendChild(#text)',
-				'<ol>01123.insertBefore(<li>2, <li>1)',
-				'<li>3.remove()',
-				'<li>1.remove()'
-			],
-			'rendering from false to true'
-		);
+		expectDomLogToBe([], 'rendering from false to true');
 	});
 
 	it('should support conditionally rendered Fragment or null', () => {
@@ -2572,7 +2549,6 @@ describe('Fragment', () => {
 	});
 
 	it('should properly place conditional elements around strictly equal vnodes', () => {
-		expectDomLog = true;
 		let set;
 
 		const Children = () => (
@@ -2648,7 +2624,182 @@ describe('Fragment', () => {
 			'<div>NavigationContentbottom panel.insertBefore(<div>top panel, <div>Navigation)',
 			'<div>bottom panel.remove()'
 		]);
+	});
 
-		expectDomLog = false;
+	it('should efficiently unmount Fragment children', () => {
+		// <div>1 => <span>1 and Fragment sibling unmounts. Does <span>1 get correct _nextDom pointer?
+		function App({ condition }) {
+			return condition ? (
+				<div>
+					<Fragment>
+						<div>1</div>
+						<div>2</div>
+					</Fragment>
+					<Fragment>
+						<div>A</div>
+					</Fragment>
+				</div>
+			) : (
+				<div>
+					<Fragment>
+						<div>1</div>
+					</Fragment>
+					<Fragment>
+						<div>A</div>
+					</Fragment>
+				</div>
+			);
+		}
+
+		render(<App condition={true} />, scratch);
+		expect(scratch.innerHTML).to.equal(div([div(1), div(2), div('A')]));
+
+		clearLog();
+		render(<App condition={false} />, scratch);
+
+		expect(scratch.innerHTML).to.equal(div([div(1), div('A')]));
+		expectDomLogToBe(['<div>2.remove()']);
+	});
+
+	it('should efficiently unmount nested Fragment children', () => {
+		// Fragment wrapping <div>2 and <div>3 unmounts. Does <div>1 get correct
+		// _nextDom pointer to efficiently update DOM? _nextDom should be <div>A
+		function App({ condition }) {
+			return condition ? (
+				<div>
+					<Fragment>
+						<div>1</div>
+						<Fragment>
+							<div>2</div>
+							<div>3</div>
+						</Fragment>
+					</Fragment>
+					<Fragment>
+						<div>A</div>
+						<div>B</div>
+					</Fragment>
+				</div>
+			) : (
+				<div>
+					<Fragment>
+						<div>1</div>
+					</Fragment>
+					<Fragment>
+						<div>A</div>
+						<div>B</div>
+					</Fragment>
+				</div>
+			);
+		}
+
+		clearLog();
+		render(<App condition={true} />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			div([div(1), div(2), div(3), div('A'), div('B')])
+		);
+
+		clearLog();
+		render(<App condition={false} />, scratch);
+
+		expect(scratch.innerHTML).to.equal(div([div(1), div('A'), div('B')]));
+		expectDomLogToBe(['<div>2.remove()', '<div>3.remove()']);
+	});
+
+	it('should efficiently place new children and unmount nested Fragment children', () => {
+		// <div>4 is added and Fragment sibling unmounts. Does <div>4 get correct _nextDom pointer?
+		function App({ condition }) {
+			return condition ? (
+				<div>
+					<Fragment>
+						<div>1</div>
+						<Fragment>
+							<div>2</div>
+							<div>3</div>
+						</Fragment>
+					</Fragment>
+					<Fragment>
+						<div>A</div>
+						<div>B</div>
+					</Fragment>
+				</div>
+			) : (
+				<div>
+					<Fragment>
+						<div>1</div>
+						<div>4</div>
+					</Fragment>
+					<Fragment>
+						<div>A</div>
+						<div>B</div>
+					</Fragment>
+				</div>
+			);
+		}
+
+		render(<App condition={true} />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			div([div(1), div(2), div(3), div('A'), div('B')])
+		);
+
+		clearLog();
+		render(<App condition={false} />, scratch);
+
+		expect(scratch.innerHTML).to.equal(
+			div([div(1), div(4), div('A'), div('B')])
+		);
+		expectDomLogToBe([
+			'<div>.appendChild(#text)',
+			'<div>123AB.insertBefore(<div>4, <div>2)',
+			'<div>2.remove()',
+			'<div>3.remove()'
+		]);
+	});
+
+	it('should efficiently unmount nested Fragment children when changing node type', () => {
+		// <div>1 => <span>1 and Fragment sibling unmounts. Does <span>1 get correct _nextDom pointer?
+		function App({ condition }) {
+			return condition ? (
+				<div>
+					<Fragment>
+						<div>1</div>
+						<Fragment>
+							<div>2</div>
+							<div>3</div>
+						</Fragment>
+					</Fragment>
+					<Fragment>
+						<div>A</div>
+						<div>B</div>
+					</Fragment>
+				</div>
+			) : (
+				<div>
+					<Fragment>
+						<span>1</span>
+					</Fragment>
+					<Fragment>
+						<div>A</div>
+						<div>B</div>
+					</Fragment>
+				</div>
+			);
+		}
+
+		render(<App condition={true} />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			div([div(1), div(2), div(3), div('A'), div('B')])
+		);
+
+		clearLog();
+		render(<App condition={false} />, scratch);
+
+		expect(scratch.innerHTML).to.equal(div([span(1), div('A'), div('B')]));
+		expectDomLogToBe([
+			'<span>.appendChild(#text)',
+			'<div>123AB.insertBefore(<span>1, <div>1)',
+			'<div>2.remove()',
+			'<div>3.remove()',
+			'<div>1.remove()'
+		]);
 	});
 });


### PR DESCRIPTION
While investigating ways to simplify and improve `placeChild` I stumbled upon a bug in how we diff Fragments. If child of a Fragment is unmounted, a Fragment's `_nextDom` pointer could point to this unmounted child. In situations where this happens, the Fragment's parent will correct this by re-appending all the children after the Fragment. While the DOM output is correct, the way we go about achieving it is sub-optimal. This change fixes the `_nextDom` to not point at a DOM that is going to be unmounted.

For example, take the following code:
```html
<div>
  <Fragment> <!-- Fragment 1 -->
    <div>1</div>
    <div>2</div> <!-- this node will get unmounted -->
  </Fragment>
  <Fragment> <!-- Fragment 2 -->
    <div>A</div>
  </Fragment>
</div>
```

If doing a diff from the top where `<div>2` gets unmounted, Fragment 1 should finish it's `diffChildren` call with a `_nextDom` pointer to `<div>A`.  However, before this fix, when Fragment 1 diffs `<div>1`, it sets its `_nextDom` pointer to `<div>1.nextSibling` which is `<div>2` (it hasn't been unmounted yet). This fix detects that the `_nextDom` pointer will be unmounted and resets it to the next DOM sibling, in this case `<div>A`.

This PR fixes a long standing Fragment issue that prevented us from asserting expected DOM operations on Fragment diffing and this PR enables us to them turn on! We can now catch regressions in how we mount & move around fragment children!

Specifically, on master the test "should handle changing node type within a Component that returns a Fragment #1326" in fragments.test.js has more than necessary dom operations. The same is true for the tests I've added. All have reduced number of DOM ops.