### PR TITLE
Fix Children.toArray not setting index keys

### DIFF
--- a/compat/src/Children.js
+++ b/compat/src/Children.js
@@ -17,5 +17,14 @@ export const Children = {
 		if (normalized.length !== 1) throw 'Children.only';
 		return normalized[0];
 	},
-	toArray: toChildArray
+	toArray(children) {
+		return toChildArray(children).map((child, i) => {
+			// Only normalized vnodes will be keyed #2888
+			if (child != null && typeof child === 'object') {
+				child.key = child.key != null ? child.key : i;
+			}
+
+			return child;
+		});
+	}
 };

--- a/compat/test/browser/Children.test.js
+++ b/compat/test/browser/Children.test.js
@@ -4,7 +4,12 @@ import {
 	serializeHtml
 } from '../../../test/_util/helpers';
 import { div, span } from '../../../test/_util/dom';
-import React, { createElement, Children, render } from 'preact/compat';
+import React, {
+	createElement,
+	Children,
+	render,
+	Fragment
+} from 'preact/compat';
 
 describe('Children', () => {
 	/** @type {HTMLDivElement} */
@@ -180,6 +185,29 @@ describe('Children', () => {
 			);
 			let expected = div([span('foo'), span(div('bar'))]);
 			expect(serializeHtml(scratch)).to.equal(expected);
+		});
+	});
+
+	describe('toArray', () => {
+		it('should add keys based on index if none present #2888', () => {
+			const res = Children.toArray([
+				<div key="a" />,
+				<span />,
+				<Fragment />,
+				'foo',
+				null,
+				false,
+				0
+			]);
+
+			expect(res[0].key).to.equal('a');
+			expect(res[1].key).to.equal(1);
+			expect(res[2].key).to.equal(2);
+
+			// Non-normalized vnodes should remain untouched,
+			// falsy vnodes will be filtered away
+			expect(res[3]).to.equal('foo');
+			expect(res[4]).to.equal(0);
 		});
 	});
 });


### PR DESCRIPTION
Turns out that React always sets keys when calling `Children.toArray` that are based on the array index.

Fixes #2888 