### PR TITLE
Add support for pretty printing karma console logs

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,6 +12,17 @@ var coverage = String(process.env.COVERAGE) === 'true',
 	errorstacks = require('errorstacks'),
 	kl = require('kolorist');
 
+// This strips Karma's annoying `LOG: '...'` string from logs
+const orgStdoutWrite = process.stdout.write;
+process.stdout.write = msg => {
+	const match = msg.match(/(LOG|WARN|ERROR):\s'(.*)'/);
+	if (match && match.length >= 3) {
+		msg = match[2] + '\n';
+	}
+
+	return orgStdoutWrite.call(process.stdout, msg);
+};
+
 var sauceLabsLaunchers = {
 	sl_chrome: {
 		base: 'SauceLabs',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,12 +15,25 @@ var coverage = String(process.env.COVERAGE) === 'true',
 // This strips Karma's annoying `LOG: '...'` string from logs
 const orgStdoutWrite = process.stdout.write;
 process.stdout.write = msg => {
-	const match = msg.match(/(LOG|WARN|ERROR):\s'(.*)'/);
-	if (match && match.length >= 3) {
-		msg = match[2] + '\n';
+	let out = '';
+	const match = msg.match(/(^|.*\s)(LOG|WARN|ERROR):\s'([\s\S]*)'/);
+	if (match && match.length >= 4) {
+		// Sometimes the UA of the browser will be included in the message
+		if (match[1].length) {
+			out += kl.yellow(kl.italic(match[1]));
+			out += match[3]
+				.split('\n')
+				.map(line => '  ' + line)
+				.join('\n');
+		} else {
+			out += match[3];
+		}
+		out += '\n';
+	} else {
+		out = msg;
 	}
 
-	return orgStdoutWrite.call(process.stdout, msg);
+	return orgStdoutWrite.call(process.stdout, out);
 };
 
 var sauceLabsLaunchers = {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -107,9 +107,7 @@ module.exports = function(config) {
 			if (!frames.length || frames[0].column === -1) return '\n' + msg + '\n';
 
 			const frame = frames[0];
-			const filePath = kl.lightCyan(
-				path.relative(__dirname, frame.sourceFileName)
-			);
+			const filePath = kl.lightCyan(frame.fileName.replace('webpack:///', ''));
 
 			const indentMatch = msg.match(/^(\s*)/);
 			const indent = indentMatch ? indentMatch[1] : '  ';

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,7 +8,9 @@ var coverage = String(process.env.COVERAGE) === 'true',
 	sauceLabs = ci && !pullRequest && masterBranch,
 	performance = !coverage && String(process.env.PERFORMANCE) !== 'false',
 	webpack = require('webpack'),
-	path = require('path');
+	path = require('path'),
+	errorstacks = require('errorstacks'),
+	kl = require('kolorist');
 
 var sauceLabsLaunchers = {
 	sl_chrome: {
@@ -75,6 +77,18 @@ module.exports = function(config) {
 			coverage ? 'coverage' : [],
 			sauceLabs ? 'saucelabs' : []
 		),
+
+		formatError(msg) {
+			const frames = errorstacks.parseStackTrace(msg);
+			if (!frames.length) return msg;
+
+			const frame = frames[0];
+			const filePath = kl.lightCyan(
+				path.relative(__dirname, frame.sourceFileName)
+			);
+			const location = kl.yellow(`:${frame.line}:${frame.column}`);
+			return `  at ${frame.name} (${filePath}${location})\n`;
+		},
 
 		coverageReporter: {
 			dir: path.join(__dirname, 'coverage'),

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -104,14 +104,17 @@ module.exports = function(config) {
 
 		formatError(msg) {
 			const frames = errorstacks.parseStackTrace(msg);
-			if (!frames.length) return msg;
+			if (!frames.length || frames[0].column === -1) return '\n' + msg + '\n';
 
 			const frame = frames[0];
 			const filePath = kl.lightCyan(
 				path.relative(__dirname, frame.sourceFileName)
 			);
+
+			const indentMatch = msg.match(/^(\s*)/);
+			const indent = indentMatch ? indentMatch[1] : '  ';
 			const location = kl.yellow(`:${frame.line}:${frame.column}`);
-			return `  at ${frame.name} (${filePath}${location})\n`;
+			return `${indent}at ${frame.name} (${filePath}${location})\n`;
 		},
 
 		coverageReporter: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8490,9 +8490,9 @@
 			"dev": true
 		},
 		"kolorist": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.2.3.tgz",
-			"integrity": "sha512-tKAyr5m4kClO8IfBXUKC8t9jUYmIlGGm5eYCbJlf86JWYUqpYMPszTyxpkSnJmIz3zd3rFL1uhmqkaUdWr6tIg==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.2.8.tgz",
+			"integrity": "sha512-w9SdDIp7TV8zSGy46lwFyY1O4ZlDa2a8HDQWPkFqtKj+AbwHef5cNcgx3dz9UXo/swfwht2+2cydpdAPuhNFRw==",
 			"dev": true
 		},
 		"lazystream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5293,6 +5293,12 @@
 				"is-arrayish": "^0.2.1"
 			}
 		},
+		"errorstacks": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/errorstacks/-/errorstacks-2.0.0.tgz",
+			"integrity": "sha512-t5ZcfunrgHDQL83nSvpLNVrtrLUmQmiHPPdTUOnScU8y5g5ErBIFC0K7ec/7pbmxfOc8m/hIYB00Xlw8GdubvQ==",
+			"dev": true
+		},
 		"es-abstract": {
 			"version": "1.16.2",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",

--- a/package.json
+++ b/package.json
@@ -242,6 +242,7 @@
 		"karma-sinon": "^1.0.5",
 		"karma-sourcemap-loader": "^0.3.7",
 		"karma-webpack": "^3.0.5",
+		"kolorist": "^1.2.8",
 		"lint-staged": "^10.5.2",
 		"lodash": "^4.17.20",
 		"microbundle": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -227,6 +227,7 @@
 		"cross-env": "^7.0.2",
 		"csstype": "^3.0.5",
 		"diff": "^5.0.0",
+		"errorstacks": "^2.0.0",
 		"eslint": "5.15.1",
 		"eslint-config-developit": "^1.1.1",
 		"eslint-config-prettier": "^6.5.0",

--- a/test/polyfills.js
+++ b/test/polyfills.js
@@ -92,7 +92,7 @@ function serializeConsoleArgs(args) {
 	// format everything into one line if possible and assume a terminal
 	// width of 80 chars
 	if (kl.stripColors(flat.join(', ')).length <= 80) {
-		return ['\n' + flat.join(', ') + '\n'];
+		return [flat.join(', ')];
 	}
 
 	const serialized = args.map(arg => serialize(arg, 'default', 0, new Set()));

--- a/test/polyfills.js
+++ b/test/polyfills.js
@@ -73,6 +73,8 @@ function patchConsole(method) {
 	Object.defineProperty(window.console, method, {
 		get() {
 			return (...args) => {
+				// @ts-ignore
+				// eslint-disable-next-line no-undef
 				__karma__.log(method, serializeConsoleArgs(args));
 			};
 		}

--- a/test/polyfills.js
+++ b/test/polyfills.js
@@ -11,6 +11,7 @@ import 'core-js/fn/string/starts-with';
 import 'core-js/fn/string/code-point-at';
 import 'core-js/fn/string/from-code-point';
 import 'core-js/fn/string/repeat';
+import * as kl from 'kolorist';
 
 // Fix Function#name on browsers that do not support it (IE).
 // Taken from: https://stackoverflow.com/a/17056530/755391
@@ -61,3 +62,183 @@ chai.use((chai, util) => {
 		}
 	});
 });
+
+//
+// The following code overwrites karma's internal logging feature to
+// support a much prettier and humand readable represantation of
+// console logs in our terminal. This includes indentation, coloring
+// and support for Map and Set objects.
+//
+function patchConsole(method) {
+	Object.defineProperty(window.console, method, {
+		get() {
+			return (...args) => {
+				__karma__.log(method, serializeConsoleArgs(args));
+			};
+		}
+	});
+}
+
+patchConsole('log');
+patchConsole('warn');
+patchConsole('error');
+patchConsole('info');
+
+/**
+ * @param {any[]} args
+ * @returns {[string]}
+ */
+function serializeConsoleArgs(args) {
+	const flat = args.map(arg => serialize(arg, 'flat', 0, new Set()));
+	// We don't have access to the users terminal width, so we'll try to
+	// format everything into one line if possible and assume a terminal
+	// width of 80 chars
+	if (kl.stripColors(flat.join(', ')).length <= 80) {
+		return ['\n' + flat.join(', ') + '\n'];
+	}
+
+	const serialized = args.map(arg => serialize(arg, 'default', 0, new Set()));
+	return ['\n' + serialized.join(',\n') + '\n'];
+}
+
+/**
+ * @param {number} n
+ * @returns {string}
+ */
+function applyIndent(n) {
+	if (n <= 0) return '';
+	return '  '.repeat(n);
+}
+
+/**
+ * @param {any} value
+ * @param {"flat" | "default"} mode
+ * @param {number} indent
+ * @param {Set<any>} seen
+ * @returns {string}
+ */
+function serialize(value, mode, indent, seen) {
+	if (seen.has(value)) {
+		return kl.cyan('[Circular]');
+	}
+
+	if (value === null) {
+		return kl.bold('null');
+	} else if (Array.isArray(value)) {
+		seen.add(value);
+		const values = value.map(v => serialize(v, mode, indent + 1, seen));
+		if (mode === 'flat') {
+			return `[ ${values.join(', ')} ]`;
+		}
+
+		const space = applyIndent(indent);
+		const pretty = values.map(v => applyIndent(indent + 1) + v).join(',\n');
+		return `[\n${pretty}\n${space}]`;
+	} else if (value instanceof Set) {
+		const values = [];
+		value.forEach(v => {
+			values.push(serialize(v, mode, indent, seen));
+		});
+
+		if (mode === 'flat') {
+			return `Set(${value.size}) { ${values.join(', ')} }`;
+		}
+
+		const pretty = values.map(v => applyIndent(indent + 1) + v).join(',\n');
+		return `Set(${value.size}) {\n${pretty}\n${applyIndent(indent)}}`;
+	} else if (value instanceof Map) {
+		const values = [];
+		value.forEach((v, k) => {
+			values.push([
+				serialize(v, 'flat', indent, seen),
+				serialize(k, 'flat', indent, seen)
+			]);
+		});
+
+		if (mode === 'flat') {
+			const pretty = values.map(v => `${v[0]} => ${v[1]}`).join(', ');
+			return `Map(${value.size}) { ${pretty} }`;
+		}
+
+		const pretty = values
+			.map(v => {
+				return applyIndent(indent + 1) + `${v[0]} => ${v[1]}`;
+			})
+			.join(', ');
+		return `Map(${value.size}) {\n${pretty}\n${applyIndent(indent)}}`;
+	}
+
+	switch (typeof value) {
+		case 'undefined':
+			return kl.dim('undefined');
+
+		case 'bigint':
+		case 'number':
+		case 'boolean':
+			return kl.yellow(String(value));
+		case 'string': {
+			const quote = /[^\\]"/.test(value) ? '"' : "'";
+			return kl.green(String(quote + value + quote));
+		}
+		case 'symbol':
+			return kl.green(value.toString());
+		case 'function':
+			return kl.cyan(`[Function: ${value.name || 'anonymous'}]`);
+	}
+
+	seen.add(value);
+
+	const props = Object.keys(value).map(key => {
+		const v = serialize(value[key], mode, indent + 1, seen);
+		return `${key}: ${v}`;
+	});
+
+	if (props.length === 0) {
+		return '{}';
+	} else if (mode === 'flat') {
+		const pretty = props.join(', ');
+		return `{ ${pretty} }`;
+	}
+
+	const pretty = props.map(p => applyIndent(indent + 1) + p).join(',\n');
+	return `{\n${pretty}\n${applyIndent(indent)}}`;
+}
+
+// Use these lines to test pretty formatting:
+//
+// const obj = { foo: 123 };
+// obj.obj = obj;
+// console.log(obj);
+// console.log([1, 2]);
+// console.log(new Set([1, 2]));
+// console.log(new Map([[1, 2]]));
+// console.log({
+// 	foo: { bar: 123, bob: { a: 1 } }
+// });
+// console.log(
+// 	'hey',
+// 	null,
+// 	undefined,
+// 	[1, 2, ['a']],
+// 	() => {},
+// 	{
+// 		type: 'div',
+// 		props: {},
+// 		key: undefined,
+// 		ref: undefined,
+// 		__k: null,
+// 		__: null,
+// 		__b: 0,
+// 		__e: null,
+// 		__d: undefined,
+// 		__c: null,
+// 		__h: null,
+// 		constructor: undefined,
+// 		__v: 1
+// 	},
+// 	{
+// 		foo: { bar: 123, bob: { a: 1, b: new Set([1, 2]), c: new Map([[1, 2]]) } }
+// 	},
+// 	new Set([1, 2]),
+// 	new Map([[1, 2]])
+// );

--- a/test/polyfills.js
+++ b/test/polyfills.js
@@ -55,7 +55,7 @@ chai.use((chai, util) => {
 			this.assert(
 				obj === expectedNode,
 				`${message}: expected #{this} to be #{exp} but got #{act}`,
-				`${message}: expected #{this} not to be #{exp}`,
+				`${message}: expected #	{this} not to be #{exp}`,
 				expectedNode,
 				obj
 			);
@@ -70,15 +70,11 @@ chai.use((chai, util) => {
 // and support for Map and Set objects.
 //
 function patchConsole(method) {
-	Object.defineProperty(window.console, method, {
-		get() {
-			return (...args) => {
-				// @ts-ignore
-				// eslint-disable-next-line no-undef
-				__karma__.log(method, serializeConsoleArgs(args));
-			};
-		}
-	});
+	window.console[method] = (...args) => {
+		// @ts-ignore
+		// eslint-disable-next-line no-undef
+		__karma__.log(method, serializeConsoleArgs(args));
+	};
 }
 
 patchConsole('log');

--- a/test/polyfills.js
+++ b/test/polyfills.js
@@ -175,6 +175,11 @@ function serialize(value, mode, indent, seen) {
 		case 'boolean':
 			return kl.yellow(String(value));
 		case 'string': {
+			// By default node's built in logging doesn't wrap top level
+			// strings with quotes
+			if (indent === 0) {
+				return String(value);
+			}
 			const quote = /[^\\]"/.test(value) ? '"' : "'";
 			return kl.green(String(quote + value + quote));
 		}


### PR DESCRIPTION
Not sure why I didn't think of this earlier. To get pretty console logs out of karma we can sidestep their own (limited) console argument serializer by simply overwriting it. With this in place we now have the same console output as if we'd write native node code. This should make debugging our vnode trees much easier as they are now longer cut off and printed in a single line.

Before:
![image](https://user-images.githubusercontent.com/1062408/103416807-81c8fb80-4b88-11eb-80df-339b9f9790bc.png)

After:
![image](https://user-images.githubusercontent.com/1062408/103416366-ab812300-4b86-11eb-84c7-ac481c5c9ca7.png)

Stack traces have also received some attention and now easier to scan for the eyes. Jumping to that line via cmd+click works now too 👍 

Before:
![image](https://user-images.githubusercontent.com/1062408/103416812-8ab9cd00-4b88-11eb-9bff-1b186e47b589.png)

After:
![image](https://user-images.githubusercontent.com/1062408/103417071-86da7a80-4b89-11eb-9d55-c977b5526c00.png)



