### PR TITLE
Improve hydration tests

### DIFF
--- a/compat/test/browser/suspense-hydration.test.js
+++ b/compat/test/browser/suspense-hydration.test.js
@@ -217,12 +217,9 @@ describe('suspense hydration', () => {
 	});
 
 	it('should properly hydrate suspense with Fragment siblings', () => {
-		const originalHtml = ul(
-			[li(0), li(1), li(2), li(3), li(4), li(5)].join('')
-		);
+		const originalHtml = ul([li(0), li(1), li(2), li(3), li(4)].join(''));
 
 		const listeners = [
-			sinon.spy(),
 			sinon.spy(),
 			sinon.spy(),
 			sinon.spy(),
@@ -244,8 +241,8 @@ describe('suspense hydration', () => {
 					<Lazy />
 				</Suspense>
 				<Fragment>
+					<li onClick={listeners[3]}>3</li>
 					<li onClick={listeners[4]}>4</li>
-					<li onClick={listeners[5]}>5</li>
 				</Fragment>
 			</ul>,
 			scratch
@@ -253,16 +250,15 @@ describe('suspense hydration', () => {
 		rerender(); // Flush rerender queue to mimic what preact will really do
 		expect(scratch.innerHTML).to.equal(originalHtml);
 		expect(getLog()).to.deep.equal([]);
-		expect(listeners[5]).not.to.have.been.called;
+		expect(listeners[4]).not.to.have.been.called;
 
 		clearLog();
 		scratch.querySelector('li:last-child').dispatchEvent(createEvent('click'));
-		expect(listeners[5]).to.have.been.calledOnce;
+		expect(listeners[4]).to.have.been.calledOnce;
 
 		return resolve(() => (
 			<Fragment>
 				<li onClick={listeners[2]}>2</li>
-				<li onClick={listeners[3]}>3</li>
 			</Fragment>
 		)).then(() => {
 			rerender();
@@ -271,18 +267,80 @@ describe('suspense hydration', () => {
 			clearLog();
 
 			scratch
-				.querySelector('li:nth-child(4)')
+				.querySelector('li:nth-child(3)')
 				.dispatchEvent(createEvent('click'));
-			expect(listeners[3]).to.have.been.calledOnce;
+			expect(listeners[2]).to.have.been.calledOnce;
 
 			scratch
 				.querySelector('li:last-child')
 				.dispatchEvent(createEvent('click'));
-			expect(listeners[5]).to.have.been.calledTwice;
+			expect(listeners[4]).to.have.been.calledTwice;
 		});
 	});
 
 	it('should properly hydrate suspense with Component & Fragment siblings', () => {
+		const originalHtml = ul([li(0), li(1), li(2), li(3), li(4)].join(''));
+
+		const listeners = [
+			sinon.spy(),
+			sinon.spy(),
+			sinon.spy(),
+			sinon.spy(),
+			sinon.spy()
+		];
+
+		scratch.innerHTML = originalHtml;
+		clearLog();
+
+		const [Lazy, resolve] = createLazy();
+		hydrate(
+			<List>
+				<Fragment>
+					<ListItem onClick={listeners[0]}>0</ListItem>
+					<ListItem onClick={listeners[1]}>1</ListItem>
+				</Fragment>
+				<Suspense>
+					<Lazy />
+				</Suspense>
+				<Fragment>
+					<ListItem onClick={listeners[3]}>3</ListItem>
+					<ListItem onClick={listeners[4]}>4</ListItem>
+				</Fragment>
+			</List>,
+			scratch
+		);
+		rerender(); // Flush rerender queue to mimic what preact will really do
+		expect(scratch.innerHTML).to.equal(originalHtml);
+		expect(getLog()).to.deep.equal([]);
+		expect(listeners[4]).not.to.have.been.called;
+
+		clearLog();
+		scratch.querySelector('li:last-child').dispatchEvent(createEvent('click'));
+		expect(listeners[4]).to.have.been.calledOnce;
+
+		return resolve(() => (
+			<Fragment>
+				<ListItem onClick={listeners[2]}>2</ListItem>
+			</Fragment>
+		)).then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.equal(originalHtml);
+			expect(getLog()).to.deep.equal([]);
+			clearLog();
+
+			scratch
+				.querySelector('li:nth-child(3)')
+				.dispatchEvent(createEvent('click'));
+			expect(listeners[2]).to.have.been.calledOnce;
+
+			scratch
+				.querySelector('li:last-child')
+				.dispatchEvent(createEvent('click'));
+			expect(listeners[4]).to.have.been.calledTwice;
+		});
+	});
+
+	it.skip('should properly hydrate suspense when resolves to a Fragment', () => {
 		const originalHtml = ul(
 			[li(0), li(1), li(2), li(3), li(4), li(5)].join('')
 		);

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -4,7 +4,8 @@ import {
 	teardown,
 	sortAttributes,
 	serializeHtml,
-	spyOnElementAttributes
+	spyOnElementAttributes,
+	createEvent
 } from '../_util/helpers';
 import { ul, li, div } from '../_util/dom';
 import { logCall, clearLog, getLog } from '../_util/logCall';
@@ -12,10 +13,14 @@ import { logCall, clearLog, getLog } from '../_util/logCall';
 /** @jsx createElement */
 
 describe('hydrate()', () => {
-	let scratch, attributesSpy;
+	/** @type {HTMLElement} */
+	let scratch;
+	let attributesSpy;
 
 	const List = ({ children }) => <ul>{children}</ul>;
-	const ListItem = ({ children }) => <li>{children}</li>;
+	const ListItem = ({ children, onClick = null }) => (
+		<li onClick={onClick}>{children}</li>
+	);
 
 	let resetAppendChild;
 	let resetInsertBefore;
@@ -53,6 +58,7 @@ describe('hydrate()', () => {
 	});
 
 	it('should reuse existing DOM', () => {
+		const onClickSpy = sinon.spy();
 		const html = ul([li('1'), li('2'), li('3')]);
 
 		scratch.innerHTML = html;
@@ -62,16 +68,22 @@ describe('hydrate()', () => {
 			<ul>
 				<li>1</li>
 				<li>2</li>
-				<li>3</li>
+				<li onClick={onClickSpy}>3</li>
 			</ul>,
 			scratch
 		);
 
 		expect(scratch.innerHTML).to.equal(html);
 		expect(getLog()).to.deep.equal([]);
+		expect(onClickSpy).not.to.have.been.called;
+
+		scratch.querySelector('li:last-child').dispatchEvent(createEvent('click'));
+
+		expect(onClickSpy).to.have.been.called.calledOnce;
 	});
 
 	it('should reuse existing DOM when given components', () => {
+		const onClickSpy = sinon.spy();
 		const html = ul([li('1'), li('2'), li('3')]);
 
 		scratch.innerHTML = html;
@@ -81,13 +93,47 @@ describe('hydrate()', () => {
 			<List>
 				<ListItem>1</ListItem>
 				<ListItem>2</ListItem>
-				<ListItem>3</ListItem>
+				<ListItem onClick={onClickSpy}>3</ListItem>
 			</List>,
 			scratch
 		);
 
 		expect(scratch.innerHTML).to.equal(html);
 		expect(getLog()).to.deep.equal([]);
+		expect(onClickSpy).not.to.have.been.called;
+
+		scratch.querySelector('li:last-child').dispatchEvent(createEvent('click'));
+
+		expect(onClickSpy).to.have.been.called.calledOnce;
+	});
+
+	it('should properly set event handlers to existing DOM when given components', () => {
+		const proto = Element.prototype;
+		sinon.spy(proto, 'addEventListener');
+
+		const clickHandlers = [sinon.spy(), sinon.spy(), sinon.spy()];
+
+		const html = ul([li('1'), li('2'), li('3')]);
+
+		scratch.innerHTML = html;
+		clearLog();
+
+		hydrate(
+			<List>
+				<ListItem onClick={clickHandlers[0]}>1</ListItem>
+				<ListItem onClick={clickHandlers[1]}>2</ListItem>
+				<ListItem onClick={clickHandlers[2]}>3</ListItem>
+			</List>,
+			scratch
+		);
+
+		expect(scratch.innerHTML).to.equal(html);
+		expect(getLog()).to.deep.equal([]);
+		expect(proto.addEventListener).to.have.been.calledThrice;
+		expect(clickHandlers[2]).not.to.have.been.called;
+
+		scratch.querySelector('li:last-child').dispatchEvent(createEvent('click'));
+		expect(clickHandlers[2]).to.have.been.calledOnce;
 	});
 
 	it('should add missing nodes to existing DOM when hydrating', () => {
@@ -168,20 +214,29 @@ describe('hydrate()', () => {
 		scratch.innerHTML = html;
 		clearLog();
 
+		const clickHandlers = [sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy()];
+
 		hydrate(
 			<List>
-				<ListItem>1</ListItem>
+				<ListItem onClick={clickHandlers[0]}>1</ListItem>
 				<Fragment>
-					<ListItem>2</ListItem>
-					<ListItem>3</ListItem>
+					<ListItem onClick={clickHandlers[1]}>2</ListItem>
+					<ListItem onClick={clickHandlers[2]}>3</ListItem>
 				</Fragment>
-				<ListItem>4</ListItem>
+				<ListItem onClick={clickHandlers[3]}>4</ListItem>
 			</List>,
 			scratch
 		);
 
 		expect(scratch.innerHTML).to.equal(html);
 		expect(getLog()).to.deep.equal([]);
+		expect(clickHandlers[2]).not.to.have.been.called;
+
+		scratch
+			.querySelector('li:nth-child(3)')
+			.dispatchEvent(createEvent('click'));
+
+		expect(clickHandlers[2]).to.have.been.called.calledOnce;
 	});
 
 	it('should correctly hydrate root Fragments', () => {
@@ -193,23 +248,44 @@ describe('hydrate()', () => {
 		scratch.innerHTML = html;
 		clearLog();
 
+		const clickHandlers = [
+			sinon.spy(),
+			sinon.spy(),
+			sinon.spy(),
+			sinon.spy(),
+			sinon.spy()
+		];
+
 		hydrate(
 			<Fragment>
 				<List>
 					<Fragment>
-						<ListItem>1</ListItem>
-						<ListItem>2</ListItem>
+						<ListItem onClick={clickHandlers[0]}>1</ListItem>
+						<ListItem onClick={clickHandlers[1]}>2</ListItem>
 					</Fragment>
-					<ListItem>3</ListItem>
-					<ListItem>4</ListItem>
+					<ListItem onClick={clickHandlers[2]}>3</ListItem>
+					<ListItem onClick={clickHandlers[3]}>4</ListItem>
 				</List>
-				<div>sibling</div>
+				<div onClick={clickHandlers[4]}>sibling</div>
 			</Fragment>,
 			scratch
 		);
 
 		expect(scratch.innerHTML).to.equal(html);
 		expect(getLog()).to.deep.equal([]);
+		expect(clickHandlers[2]).not.to.have.been.called;
+
+		scratch
+			.querySelector('li:nth-child(3)')
+			.dispatchEvent(createEvent('click'));
+
+		expect(clickHandlers[2]).to.have.been.calledOnce;
+		expect(clickHandlers[4]).not.to.have.been.called;
+
+		scratch.querySelector('div').dispatchEvent(createEvent('click'));
+
+		expect(clickHandlers[2]).to.have.been.calledOnce;
+		expect(clickHandlers[4]).to.have.been.calledOnce;
 	});
 
 	// Failing because the following condition in diffElementNodes doesn't evaluate to true


### PR DESCRIPTION
Improve our hydration tests to actually assert what hydration should do: attach event listeners. Did this for normal and suspended hydration as well as fix a bug in our Suspense implementation of suspended hydration so these new tests pass.