### PR TITLE
Prepare test code to be run in ES2015+ environments

### DIFF
--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -255,16 +255,6 @@ export function sortAttributes(html) {
 	);
 }
 
-export const spyAll = obj =>
-	Object.keys(obj).forEach(key => sinon.spy(obj, key));
-
-export const resetAllSpies = obj =>
-	Object.keys(obj).forEach(key => {
-		if (obj[key].args) {
-			obj[key].resetHistory();
-		}
-	});
-
 let attributesSpy, originalAttributesPropDescriptor;
 
 export function spyOnElementAttributes() {

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -6,8 +6,7 @@ import {
 	getMixedArray,
 	mixedArrayHTML,
 	serializeHtml,
-	sortAttributes,
-	spyAll
+	sortAttributes
 } from '../_util/helpers';
 import { div, span, p } from '../_util/dom';
 
@@ -1298,7 +1297,10 @@ describe('Components', () => {
 				}
 			}
 
-			spyAll(Inner.prototype);
+			sinon.spy(Inner.prototype, 'componentWillUnmount');
+			sinon.spy(Inner.prototype, 'componentWillMount');
+			sinon.spy(Inner.prototype, 'componentDidMount');
+			sinon.spy(Inner.prototype, 'render');
 
 			render(<Root />, scratch);
 
@@ -1333,7 +1335,10 @@ describe('Components', () => {
 					return <C />;
 				}
 			}
-			spyAll(Outer.prototype);
+			sinon.spy(Outer.prototype, 'componentWillUnmount');
+			sinon.spy(Outer.prototype, 'componentWillMount');
+			sinon.spy(Outer.prototype, 'componentDidMount');
+			sinon.spy(Outer.prototype, 'render');
 
 			class Inner extends Component {
 				componentWillUnmount() {}
@@ -1343,7 +1348,10 @@ describe('Components', () => {
 					return h('element' + ++counter);
 				}
 			}
-			spyAll(Inner.prototype);
+			sinon.spy(Inner.prototype, 'componentWillUnmount');
+			sinon.spy(Inner.prototype, 'componentWillMount');
+			sinon.spy(Inner.prototype, 'componentDidMount');
+			sinon.spy(Inner.prototype, 'render');
 
 			class Inner2 extends Component {
 				constructor(props, context) {
@@ -1357,7 +1365,10 @@ describe('Components', () => {
 					return h('element' + ++counter);
 				}
 			}
-			spyAll(Inner2.prototype);
+			sinon.spy(Inner2.prototype, 'componentWillUnmount');
+			sinon.spy(Inner2.prototype, 'componentWillMount');
+			sinon.spy(Inner2.prototype, 'componentDidMount');
+			sinon.spy(Inner2.prototype, 'render');
 
 			render(<Outer child={Inner} />, scratch);
 
@@ -1425,7 +1436,9 @@ describe('Components', () => {
 					return <div class="inner">foo</div>;
 				}
 			}
-			spyAll(Inner.prototype);
+			sinon.spy(Inner.prototype, 'componentWillMount');
+			sinon.spy(Inner.prototype, 'componentWillUnmount');
+			sinon.spy(Inner.prototype, 'render');
 
 			const InnerFunc = () => <div class="inner-func">bar</div>;
 
@@ -1466,7 +1479,8 @@ describe('Components', () => {
 					return <I>{children}</I>;
 				}
 			}
-			spyAll(C.prototype);
+			sinon.spy(C.prototype, 'componentWillMount');
+			sinon.spy(C.prototype, 'render');
 			return C;
 		};
 
@@ -1484,7 +1498,7 @@ describe('Components', () => {
 			[C1, C2, C3]
 				.reduce(
 					(acc, c) =>
-						acc.concat(Object.keys(c.prototype).map(key => c.prototype[key])),
+						acc.concat(c.prototype.render, c.prototype.componentWillMount),
 					[F1, F2, F3]
 				)
 				.forEach(c => c.resetHistory());

--- a/test/browser/lifecycles/componentDidCatch.test.js
+++ b/test/browser/lifecycles/componentDidCatch.test.js
@@ -1,11 +1,6 @@
 import { setupRerender } from 'preact/test-utils';
 import { createElement, render, Component, Fragment } from 'preact';
-import {
-	setupScratch,
-	teardown,
-	spyAll,
-	resetAllSpies
-} from '../../_util/helpers';
+import { setupScratch, teardown } from '../../_util/helpers';
 
 /** @jsx createElement */
 
@@ -47,7 +42,8 @@ describe('Lifecycle methods', () => {
 
 		let thrower;
 
-		spyAll(Receiver.prototype);
+		sinon.spy(Receiver.prototype, 'componentDidCatch');
+		sinon.spy(Receiver.prototype, 'render');
 
 		function throwExpectedError() {
 			throw (expectedError = new Error('Error!'));
@@ -70,7 +66,9 @@ describe('Lifecycle methods', () => {
 			sinon.spy(ThrowErr.prototype, 'componentDidCatch');
 
 			expectedError = undefined;
-			resetAllSpies(Receiver.prototype);
+
+			Receiver.prototype.componentDidCatch.resetHistory();
+			Receiver.prototype.render.resetHistory();
 		});
 
 		afterEach(() => {

--- a/test/browser/lifecycles/componentWillUnmount.test.js
+++ b/test/browser/lifecycles/componentWillUnmount.test.js
@@ -1,5 +1,5 @@
 import { createElement, render, Component } from 'preact';
-import { setupScratch, teardown, spyAll } from '../../_util/helpers';
+import { setupScratch, teardown } from '../../_util/helpers';
 
 /** @jsx createElement */
 
@@ -31,8 +31,13 @@ describe('Lifecycle methods', () => {
 					return 'bar';
 				}
 			}
-			spyAll(Foo.prototype);
-			spyAll(Bar.prototype);
+			sinon.spy(Foo.prototype, 'componentDidMount');
+			sinon.spy(Foo.prototype, 'componentWillUnmount');
+			sinon.spy(Foo.prototype, 'render');
+
+			sinon.spy(Bar.prototype, 'componentDidMount');
+			sinon.spy(Bar.prototype, 'componentWillUnmount');
+			sinon.spy(Bar.prototype, 'render');
 
 			render(<Foo />, scratch);
 			expect(Foo.prototype.componentDidMount, 'initial render').to.have.been

--- a/test/browser/lifecycles/getDerivedStateFromError.test.js
+++ b/test/browser/lifecycles/getDerivedStateFromError.test.js
@@ -1,11 +1,6 @@
 import { setupRerender } from 'preact/test-utils';
 import { createElement, render, Component } from 'preact';
-import {
-	setupScratch,
-	teardown,
-	spyAll,
-	resetAllSpies
-} from '../../_util/helpers';
+import { setupScratch, teardown } from '../../_util/helpers';
 
 /** @jsx createElement */
 
@@ -47,8 +42,8 @@ describe('Lifecycle methods', () => {
 			}
 		}
 
-		spyAll(Receiver);
-		spyAll(Receiver.prototype);
+		sinon.spy(Receiver, 'getDerivedStateFromError');
+		sinon.spy(Receiver.prototype, 'render');
 
 		function throwExpectedError() {
 			throw (expectedError = new Error('Error!'));
@@ -73,8 +68,8 @@ describe('Lifecycle methods', () => {
 
 			expectedError = undefined;
 
-			resetAllSpies(Receiver);
-			resetAllSpies(Receiver.prototype);
+			Receiver.getDerivedStateFromError.resetHistory();
+			Receiver.prototype.render.resetHistory();
 		});
 
 		afterEach(() => {

--- a/test/browser/lifecycles/lifecycle.test.js
+++ b/test/browser/lifecycles/lifecycle.test.js
@@ -1,6 +1,6 @@
 import { setupRerender } from 'preact/test-utils';
 import { createElement, render, Component } from 'preact';
-import { setupScratch, teardown, spyAll } from '../../_util/helpers';
+import { setupScratch, teardown } from '../../_util/helpers';
 
 /** @jsx createElement */
 
@@ -627,7 +627,8 @@ describe('Lifecycle methods', () => {
 						return fn(props);
 					}
 				}
-				spyAll(C.prototype);
+				sinon.spy(C.prototype, 'componentWillUnmount');
+				sinon.spy(C.prototype, 'render');
 				return C;
 			};
 


### PR DESCRIPTION
Today I played around a bit with running our test suite in native ES2015+ environments. That is to say that I skipped the transpilation step to ES5. By doing so I noticed that the prototype of a native class is not iterable. So calling `Object.keys(MyClass.prototype)` will always return an empty array. This breaks some of our tests.

Since we don't iterate over prototypes that often I just inlined our helper functions.