### PR TITLE
Fix invalid jsx comment

### DIFF
--- a/hooks/test/browser/useDebugValue.test.js
+++ b/hooks/test/browser/useDebugValue.test.js
@@ -2,7 +2,7 @@ import { createElement, render, options } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useDebugValue, useState } from 'preact/hooks';
 
-/** @jsx createElement*/
+/** @jsx createElement */
 
 describe('useDebugValue', () => {
 	/** @type {HTMLDivElement} */


### PR DESCRIPTION
Was playing around with transpiling our test suite via `esbuild` and noticed that fails because of the missing space character in one of our jsx comments.