### PR TITLE
Fix bug when rerendering a suspended hydration node

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -171,6 +171,7 @@ export function diffChildren(
 
 			if (
 				typeof childVNode.type == 'function' &&
+				childVNode._children != null && // Can be null if childVNode suspended
 				childVNode._children === oldVNode._children
 			) {
 				childVNode._nextDom = oldDom = reorderChildren(


### PR DESCRIPTION
Added a test where a suspended hydration node is rerendered but still suspends which revealed a bug. This PR fixes it and adds some more tests. This completes the TODOs at the bottom of this test file