### PR TITLE
Rename "coverage" env to "COVERAGE"

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -217,7 +217,7 @@ module.exports = function(config) {
 			},
 			plugins: [
 				new webpack.DefinePlugin({
-					coverage: coverage,
+					COVERAGE: coverage,
 					NODE_ENV: JSON.stringify(process.env.NODE_ENV || ''),
 					ENABLE_PERFORMANCE: performance
 				})

--- a/test/benchmarks/performance.test.js
+++ b/test/benchmarks/performance.test.js
@@ -1,4 +1,4 @@
-/*global coverage, ENABLE_PERFORMANCE*/
+/*global COVERAGE, ENABLE_PERFORMANCE*/
 /*eslint no-console:0*/
 /** @jsx createElement */
 import { setupScratch, teardown } from '../_util/helpers';
@@ -9,7 +9,7 @@ import {
 	hydrate
 } from 'preact/dist/preact.module';
 
-const MULTIPLIER = ENABLE_PERFORMANCE ? (coverage ? 5 : 1) : 999999;
+const MULTIPLIER = ENABLE_PERFORMANCE ? (COVERAGE ? 5 : 1) : 999999;
 
 // let now = typeof performance!=='undefined' && performance.now ? () => performance.now() : () => +new Date();
 if (typeof performance == 'undefined') {
@@ -67,7 +67,7 @@ describe('performance', function() {
 
 	before(function() {
 		if (!ENABLE_PERFORMANCE) this.skip();
-		if (coverage) {
+		if (COVERAGE) {
 			console.warn(
 				'WARNING: Code coverage is enabled, which dramatically reduces performance. Do not pay attention to these numbers.'
 			);

--- a/test/benchmarks/text.test.js
+++ b/test/benchmarks/text.test.js
@@ -1,4 +1,4 @@
-/*global coverage, ENABLE_PERFORMANCE */
+/*global COVERAGE, ENABLE_PERFORMANCE */
 /*eslint no-console:0*/
 /** @jsx createElement */
 
@@ -6,7 +6,7 @@ import { setupScratch, teardown } from '../_util/helpers';
 import bench from '../_util/bench';
 import preact8 from '../fixtures/preact';
 import * as preactX from '../../dist/preact.module';
-const MULTIPLIER = ENABLE_PERFORMANCE ? (coverage ? 5 : 1) : 999999;
+const MULTIPLIER = ENABLE_PERFORMANCE ? (COVERAGE ? 5 : 1) : 999999;
 
 describe('benchmarks', function() {
 	let scratch;
@@ -15,7 +15,7 @@ describe('benchmarks', function() {
 
 	before(function() {
 		if (!ENABLE_PERFORMANCE) this.skip();
-		if (coverage) {
+		if (COVERAGE) {
 			console.warn(
 				'WARNING: Code coverage is enabled, which dramatically reduces performance. Do not pay attention to these numbers.'
 			);


### PR DESCRIPTION
This fixes invalid code in test runners with more basic string replace based define plugins as they tend to accidentally replace parts of a variable.