### PR TITLE
Compat: Add basic shims for some scheduler functions

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -125,4 +125,16 @@ declare namespace React {
 		only: (children: preact.ComponentChildren) => preact.ComponentChild;
 		toArray: (children: preact.ComponentChildren) => preact.VNode<{}>[];
 	};
+
+	// scheduler
+	export const unstable_ImmediatePriority: number;
+	export const unstable_UserBlockingPriority: number;
+	export const unstable_NormalPriority: number;
+	export const unstable_LowPriority: number;
+	export const unstable_IdlePriority: number;
+	export function unstable_runWithPriority(
+		priority: number,
+		callback: () => void
+	): void;
+	export const unstable_now: () => number;
 }

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -32,6 +32,7 @@ import {
 	REACT_ELEMENT_TYPE,
 	__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
 } from './render';
+export * from './scheduler';
 
 const version = '16.8.0'; // trick libraries to think we are react
 

--- a/compat/src/scheduler.js
+++ b/compat/src/scheduler.js
@@ -1,0 +1,24 @@
+// This file includes experimental React APIs exported from the "scheduler"
+// npm package. Despite being explicitely marked as unstable some libraries
+// already make use of them. This file is not a full replacement for the
+// scheduler package, but includes the necessary shims to make those libraries
+// work with Preact.
+
+export const unstable_ImmediatePriority = 1;
+export const unstable_UserBlockingPriority = 2;
+export const unstable_NormalPriority = 3;
+export const unstable_LowPriority = 4;
+export const unstable_IdlePriority = 5;
+
+/**
+ * @param {number} priority
+ * @param {() => void} callback
+ */
+export function unstable_runWithPriority(priority, callback) {
+	return callback();
+}
+
+export const unstable_now =
+	typeof performance === 'object' && typeof performance.now === 'function'
+		? performance.now.bind(performance)
+		: () => Date.now();

--- a/compat/test/browser/scheduler.test.js
+++ b/compat/test/browser/scheduler.test.js
@@ -1,0 +1,39 @@
+import {
+	unstable_runWithPriority,
+	unstable_NormalPriority,
+	unstable_LowPriority,
+	unstable_IdlePriority,
+	unstable_UserBlockingPriority,
+	unstable_ImmediatePriority,
+	unstable_now
+} from 'preact/compat';
+
+describe('scheduler', () => {
+	describe('runWithPriority', () => {
+		it('should call callback ', () => {
+			const spy = sinon.spy();
+			unstable_runWithPriority(unstable_IdlePriority, spy);
+			expect(spy.callCount).to.equal(1);
+
+			unstable_runWithPriority(unstable_LowPriority, spy);
+			expect(spy.callCount).to.equal(2);
+
+			unstable_runWithPriority(unstable_NormalPriority, spy);
+			expect(spy.callCount).to.equal(3);
+
+			unstable_runWithPriority(unstable_UserBlockingPriority, spy);
+			expect(spy.callCount).to.equal(4);
+
+			unstable_runWithPriority(unstable_ImmediatePriority, spy);
+			expect(spy.callCount).to.equal(5);
+		});
+	});
+
+	describe('unstable_now', () => {
+		it('should return number', () => {
+			const res = unstable_now();
+			expect(res).is.a('number');
+			expect(res > 0).to.equal(true);
+		});
+	});
+});

--- a/compat/test/ts/scheduler.ts
+++ b/compat/test/ts/scheduler.ts
@@ -1,0 +1,19 @@
+import {
+	unstable_runWithPriority,
+	unstable_NormalPriority,
+	unstable_LowPriority,
+	unstable_IdlePriority,
+	unstable_UserBlockingPriority,
+	unstable_ImmediatePriority,
+	unstable_now
+} from '../../src';
+
+const noop = () => null;
+unstable_runWithPriority(unstable_IdlePriority, noop);
+unstable_runWithPriority(unstable_LowPriority, noop);
+unstable_runWithPriority(unstable_NormalPriority, noop);
+unstable_runWithPriority(unstable_UserBlockingPriority, noop);
+unstable_runWithPriority(unstable_ImmediatePriority, noop);
+
+if (typeof unstable_now() === 'number') {
+}


### PR DESCRIPTION
Was notified of a library that makes use of some experimental concurrent mode APIs from React. This PR adds the necessary shims for that.

See https://github.com/dai-shi/use-context-selector/pull/36/files

cc @mischnic