### PR TITLE
Avoid overriding render method in Suspense

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -39,6 +39,7 @@ function detachedClone(vnode, detachedParent, parentDom) {
 			}
 			vnode._component = null;
 		}
+
 		vnode._children =
 			vnode._children &&
 			vnode._children.map(child =>
@@ -57,6 +58,7 @@ function removeOriginal(vnode, detachedParent, originalParent) {
 			vnode._children.map(child =>
 				removeOriginal(child, detachedParent, originalParent)
 			);
+
 		if (vnode._component) {
 			if (vnode._component._parentDom === detachedParent) {
 				if (vnode._dom) {
@@ -67,6 +69,7 @@ function removeOriginal(vnode, detachedParent, originalParent) {
 			}
 		}
 	}
+
 	return vnode;
 }
 
@@ -124,20 +127,6 @@ Suspense.prototype._childDidSuspend = function(promise, suspendingVNode) {
 		if (suspendingComponent._suspendedComponentWillUnmount) {
 			suspendingComponent._suspendedComponentWillUnmount();
 		}
-	};
-	const _suspendedRender = suspendingComponent.render;
-	suspendingComponent.render = (props, state, context) => {
-		const result = _suspendedRender.call(
-			suspendingComponent,
-			props,
-			state,
-			context
-		);
-
-		suspendingComponent._renderCallbacks.push(onResolved);
-
-		suspendingComponent.render = _suspendedRender;
-		return result;
 	};
 
 	const onSuspensionComplete = () => {

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -1210,6 +1210,43 @@ describe('suspense', () => {
 			});
 	});
 
+	it('should correctly render nested Suspense components without intermediate DOM #2747', () => {
+		const [ProfileDetails, resolveDetails] = createLazy();
+		const [ProfileTimeline, resolveTimeline] = createLazy();
+
+		function ProfilePage() {
+			return (
+				<Suspense fallback={<h1>Loading profile...</h1>}>
+					<ProfileDetails />
+					<Suspense fallback={<h2>Loading posts...</h2>}>
+						<ProfileTimeline />
+					</Suspense>
+				</Suspense>
+			);
+		}
+
+		render(<ProfilePage />, scratch);
+		rerender(); // Render fallback
+
+		expect(scratch.innerHTML).to.equal('<h1>Loading profile...</h1>');
+
+		return resolveDetails(() => <h1>Ringo Starr</h1>)
+			.then(() => {
+				rerender();
+				expect(scratch.innerHTML).to.equal(
+					'<h1>Ringo Starr</h1><h2>Loading posts...</h2>'
+				);
+
+				return resolveTimeline(() => <p>Timeline details</p>);
+			})
+			.then(() => {
+				rerender();
+				expect(scratch.innerHTML).to.equal(
+					'<h1>Ringo Starr</h1><p>Timeline details</p>'
+				);
+			});
+	});
+
 	it('should correctly render Suspense components inside Fragments', () => {
 		// Issue #2106.
 

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -1705,7 +1705,10 @@ describe('suspense', () => {
 		});
 	});
 
-	it('should allow suspended children to update', () => {
+	// TODO: Revisit later. Consider using an "options.commit" plugin to detect
+	// when a suspended component has rerendered and trigger a rerender on the
+	// parent Suspense
+	it.skip('should allow suspended children to update', () => {
 		const log = [];
 		class Logger extends Component {
 			constructor(props) {
@@ -1767,7 +1770,10 @@ describe('suspense', () => {
 		);
 	});
 
-	it('should allow multiple suspended children to update', () => {
+	// TODO: Revisit later. Consider using an "options.commit" plugin to detect
+	// when a suspended component has rerendered and trigger a rerender on the
+	// parent Suspense
+	it.skip('should allow multiple suspended children to update', () => {
 		function createSuspender() {
 			let suspender;
 			class Suspender extends Component {
@@ -1831,7 +1837,10 @@ describe('suspense', () => {
 		);
 	});
 
-	it('should allow suspended children children to update', () => {
+	// TODO: Revisit later. Consider using an "options.commit" plugin to detect
+	// when a suspended component has rerendered and trigger a rerender on the
+	// parent Suspense
+	it.skip('should allow suspended children children to update', () => {
 		function Suspender({ promise, content }) {
 			if (promise) {
 				throw promise;


### PR DESCRIPTION
The current workaround to enable suspended components to resume without resolving their promise requires overriding the component's render method. Overriding methods on objects we don't own isn't a great pattern and while we do it for `componentWillUnmount` in Suspense, its something we should move away from (should really be using an `options.unmount` plugin).

We may come back to this use case later after a planned rewrite (more details coming soon) which will hopefully simplify many of these scenarios.

And FWIW, [React doesn't support this scenario](https://codesandbox.io/s/resume-with-rerender-kim18) (resuming from Suspense without resolving the Promise)