### PR TITLE
use options.unmount instead of overriding component.componentWillUnmount

### DIFF
--- a/compat/src/internal.d.ts
+++ b/compat/src/internal.d.ts
@@ -17,7 +17,7 @@ export interface Component<P = {}, S = {}> extends PreactComponent<P, S> {
 	// Suspense internal properties
 	_childDidSuspend?(error: Promise<void>, suspendingVNode: VNode): void;
 	_suspended: (vnode: VNode) => (unsuspend: () => void) => void;
-	_suspendedComponentWillUnmount?(): void;
+	_onResolve?(): void;
 
 	// Portal internal properties
 	_temp: any;

--- a/compat/src/util.js
+++ b/compat/src/util.js
@@ -21,3 +21,8 @@ export function shallowDiffers(a, b) {
 	for (let i in b) if (i !== '__source' && a[i] !== b[i]) return true;
 	return false;
 }
+
+export function removeNode(node) {
+	let parentNode = node.parentNode;
+	if (parentNode) parentNode.removeChild(node);
+}

--- a/mangle.json
+++ b/mangle.json
@@ -46,7 +46,7 @@
       "$_children": "__k",
       "$_pendingSuspensionCount": "__u",
       "$_childDidSuspend": "__c",
-      "$_suspendedComponentWillUnmount": "__c",
+      "$_onResolve": "__R",
       "$_suspended": "__e",
       "$_dom": "__e",
       "$_hydrating": "__h",


### PR DESCRIPTION
Following up to https://github.com/preactjs/preact/pull/2917, use `options.unmount` instead of overriding `componentWillUnmount`

this will check `component._onResolve` on every unmount though, not sure how much will this add up to slow things down