### PR TITLE
Fix broken watcher after build error in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6862,9 +6862,9 @@
 			}
 		},
 		"karma-esbuild": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/karma-esbuild/-/karma-esbuild-1.0.4.tgz",
-			"integrity": "sha512-BSFBMKLNsW1/JDSc2OS6Y6qwEQgr8odSjGH9i2isHC9VvsxWnMyMGae2JYxDP1EXCqdE6iVrLlBQyfl9SyHWyg==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/karma-esbuild/-/karma-esbuild-1.0.6.tgz",
+			"integrity": "sha512-VpqXYP0fKSxiBWIW/AmoNspb/8imntJIhLmlDJA/1cL+saTUSYkAwJ74maImUjuuln5WLMiIbqucfonx7b7dYg==",
 			"dev": true,
 			"requires": {
 				"chokidar": "^3.4.3"

--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
 		"karma-chai-sinon": "^0.1.5",
 		"karma-chrome-launcher": "^3.1.0",
 		"karma-coverage": "^2.0.3",
-		"karma-esbuild": "^1.0.4",
+		"karma-esbuild": "^1.0.6",
 		"karma-mocha": "^2.0.1",
 		"karma-mocha-reporter": "^2.2.5",
 		"karma-sauce-launcher": "^4.3.4",


### PR DESCRIPTION
Turns out `karma`'s error reporting isn't built with watch mode in mind. Whenever one forwards an error to `karma` the watcher fails to process new events. So `karma-esbuild` will now rely on `esbuild`'s logging and return an empty file instead.