### PR TITLE
Fix incorrect sourcemap line mapping in tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -162,6 +162,7 @@ function createEsbuildPlugin() {
 
 					const tmp = await babel.transformAsync(result, {
 						filename: args.path,
+						sourceMaps: 'inline',
 						plugins: [
 							coverage && [
 								'istanbul',


### PR DESCRIPTION
Forgot to tell babel to always generate sourcemaps, otherwise the line mappings are wrong in stack traces or breakpoints won't be hit.