### PR TITLE
Add workflow_dispatch and restructure branch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,14 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - '**'
   push:
     branches:
       - master
+      - restructure
 
 jobs:
   build_test:

--- a/.github/workflows/saucelabs.yml
+++ b/.github/workflows/saucelabs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - restructure
 
 jobs:
   build_test:


### PR DESCRIPTION
The new `workflow_dispatch` trigger enables us to manually trigger workflows for any branch from the Actions tab which can be useful to generate artifacts for branches that may not otherwise have them. In particular this can be useful for the benchmarks to have an artifact to compare against.

Also enable our workflows to run on the restructure branch.