### PR TITLE
Fail build on missing compat entries in files entry

### DIFF
--- a/config/compat-entries.js
+++ b/config/compat-entries.js
@@ -1,0 +1,25 @@
+const path = require('path');
+const fs = require('fs');
+const kl = require('kolorist');
+
+const pkgFiles = new Set(require('../package.json').files);
+const compatDir = path.join(__dirname, '..', 'compat');
+const files = fs.readdirSync(compatDir);
+
+let missing = 0;
+for (const file of files) {
+	const expected = 'compat/' + file;
+	if (/\.(js|mjs)$/.test(file) && !pkgFiles.has(expected)) {
+		missing++;
+
+		const filePath = kl.cyan('compat/' + file);
+		const label = kl.inverse(kl.red(' ERROR '));
+		console.error(
+			`${label} File ${filePath} is missing in "files" entry in package.json`
+		);
+	}
+}
+
+if (missing > 0) {
+	process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
 		"compat/dist",
 		"compat/src",
 		"compat/server.js",
+		"compat/test-utils.js",
 		"compat/jsx-runtime.js",
 		"compat/jsx-runtime.mjs",
 		"compat/jsx-dev-runtime.js",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
 		"build:test-utils": "microbundle build --raw --cwd test-utils",
 		"build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks'",
 		"build:jsx": "microbundle build --raw --cwd jsx-runtime",
-		"postbuild": "node ./config/node-13-exports.js",
+		"postbuild": "node ./config/node-13-exports.js && node ./config/compat-entries.js",
 		"dev": "microbundle watch --raw --format cjs",
 		"dev:hooks": "microbundle watch --raw --format cjs --cwd hooks",
 		"dev:compat": "microbundle watch --raw --format cjs --cwd compat --globals 'preact/hooks=preactHooks'",


### PR DESCRIPTION
Add a post build script to verify that all entry files in `compat` are present in the `"files"` entry in `package.json`. Discovered that `compat/test-utils.js` was never shipped in our npm package with that. In the long run the hope is that everyone plays nice and respects the defined package entries in `"exports"`. Until then this should allow us to catch missing files and prevent issues like #2930 from happening.