### PR TITLE
Use try/catch for properties instead of an allow list, remove `xlink:`

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -126,7 +126,10 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 
 		if (typeof value === 'function') {
 			// never serialize functions as attribute values
-		} else if (value != null && (value !== false || /^ar/.test(name))) {
+		} else if (
+			value != null &&
+			(value !== false || (name[0] === 'a' && name[1] === 'r'))
+		) {
 			dom.setAttribute(name, value);
 		} else {
 			dom.removeAttribute(name);

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -103,22 +103,13 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 		} else {
 			dom.removeEventListener(name, proxy, useCapture);
 		}
-	} else if (
-		name !== 'list' &&
-		name !== 'tagName' &&
-		// HTMLButtonElement.form and HTMLInputElement.form are read-only but can be set using
-		// setAttribute
-		name !== 'form' &&
-		name !== 'type' &&
-		name !== 'size' &&
-		name !== 'download' &&
-		name !== 'href' &&
-		name !== 'contentEditable' &&
-		!isSvg &&
-		name in dom
-	) {
-		dom[name] = value == null ? '' : value;
-	} else if (typeof value != 'function' && name !== 'dangerouslySetInnerHTML') {
+	} else if (name !== 'dangerouslySetInnerHTML') {
+		 if (!isSvg && name in dom || typeof value == 'function') {
+			try {
+				dom[name] = value == null ? '' : value;
+				return;
+			} catch (e) {}
+		 }
 		if (name !== (name = name.replace(/xlink:?/, ''))) {
 			if (value == null || value === false) {
 				dom.removeAttributeNS(

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -102,7 +102,7 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 			// Normalize incorrect prop usage for SVG:
 			// - xlink:href / xlinkHref --> href (xlink:href was removed from SVG and isn't needed)
 			// - className --> class
-			name = name.replace(/xlink[H:h]/, 'h').replace(/Name$/, '');
+			name = name.replace(/xlink[H:h]/, 'h').replace(/sName$/, 's');
 		} else if (
 			name !== 'href' &&
 			name !== 'list' &&

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -103,7 +103,13 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 			// - xlink:href / xlinkHref --> href (xlink:href was removed from SVG and isn't needed)
 			// - className --> class
 			name = name.replace(/xlink[H:h]/, 'h').replace(/Name$/, '');
-		} else if (name !== 'list' && name !== 'download' && name in dom) {
+		} else if (
+			name !== 'href' &&
+			name !== 'list' &&
+			name !== 'form' &&
+			name !== 'download' &&
+			name in dom
+		) {
 			try {
 				dom[name] = value == null ? '' : value;
 				// labelled break is 1b smaller here than a return statement (sorry)

--- a/test/browser/svg.test.js
+++ b/test/browser/svg.test.js
@@ -65,7 +65,7 @@ describe('svg', () => {
 		expect(html).to.equal(
 			sortAttributes(
 				`
-			<svg viewBox="0 0 360 360" xlink:href="www.preact.com">
+			<svg viewBox="0 0 360 360" href="www.preact.com">
 				<path d="M 347.1 357.9 L 183.3 256.5 L 13 357.9 V 1.7 h 334.1 v 356.2 Z M 58.5 47.2 v 231.4 l 124.8 -74.1 l 118.3 72.8 V 47.2 H 58.5 Z" fill="black" stroke="white"></path>
 			</svg>
 		`.replace(/[\n\t]+/g, '')


### PR DESCRIPTION
This PR includes two fundamental changes to the way we do prop diffing:

1. Instead of safeguarding against setting read-only reflected DOM properties, it attempts to set the property in a `try/catch` and falls back to setting an attribute

2. The codepath for detecting `xlink:href` / `xlinkHref` props and applying them via `setAttributeNS()` is simply removed. This was only ever used for the `xlink:href` attribute, which was removed from SVG 2. The non-namespaced `href` attribute works exactly the same way. As a bridging solution, since there are lots of folks using `<use xlinkHref="..">`, I've retained the code that strips any `xlink` namespace prefix off of the prop name.

Fixes #2926.