### PR TITLE
Simplify top-level render and remove dead code

### DIFF
--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -9,8 +9,6 @@ export function _catchError(error, vnode) {
 	/** @type {import('../internal').Component} */
 	let component, ctor, handled;
 
-	const wasHydrating = vnode._hydrating;
-
 	for (; (vnode = vnode._parent); ) {
 		if ((component = vnode._component) && !component._processingException) {
 			try {
@@ -28,7 +26,6 @@ export function _catchError(error, vnode) {
 
 				// This is an error boundary. Mark it as having bailed out, and whether it was mid-hydration.
 				if (handled) {
-					vnode._hydrating = wasHydrating;
 					return (component._pendingError = component);
 				}
 			} catch (e) {

--- a/src/render.js
+++ b/src/render.js
@@ -28,9 +28,9 @@ export function render(vnode, parentDom, replaceNode) {
 		? null
 		: (replaceNode && replaceNode._children) || parentDom._children;
 
-	vnode = (!isHydrating && replaceNode
-		? replaceNode
-		: parentDom
+	vnode = (
+		(!isHydrating && replaceNode) ||
+		parentDom
 	)._children = createElement(Fragment, null, [vnode]);
 
 	// List of effects that need to be called after diffing.
@@ -51,7 +51,7 @@ export function render(vnode, parentDom, replaceNode) {
 			? EMPTY_ARR.slice.call(parentDom.childNodes)
 			: null,
 		commitQueue,
-		!isHydrating && replaceNode ? replaceNode : EMPTY_OBJ,
+		(!isHydrating && replaceNode) || EMPTY_OBJ,
 		isHydrating
 	);
 

--- a/src/render.js
+++ b/src/render.js
@@ -3,8 +3,6 @@ import { commitRoot, diff } from './diff/index';
 import { createElement, Fragment } from './create-element';
 import options from './options';
 
-const IS_HYDRATE = EMPTY_OBJ;
-
 /**
  * Render a Preact virtual node into a DOM element
  * @param {import('./internal').ComponentChild} vnode The virtual node to render
@@ -16,10 +14,10 @@ const IS_HYDRATE = EMPTY_OBJ;
 export function render(vnode, parentDom, replaceNode) {
 	if (options._root) options._root(vnode, parentDom);
 
-	// We abuse the `replaceNode` parameter in `hydrate()` to signal if we
-	// are in hydration mode or not by passing `IS_HYDRATE` instead of a
-	// DOM element.
-	let isHydrating = replaceNode === IS_HYDRATE;
+	// We abuse the `replaceNode` parameter in `hydrate()` to signal if we are in
+	// hydration mode or not by passing the `hydrate` function instead of a DOM
+	// element..
+	let isHydrating = typeof replaceNode === 'function';
 
 	// To be able to support calling `render()` multiple times on the same
 	// DOM node, we need to obtain a reference to the previous tree. We do
@@ -29,7 +27,11 @@ export function render(vnode, parentDom, replaceNode) {
 	let oldVNode = isHydrating
 		? null
 		: (replaceNode && replaceNode._children) || parentDom._children;
-	vnode = createElement(Fragment, null, [vnode]);
+
+	vnode = (!isHydrating && replaceNode
+		? replaceNode
+		: parentDom
+	)._children = createElement(Fragment, null, [vnode]);
 
 	// List of effects that need to be called after diffing.
 	let commitQueue = [];
@@ -37,11 +39,11 @@ export function render(vnode, parentDom, replaceNode) {
 		parentDom,
 		// Determine the new vnode tree and store it on the DOM element on
 		// our custom `_children` property.
-		((isHydrating ? parentDom : replaceNode || parentDom)._children = vnode),
+		vnode,
 		oldVNode || EMPTY_OBJ,
 		EMPTY_OBJ,
 		parentDom.ownerSVGElement !== undefined,
-		replaceNode && !isHydrating
+		!isHydrating && replaceNode
 			? [replaceNode]
 			: oldVNode
 			? null
@@ -49,7 +51,7 @@ export function render(vnode, parentDom, replaceNode) {
 			? EMPTY_ARR.slice.call(parentDom.childNodes)
 			: null,
 		commitQueue,
-		replaceNode || EMPTY_OBJ,
+		!isHydrating && replaceNode ? replaceNode : EMPTY_OBJ,
 		isHydrating
 	);
 
@@ -64,5 +66,5 @@ export function render(vnode, parentDom, replaceNode) {
  * update
  */
 export function hydrate(vnode, parentDom) {
-	render(vnode, parentDom, IS_HYDRATE);
+	render(vnode, parentDom, hydrate);
 }


### PR DESCRIPTION
Simplify top-level render a bit by removing IS_HYDRATE constant and making sure we use the same condition for checking replaceNode everywhere so it gzips better.

Also, remove some code from our suspended hydration catching mechanism I believe is unused. It bubbles up the value of the `_hydrating` flag to the VNode that catches the suspension. However in our Suspense implementation, it looks at the value of the `_hydrating` on the VNode that suspended (not Suspense itself) to determine if a node suspended while hydrating. So we have no need to bubble up the `_hydrating` flag.