### PR TITLE
Pass all props to createElement instead of just `is` [-5b]

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -344,7 +344,7 @@ function diffElementNodes(
 			dom = document.createElement(
 				// @ts-ignore We know `newVNode.type` is a string
 				newVNode.type,
-				newProps
+				newProps.is && newProps
 			);
 		}
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -344,7 +344,7 @@ function diffElementNodes(
 			dom = document.createElement(
 				// @ts-ignore We know `newVNode.type` is a string
 				newVNode.type,
-				newProps.is && { is: newProps.is }
+				newProps
 			);
 		}
 


### PR DESCRIPTION
The second argument to createElement accepts an object, but only looks at the `is` property. We can just always pass `props` (or we could remove this feature? not sure if it's actually still being used).