### PR TITLE
Use artifact flow to report benchmarks results

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -89,12 +89,6 @@ jobs:
         with:
           name: results
           path: benches/results/text_update.json
-      - uses: andrewiggins/tachometer-reporter-action@v2
-        with:
-          path: benches/results/text_update.json
-          report-id: text_update
-          base-bench-name: preact-master
-          pr-bench-name: preact-local
 
   bench_many_updates:
     name: Bench many_updates
@@ -123,12 +117,6 @@ jobs:
         with:
           name: results
           path: benches/results/many_updates.json
-      - uses: andrewiggins/tachometer-reporter-action@v2
-        with:
-          path: benches/results/many_updates.json
-          report-id: many_updates
-          base-bench-name: preact-master
-          pr-bench-name: preact-local
 
   bench_02_replace1k:
     name: Bench 02_replace1k
@@ -157,13 +145,6 @@ jobs:
         with:
           name: results
           path: benches/results/02_replace1k.json
-      - uses: andrewiggins/tachometer-reporter-action@v2
-        with:
-          path: benches/results/02_replace1k.json
-          report-id: 02_replace1k
-          base-bench-name: preact-master
-          pr-bench-name: preact-local
-          summarize: 'duration, usedJSHeapSize'
 
   bench_03_update10th1k_x16:
     name: Bench 03_update10th1k_x16
@@ -192,12 +173,6 @@ jobs:
         with:
           name: results
           path: benches/results/03_update10th1k_x16.json
-      - uses: andrewiggins/tachometer-reporter-action@v2
-        with:
-          path: benches/results/03_update10th1k_x16.json
-          report-id: 03_update10th1k_x16
-          base-bench-name: preact-master
-          pr-bench-name: preact-local
 
   bench_07_create10k:
     name: Bench 07_create10k
@@ -226,12 +201,6 @@ jobs:
         with:
           name: results
           path: benches/results/07_create10k.json
-      - uses: andrewiggins/tachometer-reporter-action@v2
-        with:
-          path: benches/results/07_create10k.json
-          report-id: 07_create10k
-          base-bench-name: preact-master
-          pr-bench-name: preact-local
 
   bench_hydrate1k:
     name: Bench hydrate1k
@@ -260,12 +229,6 @@ jobs:
         with:
           name: results
           path: benches/results/hydrate1k.json
-      - uses: andrewiggins/tachometer-reporter-action@v2
-        with:
-          path: benches/results/hydrate1k.json
-          report-id: hydrate1k
-          base-bench-name: preact-master
-          pr-bench-name: preact-local
 
   bench_filter_list:
     name: Bench filter_list
@@ -294,9 +257,26 @@ jobs:
         with:
           name: results
           path: benches/results/filter_list.json
+
+  report_results:
+    name: Report Results
+    runs-on: ubuntu-latest
+    needs:
+      - bench_text_update
+      - bench_many_updates
+      - bench_02_replace1k
+      - bench_03_update10th1k_x16
+      - bench_07_create10k
+      - bench_hydrate1k
+      - bench_filter_list
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: results
+          path: results
       - uses: andrewiggins/tachometer-reporter-action@v2
         with:
-          path: benches/results/filter_list.json
-          report-id: filter_list
+          path: results/*.json
           base-bench-name: preact-master
           pr-bench-name: preact-local
+          summarize: 'duration, usedJSHeapSize'


### PR DESCRIPTION
Instead of reporting results in each benchmark job (which requires coordinating updating the comment between the concurrent jobs), we'll collect all the results in an artifact and then report the results after the benchmarks have finished.

This change dramatically reduces the number GitHub APIs calls and so should reduce the likelihood of our action getting throttled. The action still does more API calls than I like but figured I get this update out first to reduce the current strain.

Further, this serves as a building block to setting up the flow to enable benchmark reports for PRs from forks!! :D