### PR TITLE
Fix HTML comments breaking hydration

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -320,9 +320,9 @@ function diffElementNodes(
 			// which is loosely equal to Text VNodes' `.type=null`. Elements use string equality.
 			if (
 				child != null &&
-				((newVNode.type === null
+				((nodeType === null
 					? child.nodeType === 3
-					: child.localName === newVNode.type) ||
+					: child.localName === nodeType) ||
 					dom == child)
 			) {
 				dom = child;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -318,7 +318,13 @@ function diffElementNodes(
 			//
 			// Note: This takes advantage of Text nodes having `.localName=undefined`,
 			// which is loosely equal to Text VNodes' `.type=null`. Elements use string equality.
-			if (child != null && (dom == child || child.localName == nodeType)) {
+			if (
+				child != null &&
+				((newVNode.type === null
+					? child.nodeType === 3
+					: child.localName === newVNode.type) ||
+					dom == child)
+			) {
 				dom = child;
 				excessDomChildren[i] = null;
 				break;

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -445,4 +445,10 @@ describe('hydrate()', () => {
 			'<p class="hi">hello baz</p><p class="hi">hello bar</p>'
 		);
 	});
+
+	it('should skip comment nodes', () => {
+		scratch.innerHTML = '<p>hello <!-- c -->foo</p>';
+		hydrate(<p>hello {'foo'}</p>, scratch);
+		expect(scratch.innerHTML).to.equal('<p>hello foo</p>');
+	});
 });


### PR DESCRIPTION
This PR resolves a regression when `react-dom/server` was used to render a Preact app instead of `preact-render-to-string`. It was introduced in #2942 and reverts a part of it to what it was like before.

Fixes #2950 .