### PR TITLE
Compat: Fix defaultValue not applied when value==null/undefined

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -117,7 +117,15 @@ options.vnode = vnode => {
 		for (let i in props) {
 			let value = props[i];
 
-			if (i === 'defaultValue' && 'value' in props && props.value == null) {
+			if (i === 'value' && 'defaultValue' in props && value == null) {
+				// Skip applying value if it is null/undefined and we already set
+				// a default value
+				continue;
+			} else if (
+				i === 'defaultValue' &&
+				'value' in props &&
+				props.value == null
+			) {
 				// `defaultValue` is treated as a fallback `value` when a value prop is present but null/undefined.
 				// `defaultValue` for Elements with no value prop is the same as the DOM defaultValue property.
 				i = 'value';

--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -110,6 +110,14 @@ describe('compat render', () => {
 		expect(scratch.firstElementChild).to.have.property('value', 'foo');
 	});
 
+	it('should add defaultValue when value is null/undefined', () => {
+		render(<input defaultValue="foo" value={null} />, scratch);
+		expect(scratch.firstElementChild).to.have.property('value', 'foo');
+
+		render(<input defaultValue="foo" value={undefined} />, scratch);
+		expect(scratch.firstElementChild).to.have.property('value', 'foo');
+	});
+
 	it('should support defaultValue for select tag', () => {
 		function App() {
 			return (


### PR DESCRIPTION
This PR addresses an issue in `preact/compat` in regards to the handling of `defaultValue`. When both `defaulValue` and `value` are present, but the latter is `null` or `undefined` we would overwrite the correct value we set earlier with the wrong one. This lead to `defaultValue` effectively never being set.

Fixes #2954