### PR TITLE
Size optimizations for excessDomChildren

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -300,30 +300,25 @@ function diffElementNodes(
 	commitQueue,
 	isHydrating
 ) {
-	let i;
 	let oldProps = oldVNode.props;
 	let newProps = newVNode.props;
 	let nodeType = newVNode.type;
+	let i = 0;
 
 	// Tracks entering and exiting SVG namespace when descending through the tree.
 	if (nodeType === 'svg') isSvg = true;
 
 	if (excessDomChildren != null) {
-		for (i = 0; i < excessDomChildren.length; i++) {
+		for (; i < excessDomChildren.length; i++) {
 			const child = excessDomChildren[i];
 
 			// if newVNode matches an element in excessDomChildren or the `dom`
 			// argument matches an element in excessDomChildren, remove it from
 			// excessDomChildren so it isn't later removed in diffChildren
-			//
-			// Note: This takes advantage of Text nodes having `.localName=undefined`,
-			// which is loosely equal to Text VNodes' `.type=null`. Elements use string equality.
 			if (
-				child != null &&
-				((nodeType === null
-					? child.nodeType === 3
-					: child.localName === nodeType) ||
-					dom == child)
+				child &&
+				(child === dom ||
+					(nodeType ? child.localName == nodeType : child.nodeType == 3))
 			) {
 				dom = child;
 				excessDomChildren[i] = null;
@@ -364,9 +359,9 @@ function diffElementNodes(
 			dom.data = newProps;
 		}
 	} else {
-		if (excessDomChildren != null) {
-			excessDomChildren = EMPTY_ARR.slice.call(dom.childNodes);
-		}
+		// If excessDomChildren was not null, repopulate it with the current element's children:
+		excessDomChildren =
+			excessDomChildren && EMPTY_ARR.slice.call(dom.childNodes);
 
 		oldProps = oldVNode.props || EMPTY_OBJ;
 


### PR DESCRIPTION
This optimizes `excessDomChildren` usage while retaining the comment resiliency (issue #2950) added in #2956, which was a revert of the optimization in #2942. The size should be smaller than my original optimization, but properly ignores nodes that are not elements/text.