### PR TITLE
Report benchmarks on PRs from forks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -257,26 +257,3 @@ jobs:
         with:
           name: results
           path: benches/results/filter_list.json
-
-  report_results:
-    name: Report Results
-    runs-on: ubuntu-latest
-    needs:
-      - bench_text_update
-      - bench_many_updates
-      - bench_02_replace1k
-      - bench_03_update10th1k_x16
-      - bench_07_create10k
-      - bench_hydrate1k
-      - bench_filter_list
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: results
-          path: results
-      - uses: andrewiggins/tachometer-reporter-action@v2
-        with:
-          path: results/*.json
-          base-bench-name: preact-master
-          pr-bench-name: preact-local
-          summarize: 'duration, usedJSHeapSize'

--- a/.github/workflows/pr-reporter.yml
+++ b/.github/workflows/pr-reporter.yml
@@ -1,0 +1,53 @@
+name: Report Results to PR
+
+on:
+  # The pull_request event can't write comments for PRs from forks so using this
+  # workflow_run workflow as a workaround
+  workflow_run:
+    workflows: ['Benchmarks']
+    branches: ['**']
+    types:
+      - completed
+      - requested
+
+jobs:
+  report_running:
+    name: Report benchmarks are in-progress
+    runs-on: ubuntu-latest
+    # Only add the "benchmarks are running" text when a workflow_run is
+    # requested (a.k.a starting)
+    if: ${{ github.event.action == 'requested' }}
+    steps:
+      - name: Report Tachometer Running
+        uses: andrewiggins/tachometer-reporter-action@v2
+        with:
+          # Set initialize to true so this action just creates the comment or
+          # adds the "benchmarks are running" text
+          initialize: true
+
+  report_results:
+    name: Report benchmark results
+    runs-on: ubuntu-latest
+    # Only run this job if the event action was "completed" and the triggering
+    # workflow_run was successful
+    if: >
+      ${{ github.event.action == 'completed' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      # Download the artifact from the triggering workflow that contains the
+      # Tachometer results to report
+      - uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow.id }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: results
+          path: results
+
+      # Create/update the comment with the latest results
+      - name: Report Tachometer Results
+        uses: andrewiggins/tachometer-reporter-action@v2
+        with:
+          path: results/*.json
+          base-bench-name: preact-master
+          pr-bench-name: preact-local
+          summarize: 'duration, usedJSHeapSize'


### PR DESCRIPTION
Take advantage of the improvements from the latest tachometer-reporter-action release to enable benchmark results on PRs from forks.

Note: won't be able to test this until after merging since the `workflow_run` event only runs using version of the workflow files on the repo's main branch. Hopefully it should work though - [testing in another repo worked](https://github.com/andrewiggins/tachometer-reporter-action/pull/48).