### PR TITLE
Remove excessDomChildren parameter

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -1,4 +1,5 @@
 import { Component, createElement, options, Fragment } from 'preact';
+import { MODE_HYDRATE } from '../../src/constants';
 import { assign } from './util';
 
 const oldCatchError = options._catchError;
@@ -165,7 +166,7 @@ Suspense.prototype._childDidSuspend = function(promise, suspendingVNode) {
 				// component so the component instance stored by Suspense is no longer
 				// valid. Likely needs to be fixed with backing nodes and a way to
 				// trigger a rerender for backing nodes
-				if (suspended._vnode._hydrating == null) {
+				if (!(suspended._vnode._mode & MODE_HYDRATE)) {
 					suspended.forceUpdate();
 				}
 			}
@@ -177,7 +178,7 @@ Suspense.prototype._childDidSuspend = function(promise, suspendingVNode) {
 	 * to remain on screen and hydrate it when the suspense actually gets resolved.
 	 * While in non-hydration cases the usual fallback -> component flow would occur.
 	 */
-	const wasHydrating = suspendingVNode._hydrating === true;
+	const wasHydrating = (suspendingVNode._mode & MODE_HYDRATE) === MODE_HYDRATE;
 	if (!c._pendingSuspensionCount++ && !wasHydrating) {
 		c.setState({ _suspended: (c._detachOnNextRender = c._vnode._children[0]) });
 	}
@@ -215,7 +216,6 @@ Suspense.prototype.render = function(props, state) {
 	/** @type {import('./internal').VNode} */
 	const fallback =
 		state._suspended && createElement(Fragment, null, props.fallback);
-	if (fallback) fallback._hydrating = null;
 
 	return [
 		// Wrap with a Fragment to prevent the current reconciler from

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -2,7 +2,6 @@
 
 ## TODOs
 
-* Use bit-wise comparison for `_mode` checks
 * Replace `_hydrating` with `_mode`
 * Consider further removing _dom pointers from non-dom VNodes
 * Combine placeChild and unmounting loop?? Do placeChild backwards? Do

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -2,11 +2,11 @@
 
 ## TODOs
 
+* Use bit-wise comparison for `_mode` checks
+* Replace `_hydrating` with `_mode`
+* Consider further removing _dom pointers from non-dom VNodes
 * Combine placeChild and unmounting loop?? Do placeChild backwards? Do
   unmounting first then placeChild loop
-* Remove the need for `excessDomChildren`. Do hydration more similarly to
-  `keyed` if possible.
-* Consider further removing _dom pointers from non-dom VNodes
 * Fix Suspense tests:
 	* "should correctly render nested Suspense components without intermediate DOM #2747"
 * Fix Suspense hydration tests:

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -2,7 +2,8 @@
 
 ## TODOs
 
-* Replace `_hydrating` with `_mode`
+* Investigate consolidating _processingException & _pendingError into MODEs
+  (might need backing nodes)
 * Consider further removing _dom pointers from non-dom VNodes
 * Combine placeChild and unmounting loop?? Do placeChild backwards? Do
   unmounting first then placeChild loop

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -2,8 +2,8 @@
 
 ## TODOs
 
-* Investigate consolidating _processingException & _pendingError into MODEs
-  (might need backing nodes)
+* Investigate consolidating _processingException & _pendingError into flags on
+  the VNode (might need backing nodes)
 * Consider further removing _dom pointers from non-dom VNodes
 * Combine placeChild and unmounting loop?? Do placeChild backwards? Do
   unmounting first then placeChild loop

--- a/jsx-runtime/src/index.js
+++ b/jsx-runtime/src/index.js
@@ -1,4 +1,5 @@
 import { options, Fragment } from 'preact';
+import { MODE_NONE } from '../../src/constants';
 
 /** @typedef {import('preact').VNode} VNode */
 
@@ -45,6 +46,7 @@ function createVNode(type, props, key, __source, __self) {
 		_hydrating: null,
 		constructor: undefined,
 		_original: ++options._vnodeId,
+		_mode: MODE_NONE,
 		__source,
 		__self
 	};

--- a/jsx-runtime/src/index.js
+++ b/jsx-runtime/src/index.js
@@ -43,7 +43,6 @@ function createVNode(type, props, key, __source, __self) {
 		_depth: 0,
 		_dom: null,
 		_component: null,
-		_hydrating: null,
 		constructor: undefined,
 		_original: ++options._vnodeId,
 		_mode: MODE_NONE,

--- a/mangle.json
+++ b/mangle.json
@@ -49,6 +49,7 @@
       "$_suspended": "__e",
       "$_dom": "__e",
       "$_hydrating": "__h",
+      "$_mode": "__m",
       "$_component": "__c",
       "$__html": "__html",
       "$_parent": "__",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,2 +1,10 @@
+/** Normal mount/patch. Not hydration or side-effecting top-level render. */
+export const MODE_NONE = 0;
+/** Normal hydration that attaches to a DOM tree but does not diff it. */
+export const MODE_HYDRATE = 1;
+/** Top level render unspecified behaviour (old replaceNode parameter to render) */
+export const MODE_MUTATIVE_HYDRATE = 2;
+
 export const EMPTY_ARR = [];
+
 export const IS_NON_DIMENSIONAL = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i;

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,6 +4,8 @@ export const MODE_NONE = 0;
 export const MODE_HYDRATE = 1;
 /** Top level render unspecified behaviour (old replaceNode parameter to render) */
 export const MODE_MUTATIVE_HYDRATE = 2;
+/** Signifies this VNode suspended on the previous render */
+export const MODE_SUSPENDED = 4;
 
 export const EMPTY_ARR = [];
 

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -1,3 +1,4 @@
+import { MODE_NONE } from './constants';
 import options from './options';
 
 /**
@@ -70,7 +71,8 @@ export function createVNode(type, props, key, ref, original) {
 		_component: null,
 		_hydrating: null,
 		constructor: undefined,
-		_original: original == null ? ++options._vnodeId : original
+		_original: original == null ? ++options._vnodeId : original,
+		_mode: MODE_NONE
 	};
 
 	if (options.vnode != null) options.vnode(vnode);

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -69,7 +69,6 @@ export function createVNode(type, props, key, ref, original) {
 		_depth: 0,
 		_dom: null,
 		_component: null,
-		_hydrating: null,
 		constructor: undefined,
 		_original: original == null ? ++options._vnodeId : original,
 		_mode: MODE_NONE

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -100,7 +100,6 @@ export function diffChildren(
 				childVNode,
 				globalContext,
 				isSvg,
-				null,
 				commitQueue,
 				startDom
 			);
@@ -115,7 +114,6 @@ export function diffChildren(
 				childVNode,
 				globalContext,
 				isSvg,
-				[startDom],
 				commitQueue,
 				startDom,
 				oldVNode._hydrating

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -1,6 +1,6 @@
 import { applyRef } from './refs';
 import { normalizeToVNode } from '../create-element';
-import { EMPTY_ARR } from '../constants';
+import { EMPTY_ARR, MODE_HYDRATE, MODE_SUSPENDED } from '../constants';
 import { getDomSibling } from '../component';
 import { mount } from './mount';
 import { patch } from './patch';
@@ -103,10 +103,12 @@ export function diffChildren(
 				commitQueue,
 				startDom
 			);
-		} else if (oldVNode._hydrating != null) {
+		} else if (
+			(oldVNode._mode & (MODE_HYDRATE | MODE_SUSPENDED)) ==
+			(MODE_HYDRATE | MODE_SUSPENDED)
+		) {
 			// We are resuming the hydration of a VNode
 			startDom = childVNode._dom = oldVNode._dom;
-			childVNode._hydrating = null;
 			// Resume the same mode as before suspending
 			childVNode._mode = oldVNode._mode;
 			oldVNodeRef = oldVNode.ref;

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -108,7 +108,7 @@ export function diffChildren(
 			(MODE_HYDRATE | MODE_SUSPENDED)
 		) {
 			// We are resuming the hydration of a VNode
-			startDom = childVNode._dom = oldVNode._dom;
+			startDom = oldVNode._dom;
 			// Resume the same mode as before suspending
 			childVNode._mode = oldVNode._mode;
 			oldVNodeRef = oldVNode.ref;

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -107,6 +107,8 @@ export function diffChildren(
 			// We are resuming the hydration of a VNode
 			startDom = childVNode._dom = oldVNode._dom;
 			childVNode._hydrating = null;
+			// Resume the same mode as before suspending
+			childVNode._mode = oldVNode._mode;
 			oldVNodeRef = oldVNode.ref;
 
 			nextDomSibling = mount(
@@ -115,8 +117,7 @@ export function diffChildren(
 				globalContext,
 				isSvg,
 				commitQueue,
-				startDom,
-				oldVNode._hydrating
+				startDom
 			);
 		} else {
 			// Morph the old element into the new one, but don't append it to the dom yet

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -15,7 +15,6 @@ import { diffChildren } from './children';
  * @param {Array<import('../internal').Component>} commitQueue List of components
  * which have callbacks to invoke in commitRoot
  * @param {import('../internal').PreactElement} startDom
- * @param {Array<import('../internal').PreactElement>} [excessDomChildren]
  * @param {boolean} [isHydrating] Whether or not we are in hydration
  * @returns {import('../internal').PreactElement} pointer to the next DOM node (in order) to be rendered (or null)
  */
@@ -27,7 +26,6 @@ export function renderComponent(
 	isSvg,
 	commitQueue,
 	startDom,
-	excessDomChildren,
 	isHydrating
 ) {
 	/** @type {import('../internal').Component} */
@@ -177,7 +175,6 @@ export function renderComponent(
 			newVNode,
 			globalContext,
 			isSvg,
-			excessDomChildren,
 			commitQueue,
 			startDom,
 			isHydrating

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -15,7 +15,6 @@ import { diffChildren } from './children';
  * @param {Array<import('../internal').Component>} commitQueue List of components
  * which have callbacks to invoke in commitRoot
  * @param {import('../internal').PreactElement} startDom
- * @param {boolean} [isHydrating] Whether or not we are in hydration
  * @returns {import('../internal').PreactElement} pointer to the next DOM node (in order) to be rendered (or null)
  */
 export function renderComponent(
@@ -25,8 +24,7 @@ export function renderComponent(
 	globalContext,
 	isSvg,
 	commitQueue,
-	startDom,
-	isHydrating
+	startDom
 ) {
 	/** @type {import('../internal').Component} */
 	let c;
@@ -176,8 +174,7 @@ export function renderComponent(
 			globalContext,
 			isSvg,
 			commitQueue,
-			startDom,
-			isHydrating
+			startDom
 		);
 	} else {
 		nextDomSibling = diffChildren(

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -107,6 +107,14 @@ function mountDOMElement(dom, newVNode, globalContext, isSvg, commitQueue) {
 	let i;
 
 	let isHydrating = (newVNode._mode & MODE_HYDRATE) === MODE_HYDRATE;
+	if (isHydrating) {
+		while (
+			dom &&
+			(nodeType ? dom.localName !== nodeType : dom.nodeType !== 3)
+		) {
+			dom = dom.nextSibling;
+		}
+	}
 
 	if (nodeType == null) {
 		// TODO: Skip over wrong type nodes

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -104,7 +104,7 @@ function mountDOMElement(dom, newVNode, globalContext, isSvg, commitQueue) {
 	let newProps = newVNode.props;
 	let nodeType = newVNode.type;
 	/** @type {any} */
-	let i = 0;
+	let i;
 
 	let isHydrating = (newVNode._mode & MODE_HYDRATE) === MODE_HYDRATE;
 
@@ -153,7 +153,7 @@ function mountDOMElement(dom, newVNode, globalContext, isSvg, commitQueue) {
 		if (newVNode._mode & MODE_MUTATIVE_HYDRATE) {
 			// But, if we are in a situation where we are using existing DOM (e.g. replaceNode)
 			// we should read the existing DOM attributes to diff them
-			for (let i = 0; i < dom.attributes.length; i++) {
+			for (i = 0; i < dom.attributes.length; i++) {
 				const name = dom.attributes[i].name;
 				if (!(name in newProps)) {
 					dom.removeAttribute(name);

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -15,7 +15,6 @@ import { renderComponent } from './component';
  * @param {Array<import('../internal').Component>} commitQueue List of components
  * which have callbacks to invoke in commitRoot
  * @param {import('../internal').PreactElement} startDom
- * @para\m {boolean} [isHydrating] Whether or not we are in hydration
  * @returns {import('../internal').PreactElement | null} pointer to the next DOM node to be hydrated (or null)
  */
 export function mount(
@@ -25,7 +24,6 @@ export function mount(
 	isSvg,
 	commitQueue,
 	startDom
-	// isHydrating
 ) {
 	// When passing through createElement it assigns the object
 	// constructor as undefined. This to prevent JSON-injection.
@@ -57,7 +55,6 @@ export function mount(
 				globalContext,
 				isSvg,
 				commitQueue
-				// isHydrating
 			);
 
 			// @ts-ignore Trust me TS, nextSibling is a PreactElement
@@ -103,7 +100,6 @@ export function mount(
  * @param {boolean} isSvg Whether or not this DOM node is an SVG node
  * @param {Array<import('../internal').Component>} commitQueue List of components
  * which have callbacks to invoke in commitRoot
- * @para\m {boolean} isHydrating Whether or not we are in hydration
  * @returns {import('../internal').PreactElement}
  */
 function mountDOMElement(dom, newVNode, globalContext, isSvg, commitQueue) {
@@ -239,7 +235,6 @@ function mountDOMElement(dom, newVNode, globalContext, isSvg, commitQueue) {
  * @param {Array<import('../internal').Component>} commitQueue List of components
  * which have callbacks to invoke in commitRoot
  * @param {import('../internal').PreactElement} startDom
- * @para\m {boolean} isHydrating Whether or not we are in hydration
  */
 export function mountChildren(
 	parentDom,
@@ -249,7 +244,6 @@ export function mountChildren(
 	isSvg,
 	commitQueue,
 	startDom
-	// isHydrating
 ) {
 	let i,
 		childVNode,
@@ -314,7 +308,6 @@ export function mountChildren(
 			isSvg,
 			commitQueue,
 			startDom
-			// isHydrating
 		);
 
 		newDom = childVNode._dom;

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -12,7 +12,6 @@ import { renderComponent } from './component';
  * @param {import('../internal').VNode} newVNode The new virtual node
  * @param {object} globalContext The current context object. Modified by getChildContext
  * @param {boolean} isSvg Whether or not this element is an SVG node
- * @param {Array<import('../internal').PreactElement>} excessDomChildren
  * @param {Array<import('../internal').Component>} commitQueue List of components
  * which have callbacks to invoke in commitRoot
  * @param {import('../internal').PreactElement} startDom
@@ -24,7 +23,6 @@ export function mount(
 	newVNode,
 	globalContext,
 	isSvg,
-	excessDomChildren,
 	commitQueue,
 	startDom,
 	isHydrating
@@ -48,16 +46,14 @@ export function mount(
 				isSvg,
 				commitQueue,
 				startDom,
-				excessDomChildren,
 				isHydrating
 			);
 		} else {
 			newVNode._dom = mountDOMElement(
-				null,
+				newVNode._dom,
 				newVNode,
 				globalContext,
 				isSvg,
-				excessDomChildren,
 				commitQueue,
 				isHydrating
 			);
@@ -73,7 +69,8 @@ export function mount(
 	} catch (e) {
 		newVNode._original = null;
 		// if hydrating or creating initial tree, bailout preserves DOM:
-		if (isHydrating || excessDomChildren != null) {
+		// TODO: include replaceNode
+		if (isHydrating) {
 			// @ts-ignore Trust me TS, nextSibling is a PreactElement
 			nextDomSibling = startDom && startDom.nextSibling;
 			newVNode._dom = startDom;
@@ -82,7 +79,8 @@ export function mount(
 			// _hydrating = false if bailed out during mounting
 			// _hydrating = null if it didn't bail out
 			newVNode._hydrating = !!isHydrating;
-			excessDomChildren[excessDomChildren.indexOf(startDom)] = null;
+
+			// excessDomChildren[excessDomChildren.indexOf(startDom)] = null;
 			// ^ could possibly be simplified to:
 			// excessDomChildren.length = 0;
 		}
@@ -99,7 +97,6 @@ export function mount(
  * @param {import('../internal').VNode} newVNode The new virtual node
  * @param {object} globalContext The current context object
  * @param {boolean} isSvg Whether or not this DOM node is an SVG node
- * @param {*} excessDomChildren
  * @param {Array<import('../internal').Component>} commitQueue List of components
  * which have callbacks to invoke in commitRoot
  * @param {boolean} isHydrating Whether or not we are in hydration
@@ -110,7 +107,6 @@ function mountDOMElement(
 	newVNode,
 	globalContext,
 	isSvg,
-	excessDomChildren,
 	commitQueue,
 	isHydrating
 ) {
@@ -118,25 +114,6 @@ function mountDOMElement(
 	let nodeType = newVNode.type;
 	/** @type {any} */
 	let i = 0;
-
-	if (excessDomChildren != null) {
-		for (; i < excessDomChildren.length; i++) {
-			const child = excessDomChildren[i];
-
-			// if newVNode matches an element in excessDomChildren or the `dom`
-			// argument matches an element in excessDomChildren, remove it from
-			// excessDomChildren so it isn't later removed in diffChildren
-			if (
-				child &&
-				(child === dom ||
-					(nodeType ? child.localName == nodeType : child.nodeType == 3))
-			) {
-				dom = child;
-				excessDomChildren[i] = null;
-				break;
-			}
-		}
-	}
 
 	if (nodeType == null) {
 		if (dom == null) {
@@ -164,8 +141,6 @@ function mountDOMElement(
 				);
 			}
 
-			// we created a new parent, so none of the previously attached children can be reused:
-			excessDomChildren = null;
 			// we are creating a new node, so we can assume this is a new subtree (in case we are hydrating), this deopts the hydrate
 			isHydrating = false;
 		}
@@ -173,9 +148,11 @@ function mountDOMElement(
 		// @TODO: Consider removing and instructing users to instead set the desired
 		// prop for removal to undefined/null. During hydration, props are not
 		// diffed at all (including dangerouslySetInnerHTML)
-		if (!isHydrating && excessDomChildren != null) {
+		if (!isHydrating) {
 			// But, if we are in a situation where we are using existing DOM (e.g. replaceNode)
 			// we should read the existing DOM attributes to diff them
+
+			// TODO: How to make this only for replaceNode
 			for (let i = 0; i < dom.attributes.length; i++) {
 				const name = dom.attributes[i].name;
 				if (!(name in newProps)) {
@@ -210,29 +187,23 @@ function mountDOMElement(
 		} else {
 			i = newVNode.props.children;
 
-			// If excessDomChildren was not null, repopulate it with the current
-			// element's children:
-			excessDomChildren =
-				excessDomChildren && EMPTY_ARR.slice.call(dom.childNodes);
-
 			mountChildren(
 				dom,
 				Array.isArray(i) ? i : [i],
 				newVNode,
 				globalContext,
 				isSvg && nodeType !== 'foreignObject',
-				excessDomChildren,
 				commitQueue,
 				dom.firstChild,
 				isHydrating
 			);
 
-			// Remove children that are not part of any vnode.
-			if (excessDomChildren != null) {
-				for (i = excessDomChildren.length; i--; ) {
-					if (excessDomChildren[i] != null) removeNode(excessDomChildren[i]);
-				}
-			}
+			// // Remove children that are not part of any vnode.
+			// if (excessDomChildren != null) {
+			// 	for (i = excessDomChildren.length; i--; ) {
+			// 		if (excessDomChildren[i] != null) removeNode(excessDomChildren[i]);
+			// 	}
+			// }
 		}
 
 		// (as above, don't diff props during hydration)
@@ -255,10 +226,9 @@ function mountDOMElement(
  * children are being diffed
  * @param {import('../internal').ComponentChildren[]} renderResult
  * @param {import('../internal').VNode} newParentVNode The new virtual
- * node whose children should be diff'ed against oldParentVNode
+ * node whose children should be diffed against oldParentVNode
  * @param {object} globalContext The current context object - modified by getChildContext
  * @param {boolean} isSvg Whether or not this DOM node is an SVG node
- * @param {Array<import('../internal').PreactElement>} excessDomChildren
  * @param {Array<import('../internal').Component>} commitQueue List of components
  * which have callbacks to invoke in commitRoot
  * @param {import('../internal').PreactElement} startDom
@@ -270,12 +240,27 @@ export function mountChildren(
 	newParentVNode,
 	globalContext,
 	isSvg,
-	excessDomChildren,
 	commitQueue,
 	startDom,
 	isHydrating
 ) {
-	let i, childVNode, newDom, firstChildDom, mountedNextChild;
+	let i,
+		childVNode,
+		newDom,
+		firstChildDom,
+		mountedNextChild,
+		excessDomChildren,
+		hydrateDom;
+
+	if (isHydrating) {
+		if (typeof newParentVNode.type !== 'function') {
+			// excessDomChildren = EMPTY_ARR.slice.call(parentDom.childNodes);
+			// hydrateDom = startDom = excessDomChildren[0];
+			hydrateDom = startDom = parentDom.childNodes[0];
+		} else {
+			hydrateDom = newParentVNode._dom;
+		}
+	}
 
 	newParentVNode._children = [];
 	for (i = 0; i < renderResult.length; i++) {
@@ -289,8 +274,28 @@ export function mountChildren(
 			continue;
 		}
 
+		// if (typeof childVNode.type !== 'function' && excessDomChildren != null) {
+		// 	for (; i < excessDomChildren.length; i++) {
+		// 		const child = excessDomChildren[i];
+		//
+		// 		// if newVNode matches an element in excessDomChildren or the `dom`
+		// 		// argument matches an element in excessDomChildren, remove it from
+		// 		// excessDomChildren so it isn't later removed in diffChildren
+		// 		if (
+		// 			child &&
+		// 			(child === dom ||
+		// 				(nodeType ? child.localName == nodeType : child.nodeType == 3))
+		// 		) {
+		// 			dom = child;
+		// 			excessDomChildren[i] = null;
+		// 			break;
+		// 		}
+		// 	}
+		// }
+
 		childVNode._parent = newParentVNode;
 		childVNode._depth = newParentVNode._depth + 1;
+		childVNode._dom = hydrateDom;
 
 		// Morph the old element into the new one, but don't append it to the dom yet
 		mountedNextChild = mount(
@@ -298,7 +303,6 @@ export function mountChildren(
 			childVNode,
 			globalContext,
 			isSvg,
-			excessDomChildren,
 			commitQueue,
 			startDom,
 			isHydrating
@@ -315,7 +319,7 @@ export function mountChildren(
 				// If the child is a Fragment-like or if it is DOM VNode and its _dom
 				// property matches the dom we are diffing (i.e. startDom), just
 				// continue with the mountedNextChild
-				startDom = mountedNextChild;
+				hydrateDom = startDom = mountedNextChild;
 			} else {
 				// The DOM the diff should begin with is now startDom (since we inserted
 				// newDom before startDom) so ignore mountedNextChild and continue with

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -46,8 +46,13 @@ export function mount(
 				startDom
 			);
 		} else {
+			let hydrateDom =
+				newVNode._mode & (MODE_HYDRATE | MODE_MUTATIVE_HYDRATE)
+					? startDom
+					: null;
+
 			newVNode._dom = mountDOMElement(
-				newVNode._mode !== MODE_NONE ? startDom : null,
+				hydrateDom,
 				newVNode,
 				globalContext,
 				isSvg,
@@ -70,7 +75,7 @@ export function mount(
 
 		// TODO: include replaceNode using MODE_MUTATIVE_HYDRATE, or could we just
 		// not allow this during MUTATIVE_HYDRATE?
-		if (newVNode._mode === MODE_HYDRATE) {
+		if (newVNode._mode & MODE_HYDRATE) {
 			// @ts-ignore Trust me TS, nextSibling is a PreactElement
 			nextDomSibling = startDom && startDom.nextSibling;
 			newVNode._dom = startDom;
@@ -81,7 +86,7 @@ export function mount(
 
 			// TODO: Is always true unless we change the above condition to allow this
 			// code path in MUTATIVE_HYDRATE
-			newVNode._hydrating = newVNode._mode === MODE_HYDRATE;
+			newVNode._hydrating = (newVNode._mode & MODE_HYDRATE) === MODE_HYDRATE;
 
 			// excessDomChildren[excessDomChildren.indexOf(startDom)] = null;
 			// ^ could possibly be simplified to:
@@ -110,7 +115,7 @@ function mountDOMElement(dom, newVNode, globalContext, isSvg, commitQueue) {
 	/** @type {any} */
 	let i = 0;
 
-	let isHydrating = newVNode._mode === MODE_HYDRATE;
+	let isHydrating = (newVNode._mode & MODE_HYDRATE) === MODE_HYDRATE;
 
 	if (nodeType == null) {
 		// TODO: Skip over wrong type nodes
@@ -154,7 +159,7 @@ function mountDOMElement(dom, newVNode, globalContext, isSvg, commitQueue) {
 		// @TODO: Consider removing and instructing users to instead set the desired
 		// prop for removal to undefined/null. During hydration, props are not
 		// diffed at all (including dangerouslySetInnerHTML)
-		if (newVNode._mode === MODE_MUTATIVE_HYDRATE) {
+		if (newVNode._mode & MODE_MUTATIVE_HYDRATE) {
 			// But, if we are in a situation where we are using existing DOM (e.g. replaceNode)
 			// we should read the existing DOM attributes to diff them
 
@@ -242,9 +247,8 @@ export function mountChildren(
 ) {
 	let i, childVNode, newDom, firstChildDom, mountedNextChild;
 
-	// TODO: bitwise MODE_HYDRATE|MODE_MUTATIVE_HYDRATE
 	if (
-		newParentVNode._mode !== MODE_NONE &&
+		newParentVNode._mode & (MODE_HYDRATE | MODE_MUTATIVE_HYDRATE) &&
 		typeof newParentVNode.type !== 'function'
 	) {
 		startDom = parentDom.childNodes[0];
@@ -304,9 +308,8 @@ export function mountChildren(
 	newParentVNode._dom = firstChildDom;
 
 	// Remove children that are not part of any vnode.
-	// TODO: bitwise MODE_HYDRATE|MODE_MUTATIVE_HYDRATE
 	if (
-		newParentVNode._mode !== MODE_NONE &&
+		newParentVNode._mode & (MODE_HYDRATE | MODE_MUTATIVE_HYDRATE) &&
 		typeof newParentVNode.type !== 'function'
 	) {
 		// TODO: Would it be simpler to just clear the pre-existing DOM in top-level

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -7,9 +7,9 @@ import {
 } from '../constants';
 import { normalizeToVNode } from '../create-element';
 import { setProperty } from './props';
+import { removeNode } from '../util';
 import options from '../options';
 import { renderComponent } from './component';
-import { removeNode } from '../util';
 
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
@@ -76,12 +76,10 @@ export function mount(
 		newVNode._original = null;
 		newVNode._mode = newVNode._mode | MODE_SUSPENDED;
 
-		// TODO: include replaceNode using MODE_MUTATIVE_HYDRATE, or could we just
-		// not allow this during MUTATIVE_HYDRATE?
 		if (newVNode._mode & MODE_HYDRATE) {
 			// @ts-ignore Trust me TS, nextSibling is a PreactElement
 			nextDomSibling = startDom && startDom.nextSibling;
-			newVNode._dom = startDom; // Save our current DOM position
+			newVNode._dom = startDom; // Save our current DOM position to resume later
 		}
 		options._catchError(e, newVNode, newVNode);
 	}
@@ -117,10 +115,6 @@ function mountDOMElement(dom, newVNode, globalContext, isSvg, commitQueue) {
 	}
 
 	if (nodeType == null) {
-		// TODO: Skip over wrong type nodes
-		// if we have been given the wrong type, seek forward to the right one:
-		// while (dom && dom.nodeType !== 3) dom = dom.nextSibling;
-
 		if (dom == null) {
 			// @ts-ignore createTextNode returns Text, we expect PreactElement
 			dom = document.createTextNode(newProps);
@@ -130,10 +124,6 @@ function mountDOMElement(dom, newVNode, globalContext, isSvg, commitQueue) {
 	} else {
 		// Tracks entering and exiting SVG namespace when descending through the tree.
 		if (nodeType === 'svg') isSvg = true;
-
-		// TODO: Skip over wrong type nodes and remove them
-		// if we have been given the wrong type, seek forward to the right one:
-		// while (dom && dom.localName !== newVNode.type) dom = dom.nextSibling;
 
 		if (dom == null) {
 			if (isSvg) {

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -67,7 +67,9 @@ export function mount(
 	} catch (e) {
 		newVNode._original = null;
 		// if hydrating or creating initial tree, bailout preserves DOM:
-		// TODO: include replaceNode
+
+		// TODO: include replaceNode using MODE_MUTATIVE_HYDRATE, or could we just
+		// not allow this during MUTATIVE_HYDRATE?
 		if (newVNode._mode === MODE_HYDRATE) {
 			// @ts-ignore Trust me TS, nextSibling is a PreactElement
 			nextDomSibling = startDom && startDom.nextSibling;
@@ -76,6 +78,9 @@ export function mount(
 			// _hydrating = true if bailed out during hydration
 			// _hydrating = false if bailed out during mounting
 			// _hydrating = null if it didn't bail out
+
+			// TODO: Is always true unless we change the above condition to allow this
+			// code path in MUTATIVE_HYDRATE
 			newVNode._hydrating = newVNode._mode === MODE_HYDRATE;
 
 			// excessDomChildren[excessDomChildren.indexOf(startDom)] = null;
@@ -235,20 +240,13 @@ export function mountChildren(
 	commitQueue,
 	startDom
 ) {
-	let i,
-		childVNode,
-		newDom,
-		firstChildDom,
-		// excessDomChildren
-		mountedNextChild;
+	let i, childVNode, newDom, firstChildDom, mountedNextChild;
 
-	// Todo: bitwise MODE_HYDRATE|MODE_MUTATIVE_HYDRATE
+	// TODO: bitwise MODE_HYDRATE|MODE_MUTATIVE_HYDRATE
 	if (
 		newParentVNode._mode !== MODE_NONE &&
 		typeof newParentVNode.type !== 'function'
 	) {
-		// excessDomChildren = EMPTY_ARR.slice.call(parentDom.childNodes);
-		// hydrateDom = startDom = excessDomChildren[0];
 		startDom = parentDom.childNodes[0];
 	}
 
@@ -263,25 +261,6 @@ export function mountChildren(
 		if (childVNode == null) {
 			continue;
 		}
-
-		// if (typeof childVNode.type !== 'function' && excessDomChildren != null) {
-		// 	for (; i < excessDomChildren.length; i++) {
-		// 		const child = excessDomChildren[i];
-		//
-		// 		// if newVNode matches an element in excessDomChildren or the `dom`
-		// 		// argument matches an element in excessDomChildren, remove it from
-		// 		// excessDomChildren so it isn't later removed in diffChildren
-		// 		if (
-		// 			child &&
-		// 			(child === dom ||
-		// 				(nodeType ? child.localName == nodeType : child.nodeType == 3))
-		// 		) {
-		// 			dom = child;
-		// 			excessDomChildren[i] = null;
-		// 			break;
-		// 		}
-		// 	}
-		// }
 
 		childVNode._parent = newParentVNode;
 		childVNode._depth = newParentVNode._depth + 1;
@@ -325,13 +304,13 @@ export function mountChildren(
 	newParentVNode._dom = firstChildDom;
 
 	// Remove children that are not part of any vnode.
-	// Todo: bitwise MODE_HYDRATE|MODE_MUTATIVE_HYDRATE
+	// TODO: bitwise MODE_HYDRATE|MODE_MUTATIVE_HYDRATE
 	if (
 		newParentVNode._mode !== MODE_NONE &&
 		typeof newParentVNode.type !== 'function'
 	) {
-		// TODO: At this point, would it be simpler to just clear the pre-existing
-		// DOM if render is called with no oldVNode & existing children & no
+		// TODO: Would it be simpler to just clear the pre-existing DOM in top-level
+		// render if render is called with no oldVNode & existing children & no
 		// replaceNode? Instead of patching the DOM to match the VNode tree? (remove
 		// attributes & unused DOM)
 		while (startDom) {

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -246,18 +246,17 @@ export function mountChildren(
 		childVNode,
 		newDom,
 		firstChildDom,
-		mountedNextChild,
-		// excessDomChildren,
-		hydrateDom;
+		// excessDomChildren
+		mountedNextChild;
 
 	// Todo: bitwise MODE_HYDRATE|MODE_MUTATIVE_HYDRATE
 	if (newParentVNode._mode !== MODE_NONE) {
 		if (typeof newParentVNode.type !== 'function') {
 			// excessDomChildren = EMPTY_ARR.slice.call(parentDom.childNodes);
 			// hydrateDom = startDom = excessDomChildren[0];
-			hydrateDom = startDom = parentDom.childNodes[0];
+			startDom = parentDom.childNodes[0];
 		} else {
-			hydrateDom = newParentVNode._dom;
+			startDom = newParentVNode._dom;
 		}
 	}
 
@@ -294,8 +293,12 @@ export function mountChildren(
 
 		childVNode._parent = newParentVNode;
 		childVNode._depth = newParentVNode._depth + 1;
-		childVNode._dom = hydrateDom;
 		childVNode._mode = newParentVNode._mode;
+
+		// Todo: bitwise MODE_HYDRATE|MODE_MUTATIVE_HYDRATE
+		if (newParentVNode._mode !== MODE_NONE) {
+			childVNode._dom = startDom;
+		}
 
 		// Morph the old element into the new one, but don't append it to the dom yet
 		mountedNextChild = mount(
@@ -318,7 +321,7 @@ export function mountChildren(
 				// If the child is a Fragment-like or if it is DOM VNode and its _dom
 				// property matches the dom we are diffing (i.e. startDom), just
 				// continue with the mountedNextChild
-				hydrateDom = startDom = mountedNextChild;
+				startDom = mountedNextChild;
 			} else {
 				// The DOM the diff should begin with is now startDom (since we inserted
 				// newDom before startDom) so ignore mountedNextChild and continue with

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -153,8 +153,6 @@ function mountDOMElement(dom, newVNode, globalContext, isSvg, commitQueue) {
 		if (newVNode._mode & MODE_MUTATIVE_HYDRATE) {
 			// But, if we are in a situation where we are using existing DOM (e.g. replaceNode)
 			// we should read the existing DOM attributes to diff them
-
-			// TODO: How to make this only for replaceNode
 			for (let i = 0; i < dom.attributes.length; i++) {
 				const name = dom.attributes[i].name;
 				if (!(name in newProps)) {
@@ -237,13 +235,6 @@ export function mountChildren(
 	startDom
 ) {
 	let i, childVNode, newDom, firstChildDom, mountedNextChild;
-
-	if (
-		newParentVNode._mode & (MODE_HYDRATE | MODE_MUTATIVE_HYDRATE) &&
-		typeof newParentVNode.type !== 'function'
-	) {
-		startDom = parentDom.childNodes[0];
-	}
 
 	newParentVNode._children = [];
 	for (i = 0; i < renderResult.length; i++) {

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -34,8 +34,6 @@ export function mount(
 	/** @type {import('../internal').PreactElement} */
 	let nextDomSibling;
 
-	const isHydrating = newVNode._mode === MODE_HYDRATE;
-
 	try {
 		if (typeof newVNode.type == 'function') {
 			nextDomSibling = renderComponent(
@@ -45,8 +43,7 @@ export function mount(
 				globalContext,
 				isSvg,
 				commitQueue,
-				startDom,
-				isHydrating
+				startDom
 			);
 		} else {
 			newVNode._dom = mountDOMElement(
@@ -71,7 +68,7 @@ export function mount(
 		newVNode._original = null;
 		// if hydrating or creating initial tree, bailout preserves DOM:
 		// TODO: include replaceNode
-		if (isHydrating) {
+		if (newVNode._mode === MODE_HYDRATE) {
 			// @ts-ignore Trust me TS, nextSibling is a PreactElement
 			nextDomSibling = startDom && startDom.nextSibling;
 			newVNode._dom = startDom;
@@ -79,7 +76,7 @@ export function mount(
 			// _hydrating = true if bailed out during hydration
 			// _hydrating = false if bailed out during mounting
 			// _hydrating = null if it didn't bail out
-			newVNode._hydrating = !!isHydrating;
+			newVNode._hydrating = newVNode._mode === MODE_HYDRATE;
 
 			// excessDomChildren[excessDomChildren.indexOf(startDom)] = null;
 			// ^ could possibly be simplified to:

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -2,7 +2,6 @@ import { applyRef } from './refs';
 import { MODE_HYDRATE, MODE_MUTATIVE_HYDRATE, MODE_NONE } from '../constants';
 import { normalizeToVNode } from '../create-element';
 import { setProperty } from './props';
-// import { removeNode } from '../util';
 import options from '../options';
 import { renderComponent } from './component';
 import { removeNode } from '../util';
@@ -48,7 +47,7 @@ export function mount(
 			);
 		} else {
 			newVNode._dom = mountDOMElement(
-				newVNode._dom,
+				newVNode._mode !== MODE_NONE ? startDom : null,
 				newVNode,
 				globalContext,
 				isSvg,
@@ -244,14 +243,13 @@ export function mountChildren(
 		mountedNextChild;
 
 	// Todo: bitwise MODE_HYDRATE|MODE_MUTATIVE_HYDRATE
-	if (newParentVNode._mode !== MODE_NONE) {
-		if (typeof newParentVNode.type !== 'function') {
-			// excessDomChildren = EMPTY_ARR.slice.call(parentDom.childNodes);
-			// hydrateDom = startDom = excessDomChildren[0];
-			startDom = parentDom.childNodes[0];
-		} else {
-			startDom = newParentVNode._dom;
-		}
+	if (
+		newParentVNode._mode !== MODE_NONE &&
+		typeof newParentVNode.type !== 'function'
+	) {
+		// excessDomChildren = EMPTY_ARR.slice.call(parentDom.childNodes);
+		// hydrateDom = startDom = excessDomChildren[0];
+		startDom = parentDom.childNodes[0];
 	}
 
 	newParentVNode._children = [];
@@ -288,11 +286,6 @@ export function mountChildren(
 		childVNode._parent = newParentVNode;
 		childVNode._depth = newParentVNode._depth + 1;
 		childVNode._mode = newParentVNode._mode;
-
-		// Todo: bitwise MODE_HYDRATE|MODE_MUTATIVE_HYDRATE
-		if (newParentVNode._mode !== MODE_NONE) {
-			childVNode._dom = startDom;
-		}
 
 		// Morph the old element into the new one, but don't append it to the dom yet
 		mountedNextChild = mount(
@@ -337,6 +330,10 @@ export function mountChildren(
 		newParentVNode._mode !== MODE_NONE &&
 		typeof newParentVNode.type !== 'function'
 	) {
+		// TODO: At this point, would it be simpler to just clear the pre-existing
+		// DOM if render is called with no oldVNode & existing children & no
+		// replaceNode? Instead of patching the DOM to match the VNode tree? (remove
+		// attributes & unused DOM)
 		while (startDom) {
 			i = startDom;
 			startDom = startDom.nextSibling;

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -5,6 +5,7 @@ import { setProperty } from './props';
 // import { removeNode } from '../util';
 import options from '../options';
 import { renderComponent } from './component';
+import { removeNode } from '../util';
 
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
@@ -110,7 +111,7 @@ function mountDOMElement(dom, newVNode, globalContext, isSvg, commitQueue) {
 	if (nodeType == null) {
 		// TODO: Skip over wrong type nodes
 		// if we have been given the wrong type, seek forward to the right one:
-		// while (dom && dom.nodeType !== 1) dom = dom.nextSibling;
+		// while (dom && dom.nodeType !== 3) dom = dom.nextSibling;
 
 		if (dom == null) {
 			// @ts-ignore createTextNode returns Text, we expect PreactElement
@@ -197,13 +198,6 @@ function mountDOMElement(dom, newVNode, globalContext, isSvg, commitQueue) {
 				commitQueue,
 				dom.firstChild
 			);
-
-			// // Remove children that are not part of any vnode.
-			// if (excessDomChildren != null) {
-			// 	for (i = excessDomChildren.length; i--; ) {
-			// 		if (excessDomChildren[i] != null) removeNode(excessDomChildren[i]);
-			// 	}
-			// }
 		}
 
 		// (as above, don't diff props during hydration)
@@ -336,6 +330,19 @@ export function mountChildren(
 	}
 
 	newParentVNode._dom = firstChildDom;
+
+	// Remove children that are not part of any vnode.
+	// Todo: bitwise MODE_HYDRATE|MODE_MUTATIVE_HYDRATE
+	if (
+		newParentVNode._mode !== MODE_NONE &&
+		typeof newParentVNode.type !== 'function'
+	) {
+		while (startDom) {
+			i = startDom;
+			startDom = startDom.nextSibling;
+			removeNode(i);
+		}
+	}
 
 	return startDom;
 }

--- a/src/diff/patch.js
+++ b/src/diff/patch.js
@@ -1,7 +1,6 @@
 import { diffChildren } from './children';
 import { diffProps, setProperty } from './props';
 import options from '../options';
-import { getDomSibling } from '../component';
 import { renderComponent } from './component';
 
 /**
@@ -133,9 +132,7 @@ function patchDOMElement(
 				globalContext,
 				isSvg && newType !== 'foreignObject',
 				commitQueue,
-				// Find the first non-null child with a dom pointer and begin the diff
-				// with that (i.e. what getDomSibling does)
-				getDomSibling(oldVNode, 0)
+				dom.firstChild
 			);
 		}
 

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -115,6 +115,7 @@ export interface VNode<P = {}> extends preact.VNode<P> {
 	_hydrating: boolean | null;
 	constructor: undefined;
 	_original: number;
+	_mode: number;
 }
 
 export interface Component<P = {}, S = {}> extends preact.Component<P, S> {

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -112,7 +112,6 @@ export interface VNode<P = {}> extends preact.VNode<P> {
 	 */
 	_dom: PreactElement | null;
 	_component: Component | null;
-	_hydrating: boolean | null;
 	constructor: undefined;
 	_original: number;
 	_mode: number;

--- a/src/render.js
+++ b/src/render.js
@@ -6,15 +6,6 @@ import { mount } from './diff/mount';
 import { patch } from './diff/patch';
 
 /**
- * Find the DOM for a given VNode
- * @param {import('./internal').VNode} vnode
- */
-function findDomNode(vnode) {
-	return vnode._dom;
-	// return vnode._dom || vnode._children.filter(findDomNode)[0];
-}
-
-/**
  * Render a Preact virtual node into a DOM element
  * @param {import('./internal').ComponentChild} vnode The virtual node to render
  * @param {import('./internal').PreactElement} parentDom The DOM element to
@@ -67,7 +58,8 @@ export function render(vnode, parentDom, replaceNode) {
 		mode = MODE_MUTATIVE_HYDRATE;
 		startDom = replaceNode;
 	} else if (oldVNode) {
-		startDom = findDomNode(oldVNode);
+		// Eventually, this'll be something like findDomNode(oldVnode)
+		startDom = oldVNode._dom;
 	} else if (startDom) {
 		mode = MODE_MUTATIVE_HYDRATE;
 	}

--- a/src/render.js
+++ b/src/render.js
@@ -37,6 +37,10 @@ export function render(vnode, parentDom, replaceNode) {
 		parentDom
 	)._children = createElement(Fragment, null, [vnode]);
 
+	if (isHydrating) {
+		vnode._dom = parentDom.firstChild;
+	}
+
 	// List of effects that need to be called after diffing.
 	let commitQueue = [];
 	if (oldVNode) {
@@ -55,11 +59,6 @@ export function render(vnode, parentDom, replaceNode) {
 			vnode,
 			{},
 			parentDom.ownerSVGElement !== undefined,
-			!isHydrating && replaceNode
-				? [replaceNode]
-				: parentDom.firstChild
-				? EMPTY_ARR.slice.call(parentDom.childNodes)
-				: null,
 			commitQueue,
 			!isHydrating && replaceNode ? replaceNode : parentDom.firstChild,
 			isHydrating

--- a/src/render.js
+++ b/src/render.js
@@ -51,9 +51,6 @@ export function render(vnode, parentDom, replaceNode) {
 	if (isHydrating) {
 		mode = MODE_HYDRATE;
 		// startDom = parentDom.firstChild;
-		// newVNode._dom = replaceNode = excessDomChildren
-		// 	? excessDomChildren[0]
-		// 	: null;
 	} else if (replaceNode) {
 		mode = MODE_MUTATIVE_HYDRATE;
 		startDom = replaceNode;
@@ -64,7 +61,6 @@ export function render(vnode, parentDom, replaceNode) {
 		mode = MODE_MUTATIVE_HYDRATE;
 	}
 	vnode._mode = mode;
-	vnode._dom = startDom;
 
 	// List of effects that need to be called after diffing.
 	let commitQueue = [];

--- a/src/render.js
+++ b/src/render.js
@@ -53,6 +53,8 @@ export function render(vnode, parentDom, replaceNode) {
 	// render(vnode, parent) on existing tree: excessDomChildren=null --> startDom = (oldVNode=parent.__k)._dom
 	// const startDom = replaceNode || oldVNode && oldVNode._dom || parentDom.firstChild;
 
+	/** @type {import('./internal').PreactElement} */
+	// @ts-ignore Trust me TS, parentDom.firstChild is correct
 	let startDom = parentDom.firstChild;
 	let mode = MODE_NONE;
 	if (isHydrating) {
@@ -91,10 +93,7 @@ export function render(vnode, parentDom, replaceNode) {
 			{},
 			parentDom.ownerSVGElement !== undefined,
 			commitQueue,
-			// replaceNode || null,
 			startDom
-			// mode === MODE_HYDRATE
-			// isHydrating
 		);
 	}
 

--- a/src/render.js
+++ b/src/render.js
@@ -42,25 +42,15 @@ export function render(vnode, parentDom, replaceNode) {
 	// hydrate(vnode, parent): excessDomChildren=.childNodes --> startDom = parent.firstChild
 	// render(vnode, parent, child): excessDomChildren=[child] --> startDom = child
 	// render(vnode, parent) on existing tree: excessDomChildren=null --> startDom = (oldVNode=parent.__k)._dom
-	// const startDom = replaceNode || oldVNode && oldVNode._dom || parentDom.firstChild;
 
-	/** @type {import('./internal').PreactElement} */
-	// @ts-ignore Trust me TS, parentDom.firstChild is correct
-	let startDom = parentDom.firstChild;
-	let mode = MODE_NONE;
+	// Set vnode._mode
 	if (isHydrating) {
-		mode = MODE_HYDRATE;
-		// startDom = parentDom.firstChild;
-	} else if (replaceNode) {
-		mode = MODE_MUTATIVE_HYDRATE;
-		startDom = replaceNode;
-	} else if (oldVNode) {
-		// Eventually, this'll be something like findDomNode(oldVnode)
-		startDom = oldVNode._dom;
-	} else if (startDom) {
-		mode = MODE_MUTATIVE_HYDRATE;
+		vnode._mode = MODE_HYDRATE;
+	} else if (replaceNode || parentDom.firstChild) {
+		// Providing a replaceNode parameter or calling `render` on a container with
+		// existing DOM elements puts the diff into mutative hydrate mode
+		vnode._mode = MODE_MUTATIVE_HYDRATE;
 	}
-	vnode._mode = mode;
 
 	// List of effects that need to be called after diffing.
 	let commitQueue = [];
@@ -72,7 +62,7 @@ export function render(vnode, parentDom, replaceNode) {
 			{},
 			parentDom.ownerSVGElement !== undefined,
 			commitQueue,
-			startDom
+			oldVNode._dom
 		);
 	} else {
 		mount(
@@ -81,7 +71,7 @@ export function render(vnode, parentDom, replaceNode) {
 			{},
 			parentDom.ownerSVGElement !== undefined,
 			commitQueue,
-			startDom
+			!isHydrating && replaceNode ? replaceNode : parentDom.firstChild
 		);
 	}
 

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -446,10 +446,22 @@ describe('hydrate()', () => {
 		);
 	});
 
-	it('should skip comment nodes', () => {
+	it('should skip comment nodes between text nodes', () => {
 		scratch.innerHTML = '<p>hello <!-- c -->foo</p>';
 		hydrate(<p>hello {'foo'}</p>, scratch);
 		expect(scratch.innerHTML).to.equal('<p>hello foo</p>');
+	});
+
+	it('should skip comment nodes between dom nodes', () => {
+		scratch.innerHTML = '<p><i>0</i><!-- c --><b>1</b></p>';
+		hydrate(
+			<p>
+				<i>0</i>
+				<b>1</b>
+			</p>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal('<p><i>0</i><b>1</b></p>');
 	});
 
 	it('should not hydrate with dangerouslySetInnerHTML', () => {

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -451,4 +451,18 @@ describe('hydrate()', () => {
 		hydrate(<p>hello {'foo'}</p>, scratch);
 		expect(scratch.innerHTML).to.equal('<p>hello foo</p>');
 	});
+
+	it('should not hydrate with dangerouslySetInnerHTML', () => {
+		let html = '<b>foo &amp; bar</b>';
+		scratch.innerHTML = `<div>${html}</div>`;
+
+		clearLog();
+
+		// eslint-disable-next-line react/no-danger
+		hydrate(<div dangerouslySetInnerHTML={{ __html: html }} />, scratch);
+
+		expect(scratch.firstChild).to.have.property('innerHTML', html);
+		expect(scratch.innerHTML).to.equal(`<div>${html}</div>`);
+		expect(getLog()).to.deep.equal([]);
+	});
 });

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -549,7 +549,10 @@ describe('render()', () => {
 			);
 		});
 
-		it('should not hydrate with dangerouslySetInnerHTML', () => {
+		it('should not mutative render with dangerouslySetInnerHTML', () => {
+			// In other words, if render is called with a container with existing
+			// children, dangerouslySetInnerHTML should leave the DOM intact
+
 			let html = '<b>foo &amp; bar</b>';
 			scratch.innerHTML = `<div>${html}</div>`;
 			// eslint-disable-next-line react/no-danger
@@ -608,7 +611,7 @@ describe('render()', () => {
 		});
 	});
 
-	it('should reconcile mutated DOM attributes', () => {
+	it('should reconcile mutated checked property', () => {
 		let check = p => render(<input type="checkbox" checked={p} />, scratch),
 			value = () => scratch.lastChild.checked,
 			setValue = p => (scratch.lastChild.checked = p);


### PR DESCRIPTION
Remove excessDomChildren parameter and instead use the startDom parameter to pass hydration DOM nodes down the tree.

This PR also introduces the concept of modes on VNodes. This mode property determines whether a VNode is hydrating or suspended, etc. 