### PR TITLE
Fix _mode check in catchError

### DIFF
--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -9,24 +9,24 @@ import { MODE_ERRORED } from '../constants';
  */
 export function _catchError(error, vnode) {
 	/** @type {import('../internal').Component} */
-	let component, ctor;
+	let component;
 
 	if (vnode) vnode._mode |= MODE_ERRORED;
 
 	for (; (vnode = vnode._parent); ) {
-		if ((component = vnode._component) && vnode._mode ^ MODE_ERRORED) {
+		if ((component = vnode._component) && ~vnode._mode & MODE_ERRORED) {
 			try {
-				ctor = component.constructor;
-
-				if (ctor && ctor.getDerivedStateFromError != null) {
-					component.setState(ctor.getDerivedStateFromError(error));
+				if (vnode.type.getDerivedStateFromError != null) {
+					component.setState(vnode.type.getDerivedStateFromError(error));
 				}
 
 				if (component.componentDidCatch != null) {
 					component.componentDidCatch(error);
 				}
 
-				// This is an error boundary. Mark it as having bailed out, and whether it was mid-hydration.
+				// NOTE: We're checking that any component in the stack got marked as dirty, even if it did so prior to this loop,
+				// which is technically incorrect. However, there is no way for a component to mark itself as dirty during rendering.
+				// The only way for a component to falsely intercept error bubbling would be to manually sets its internal dirty flag.
 				if (component._dirty) {
 					return;
 				}


### PR DESCRIPTION
This corrects [my incorrect suggestion](https://github.com/preactjs/preact/pull/2972#discussion_r568271440) for the `_mode` check in catchError from #2972, add test.