### PR TITLE
Add support for root nodes

### DIFF
--- a/compat/src/portals.js
+++ b/compat/src/portals.js
@@ -17,5 +17,5 @@ function Portal(props) {
  * @param {import('./internal').PreactElement} container The DOM node to continue rendering in to.
  */
 export function createPortal(vnode, container) {
-	return createElement(Portal, { _parentNode: container }, vnode);
+	return createElement(Portal, { _parentDom: container }, vnode);
 }

--- a/compat/src/portals.js
+++ b/compat/src/portals.js
@@ -1,12 +1,4 @@
-import { createElement, render } from 'preact';
-
-/**
- * @param {import('../../src/index').RenderableProps<{ context: any }>} props
- */
-function ContextProvider(props) {
-	this.getChildContext = () => props.context;
-	return props.children;
-}
+import { createElement } from 'preact';
 
 /**
  * Portal component
@@ -16,58 +8,7 @@ function ContextProvider(props) {
  * TODO: use createRoot() instead of fake root
  */
 function Portal(props) {
-	const _this = this;
-	let container = props._container;
-
-	_this.componentWillUnmount = function() {
-		render(null, _this._temp);
-		_this._temp = null;
-		_this._container = null;
-	};
-
-	// When we change container we should clear our old container and
-	// indicate a new mount.
-	if (_this._container && _this._container !== container) {
-		_this.componentWillUnmount();
-	}
-
-	// When props.vnode is undefined/false/null we are dealing with some kind of
-	// conditional vnode. This should not trigger a render.
-	if (props._vnode) {
-		if (!_this._temp) {
-			_this._container = container;
-
-			// Create a fake DOM parent node that manages a subset of `container`'s children:
-			_this._temp = {
-				nodeType: 1,
-				parentNode: container,
-				childNodes: [],
-				appendChild(child) {
-					this.childNodes.push(child);
-					_this._container.appendChild(child);
-				},
-				insertBefore(child, before) {
-					this.childNodes.push(child);
-					_this._container.appendChild(child);
-				},
-				removeChild(child) {
-					this.childNodes.splice(this.childNodes.indexOf(child) >>> 1, 1);
-					_this._container.removeChild(child);
-				}
-			};
-		}
-
-		// Render our wrapping element into temp.
-		render(
-			createElement(ContextProvider, { context: _this.context }, props._vnode),
-			_this._temp
-		);
-	}
-	// When we come from a conditional render, on a mounted
-	// portal we should clear the DOM.
-	else if (_this._temp) {
-		_this.componentWillUnmount();
-	}
+	return props.children;
 }
 
 /**
@@ -76,5 +17,5 @@ function Portal(props) {
  * @param {import('./internal').PreactElement} container The DOM node to continue rendering in to.
  */
 export function createPortal(vnode, container) {
-	return createElement(Portal, { _vnode: vnode, _container: container });
+	return createElement(Portal, { _parentNode: container }, vnode);
 }

--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -372,7 +372,8 @@ describe('Portal', () => {
 		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
 	});
 
-	it('should work with removing an element from stacked container to new one', () => {
+	// TODO: Our reconciler always appends here
+	it.skip('should work with removing an element from stacked container to new one', () => {
 		let toggle, root2;
 
 		function Foo(props) {
@@ -458,7 +459,8 @@ describe('Portal', () => {
 		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
 	});
 
-	it('should support nested portals remounting #2669', () => {
+	// TODO: Our reconciler always appends here
+	it.skip('should support nested portals remounting #2669', () => {
 		let setVisible;
 		let i = 0;
 

--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -6,6 +6,7 @@ import React, {
 	Component
 } from 'preact/compat';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { getLog, clearLog } from '../../../test/_util/logCall';
 import { setupRerender, act } from 'preact/test-utils';
 
 /* eslint-disable react/jsx-boolean-value, react/display-name, prefer-arrow-callback */
@@ -625,5 +626,40 @@ describe('Portal', () => {
 		expect(scratch.innerHTML).to.equal(
 			'<div><div>Closed</div><button>Show</button>Closed</div>'
 		);
+	});
+
+	it.skip('should not needlessly append siblings to Portals', () => {
+		/** @type {() => void} */
+		let update;
+		function Foo(props) {
+			const [state, setState] = useState(false);
+			update = () => setState(state => !state);
+			return (
+				<div>
+					<p>Hello</p>
+					{createPortal(props.children, scratch)}
+					<p>World!</p>
+				</div>
+			);
+		}
+
+		render(
+			<Foo>
+				<div>foobar</div>
+			</Foo>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal(
+			'<div>foobar</div><div><p>Hello</p><p>World!</p></div>'
+		);
+
+		clearLog();
+		update();
+		rerender();
+
+		expect(scratch.innerHTML).to.equal(
+			'<div>foobar</div><div><p>Hello</p><p>World!</p></div>'
+		);
+		expect(getLog()).to.deep.equal([]);
 	});
 });

--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -373,8 +373,7 @@ describe('Portal', () => {
 		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
 	});
 
-	// TODO: Our reconciler always appends here
-	it.skip('should work with removing an element from stacked container to new one', () => {
+	it('should work with removing an element from stacked container to new one', () => {
 		let toggle, root2;
 
 		function Foo(props) {
@@ -460,8 +459,7 @@ describe('Portal', () => {
 		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
 	});
 
-	// TODO: Our reconciler always appends here
-	it.skip('should support nested portals remounting #2669', () => {
+	it('should support nested portals remounting #2669', () => {
 		let setVisible;
 		let i = 0;
 
@@ -628,7 +626,7 @@ describe('Portal', () => {
 		);
 	});
 
-	it.skip('should not needlessly append siblings to Portals', () => {
+	it('should not needlessly append siblings to Portals', () => {
 		/** @type {() => void} */
 		let update;
 		function Foo(props) {

--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -630,6 +630,7 @@ describe('Portal', () => {
 		/** @type {() => void} */
 		let update;
 		function Foo(props) {
+			// eslint-disable-next-line no-unused-vars
 			const [state, setState] = useState(false);
 			update = () => setState(state => !state);
 			return (

--- a/mangle.json
+++ b/mangle.json
@@ -55,6 +55,7 @@
       "$_id": "__c",
       "$_contextRef": "__",
       "$_parentDom": "__P",
+      "$_parentNode": "__N",
       "$_originalParentDom": "__O",
       "$_prevState": "__u",
       "$_root": "__",

--- a/mangle.json
+++ b/mangle.json
@@ -55,7 +55,6 @@
       "$_id": "__c",
       "$_contextRef": "__",
       "$_parentDom": "__P",
-      "$_parentNode": "__N",
       "$_originalParentDom": "__O",
       "$_prevState": "__u",
       "$_root": "__",

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -147,6 +147,19 @@ export function renderComponent(
 
 	if ((tmp = options._render)) tmp(internal);
 
+	// Root nodes signal that we attempt to render into a specific DOM node
+	// on the page. Root nodes can occur anywhere in the tree and not just
+	// at the top.
+	if (newProps._parentNode) {
+		parentDom = newProps._parentNode;
+
+		// The `startDom` variable might point to a node from another
+		// tree from a previous render
+		if (startDom != null && startDom.parentNode !== parentDom) {
+			startDom = null;
+		}
+	}
+
 	internal._flags &= ~DIRTY_BIT;
 	c._internal = internal;
 	c._parentDom = parentDom;

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -153,8 +153,8 @@ export function renderComponent(
 	if (newProps._parentDom) {
 		parentDom = newProps._parentDom;
 
-		if (oldVNode && oldVNode._dom) {
-			startDom = oldVNode._dom;
+		if (internal && internal._dom) {
+			startDom = internal._dom;
 		}
 
 		// The `startDom` variable might point to a node from another

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -153,6 +153,10 @@ export function renderComponent(
 	if (newProps._parentDom) {
 		parentDom = newProps._parentDom;
 
+		if (oldVNode && oldVNode._dom) {
+			startDom = oldVNode._dom;
+		}
+
 		// The `startDom` variable might point to a node from another
 		// tree from a previous render
 		if (startDom != null && startDom.parentNode !== parentDom) {

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -150,6 +150,7 @@ export function renderComponent(
 	// Root nodes signal that we attempt to render into a specific DOM node
 	// on the page. Root nodes can occur anywhere in the tree and not just
 	// at the top.
+	let oldStartDom = startDom;
 	if (newProps._parentDom) {
 		parentDom = newProps._parentDom;
 
@@ -211,6 +212,11 @@ export function renderComponent(
 
 	if (c._renderCallbacks.length) {
 		commitQueue.push(c);
+	}
+
+	// Resume where we left of before the Portal
+	if (newProps._parentDom) {
+		return oldStartDom;
 	}
 
 	return nextDomSibling;

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -150,8 +150,8 @@ export function renderComponent(
 	// Root nodes signal that we attempt to render into a specific DOM node
 	// on the page. Root nodes can occur anywhere in the tree and not just
 	// at the top.
-	if (newProps._parentNode) {
-		parentDom = newProps._parentNode;
+	if (newProps._parentDom) {
+		parentDom = newProps._parentDom;
 
 		// The `startDom` variable might point to a node from another
 		// tree from a previous render

--- a/src/diff/unmount.js
+++ b/src/diff/unmount.js
@@ -23,6 +23,8 @@ export function unmount(internal, parentInternal, skipRemove) {
 	let dom;
 	if (!skipRemove && internal._flags & TYPE_DOM) {
 		skipRemove = (dom = internal._dom) != null;
+	} else if (internal.props._parentNode) {
+		skipRemove = false;
 	}
 
 	internal._dom = null;

--- a/src/diff/unmount.js
+++ b/src/diff/unmount.js
@@ -23,7 +23,7 @@ export function unmount(internal, parentInternal, skipRemove) {
 	let dom;
 	if (!skipRemove && internal._flags & TYPE_DOM) {
 		skipRemove = (dom = internal._dom) != null;
-	} else if (internal.props._parentNode) {
+	} else if (internal.props._parentDom) {
 		skipRemove = false;
 	}
 

--- a/src/render.js
+++ b/src/render.js
@@ -80,7 +80,7 @@ export function hydrate(vnode, parentDom) {
 	/** @type {import('./internal').PreactElement} */
 	const hydrateDom = (parentDom.firstChild);
 
-	vnode = createElement(Fragment, { _parentNode: parentDom }, [vnode]);
+	vnode = createElement(Fragment, { _parentDom: parentDom }, [vnode]);
 	const rootInternal = createInternal(vnode);
 	rootInternal._flags |= MODE_HYDRATE;
 	parentDom._children = rootInternal;

--- a/src/render.js
+++ b/src/render.js
@@ -80,7 +80,7 @@ export function hydrate(vnode, parentDom) {
 	/** @type {import('./internal').PreactElement} */
 	const hydrateDom = (parentDom.firstChild);
 
-	vnode = createElement(Fragment, null, [vnode]);
+	vnode = createElement(Fragment, { _parentNode: parentDom }, [vnode]);
 	const rootInternal = createInternal(vnode);
 	rootInternal._flags |= MODE_HYDRATE;
 	parentDom._children = rootInternal;

--- a/src/render.js
+++ b/src/render.js
@@ -27,7 +27,7 @@ export function render(vnode, parentDom, replaceNode) {
 	// means that we are mounting a new tree for the first time.
 	let rootInternal =
 		(replaceNode && replaceNode._children) || parentDom._children;
-	vnode = createElement(Fragment, null, [vnode]);
+	vnode = createElement(Fragment, { _parentDom: parentDom }, [vnode]);
 	if (rootInternal) {
 		patch(
 			parentDom,


### PR DESCRIPTION
This PR introduces the concept of a root node which specifies into which dom node its children should be rendered into. This ensures that the vnode tree contains _all_ vnodes and isn't spliced up into random detached branches like before. It's based on the ideas in #2627, minus the `createRoot` API itself.

With these in place we can experiment with removing the `_parentDom` property on component instances, too. Previously we didn't have a way to get the topmost dom node because the vnode tree didn't store any reference to it.

~I skipped two Portals test that we need to get back working for v11. Conceptually Portals always render before the first child of the container node. But existing portals should remain where they are and this leads to awkward outcomes like:~

```html
<div><i>Portal #1</i><div>hello</div><i>Portal #2</i></div>
```

~Personally I feel like this PR is good enough to be merged and unblocks the work on extracting component classes, despite skipping those two Portal tests. Or should I spent more time trying to get those passing?~