### PR TITLE
fix reordering issue of memoized component when the component initially render null

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -147,6 +147,9 @@ export function diff(
 					c._vnode = newVNode;
 					newVNode._dom = oldVNode._dom;
 					newVNode._children = oldVNode._children;
+					newVNode._children.forEach(vnode => {
+						if (vnode) vnode._parent = newVNode;
+					});
 					if (c._renderCallbacks.length) {
 						commitQueue.push(c);
 					}

--- a/test/browser/lifecycles/shouldComponentUpdate.test.js
+++ b/test/browser/lifecycles/shouldComponentUpdate.test.js
@@ -857,4 +857,60 @@ describe('Lifecycle methods', () => {
 		// 	'<table>id: 3a: 25b: 1000id: 1a: 5id: 2a: 50b: 10b: 100.insertBefore(<div>b: 100, <div>id: 2)'
 		// ]);
 	});
+
+	it('should maintain the order if memoised component initially rendered empty content', () => {
+		let showText, updateParent;
+		class Child extends Component {
+			constructor(props) {
+				super(props);
+				this.state = {
+					show: false
+				};
+				showText = () => this.setState({ show: true });
+			}
+			render(props, { show }) {
+				if (!show) return null;
+
+				return <div>Component</div>;
+			}
+		}
+
+		class Memoized extends Component {
+			shouldComponentUpdate() {
+				return false;
+			}
+			render() {
+				return <Child />;
+			}
+		}
+		class Parent extends Component {
+			constructor(props) {
+				super(props);
+				updateParent = () => this.setState({});
+			}
+			render() {
+				return (
+					<Fragment>
+						<div>Before</div>
+						<Memoized />
+						<div>After</div>
+					</Fragment>
+				);
+			}
+		}
+
+		render(<Parent />, scratch);
+		expect(scratch.innerHTML).to.equal(`<div>Before</div><div>After</div>`);
+
+		updateParent();
+		rerender();
+		expect(scratch.innerHTML).to.equal(`<div>Before</div><div>After</div>`);
+
+		showText();
+		rerender();
+
+		expect(scratch.innerHTML).to.equal(
+			`<div>Before</div><div>Component</div><div>After</div>`
+		);
+	});
 });


### PR DESCRIPTION
Found a reorder issue for memoised component, as the `oldVNode.vnode._children` still points to the `oldVNode`, causing it to not able to find the correct nextSibling through `getDomSibling`