### PR TITLE
fix updating suspended component after hydration

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -109,8 +109,7 @@ Suspense.prototype._childDidSuspend = function(promise, suspendingVNode) {
 		if (resolved) return;
 
 		resolved = true;
-		suspendingComponent.componentWillUnmount =
-			suspendingComponent._suspendedComponentWillUnmount;
+		suspendingComponent.componentWillUnmount = prevComponentWillUnmount;
 
 		if (resolve) {
 			resolve(onSuspensionComplete);
@@ -119,13 +118,12 @@ Suspense.prototype._childDidSuspend = function(promise, suspendingVNode) {
 		}
 	};
 
-	suspendingComponent._suspendedComponentWillUnmount =
-		suspendingComponent.componentWillUnmount;
+	let prevComponentWillUnmount = suspendingComponent.componentWillUnmount;
 	suspendingComponent.componentWillUnmount = () => {
 		onResolved();
 
-		if (suspendingComponent._suspendedComponentWillUnmount) {
-			suspendingComponent._suspendedComponentWillUnmount();
+		if (prevComponentWillUnmount) {
+			prevComponentWillUnmount.call(suspendingComponent);
 		}
 	};
 

--- a/compat/test/browser/suspense-hydration.test.js
+++ b/compat/test/browser/suspense-hydration.test.js
@@ -182,6 +182,60 @@ describe('suspense hydration', () => {
 		});
 	});
 
+	it('should allow parents to update around suspense boundary and unmount', async () => {
+		scratch.innerHTML = '<div>Count: 0</div><div>Hello</div>';
+		clearLog();
+
+		const [Lazy, resolve] = createLazy();
+
+		/** @type {() => void} */
+		let increment;
+		function Counter() {
+			const [count, setCount] = useState(0);
+			increment = () => setCount(c => c + 1);
+			return (
+				<Fragment>
+					<div>Count: {count}</div>
+					<Suspense>
+						<Lazy />
+					</Suspense>
+				</Fragment>
+			);
+		}
+
+		let hide;
+		function Component() {
+			const [show, setShow] = useState(true);
+			hide = () => setShow(false);
+
+			return show ? <Counter /> : null;
+		}
+
+		hydrate(<Component />, scratch);
+		rerender(); // Flush rerender queue to mimic what preact will really do
+		expect(scratch.innerHTML).to.equal('<div>Count: 0</div><div>Hello</div>');
+		// Re: DOM OP below - Known issue with hydrating merged text nodes
+		expect(getLog()).to.deep.equal(['<div>Count: .appendChild(#text)']);
+		clearLog();
+
+		increment();
+		rerender();
+
+		expect(scratch.innerHTML).to.equal('<div>Count: 1</div><div>Hello</div>');
+		expect(getLog()).to.deep.equal([]);
+		clearLog();
+
+		await resolve(() => <div>Hello</div>);
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div>Count: 1</div><div>Hello</div>');
+		expect(getLog()).to.deep.equal([]);
+		clearLog();
+
+		hide();
+		rerender();
+		expect(scratch.innerHTML).to.equal('');
+	});
+
 	it('should properly hydrate when there is DOM and Components between Suspense and suspender', () => {
 		scratch.innerHTML = '<div><div>Hello</div></div>';
 		clearLog();

--- a/compat/test/browser/suspense-hydration.test.js
+++ b/compat/test/browser/suspense-hydration.test.js
@@ -236,6 +236,54 @@ describe('suspense hydration', () => {
 		expect(scratch.innerHTML).to.equal('');
 	});
 
+	it('should allow parents to update around suspense boundary and unmount before resolves', async () => {
+		scratch.innerHTML = '<div>Count: 0</div><div>Hello</div>';
+		clearLog();
+
+		const [Lazy, resolve] = createLazy();
+
+		/** @type {() => void} */
+		let increment;
+		function Counter() {
+			const [count, setCount] = useState(0);
+			increment = () => setCount(c => c + 1);
+			return (
+				<Fragment>
+					<div>Count: {count}</div>
+					<Suspense>
+						<Lazy />
+					</Suspense>
+				</Fragment>
+			);
+		}
+
+		let hide;
+		function Component() {
+			const [show, setShow] = useState(true);
+			hide = () => setShow(false);
+
+			return show ? <Counter /> : null;
+		}
+
+		hydrate(<Component />, scratch);
+		rerender(); // Flush rerender queue to mimic what preact will really do
+		expect(scratch.innerHTML).to.equal('<div>Count: 0</div><div>Hello</div>');
+		// Re: DOM OP below - Known issue with hydrating merged text nodes
+		expect(getLog()).to.deep.equal(['<div>Count: .appendChild(#text)']);
+		clearLog();
+
+		increment();
+		rerender();
+
+		expect(scratch.innerHTML).to.equal('<div>Count: 1</div><div>Hello</div>');
+		expect(getLog()).to.deep.equal([]);
+		clearLog();
+
+		hide();
+		rerender();
+		expect(scratch.innerHTML).to.equal('');
+	});
+
 	it('should properly hydrate when there is DOM and Components between Suspense and suspender', () => {
 		scratch.innerHTML = '<div><div>Hello</div></div>';
 		clearLog();


### PR DESCRIPTION
as the Suspense component not rendering a placeholder during hydration, if it rerenders before the promise resolves, the same component get suspended twice, causing an infinite loop during `componentWillUnmount`

not sure this is the best fix, or maybe we should set the `<Suspense />`  shouldComponentUpdate to `false` until all the promise resolves?