### PR TITLE
restructure-backing-tree

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -68,7 +68,7 @@ export function render(vnode, parent, callback) {
 	preactRender(vnode, parent);
 	if (typeof callback == 'function') callback();
 
-	const internal = parent._children;
+	const internal = parent._children._children[0];
 	return internal ? internal._component : null;
 }
 


### PR DESCRIPTION
Fix wrong component instance returned from compat render. It should returned the `internal` reference of the `vnode` the user rendered, not of the root `Fragment`.