### PR TITLE
Tests: Fix Chrome 88 stack traces displayed wrong in terminal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4306,9 +4306,9 @@
 			}
 		},
 		"errorstacks": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/errorstacks/-/errorstacks-2.0.0.tgz",
-			"integrity": "sha512-t5ZcfunrgHDQL83nSvpLNVrtrLUmQmiHPPdTUOnScU8y5g5ErBIFC0K7ec/7pbmxfOc8m/hIYB00Xlw8GdubvQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/errorstacks/-/errorstacks-2.3.0.tgz",
+			"integrity": "sha512-VjCIUbEyLymy2N1M/uTniewz+j69YC2R7Sp1UiJn04RHwyIniBib6hUZwgmphAAZTOk7LRg/wryGFEJhblEd7Q==",
 			"dev": true
 		},
 		"es-abstract": {

--- a/package.json
+++ b/package.json
@@ -229,7 +229,7 @@
 		"cross-env": "^7.0.2",
 		"csstype": "^3.0.5",
 		"diff": "^5.0.0",
-		"errorstacks": "^2.0.0",
+		"errorstacks": "^2.3.0",
 		"esbuild": "^0.8.43",
 		"eslint": "5.15.1",
 		"eslint-config-developit": "^1.1.1",


### PR DESCRIPTION
Starting with Chrome 88 the stack trace format has changed a bit. The new version of `errorstacks` adds support for parsing that.

Before:

<img width="1109" alt="Screenshot 2021-02-13 at 08 50 57" src="https://user-images.githubusercontent.com/1062408/107845013-9da2fc80-6dd8-11eb-97ec-f4e6cc9e557b.png">

After:

<img width="793" alt="Screenshot 2021-02-13 at 08 50 48" src="https://user-images.githubusercontent.com/1062408/107845017-a3004700-6dd8-11eb-9d12-749356487418.png">

