### PR TITLE
Don't modify internal._children in place

### DIFF
--- a/follow-ups.md
+++ b/follow-ups.md
@@ -2,70 +2,72 @@
 
 ## DONE
 
-* `[MAJOR]` Deprecated `component.base`
+- `[MAJOR]` Deprecated `component.base`
 
 ## Backing Node follow ups
 
 - Revisit `prevDom` code path for null placeholders
-- Ensure we are always doing _flags check instead of vnode.type checks
+- Ensure we are always doing `_flags` check instead of vnode.type checks
 - Address many TODOs
 - Move refs to internal renderCallbacks
 - Rewrite rerender loop to operate on internals, not components
 - Rewrite commit loop to operate on internals not components
 - rewrite hooks to operate on internals?
-- Always assign a number to _original (not null, use 0 to clear?)
+- Always assign a number to `_original` (not null, use 0 to clear?)
 
 ## Child diffing investigations
 
 - Reduce allocations for text nodes
 - Investigate skip-index tracking instead of while loop
 - Loop multiple times - recursive diff, unmount children, place child
+- Combine placeChild and unmounting loop?? Do placeChild backwards? Do
+  unmounting first then placeChild loop
+- Explore replacing children in `internal._children` as we diff instead of
+  building up a new array each time
 
 ## TODOs
 
-* Consider further removing _dom pointers from non-dom VNodes
-* Combine placeChild and unmounting loop?? Do placeChild backwards? Do
-  unmounting first then placeChild loop
-* Fix Suspense tests:
-	* "should correctly render nested Suspense components without intermediate DOM #2747"
-* Fix Suspense hydration tests:
-	* "should hydrate lazy components through components using shouldComponentUpdate"
-* Rebuild Suspense List to work with backing tree
+- Consider further removing `_dom` pointers from non-dom VNodes
+- Fix Suspense tests:
+  - "should correctly render nested Suspense components without intermediate DOM #2747"
+- Fix Suspense hydration tests:
+  - "should hydrate lazy components through components using shouldComponentUpdate"
+- Rebuild Suspense List to work with backing tree
 
 ## Other
 
-* `[MAJOR]` Remove select `<option>` IE11 fix in diffChildren and tell users to
+- `[MAJOR]` Remove select `<option>` IE11 fix in diffChildren and tell users to
   always specify a value attribute for `<option>`. History:
   https://github.com/preactjs/preact/pull/1838
-* One possible implementation for effect queues: Internal nodes can have a local
+- One possible implementation for effect queues: Internal nodes can have a local
   queue of effects for that node while a global queue contains the internal
   nodes that have effects.
-* Feature: Top-level render handles Fragment root
-* Figure out a way to externally support the use case of "start rendering at
+- Feature: Top-level render handles Fragment root
+- Figure out a way to externally support the use case of "start rendering at
   this child of parentDom" (in other words, remove all that code from core &
   recommend folks use
   [this technique](https://gist.github.com/developit/f321a9ef092ad39f54f8d7c8f99eb29a))
-* Golf everything! Look for @TODO(golf)
-* Look for ways to optimize DOM element diffing, specifically how we diff props
-	- Investigate diffing props before or after children
+- Golf everything! Look for @TODO(golf)
+- Look for ways to optimize DOM element diffing, specifically how we diff props
+  - Investigate diffing props before or after children
   - Investigate inlining the loops in diffProps to capture special props
     (dangerouslySetInnerHTML, value, checked, multiple)
-* Revisit all replaceNode tests
-	- Top-level `render()` no longer accepts a `replaceNode` argument, and does not removed unmatched DOM nodes
+- Revisit all replaceNode tests
+  - Top-level `render()` no longer accepts a `replaceNode` argument, and does not removed unmatched DOM nodes
 
 ## Thoughts on Suspense
 
-* Use a special VNode (e.g. Root node) that reparents all children into a new
+- Use a special VNode (e.g. Root node) that reparents all children into a new
   DOM node (like Portals). Currently suspense manually does this but I think it
   is buggy in that it doesn't properly reset all dom pointers we currently
   maintain lol.
-* Need a way to trigger updates on VNodes that may need mounting or patching.
+- Need a way to trigger updates on VNodes that may need mounting or patching.
   I'm thinking backing nodes will help here so when a node suspends, we can
   maintain its suspended state on the backing node and not the component which
   may need to be nulled or remounted (i.e. constructor & lifecycles called
   again) (re: the bug about calling forceUpdate on a suspended hydration
   component)
-* Maintain the state (i.e. whether or not a node's last render suspended) as a
+- Maintain the state (i.e. whether or not a node's last render suspended) as a
   flag on the VNode. This flag would be useful for commit or unmount option
   hooks to discover that that a suspended node has successfully rerendered or
   unmounted. Once that is detected the nearest Suspense node that is waiting can

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -45,7 +45,8 @@ export function diffChildren(
 	/** @type {import('../internal').VNode | string} */
 	let childVNode;
 
-	let oldChildren = parentInternal._children || EMPTY_ARR;
+	let oldChildren =
+		(parentInternal._children && parentInternal._children.slice()) || EMPTY_ARR;
 	let oldChildrenLength = oldChildren.length;
 
 	const newChildren = [];


### PR DESCRIPTION
As we patch children, we mark children as used by setting their value in the children array to `undefined`. If a child is never used, it remains in the children array and we then unmount at the end.

This behavior means we modify the children array of the internal as we diff, and only after we successfully diffed the all children, do we swap the new, correct children array for the holey oldChildren array.

The new behavior is to copy the oldChildren array and modify this copy, leaving the internal._children array intact. At this point we still build a new children array and replace the old children on the internal at the end.

At some future point, we should consider replacing the children in `internal._children` as we diff if that improves perf or memory. I didn't do that this time cuz it breaks some more tests.

This PR fixes the remaining 3 suspense tests. Also, I ran prettier on our `follows-ups.md` file