### PR TITLE
Update esbuild to natively support Apple's M1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4353,9 +4353,9 @@
 			"dev": true
 		},
 		"esbuild": {
-			"version": "0.8.45",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.45.tgz",
-			"integrity": "sha512-AhR+h/Kat9QMssi0rSJIei0yR+dJ0DQ5aDqnZy4VLu9kOBHdJh8vDSE2XzUlwnm4umvMFnfQTELZlsH7Zmvksw==",
+			"version": "0.8.47",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.47.tgz",
+			"integrity": "sha512-4C9pInguP36c9CRDMSb6W1KrMfXrLIQVtI02Vglc43RBV0Dw49ODEnP6985mrz5iqCdQ2Cxmb9i670J/s3DBPA==",
 			"dev": true
 		},
 		"escalade": {
@@ -8516,19 +8516,19 @@
 			"dependencies": {
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"dev": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 					"dev": true
 				},
 				"cross-spawn": {
 					"version": "5.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"dev": true,
 					"requires": {
@@ -8539,13 +8539,13 @@
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 					"dev": true,
 					"requires": {
@@ -8560,7 +8560,7 @@
 				},
 				"find-up": {
 					"version": "2.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
@@ -8569,25 +8569,25 @@
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
 					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
 					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 					"dev": true
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
 					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
@@ -8596,19 +8596,19 @@
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
 					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 					"dev": true
 				},
 				"lcid": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 					"dev": true,
 					"requires": {
@@ -8617,7 +8617,7 @@
 				},
 				"locate-path": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
 					"requires": {
@@ -8627,7 +8627,7 @@
 				},
 				"lru-cache": {
 					"version": "4.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 					"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
 					"dev": true,
 					"requires": {
@@ -8637,7 +8637,7 @@
 				},
 				"mem": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 					"dev": true,
 					"requires": {
@@ -8646,19 +8646,19 @@
 				},
 				"mimic-fn": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
 					"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
 					"dev": true
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
 					"requires": {
@@ -8667,7 +8667,7 @@
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 					"dev": true,
 					"requires": {
@@ -8676,13 +8676,13 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"dev": true,
 					"requires": {
@@ -8693,19 +8693,19 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
 					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
 					"dev": true
 				},
 				"p-limit": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
 					"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
 					"dev": true
 				},
 				"p-locate": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"dev": true,
 					"requires": {
@@ -8714,43 +8714,43 @@
 				},
 				"path-exists": {
 					"version": "3.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
 					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
 					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
 					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
 					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
 					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
 					"dev": true
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
 					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
 					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"dev": true
 				},
 				"shebang-command": {
 					"version": "1.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 					"dev": true,
 					"requires": {
@@ -8759,19 +8759,19 @@
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"dev": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
@@ -8782,7 +8782,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
@@ -8791,13 +8791,13 @@
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 					"dev": true
 				},
 				"which": {
 					"version": "1.3.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 					"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
 					"dev": true,
 					"requires": {
@@ -8806,13 +8806,13 @@
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"dev": true,
 					"requires": {
@@ -8822,19 +8822,19 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
 					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
 					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
 					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
 					"dev": true
 				},
 				"yargs": {
 					"version": "10.0.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
 					"integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
 					"dev": true,
 					"requires": {
@@ -8854,13 +8854,13 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 							"dev": true
 						},
 						"cliui": {
 							"version": "3.2.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 							"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 							"dev": true,
 							"requires": {
@@ -8871,7 +8871,7 @@
 							"dependencies": {
 								"string-width": {
 									"version": "1.0.2",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 									"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 									"dev": true,
 									"requires": {
@@ -8884,7 +8884,7 @@
 						},
 						"string-width": {
 							"version": "2.1.1",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 							"dev": true,
 							"requires": {
@@ -8894,13 +8894,13 @@
 							"dependencies": {
 								"is-fullwidth-code-point": {
 									"version": "2.0.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 									"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 									"dev": true
 								},
 								"strip-ansi": {
 									"version": "4.0.0",
-									"resolved": false,
+									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 									"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 									"dev": true,
 									"requires": {
@@ -8913,7 +8913,7 @@
 				},
 				"yargs-parser": {
 					"version": "8.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
 					"integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
 					"dev": true,
 					"requires": {
@@ -8922,7 +8922,7 @@
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"resolved": false,
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
 							"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
 							"dev": true
 						}

--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
 		"csstype": "^3.0.5",
 		"diff": "^5.0.0",
 		"errorstacks": "^2.3.0",
-		"esbuild": "^0.8.45",
+		"esbuild": "^0.8.47",
 		"eslint": "5.15.1",
 		"eslint-config-developit": "^1.1.1",
 		"eslint-config-prettier": "^6.5.0",


### PR DESCRIPTION
This PR updates esbuild to the latest version which now includes a native binary for Apple's M1 chip. The speed improvement is quite noticable on my Macbook Air: 

| version | cold compile | watch change |
|---|---|---|
| 0.8.45 | 4s | 862ms |
| 0.8.47 | 2.5s | 649ms |

_Note: Every test file is compiled to a self contained bundle. We could even compile every test into one giant bundle to dramatically speed up things even further._