### PR TITLE
Consistently use flags to determine Internal type

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -1,4 +1,5 @@
 import { Component, createElement, options, Fragment } from 'preact';
+import { ELEMENT_NODE } from 'preact/debug/src/constants';
 import { FORCE_UPDATE, MODE_HYDRATE } from '../../src/constants';
 import { assign } from './util';
 
@@ -29,12 +30,13 @@ options.unmount = function(internal) {
 		component._onResolve();
 	}
 
-	// if the component is still hydrating most likely it is because the component
-	// is suspended we set the internal.type as `null` so that it is not a typeof
-	// function so the unmount will remove the internal._dom
+	// If a component suspended while it was hydrating and is now being unmounted,
+	// update it's _flags so it appears to be of TYPE_ELEMENT, causing `unmount`
+	// to remove the DOM nodes that were awaiting hydration (which are stored on
+	// this internal's _dom property).
 	const wasHydrating = (internal._flags & MODE_HYDRATE) === MODE_HYDRATE;
 	if (component && wasHydrating) {
-		internal.type = null;
+		internal._flags |= ELEMENT_NODE;
 	}
 
 	if (oldUnmount) oldUnmount(internal);

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -7,7 +7,6 @@
 ## Backing Node follow ups
 
 - Revisit `prevDom` code path for null placeholders
-- Ensure we are always doing `_flags` check instead of vnode.type checks
 - Address many TODOs
 - Move refs to internal renderCallbacks
 - Rewrite rerender loop to operate on internals, not components

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,6 +5,8 @@ export const TYPE_CLASS = 1 << 2;
 export const TYPE_FUNCTION = 1 << 3;
 export const TYPE_FRAGMENT = 1 << 4;
 
+/** Any type of internal representing DOM */
+export const TYPE_DOM = TYPE_TEXT | TYPE_ELEMENT;
 /** Any type of component */
 export const TYPE_COMPONENT = TYPE_CLASS | TYPE_FUNCTION | TYPE_FRAGMENT;
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -255,7 +255,7 @@ export function reorderChildren(internal, startDom, parentDom) {
 			// (childVNode here).
 			childInternal._parent = internal;
 
-			if (typeof childInternal.type == 'function') {
+			if (childInternal._flags & TYPE_COMPONENT) {
 				startDom = reorderChildren(childInternal, startDom, parentDom);
 			} else if (childInternal._dom == startDom) {
 				startDom = startDom.nextSibling;

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -185,8 +185,8 @@ function mountDOMElement(dom, internal, globalContext, isSvg, commitQueue) {
 			if (!isHydrating && newHtml.__html) {
 				dom.innerHTML = newHtml.__html;
 			}
-			internal._children = [];
-		} else if ((i = internal.props.children) != internal._children) {
+			internal._children = null;
+		} else if ((i = internal.props.children) != null) {
 			mountChildren(
 				dom,
 				Array.isArray(i) ? i : [i],

--- a/src/diff/patch.js
+++ b/src/diff/patch.js
@@ -133,7 +133,7 @@ function patchDOMElement(
 
 	// If the new vnode didn't have dangerouslySetInnerHTML, diff its children
 	if (newHtml) {
-		internal._children = [];
+		internal._children = null;
 	} else {
 		tmp = newVNode.props.children;
 		diffChildren(

--- a/src/diff/unmount.js
+++ b/src/diff/unmount.js
@@ -1,3 +1,4 @@
+import { TYPE_DOM } from '../constants';
 import options from '../options';
 import { removeNode } from '../util';
 import { applyRef } from './refs';
@@ -20,7 +21,7 @@ export function unmount(internal, parentInternal, skipRemove) {
 	}
 
 	let dom;
-	if (!skipRemove && typeof internal.type != 'function') {
+	if (!skipRemove && internal._flags & TYPE_DOM) {
 		skipRemove = (dom = internal._dom) != null;
 	}
 


### PR DESCRIPTION
Also, skip array children array allocations when using `dangerouslySetInnerHTML`, as well as simplify the `props.children` check in `mountDOMElement`. 

Depends on #3032 