### PR TITLE
Replace _parentDom on Component with a lookup function

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -1,6 +1,5 @@
 import { Component, createElement, options, Fragment } from 'preact';
-import { ELEMENT_NODE } from 'preact/debug/src/constants';
-import { FORCE_UPDATE, MODE_HYDRATE } from '../../src/constants';
+import { TYPE_ELEMENT, FORCE_UPDATE, MODE_HYDRATE } from '../../src/constants';
 import { assign } from './util';
 
 const oldCatchError = options._catchError;
@@ -36,7 +35,7 @@ options.unmount = function(internal) {
 	// this internal's _dom property).
 	const wasHydrating = (internal._flags & MODE_HYDRATE) === MODE_HYDRATE;
 	if (component && wasHydrating) {
-		internal._flags |= ELEMENT_NODE;
+		internal._flags |= TYPE_ELEMENT;
 	}
 
 	if (oldUnmount) oldUnmount(internal);

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -222,6 +222,7 @@ Suspense.prototype.render = function(props, state) {
 		// (i.e. due to a setState further up in the tree)
 		// it's _children prop is null, in this case we "forget" about the parked vnodes to detach
 		if (this._internal._children) {
+			// @TODO: Consider rebuilding suspense detached parent logic to use root nodes
 			const detachedParent = document.createElement('div');
 			const detachedComponent = this._internal._children[0]._component;
 			this._internal._children[0] = detachedClone(

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -12,7 +12,7 @@ import {
 	getDisplayName
 } from './component-stack';
 import { assign } from './util';
-import { MODE_UNMOUNTED } from 'preact/src/constants';
+import { MODE_UNMOUNTING } from 'preact/src/constants';
 
 const isWeakMapSupported = typeof WeakMap == 'function';
 
@@ -374,7 +374,7 @@ Component.prototype.setState = function(update, callback) {
 					)}`
 			);
 		}
-	} else if (this._internal._flags & MODE_UNMOUNTED) {
+	} else if (this._internal._flags & MODE_UNMOUNTING) {
 		console.warn(
 			`Can't call "this.setState" on an unmounted component. This is a no-op, ` +
 				`but it indicates a memory leak in your application. To fix, cancel all ` +
@@ -397,7 +397,7 @@ Component.prototype.forceUpdate = function(callback) {
 					getCurrentInternal()
 				)}`
 		);
-	} else if (this._internal._flags & MODE_UNMOUNTED) {
+	} else if (this._internal._flags & MODE_UNMOUNTING) {
 		console.warn(
 			`Can't call "this.forceUpdate" on an unmounted component. This is a no-op, ` +
 				`but it indicates a memory leak in your application. To fix, cancel all ` +

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -12,6 +12,7 @@ import {
 	getDisplayName
 } from './component-stack';
 import { assign } from './util';
+import { MODE_UNMOUNTED } from 'preact/src/constants';
 
 const isWeakMapSupported = typeof WeakMap == 'function';
 
@@ -356,6 +357,8 @@ export function initDebug() {
 }
 
 const setState = Component.prototype.setState;
+
+/** @this {import('../../src/internal').Component} */
 Component.prototype.setState = function(update, callback) {
 	if (this._internal == null) {
 		// `this._internal` will be `null` during componentWillMount. But it
@@ -371,7 +374,7 @@ Component.prototype.setState = function(update, callback) {
 					)}`
 			);
 		}
-	} else if (this._parentDom == null) {
+	} else if (this._internal._flags & MODE_UNMOUNTED) {
 		console.warn(
 			`Can't call "this.setState" on an unmounted component. This is a no-op, ` +
 				`but it indicates a memory leak in your application. To fix, cancel all ` +
@@ -384,6 +387,8 @@ Component.prototype.setState = function(update, callback) {
 };
 
 const forceUpdate = Component.prototype.forceUpdate;
+
+/** @this {import('../../src/internal').Component} */
 Component.prototype.forceUpdate = function(callback) {
 	if (this._internal == null) {
 		console.warn(
@@ -392,7 +397,7 @@ Component.prototype.forceUpdate = function(callback) {
 					getCurrentInternal()
 				)}`
 		);
-	} else if (this._parentDom == null) {
+	} else if (this._internal._flags & MODE_UNMOUNTED) {
 		console.warn(
 			`Can't call "this.forceUpdate" on an unmounted component. This is a no-op, ` +
 				`but it indicates a memory leak in your application. To fix, cancel all ` +

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -27,13 +27,6 @@
 ## TODOs
 
 - Consider further removing `_dom` pointers from non-dom VNodes
-- Consider adding a TYPE_ROOT for root nodes to avoid megamorphic props check on
-  every element
-  - One challenge with this approach is that the VNode for the Root node can't
-    be Fragment. Top-level Fragments returned from Components are inlined/erased
-    (diff/component.js:186), meaning if a component does something like `() => <Fragment _parentDom={} />`
-		then, that Fragment gets erased and the root node is lost :(. May want to giving
-		Root nodes their own VNode type, i.e. Portal.
 - Rewrite Suspense to use Root Nodes
 - Fix Suspense tests:
   - "should correctly render nested Suspense components without intermediate DOM #2747"

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -27,6 +27,9 @@
 ## TODOs
 
 - Consider further removing `_dom` pointers from non-dom VNodes
+- Consider adding a TYPE_ROOT for root nodes to avoid megamorphic props check on
+  every element
+- Rewrite Suspense to use Root Nodes
 - Fix Suspense tests:
   - "should correctly render nested Suspense components without intermediate DOM #2747"
 - Fix Suspense hydration tests:

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -29,6 +29,11 @@
 - Consider further removing `_dom` pointers from non-dom VNodes
 - Consider adding a TYPE_ROOT for root nodes to avoid megamorphic props check on
   every element
+  - One challenge with this approach is that the VNode for the Root node can't
+    be Fragment. Top-level Fragments returned from Components are inlined/erased
+    (diff/component.js:186), meaning if a component does something like `() => <Fragment _parentDom={} />`
+		then, that Fragment gets erased and the root node is lost :(. May want to giving
+		Root nodes their own VNode type, i.e. Portal.
 - Rewrite Suspense to use Root Nodes
 - Fix Suspense tests:
   - "should correctly render nested Suspense components without intermediate DOM #2747"

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -1,4 +1,5 @@
 import { options } from 'preact';
+import { MODE_UNMOUNTED } from '../../src/constants';
 
 /** @type {number} */
 let currentIndex;
@@ -292,7 +293,7 @@ export function useErrorBoundary(cb) {
  */
 function flushAfterPaintEffects() {
 	afterPaintEffects.forEach(component => {
-		if (component._parentDom) {
+		if (~component._internal._flags & MODE_UNMOUNTED) {
 			try {
 				component.__hooks._pendingEffects.forEach(invokeCleanup);
 				component.__hooks._pendingEffects.forEach(invokeEffect);

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -1,5 +1,5 @@
 import { options } from 'preact';
-import { MODE_UNMOUNTED } from '../../src/constants';
+import { MODE_UNMOUNTING } from '../../src/constants';
 
 /** @type {number} */
 let currentIndex;
@@ -293,7 +293,7 @@ export function useErrorBoundary(cb) {
  */
 function flushAfterPaintEffects() {
 	afterPaintEffects.forEach(component => {
-		if (~component._internal._flags & MODE_UNMOUNTED) {
+		if (~component._internal._flags & MODE_UNMOUNTING) {
 			try {
 				component.__hooks._pendingEffects.forEach(invokeCleanup);
 				component.__hooks._pendingEffects.forEach(invokeEffect);

--- a/src/component.js
+++ b/src/component.js
@@ -3,7 +3,7 @@ import { commitRoot } from './diff/commit';
 import options from './options';
 import { createVNode, Fragment } from './create-element';
 import { patch } from './diff/patch';
-import { DIRTY_BIT, FORCE_UPDATE, MODE_UNMOUNTED } from './constants';
+import { DIRTY_BIT, FORCE_UPDATE, MODE_UNMOUNTING } from './constants';
 import { getDomSibling, getParentDom, updateParentDomPointers } from './tree';
 
 /**
@@ -91,7 +91,7 @@ Component.prototype.render = Fragment;
 function rerenderComponent(component) {
 	let internal = component._internal;
 
-	if (~internal._flags & MODE_UNMOUNTED && internal._flags & DIRTY_BIT) {
+	if (~internal._flags & MODE_UNMOUNTING && internal._flags & DIRTY_BIT) {
 		let startDom = internal._dom;
 		let parentDom = getParentDom(internal);
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -19,11 +19,13 @@ export const MODE_MUTATIVE_HYDRATE = 1 << 6;
 export const MODE_SUSPENDED = 1 << 7;
 /** Signifies this VNode errored on the previous render */
 export const MODE_ERRORED = 1 << 8;
+/** Signals this internal has been unmounted */
+export const MODE_UNMOUNTED = 1 << 9;
 
 /** Signifies that bailout checks will be bypassed */
-export const FORCE_UPDATE = 1 << 9;
+export const FORCE_UPDATE = 1 << 10;
 /** Signifies that a node needs to be updated */
-export const DIRTY_BIT = 1 << 10;
+export const DIRTY_BIT = 1 << 11;
 
 /** Reset all mode flags */
 export const RESET_MODE = ~(

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,6 +3,8 @@ export const TYPE_TEXT = 1 << 0;
 export const TYPE_ELEMENT = 1 << 1;
 export const TYPE_CLASS = 1 << 2;
 export const TYPE_FUNCTION = 1 << 3;
+/** Signals this internal has a _parentDom prop that should change the parent
+ * DOM node of it's children */
 export const TYPE_ROOT = 1 << 4;
 
 /** Any type of internal representing DOM */

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,12 +3,12 @@ export const TYPE_TEXT = 1 << 0;
 export const TYPE_ELEMENT = 1 << 1;
 export const TYPE_CLASS = 1 << 2;
 export const TYPE_FUNCTION = 1 << 3;
-export const TYPE_FRAGMENT = 1 << 4;
+export const TYPE_ROOT = 1 << 4;
 
 /** Any type of internal representing DOM */
 export const TYPE_DOM = TYPE_TEXT | TYPE_ELEMENT;
 /** Any type of component */
-export const TYPE_COMPONENT = TYPE_CLASS | TYPE_FUNCTION | TYPE_FRAGMENT;
+export const TYPE_COMPONENT = TYPE_CLASS | TYPE_FUNCTION | TYPE_ROOT;
 
 // Modes of rendering
 /** Normal hydration that attaches to a DOM tree but does not diff it. */

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,7 +20,7 @@ export const MODE_SUSPENDED = 1 << 7;
 /** Signifies this VNode errored on the previous render */
 export const MODE_ERRORED = 1 << 8;
 /** Signals this internal has been unmounted */
-export const MODE_UNMOUNTED = 1 << 9;
+export const MODE_UNMOUNTING = 1 << 9;
 
 /** Signifies that bailout checks will be bypassed */
 export const FORCE_UPDATE = 1 << 10;

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -7,7 +7,7 @@ import {
 	MODE_SUSPENDED,
 	EMPTY_ARR
 } from '../constants';
-import { getDomSibling } from '../component';
+import { getDomSibling } from '../tree';
 import { mount } from './mount';
 import { patch } from './patch';
 import { unmount } from './unmount';

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -7,11 +7,10 @@ import {
 	MODE_SUSPENDED,
 	EMPTY_ARR
 } from '../constants';
-import { getDomSibling } from '../tree';
 import { mount } from './mount';
 import { patch } from './patch';
 import { unmount } from './unmount';
-import { createInternal } from '../tree';
+import { createInternal, getDomSibling } from '../tree';
 
 /**
  * Diff the children of a virtual node

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -246,6 +246,10 @@ export function diffChildren(
  * @param {import('../internal').PreactElement} parentDom
  */
 export function reorderChildren(internal, startDom, parentDom) {
+	if (internal._children == null) {
+		return startDom;
+	}
+
 	for (let tmp = 0; tmp < internal._children.length; tmp++) {
 		let childInternal = internal._children[tmp];
 		if (childInternal) {

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -4,7 +4,7 @@ import { assign } from '../util';
 import { Component } from '../component';
 import { mountChildren } from './mount';
 import { diffChildren, reorderChildren } from './children';
-import { DIRTY_BIT, FORCE_UPDATE } from '../constants';
+import { DIRTY_BIT, FORCE_UPDATE, TYPE_ROOT } from '../constants';
 
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
@@ -151,7 +151,7 @@ export function renderComponent(
 	// on the page. Root nodes can occur anywhere in the tree and not just
 	// at the top.
 	let oldStartDom = startDom;
-	if (newProps._parentDom) {
+	if (internal._flags & TYPE_ROOT) {
 		parentDom = newProps._parentDom;
 
 		if (internal && internal._dom) {

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -167,7 +167,6 @@ export function renderComponent(
 
 	internal._flags &= ~DIRTY_BIT;
 	c._internal = internal;
-	c._parentDom = parentDom;
 
 	tmp = c.render(c.props, c.state, c.context);
 

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -214,7 +214,7 @@ export function renderComponent(
 	}
 
 	// Resume where we left of before the Portal
-	if (newProps._parentDom) {
+	if (internal._flags & TYPE_ROOT) {
 		return oldStartDom;
 	}
 

--- a/src/diff/unmount.js
+++ b/src/diff/unmount.js
@@ -1,4 +1,4 @@
-import { MODE_UNMOUNTED, TYPE_DOM } from '../constants';
+import { MODE_UNMOUNTED, TYPE_DOM, TYPE_ROOT } from '../constants';
 import options from '../options';
 import { removeNode } from '../util';
 import { applyRef } from './refs';
@@ -24,7 +24,7 @@ export function unmount(internal, parentInternal, skipRemove) {
 	let dom;
 	if (!skipRemove && internal._flags & TYPE_DOM) {
 		skipRemove = (dom = internal._dom) != null;
-	} else if (internal.props._parentDom) {
+	} else if (internal._flags & TYPE_ROOT) {
 		skipRemove = false;
 	}
 

--- a/src/diff/unmount.js
+++ b/src/diff/unmount.js
@@ -1,4 +1,4 @@
-import { TYPE_DOM } from '../constants';
+import { MODE_UNMOUNTED, TYPE_DOM } from '../constants';
 import options from '../options';
 import { removeNode } from '../util';
 import { applyRef } from './refs';
@@ -14,6 +14,7 @@ import { applyRef } from './refs';
 export function unmount(internal, parentInternal, skipRemove) {
 	let r;
 	if (options.unmount) options.unmount(internal);
+	internal._flags |= MODE_UNMOUNTED;
 
 	if ((r = internal.ref)) {
 		if (!r.current || r.current === internal._dom)
@@ -37,8 +38,6 @@ export function unmount(internal, parentInternal, skipRemove) {
 				options._catchError(e, parentInternal);
 			}
 		}
-
-		r._parentDom = null;
 	}
 
 	if ((r = internal._children)) {

--- a/src/diff/unmount.js
+++ b/src/diff/unmount.js
@@ -1,4 +1,4 @@
-import { MODE_UNMOUNTED, TYPE_DOM, TYPE_ROOT } from '../constants';
+import { MODE_UNMOUNTING, TYPE_DOM, TYPE_ROOT } from '../constants';
 import options from '../options';
 import { removeNode } from '../util';
 import { applyRef } from './refs';
@@ -14,7 +14,7 @@ import { applyRef } from './refs';
 export function unmount(internal, parentInternal, skipRemove) {
 	let r;
 	if (options.unmount) options.unmount(internal);
-	internal._flags |= MODE_UNMOUNTED;
+	internal._flags |= MODE_UNMOUNTING;
 
 	if ((r = internal.ref)) {
 		if (!r.current || r.current === internal._dom)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -246,7 +246,6 @@ declare namespace preact {
 	// Preact Built-in Components
 	// -----------------------------------
 
-	// TODO: Revisit what the public type of this is...
 	const Fragment: ComponentClass<{}, {}>;
 
 	//

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -1,7 +1,5 @@
 import * as preact from './index';
 
-type CONSTANTS = typeof import('./lib/constants');
-
 export enum HookType {
 	useState = 1,
 	useReducer = 2,
@@ -114,13 +112,6 @@ export interface VNode<P = {}> extends preact.VNode<P> {
 	props: P & { children: ComponentChildren };
 	_vnodeId: number;
 }
-
-export type InternalTypeFlags =
-	| CONSTANTS['TYPE_TEXT']
-	| CONSTANTS['TYPE_ELEMENT']
-	| CONSTANTS['TYPE_CLASS']
-	| CONSTANTS['TYPE_FUNCTION']
-	| CONSTANTS['TYPE_COMPONENT'];
 
 /**
  * An Internal is a persistent backing node within Preact's virtual DOM tree.

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -162,12 +162,6 @@ export interface Component<P = {}, S = {}> extends preact.Component<P, S> {
 	_nextState?: S | null; // Only class components
 	/** Only used in the devtools to later dirty check if state has changed */
 	_prevState?: S | null;
-	/**
-	 * Pointer to the parent dom node. This is only needed for top-level Fragment
-	 * components or array returns.
-	 * @TODO this should be moved to Internal
-	 */
-	_parentDom?: PreactElement | null;
 }
 
 export interface PreactContext extends preact.Context<any> {

--- a/src/render.js
+++ b/src/render.js
@@ -28,6 +28,7 @@ export function render(vnode, parentDom, replaceNode) {
 	let rootInternal =
 		(replaceNode && replaceNode._children) || parentDom._children;
 	vnode = createElement(Fragment, { _parentDom: parentDom }, [vnode]);
+
 	if (rootInternal) {
 		patch(
 			parentDom,

--- a/src/tree.js
+++ b/src/tree.js
@@ -137,3 +137,25 @@ export function updateParentDomPointers(internal) {
 		return updateParentDomPointers(internal);
 	}
 }
+
+/**
+ * @param {import('./internal').Internal} internal
+ * @returns {import('./internal').PreactElement}
+ */
+export function getParentDom(internal) {
+	let parentDom = internal.props._parentDom ? internal.props._parentDom : null;
+	let parent = internal._parent;
+	while (parentDom == null && parent) {
+		// TODO: Give root nodes their own type to avoid this megamorphic check on
+		// every parent internal
+		if (parent.props._parentDom) {
+			parentDom = parent.props._parentDom;
+		} else if (parent._flags & TYPE_ELEMENT) {
+			parentDom = parent._dom;
+		} else {
+			parent = parent._parent;
+		}
+	}
+
+	return parentDom;
+}

--- a/src/tree.js
+++ b/src/tree.js
@@ -151,9 +151,9 @@ export function getParentDom(internal) {
 			parentDom = parent.props._parentDom;
 		} else if (parent._flags & TYPE_ELEMENT) {
 			parentDom = parent._dom;
-		} else {
-			parent = parent._parent;
 		}
+
+		parent = parent._parent;
 	}
 
 	return parentDom;

--- a/src/tree.js
+++ b/src/tree.js
@@ -5,7 +5,8 @@ import {
 	TYPE_TEXT,
 	TYPE_CLASS,
 	TYPE_FRAGMENT,
-	INHERITED_MODES
+	INHERITED_MODES,
+	TYPE_COMPONENT
 } from './constants';
 import { Fragment } from './create-element';
 
@@ -81,4 +82,58 @@ export function createInternal(vnode, parentInternal) {
 	if (options._internal) options._internal(internal, vnode);
 
 	return internal;
+}
+
+/**
+ * @param {import('./internal').Internal} internal
+ * @param {number | null} [childIndex]
+ * @returns {import('./internal').PreactNode}
+ */
+export function getDomSibling(internal, childIndex) {
+	if (childIndex == null) {
+		// Use childIndex==null as a signal to resume the search from the vnode's sibling
+		return internal._parent
+			? getDomSibling(
+					internal._parent,
+					internal._parent._children.indexOf(internal) + 1
+			  )
+			: null;
+	}
+
+	let sibling;
+	for (; childIndex < internal._children.length; childIndex++) {
+		sibling = internal._children[childIndex];
+
+		if (sibling != null && sibling._dom != null) {
+			// Since updateParentDomPointers keeps _dom pointer correct,
+			// we can rely on _dom to tell us if this subtree contains a
+			// rendered DOM node, and what the first rendered DOM node is
+			return sibling._dom;
+		}
+	}
+
+	// If we get here, we have not found a DOM node in this vnode's children.
+	// We must resume from this vnode's sibling (in it's parent _children array)
+	// Only climb up and search the parent if we aren't searching through a DOM
+	// VNode (meaning we reached the DOM parent of the original vnode that began
+	// the search)
+	return internal._flags & TYPE_COMPONENT ? getDomSibling(internal) : null;
+}
+
+/**
+ * @param {import('./internal').Internal} internal
+ */
+export function updateParentDomPointers(internal) {
+	if ((internal = internal._parent) != null && internal._component != null) {
+		internal._dom = null;
+		for (let i = 0; i < internal._children.length; i++) {
+			let child = internal._children[i];
+			if (child != null && child._dom != null) {
+				internal._dom = child._dom;
+				break;
+			}
+		}
+
+		return updateParentDomPointers(internal);
+	}
 }

--- a/src/tree.js
+++ b/src/tree.js
@@ -22,7 +22,7 @@ export function createInternal(vnode, parentInternal) {
 		key,
 		ref;
 
-	/** @type {import('./internal').InternalTypeFlags} */
+	/** @type {number} */
 	let flags = TYPE_TEXT;
 
 	// Text VNodes/Internals use NaN as an ID so that two are never equal.

--- a/test/browser/getDomSibling.test.js
+++ b/test/browser/getDomSibling.test.js
@@ -1,5 +1,5 @@
 import { createElement, render, Fragment } from '../../src/';
-import { getDomSibling } from '../../src/component';
+import { getDomSibling } from '../../src/tree';
 import { setupScratch, teardown } from '../_util/helpers';
 
 /** @jsx createElement */

--- a/test/browser/getParentDom.test.js
+++ b/test/browser/getParentDom.test.js
@@ -206,6 +206,8 @@ describe('getParentDom', () => {
 			scratch
 		);
 
+		expect(scratch.innerHTML).to.equal('<div></div>');
+
 		let internal = getRoot(scratch)._children[0]._children[0];
 		expect(internal.type).to.equal(Fragment);
 		expect(getParentDom(internal)).to.equalNode(portalParent);
@@ -226,6 +228,8 @@ describe('getParentDom', () => {
 			scratch
 		);
 
+		expect(scratch.innerHTML).to.equal('<div></div>');
+
 		let fooInternal = getRoot(scratch)._children[0]._children[0]._children[0];
 		expect(fooInternal.type).to.equal(Foo);
 		expect(getParentDom(fooInternal)).to.equalNode(portalParent);
@@ -233,5 +237,30 @@ describe('getParentDom', () => {
 		let divInternal = fooInternal._children[0];
 		expect(divInternal.type).to.equal('div');
 		expect(getParentDom(divInternal)).to.equalNode(portalParent);
+	});
+
+	// TODO: This doesn't work because Fragments returned from components are
+	// inlined/erased. Would need to give root nodes their own type, i.e. Portal
+	it.skip('should return _parentDom property of root node returned from a Component', () => {
+		const portalParent = document.createElement('div');
+
+		const Foo = () => (
+			<Fragment _parentDom={portalParent}>
+				<div>A</div>
+			</Fragment>
+		);
+
+		render(
+			<div>
+				<Foo />
+			</div>,
+			scratch
+		);
+
+		expect(scratch.innerHTML).to.equal('<div></div>');
+
+		let internal = getRoot(scratch)._children[0]._children[0]._children[0];
+		expect(internal.type).to.equal('div');
+		expect(getParentDom(internal)).to.equalNode(portalParent);
 	});
 });

--- a/test/browser/getParentDom.test.js
+++ b/test/browser/getParentDom.test.js
@@ -239,15 +239,13 @@ describe('getParentDom', () => {
 		expect(getParentDom(divInternal)).to.equalNode(portalParent);
 	});
 
-	// TODO: This doesn't work because Fragments returned from components are
-	// inlined/erased. Would need to give root nodes their own type, i.e. Portal
-	it.skip('should return _parentDom property of root node returned from a Component', () => {
+	it('should return _parentDom property of root node returned from a Component', () => {
 		const portalParent = document.createElement('div');
-
+		const Root = props => props.children;
 		const Foo = () => (
-			<Fragment _parentDom={portalParent}>
+			<Root _parentDom={portalParent}>
 				<div>A</div>
-			</Fragment>
+			</Root>
 		);
 
 		render(
@@ -259,7 +257,8 @@ describe('getParentDom', () => {
 
 		expect(scratch.innerHTML).to.equal('<div></div>');
 
-		let internal = getRoot(scratch)._children[0]._children[0]._children[0];
+		let internal = getRoot(scratch)._children[0]._children[0]._children[0]
+			._children[0];
 		expect(internal.type).to.equal('div');
 		expect(getParentDom(internal)).to.equalNode(portalParent);
 	});

--- a/test/browser/getParentDom.test.js
+++ b/test/browser/getParentDom.test.js
@@ -1,0 +1,237 @@
+import { createElement, render, Fragment } from '../../src/';
+import { getParentDom } from '../../src/tree';
+import { setupScratch, teardown } from '../_util/helpers';
+
+/** @jsx createElement */
+
+describe('getParentDom', () => {
+	/** @type {import('../../src/internal').PreactElement} */
+	let scratch;
+
+	const getRoot = dom => dom._children;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('should find direct parent of DOM children', () => {
+		render(
+			<div>
+				<div>A</div>
+				<div>B</div>
+				<div>C</div>
+			</div>,
+			scratch
+		);
+
+		let domInternals = getRoot(scratch)._children[0]._children;
+		for (let internal of domInternals) {
+			expect(internal.type).to.equal('div');
+			expect(getParentDom(internal)).to.equalNode(scratch.firstChild);
+		}
+	});
+
+	it('should find direct parent of text node', () => {
+		render(
+			<div>
+				<div>A</div>B<div>C</div>
+			</div>,
+			scratch
+		);
+
+		let domInternals = getRoot(scratch)._children[0]._children;
+		let expectedTypes = ['div', null, 'div'];
+		for (let i = 0; i < domInternals.length; i++) {
+			expect(domInternals[i].type).to.equal(expectedTypes[i]);
+			expect(getParentDom(domInternals[i])).to.equalNode(scratch.firstChild);
+		}
+	});
+
+	it('should find parent through Fragments', () => {
+		render(
+			<div>
+				<Fragment>
+					<div>A</div>
+				</Fragment>
+				<Fragment>B</Fragment>
+			</div>,
+			scratch
+		);
+
+		let domInternals = [
+			getRoot(scratch)._children[0]._children[0]._children[0],
+			getRoot(scratch)._children[0]._children[1]._children[0]
+		];
+
+		let expectedTypes = ['div', null];
+		for (let i = 0; i < domInternals.length; i++) {
+			expect(domInternals[i].type).to.equal(expectedTypes[i]);
+			expect(getParentDom(domInternals[i])).to.equalNode(scratch.firstChild);
+		}
+	});
+
+	it('should find parent through nested Fragments/Components', () => {
+		const Foo = props => props.children;
+		render(
+			<div>
+				<Fragment>
+					<Foo>
+						<div>A</div>
+					</Foo>
+				</Fragment>
+				<Fragment>
+					<Foo>B</Foo>
+				</Fragment>
+			</div>,
+			scratch
+		);
+
+		let domInternals = [
+			getRoot(scratch)._children[0]._children[0]._children[0]._children[0],
+			getRoot(scratch)._children[0]._children[1]._children[0]._children[0]
+		];
+
+		let expectedTypes = ['div', null];
+		for (let i = 0; i < domInternals.length; i++) {
+			expect(domInternals[i].type).to.equal(expectedTypes[i]);
+			expect(getParentDom(domInternals[i])).to.equalNode(scratch.firstChild);
+		}
+	});
+
+	it('should find parent of nested Fragments & Components', () => {
+		const Foo = props => props.children;
+		render(
+			<div>
+				<Fragment>
+					<Foo>
+						<div>A</div>
+					</Foo>
+				</Fragment>
+				<Fragment>
+					<Fragment>
+						<Fragment>B</Fragment>
+					</Fragment>
+				</Fragment>
+			</div>,
+			scratch
+		);
+
+		let domInternals = [
+			getRoot(scratch)._children[0]._children[0]._children[0],
+			getRoot(scratch)._children[0]._children[1]._children[0]
+		];
+
+		let expectedTypes = [Foo, Fragment];
+		for (let i = 0; i < domInternals.length; i++) {
+			expect(domInternals[i].type).to.equal(expectedTypes[i]);
+			expect(getParentDom(domInternals[i])).to.equalNode(scratch.firstChild);
+		}
+	});
+
+	it('should find correct parent if rendered in Components that wrap JSX children', () => {
+		const Foo = props => <p key="p">{props.children}</p>;
+		render(
+			<div key="0">
+				<div key="A">A</div>
+				<Foo key="Foo">
+					<span key="span">a span</span>
+				</Foo>
+			</div>,
+			scratch
+		);
+
+		let internal = getRoot(scratch)._children[0]._children[1]._children[0]
+			._children[0];
+		let parentDom = getParentDom(internal);
+
+		expect(internal.type).to.equal('span');
+		expect(scratch.firstChild.childNodes[1].nodeName).to.equal('P');
+		expect(parentDom).to.equalNode(scratch.firstChild.childNodes[1]);
+	});
+
+	it('should find parent through Components without JSX children', () => {
+		const Foo = () => (
+			<Fragment>
+				<Fragment>
+					<p>A</p>
+				</Fragment>
+			</Fragment>
+		);
+
+		render(
+			<div key="0">
+				<Foo key="Foo" />
+			</div>,
+			scratch
+		);
+
+		let internal = getRoot(scratch)._children[0]._children[0]._children[0]
+			._children[0];
+		let parent = getParentDom(internal);
+
+		expect(internal.type).to.equal('p');
+		expect(parent).to.equalNode(scratch.firstChild);
+	});
+
+	it('should return container DOM if first child is a component', () => {
+		const Foo = props => props.children;
+		render(
+			<Foo>
+				<div>A</div>
+			</Foo>,
+			scratch
+		);
+
+		const internal = getRoot(scratch)._children[0];
+		expect(internal.type).to.equal(Foo);
+		expect(getParentDom(internal)).to.equal(scratch);
+	});
+
+	it('should return _parentDom property of root node', () => {
+		const portalParent = document.createElement('div');
+
+		const Foo = props => props.children;
+		render(
+			<div>
+				<Fragment _parentDom={portalParent}>
+					<Foo>
+						<div>A</div>
+					</Foo>
+				</Fragment>
+			</div>,
+			scratch
+		);
+
+		let internal = getRoot(scratch)._children[0]._children[0];
+		expect(internal.type).to.equal(Fragment);
+		expect(getParentDom(internal)).to.equalNode(portalParent);
+	});
+
+	it('should return _parentDom property of root node if ancestors contain a root node', () => {
+		const portalParent = document.createElement('div');
+
+		const Foo = props => props.children;
+		render(
+			<div>
+				<Fragment _parentDom={portalParent}>
+					<Foo>
+						<div>A</div>
+					</Foo>
+				</Fragment>
+			</div>,
+			scratch
+		);
+
+		let fooInternal = getRoot(scratch)._children[0]._children[0]._children[0];
+		expect(fooInternal.type).to.equal(Foo);
+		expect(getParentDom(fooInternal)).to.equalNode(portalParent);
+
+		let divInternal = fooInternal._children[0];
+		expect(divInternal.type).to.equal('div');
+		expect(getParentDom(divInternal)).to.equalNode(portalParent);
+	});
+});


### PR DESCRIPTION
Instead of keeping a `_parentDom` pointer on every Component instance, this PR adds a new helper, `getParentDom`, that climbs up the tree to find the first DOM Internal or root Internal (an internal with a `_parentDom` prop, see #2983) and returns its DOM pointer.

Since the `component._parentDom` field was used to check if a component was still mounted, I added a `MODE_UNMOUNTING` flag to indicate that an internal has been unmounted. This flag is used in a couple of places where we don't want to rerender or run effects of components that have just been unmounted.

This PR also replaces the `TYPE_FRAGMENT` flag (which wasn't used anywhere) with a `TYPE_ROOT` flag. If a function component VNode contains a `_parentDom` prop when it's Internal is being created, it'll get the `TYPE_ROOT` flag. This flag signals that this internal has a `_parentDom` prop that should change the parent DOM node of its children. I wanted a flag for root nodes so that we didn't have to do a megamorphic `props._parentDom` lookup on every component (wondering if that is the slowdowns in text_update and many_updates in #2983...).