### PR TITLE
Properly handle deeply nested repeat errors

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -21,13 +21,28 @@ export const MODE_MUTATIVE_HYDRATE = 1 << 6;
 export const MODE_SUSPENDED = 1 << 7;
 /** Signifies this VNode errored on the previous render */
 export const MODE_ERRORED = 1 << 8;
+/** Signifies an error has been thrown and this component will be attempting to
+ * handle & rerender the error on next render. In other words, on the next
+ * render of this component, unset this mode and set the MODE_RERENDERING_ERROR.
+ * This flag is distinct from MODE_RERENDERING_ERROR so that a component can
+ * catch multiple errors thrown by its children in one render pass (see test
+ * "should handle double child throws").
+ */
+export const MODE_PENDING_ERROR = 1 << 9;
+/** Signifies this Internal is attempting to "handle" an error and is
+ * rerendering. This mode tracks that a component's last rerender was trying to
+ * handle an error. As such, if another error is thrown while a component has
+ * this flag set, it should not handle the newly thrown error since it failed to
+ * successfully rerender the original error. This prevents error handling
+ * infinite render loops */
+export const MODE_RERENDERING_ERROR = 1 << 10;
 /** Signals this internal has been unmounted */
-export const MODE_UNMOUNTING = 1 << 9;
+export const MODE_UNMOUNTING = 1 << 11;
 
 /** Signifies that bailout checks will be bypassed */
-export const FORCE_UPDATE = 1 << 10;
+export const FORCE_UPDATE = 1 << 12;
 /** Signifies that a node needs to be updated */
-export const DIRTY_BIT = 1 << 11;
+export const DIRTY_BIT = 1 << 13;
 
 /** Reset all mode flags */
 export const RESET_MODE = ~(
@@ -35,6 +50,7 @@ export const RESET_MODE = ~(
 	MODE_MUTATIVE_HYDRATE |
 	MODE_SUSPENDED |
 	MODE_ERRORED |
+	MODE_RERENDERING_ERROR |
 	FORCE_UPDATE
 );
 

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -4,7 +4,13 @@ import { assign } from '../util';
 import { Component } from '../component';
 import { mountChildren } from './mount';
 import { diffChildren, reorderChildren } from './children';
-import { DIRTY_BIT, FORCE_UPDATE, TYPE_ROOT } from '../constants';
+import {
+	DIRTY_BIT,
+	FORCE_UPDATE,
+	MODE_PENDING_ERROR,
+	MODE_RERENDERING_ERROR,
+	TYPE_ROOT
+} from '../constants';
 
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
@@ -36,6 +42,13 @@ export function renderComponent(
 
 	// @TODO split update + mount?
 	let newProps = newVNode ? newVNode.props : internal.props;
+
+	if (internal._flags & MODE_PENDING_ERROR) {
+		// Toggle the MODE_PENDING_ERROR and MODE_RERENDERING_ERROR flags. In
+		// actuality, this should turn off the MODE_PENDING_ERROR flag and turn on
+		// the MODE_RERENDERING_ERROR flag.
+		internal._flags ^= MODE_PENDING_ERROR | MODE_RERENDERING_ERROR;
+	}
 
 	// Necessary for createContext api. Setting this property will pass
 	// the context value as `this.context` just for this component.

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -6,7 +6,8 @@ import {
 	MODE_MUTATIVE_HYDRATE,
 	MODE_SUSPENDED,
 	RESET_MODE,
-	TYPE_TEXT
+	TYPE_TEXT,
+	MODE_ERRORED
 } from '../constants';
 import { normalizeToVNode } from '../create-element';
 import { setProperty } from './props';
@@ -76,7 +77,7 @@ export function mount(
 		internal._flags &= RESET_MODE;
 	} catch (e) {
 		internal._vnodeId = null;
-		internal._flags |= MODE_SUSPENDED;
+		internal._flags |= e.then ? MODE_SUSPENDED : MODE_ERRORED;
 
 		if (internal._flags & MODE_HYDRATE) {
 			// @ts-ignore Trust me TS, nextSibling is a PreactElement

--- a/src/diff/patch.js
+++ b/src/diff/patch.js
@@ -2,7 +2,13 @@ import { diffChildren } from './children';
 import { diffProps, setProperty } from './props';
 import options from '../options';
 import { renderComponent } from './component';
-import { TYPE_COMPONENT, RESET_MODE, TYPE_TEXT } from '../constants';
+import {
+	TYPE_COMPONENT,
+	RESET_MODE,
+	TYPE_TEXT,
+	MODE_SUSPENDED,
+	MODE_ERRORED
+} from '../constants';
 
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
@@ -78,6 +84,7 @@ export function patch(
 	} catch (e) {
 		// @TODO: assign a new VNode ID here? Or NaN?
 		// newVNode._vnodeId = null;
+		internal._flags |= e.then ? MODE_SUSPENDED : MODE_ERRORED;
 		options._catchError(e, internal);
 	}
 

--- a/test/browser/lifecycles/componentDidCatch.test.js
+++ b/test/browser/lifecycles/componentDidCatch.test.js
@@ -542,6 +542,47 @@ describe('Lifecycle methods', () => {
 			expect(scratch).to.have.property('textContent', 'Error: Error!');
 		});
 
+		it('should bubble on deeply repeated errors', () => {
+			const thrownErrors = [];
+
+			class Adapter extends Component {
+				componentDidCatch(error) {
+					// Try to handle the error
+					this.setState({ error });
+				}
+				render() {
+					// But fail at doing so and continue rendering the erroring child
+					return <div>{this.props.children}</div>;
+				}
+			}
+
+			function ThrowErr() {
+				let error = new Error('Error!');
+				thrownErrors.push(error);
+				throw error;
+			}
+
+			sinon.spy(Adapter.prototype, 'componentDidCatch');
+
+			render(
+				<Receiver>
+					<Adapter>
+						<ThrowErr />
+					</Adapter>
+				</Receiver>,
+				scratch
+			);
+			rerender();
+
+			expect(Adapter.prototype.componentDidCatch).to.have.been.calledWith(
+				thrownErrors[0]
+			);
+			expect(Receiver.prototype.componentDidCatch).to.have.been.calledWith(
+				thrownErrors[1]
+			);
+			expect(scratch).to.have.property('textContent', 'Error: Error!');
+		});
+
 		it('should bubble on ignored errors', () => {
 			class Adapter extends Component {
 				componentDidCatch() {


### PR DESCRIPTION
Fixes a bug where re-throwing an error deeply nested from the error boundary wouldn't properly bubble up.

I had to bring back the dancing PENDING_ERROR & RERENDERING_ERROR dual flags from master to get all tests to pass. I added some comments explaining the two flags and the purpose they serve. Let me know if they makes sense.