### PR TITLE
Update suspense tests to use helpers and fix some TS issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
 				2,
 				{
 					"args": "none",
-					"varsIgnorePattern": "^h|React$"
+					"varsIgnorePattern": "^h|React|_$"
 				}
 			],
 			"prefer-rest-params": 0,


### PR DESCRIPTION
* Add a little consistency to our Suspense tests by always using our suspense utilities
* Fix up the JSDoc comments so we don't have any TS VSCode errors
* Directly spy on class prototype methods so error messages print out which method failed