### PR TITLE
Add decoding TypeScript attribute

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -656,6 +656,7 @@ export namespace JSXInternal {
 		disabled?: boolean;
 		disableRemotePlayback?: boolean;
 		download?: any;
+		decoding?: 'sync' | 'async' | 'auto';
 		draggable?: boolean;
 		encType?: string;
 		form?: string;

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -811,6 +811,7 @@ export namespace JSXInternal {
 		dd: HTMLAttributes<HTMLElement>;
 		del: HTMLAttributes<HTMLModElement>;
 		details: HTMLAttributes<HTMLDetailsElement>;
+		decoding: HTMLAttributes<HTMLImageElement>;
 		dfn: HTMLAttributes<HTMLElement>;
 		dialog: HTMLAttributes<HTMLDialogElement>;
 		div: HTMLAttributes<HTMLDivElement>;

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -811,7 +811,6 @@ export namespace JSXInternal {
 		dd: HTMLAttributes<HTMLElement>;
 		del: HTMLAttributes<HTMLModElement>;
 		details: HTMLAttributes<HTMLDetailsElement>;
-		decoding: HTMLAttributes<HTMLImageElement>;
 		dfn: HTMLAttributes<HTMLElement>;
 		dialog: HTMLAttributes<HTMLDialogElement>;
 		div: HTMLAttributes<HTMLDivElement>;


### PR DESCRIPTION
currently, when I try using: 
```jsx
<img src="..." decoding="async" />
```

I get this error:
```
TS2322: Type '{ alt: string; src: string; style: { width: string; height: string; }; className: string; decoding: string; }' is not assignable to type 'HTMLAttributes<HTMLImageElement>'.
  Property 'decoding' does not exist on type 'HTMLAttributes<HTMLImageElement>'.
```

this patch fixes this issue