### PR TITLE
Fix the useRef typing to include undefined when called without initial value

### DIFF
--- a/compat/test/ts/forward-ref.tsx
+++ b/compat/test/ts/forward-ref.tsx
@@ -1,7 +1,7 @@
 import React from '../../src';
 
 const MyInput: React.ForwardFn<{ id: string }, { focus(): void }> = (props, ref) => {
-  const inputRef = React.useRef<HTMLInputElement>()
+  const inputRef = React.useRef<HTMLInputElement>(null)
 
   React.useImperativeHandle(ref, () => ({
     focus: () => {

--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -1,4 +1,4 @@
-import { PreactContext, Ref as PreactRef } from '../..';
+import { PreactContext, Ref as PreactRef, RefObject } from '../..';
 
 type Inputs = ReadonlyArray<unknown>;
 
@@ -40,6 +40,7 @@ export function useReducer<S, A, I>(
 	init: (arg: I) => S
 ): [S, (action: A) => void];
 
+/** @deprecated Use the `Ref` type instead. */
 type PropRef<T> = { current: T };
 type Ref<T> = { current: T };
 
@@ -49,15 +50,12 @@ type Ref<T> = { current: T };
  *
  * Note that `useRef()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
  * value around similar to how you’d use instance fields in classes.
+ *
+ * @param initialValue the initial value to store in the ref object
  */
-export function useRef<T>(initialValue?: T | null): Ref<T>;
-
-/**
- * `useRef` without an initial value is the special case handling `ref` props.
- * If you want a non prop-based, mutable ref, you can explicitly give it an initial value of undefined/null/etc.
- * You should explicitly set the type parameter for the expected ref value to either a DOM Element like `HTMLInputElement` or a `Component`
- */
-export function useRef<T = unknown>(): PropRef<T>;
+export function useRef<T>(initialValue: null): RefObject<T>;
+export function useRef<T>(initialValue: T): Ref<T>;
+export function useRef<T>(): Ref<T | undefined>;
 
 type EffectCallback = () => void | (() => void);
 /**


### PR DESCRIPTION
Fix the `PropRef` typing in hooks to include the `undefined` type for the `current` property, as it will be undefined (at least) on initial render.

This was changed in https://github.com/preactjs/preact/pull/2803 when the `current` property was made non-optional, but it still needs to include the `undefined` type. The `current` property will always be `undefined` on initial render, for example:

```tsx
import {useRef} from 'preact/hooks';
​
function Test() {
  const ref = useRef<HTMLButtonElement>()
  console.log(ref.current.textContent) // oops
  return <button ref={ref}>Click</button>
}
```

This change made in this PR mirrors the corresponding override in the React typings:

```ts
function useRef<T = undefined>(): MutableRefObject<T | undefined>;
```

See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e47aff8a3a1331d0c540550db79dd5065ab735e5/types/react/index.d.ts#L1045