### PR TITLE
Use named export for esm compat/server

### DIFF
--- a/compat/server.js
+++ b/compat/server.js
@@ -1,15 +1,12 @@
 /* eslint-disable */
 var renderToString;
 try {
-	renderToString = dep(require('preact-render-to-string'));
+	const mod = require('preact-render-to-string');
+	renderToString = mod.default || mod.renderToString || mod;
 } catch (e) {
 	throw Error(
 		'renderToString() error: missing "preact-render-to-string" dependency.'
 	);
-}
-
-function dep(obj) {
-	return obj['default'] || obj;
 }
 
 module.exports = {

--- a/compat/server.mjs
+++ b/compat/server.mjs
@@ -1,1 +1,4 @@
-export { renderToString, renderToStaticMarkup } from 'preact-render-to-string';
+export {
+	renderToString,
+	renderToString as renderToStaticMarkup
+} from 'preact-render-to-string';


### PR DESCRIPTION
- Ensure that we do the `renderToString` -> `renderToStaticMarkup` aliasing only here in `compat/server`
- Keep backwards compat for older versions of `preact-render-to-string` where the module object was a function. Preferred way is to use `mod.renderToString`.

This PR is in preparation for https://github.com/preactjs/preact-render-to-string/pull/185