### PR TITLE
Only reposition Suspense children when suspending & improve suspending around Fragments

### DIFF
--- a/compat/src/internal.d.ts
+++ b/compat/src/internal.d.ts
@@ -55,5 +55,5 @@ export interface SuspenseComponent
 	extends Component<SuspenseProps, SuspenseState> {
 	_pendingSuspensionCount: number;
 	_suspenders: Component[];
-	_detachOnNextRender: null | Internal<any>;
+	_portalVNodeId: number | null;
 }

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -105,13 +105,7 @@ Suspense.prototype._childDidSuspend = function(promise, suspendingInternal) {
 
 			let suspended;
 			while ((suspended = c._suspenders.pop())) {
-				// TODO: If the component that suspended was hydrating, we remount the
-				// component so the component instance stored by Suspense is no longer
-				// valid. Likely needs to be fixed with backing nodes and a way to
-				// trigger a rerender for backing nodes
-				if (!(suspended._internal._flags & MODE_HYDRATE)) {
-					suspended.forceUpdate();
-				}
+				suspended.forceUpdate();
 			}
 		}
 	};

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -50,6 +50,8 @@ export function Suspense() {
 	this._suspenders = null;
 	/** @type {import('./internal').PreactElement} */
 	this._parentDom = null;
+	/** @type {number | null} */
+	this._portalVNodeId = null;
 }
 
 // Things we do here to save some bytes but are not proper JS inheritance:
@@ -149,7 +151,16 @@ Suspense.prototype.render = function(props, state) {
 	const fallback =
 		state._suspended && createElement(Fragment, null, props.fallback);
 
-	return [createPortal(props.children, this._parentDom), fallback];
+	const portal = createPortal(props.children, this._parentDom);
+	if (state._suspended) {
+		// If we are suspended, don't rerender all of the portal's children. Instead
+		// just reorder the Portal's children
+		portal._vnodeId = this._portalVNodeId;
+	} else {
+		this._portalVNodeId = portal._vnodeId;
+	}
+
+	return [portal, fallback];
 };
 
 /**

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -2225,4 +2225,60 @@ describe('suspense', () => {
 			);
 		});
 	});
+
+	it('should support mounting Suspense after initial render', () => {
+		const [Lazy, resolve] = createLazy();
+
+		function App({ mount }) {
+			return (
+				<Fragment>
+					<Fragment>
+						<div>0</div>
+					</Fragment>
+					{mount && (
+						<Suspense fallback={<div>Suspended...</div>}>
+							<Fragment>
+								<div>1</div>
+							</Fragment>
+							<Lazy />
+							<Fragment>
+								<div>2</div>
+							</Fragment>
+						</Suspense>
+					)}
+					<Fragment>
+						<div>3</div>
+					</Fragment>
+				</Fragment>
+			);
+		}
+
+		render(<App mount={false} />, scratch);
+		expect(scratch.innerHTML).to.equal([div(0), div(3)].join(''));
+
+		render(<App mount={true} />, scratch); // Render suspense
+		rerender(); // Render fallback
+		expect(scratch.innerHTML).to.equal(
+			[div(0), div('Suspended...'), div(3)].join('')
+		);
+
+		return resolve(() => (
+			<Fragment>
+				<div>resolved A</div>
+				<div>resolved B</div>
+			</Fragment>
+		)).then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.equal(
+				[
+					div(0),
+					div(1),
+					div('resolved A'),
+					div('resolved B'),
+					div(2),
+					div(3)
+				].join('')
+			);
+		});
+	});
 });

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -86,13 +86,13 @@ describe('suspense', () => {
 		// Re-render fallback cuz lazy threw
 		rerender();
 		expect(scratch.innerHTML).to.eql(`<div>Suspended...</div>`);
-		expect(Lazy).to.have.been.calledTwice;
+		expect(Lazy).to.have.been.calledOnce;
 
 		return resolve(LazyResult).then(() => {
 			// Re-render result
 			rerender();
 			expect(scratch.innerHTML).to.eql(`<div>Hello from LazyComp</div>`);
-			expect(Lazy).to.have.been.calledThrice;
+			expect(Lazy).to.have.been.calledTwice;
 		});
 	});
 
@@ -113,9 +113,8 @@ describe('suspense', () => {
 		const [resolve, _, Lazy] = suspend();
 		rerender();
 		expect(scratch.innerHTML).to.equal(`<div>Suspended...</div>`);
-		// Lazy is called once during the first render when it throws, and again
-		// when the fallback is rendered
-		expect(Lazy).to.have.been.calledTwice;
+		// Lazy is called once during the first render when it throws
+		expect(Lazy).to.have.been.calledOnce;
 
 		return resolve(() => (
 			<Fragment>
@@ -127,7 +126,7 @@ describe('suspense', () => {
 			expect(scratch.innerHTML).to.equal(
 				`<div>resolved 1</div><div>resolved 2</div>`
 			);
-			expect(Lazy).to.have.been.calledThrice;
+			expect(Lazy).to.have.been.calledTwice;
 		});
 	});
 
@@ -2256,7 +2255,7 @@ describe('suspense', () => {
 		render(<App mount={false} />, scratch);
 		expect(scratch.innerHTML).to.equal([div(0), div(3)].join(''));
 
-		render(<App mount={true} />, scratch); // Render suspense
+		render(<App mount />, scratch); // Render suspense
 		rerender(); // Render fallback
 		expect(scratch.innerHTML).to.equal(
 			[div(0), div('Suspended...'), div(3)].join('')

--- a/debug/test/browser/debug-suspense.test.js
+++ b/debug/test/browser/debug-suspense.test.js
@@ -106,8 +106,8 @@ describe('debug with suspense', () => {
 
 				return loader.then(() => {
 					rerender();
-					expect(console.warn).to.be.calledThrice;
-					expect(warnings[2].includes('MyLazyLoaded')).to.equal(true);
+					expect(console.warn).to.be.calledTwice;
+					expect(warnings[1].includes('MyLazyLoaded')).to.equal(true);
 					expect(serializeHtml(scratch)).to.equal('<div>Hi there</div>');
 				});
 			});
@@ -132,8 +132,8 @@ describe('debug with suspense', () => {
 
 				return loader.then(() => {
 					rerender();
-					expect(console.warn).to.be.calledThrice;
-					expect(warnings[2].includes('HelloLazy')).to.equal(true);
+					expect(console.warn).to.be.calledTwice;
+					expect(warnings[1].includes('HelloLazy')).to.equal(true);
 					expect(serializeHtml(scratch)).to.equal('<div>Hi there</div>');
 				});
 			});
@@ -161,7 +161,7 @@ describe('debug with suspense', () => {
 
 					// Called once on initial render, once when rendering the fallback,
 					// and again when promise rejects
-					expect(console.warn).to.be.calledThrice;
+					expect(console.warn).to.be.calledTwice;
 				});
 			});
 

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -61,6 +61,8 @@
   - Ensure all tree traversal functions handle root nodes with different
     parentDOM. For example, getChildDom & getDomSibling should skip over root
     nodes iif they have different parentDOMs.
+  - Remove TYPE_ROOT special handling in mountChildren/diffChildren related to
+    skipping set \_dom on parent Internals through Portal/root nodes
 - Fix Suspense tests:
   - "should correctly render nested Suspense components without intermediate DOM #2747"
 - Fix Suspense hydration tests:

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -37,11 +37,13 @@
 
 ## Suspense follow ups
 
-- Can we use vnode equality to avoid rerendering a tree that just suspended?
-  
-  Perhaps reuse the same Portal VNodeId from the render that suspended to avoid
-  rerendering the portals children. Though the setting up of the parentDOM logic
-  needs to happen before/after the bailout. We can't bailout of that logic.
+- Consider simply rerendering all Suspense children when one of its Promises
+  resolves. Might simplify the suspense tracking by avoiding the need to track
+  pendingSuspensionCount and suspenders list.
+
+  With the approach above, consider maybe syncing unsuspending on the
+  "nextFrame" to gather all Promises that resolved in this microtask/frame and
+  rerendering them in one pass
 
 ## Child diffing investigations
 

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -4,6 +4,21 @@
 
 - `[MAJOR]` Deprecated `component.base`
 
+## Root node follow ups
+
+- Add specific tests for root nodes
+  - initial mount with same/different parentDOM as parent
+  - mounting on rerender with same/different parentDOM as parent
+  - diffing with same/different parentDOM as parent (inert portal node & normal portal node)
+  - diffing and switching between same <-> different
+  - toggling siblings to root nodes with same/different parentDOM
+  - Ensure interesting sibling/children patterns
+    - text children and text siblings
+    - dom children and dom siblings
+    - null children and null siblings
+    - multiple Fragment children & multiple Fragment siblings
+  - Check out portals.test.js for inspiration
+
 ## Backing Node follow ups
 
 - Revisit `prevDom` code path for null placeholders
@@ -13,6 +28,12 @@
 - Rewrite commit loop to operate on internals not components
 - rewrite hooks to operate on internals?
 - Always assign a number to `_vnodeId` (not null, use 0 to clear?)
+- Consider converting Fragment (and other special nodes, e.g. root, Portal,
+  context?) to be numbers instead of functions with special diff handling
+  - One benefit of using numbers for Roots/Portals is that a portal could be
+    created with a `null` \_parentDOM prop and still be marked as a root type.
+    Particularly, this is useful for Suspense and would remove the need for the
+    call to `getParentDom` in `Suspense.render`
 
 ## Child diffing investigations
 
@@ -27,6 +48,9 @@
 ## TODOs
 
 - Consider further removing `_dom` pointers from non-dom VNodes
+  - Ensure all tree traversal functions handle root nodes with different
+    parentDOM. For example, getChildDom & getDomSibling should skip over root
+    nodes iif they have different parentDOMs.
 - Rewrite Suspense to use Root Nodes
 - Fix Suspense tests:
   - "should correctly render nested Suspense components without intermediate DOM #2747"

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -35,6 +35,14 @@
     Particularly, this is useful for Suspense and would remove the need for the
     call to `getParentDom` in `Suspense.render`
 
+## Suspense follow ups
+
+- Can we use vnode equality to avoid rerendering a tree that just suspended?
+  
+  Perhaps reuse the same Portal VNodeId from the render that suspended to avoid
+  rerendering the portals children. Though the setting up of the parentDOM logic
+  needs to happen before/after the bailout. We can't bailout of that logic.
+
 ## Child diffing investigations
 
 - Reduce allocations for text nodes

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -59,7 +59,6 @@
   - Ensure all tree traversal functions handle root nodes with different
     parentDOM. For example, getChildDom & getDomSibling should skip over root
     nodes iif they have different parentDOMs.
-- Rewrite Suspense to use Root Nodes
 - Fix Suspense tests:
   - "should correctly render nested Suspense components without intermediate DOM #2747"
 - Fix Suspense hydration tests:

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -165,6 +165,10 @@ export function diffChildren(
 		}
 
 		if (
+			// TODO: Revisit (remove?) this conditional block when we remove _dom
+			// pointers on component internals. Note, we only need to skip bubbling up
+			// newDom value if this root node/Portal introduces a new parentDom (i.e.
+			// newDom.parentNode !== parentDom)
 			childInternal._flags & TYPE_ROOT &&
 			(newDom == null || newDom.parentNode != parentDom)
 		) {

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -5,7 +5,8 @@ import {
 	TYPE_TEXT,
 	MODE_HYDRATE,
 	MODE_SUSPENDED,
-	EMPTY_ARR
+	EMPTY_ARR,
+	TYPE_ROOT
 } from '../constants';
 import { mount } from './mount';
 import { patch } from './patch';
@@ -163,7 +164,12 @@ export function diffChildren(
 			);
 		}
 
-		if (newDom != null) {
+		if (
+			childInternal._flags & TYPE_ROOT &&
+			(newDom == null || newDom.parentNode != parentDom)
+		) {
+			startDom = nextDomSibling;
+		} else if (newDom != null) {
 			if (firstChildDom == null) {
 				firstChildDom = newDom;
 			}

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -265,12 +265,6 @@ export function renderComponent(
 		// a new parentDom, we'll assume the root node moved oldStartDom under
 		// the new parentDom. Because of this change, we need to search the
 		// internal tree for the next DOM sibling the tree should begin with
-
-		// @TODO Hmmm here we are searching the internal before the newChildren are
-		// set on the internal, meaning if this root node is being mounted it won't
-		// find itself in the parent's array to begin searching siblings after
-		// itself... Think about if this could lead to bugs... Add tests for
-		// mounting Suspense after initial render?
 		return getDomSibling(internal);
 	}
 }

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -8,10 +8,8 @@ import {
 	DIRTY_BIT,
 	FORCE_UPDATE,
 	MODE_PENDING_ERROR,
-	MODE_RERENDERING_ERROR,
-	TYPE_ROOT
+	MODE_RERENDERING_ERROR
 } from '../constants';
-import { getDomSibling } from '../tree';
 
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
@@ -158,27 +156,6 @@ export function renderComponent(
 
 	if ((tmp = options._render)) tmp(internal);
 
-	// Root nodes signal that we attempt to render into a specific DOM node
-	// on the page. Root nodes can occur anywhere in the tree and not just
-	// at the top.
-	let oldStartDom = startDom;
-	let oldParentDom = parentDom;
-	if (internal._flags & TYPE_ROOT) {
-		parentDom = newProps._parentDom;
-
-		if (parentDom !== oldParentDom) {
-			if (internal && internal._dom) {
-				startDom = internal._dom;
-			}
-
-			// The `startDom` variable might point to a node from another
-			// tree from a previous render
-			if (startDom != null && startDom.parentNode !== parentDom) {
-				startDom = null;
-			}
-		}
-	}
-
 	internal._flags &= ~DIRTY_BIT;
 	c._internal = internal;
 
@@ -236,37 +213,7 @@ export function renderComponent(
 		commitQueue.push(c);
 	}
 
-	// Determine which dom node the diff should continue with. If we just finished
-	// diffing a root node and have a startDom from the tree above/around the root
-	// node (oldStartDom !== null), then we'll do a couple more check to determine
-	// the diff should resume.
-	if (!(internal._flags & TYPE_ROOT)) {
-		// This internal is not a Root/Portal so continue with the sibling returned
-		// by mount/diffChildren
-		return nextDomSibling;
-	} else if (oldStartDom == null) {
-		// We are diffing a root node that didn't have a startDom to begin with, so
-		// we can just return null
-		return oldStartDom;
-	} else if (oldParentDom == parentDom) {
-		// If the root node rendered into the same parent DOM as its parent
-		// tree, we'll just resume from the end of the root node as if nothing
-		// happened.
-		return nextDomSibling;
-	} else if (oldStartDom.parentNode == oldParentDom) {
-		// If the previous value for start dom still has the same parent DOM has
-		// the root node's parent tree, then we can use it. This case assumes
-		// the root node rendered its children into a new parent.
-		return oldStartDom;
-
-		// eslint-disable-next-line no-else-return
-	} else {
-		// Here, if the parentDoms are different and oldStartDom has moved into
-		// a new parentDom, we'll assume the root node moved oldStartDom under
-		// the new parentDom. Because of this change, we need to search the
-		// internal tree for the next DOM sibling the tree should begin with
-		return getDomSibling(internal);
-	}
+	return nextDomSibling;
 }
 
 /** The `.render()` method for a PFC backing instance. */

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -166,14 +166,16 @@ export function renderComponent(
 	if (internal._flags & TYPE_ROOT) {
 		parentDom = newProps._parentDom;
 
-		if (internal && internal._dom) {
-			startDom = internal._dom;
-		}
+		if (parentDom !== oldParentDom) {
+			if (internal && internal._dom) {
+				startDom = internal._dom;
+			}
 
-		// The `startDom` variable might point to a node from another
-		// tree from a previous render
-		if (startDom != null && startDom.parentNode !== parentDom) {
-			startDom = null;
+			// The `startDom` variable might point to a node from another
+			// tree from a previous render
+			if (startDom != null && startDom.parentNode !== parentDom) {
+				startDom = null;
+			}
 		}
 	}
 
@@ -264,13 +266,11 @@ export function renderComponent(
 		// the new parentDom. Because of this change, we need to search the
 		// internal tree for the next DOM sibling the tree should begin with
 
-		// @TODO Ensure there is suspense test with <Fragment><div><//> siblings
-		// around Suspense and suspender
-		//
-		// @TODO Hmmm here we are searching the internal before the newChildren
-		// are set on the internal, meaning if this root node is being mounted it
-		// won't find itself in the parent's array to begin searching siblings
-		// after itself... Think about if this could lead to bugs...
+		// @TODO Hmmm here we are searching the internal before the newChildren are
+		// set on the internal, meaning if this root node is being mounted it won't
+		// find itself in the parent's array to begin searching siblings after
+		// itself... Think about if this could lead to bugs... Add tests for
+		// mounting Suspense after initial render?
 		return getDomSibling(internal);
 	}
 }

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -7,7 +7,8 @@ import {
 	MODE_SUSPENDED,
 	RESET_MODE,
 	TYPE_TEXT,
-	MODE_ERRORED
+	MODE_ERRORED,
+	TYPE_ROOT
 } from '../constants';
 import { normalizeToVNode } from '../create-element';
 import { setProperty } from './props';
@@ -266,7 +267,10 @@ export function mountChildren(
 		newDom = childInternal._dom;
 
 		if (newDom != null) {
-			if (firstChildDom == null) {
+			if (
+				firstChildDom == null &&
+				(!(childInternal._flags & TYPE_ROOT) || newDom.parentNode == parentDom)
+			) {
 				firstChildDom = newDom;
 			}
 

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -291,6 +291,10 @@ export function mountChildren(
 		if (newDom != null) {
 			if (
 				firstChildDom == null &&
+				// TODO: Revisit (remove?) this condition when we remove _dom pointers
+				// on component internals. Note, the parentNode == parentDom check is
+				// cuz if this Portal is a passthrough (_parentDom prop matches
+				// parentDom) then we should look at the dom it returns and bubble it up
 				(!(childInternal._flags & TYPE_ROOT) || newDom.parentNode == parentDom)
 			) {
 				firstChildDom = newDom;

--- a/src/tree.js
+++ b/src/tree.js
@@ -123,7 +123,10 @@ export function getDomSibling(internal, childIndex) {
  * @param {import('./internal').Internal} internal
  */
 export function updateParentDomPointers(internal) {
-	if ((internal = internal._parent) != null && internal._component != null) {
+	if (
+		(internal = internal._parent) != null &&
+		internal._flags & TYPE_COMPONENT
+	) {
 		internal._dom = null;
 		for (let i = 0; i < internal._children.length; i++) {
 			let child = internal._children[i];
@@ -133,7 +136,9 @@ export function updateParentDomPointers(internal) {
 			}
 		}
 
-		return updateParentDomPointers(internal);
+		if (!(internal._flags & TYPE_ROOT)) {
+			return updateParentDomPointers(internal);
+		}
 	}
 }
 


### PR DESCRIPTION
In #3053, upon suspending, all the children under the Suspense's portal were rerendered. This PR changes that behavior such that the children under Suspense's Portal no longer rerender when they are suspended. Instead, the Portal's previous VNode ID is reused just causing this children to be re-positioned under the Portal's parentDOM. This change requires moving the root node `startDom` handling outside of `renderComponent` so that it still happens even when a Portal's VNode ID is the same.

This change also improves handling Suspense in and around Fragments. The biggest fix is just making sure that a Portal's (or root node's) `_dom` pointer doesn't bubble up to its parent Internals when it has a different `parentDom` pointer. Those little special `if` conditionals will hopefully go away when we stop bubbling `_dom` pointer up the tree through component Internals.

Also, re-enabled the suspense hydration around `sCU` components since backing tree enables this to just work.

