### PR TITLE
fix: make typings deno compatible

### DIFF
--- a/compat/src/suspense-list.d.ts
+++ b/compat/src/suspense-list.d.ts
@@ -1,11 +1,11 @@
-import { Component, ComponentChild } from '../../src';
+import { Component, ComponentChild, ComponentChildren } from '../../src';
 
 //
 // SuspenseList
 // -----------------------------------
 
 export interface SuspenseListProps {
-	children?: preact.ComponentChildren;
+	children?: ComponentChildren;
 	revealOrder?: 'forwards' | 'backwards' | 'together';
 }
 

--- a/compat/src/suspense.d.ts
+++ b/compat/src/suspense.d.ts
@@ -1,4 +1,4 @@
-import { Component, ComponentChild } from '../../src';
+import { Component, ComponentChild, ComponentChildren } from '../../src';
 
 //
 // Suspense/lazy
@@ -6,8 +6,8 @@ import { Component, ComponentChild } from '../../src';
 export function lazy<T>(loader: () => Promise<{ default: T }>): T;
 
 export interface SuspenseProps {
-	children?: preact.ComponentChildren;
-	fallback: preact.ComponentChildren;
+	children?: ComponentChildren;
+	fallback: ComponentChildren;
 }
 
 export class Suspense extends Component<SuspenseProps> {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,310 +1,310 @@
-export = preact;
 export as namespace preact;
 
 import { JSXInternal } from './jsx';
 
-declare namespace preact {
-	export import JSX = JSXInternal;
+export import JSX = JSXInternal;
 
-	//
-	// Preact Virtual DOM
-	// -----------------------------------
+//
+// Preact Virtual DOM
+// -----------------------------------
 
-	interface VNode<P = {}> {
-		type: ComponentType<P> | string;
-		props: P & { children: ComponentChildren };
-		key: Key;
-		/**
-		 * ref is not guaranteed by React.ReactElement, for compatibility reasons
-		 * with popular react libs we define it as optional too
-		 */
-		ref?: Ref<any> | null;
-		/**
-		 * The time this `vnode` started rendering. Will only be set when
-		 * the devtools are attached.
-		 * Default value: `0`
-		 */
-		startTime?: number;
-		/**
-		 * The time that the rendering of this `vnode` was completed. Will only be
-		 * set when the devtools are attached.
-		 * Default value: `-1`
-		 */
-		endTime?: number;
-	}
-
-	//
-	// Preact Component interface
-	// -----------------------------------
-
-	type Key = string | number | any;
-
-	type RefObject<T> = { current: T | null };
-	type RefCallback<T> = (instance: T | null) => void;
-	type Ref<T> = RefObject<T> | RefCallback<T>;
-
-	type ComponentChild =
-		| VNode<any>
-		| object
-		| string
-		| number
-		| bigint
-		| boolean
-		| null
-		| undefined;
-	type ComponentChildren = ComponentChild[] | ComponentChild;
-
-	interface Attributes {
-		key?: Key;
-		jsx?: boolean;
-	}
-
-	interface ClassAttributes<T> extends Attributes {
-		ref?: Ref<T>;
-	}
-
-	interface PreactDOMAttributes {
-		children?: ComponentChildren;
-		dangerouslySetInnerHTML?: {
-			__html: string;
-		};
-	}
-
-	type RenderableProps<P, RefType = any> = P &
-		Readonly<Attributes & { children?: ComponentChildren; ref?: Ref<RefType> }>;
-
-	type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
-	type ComponentFactory<P = {}> = ComponentType<P>;
-
-	type ComponentProps<
-		C extends ComponentType<any> | keyof JSXInternal.IntrinsicElements
-	> = C extends ComponentType<infer P>
-		? P
-		: C extends keyof JSXInternal.IntrinsicElements
-		? JSXInternal.IntrinsicElements[C]
-		: never;
-
-	interface FunctionComponent<P = {}> {
-		(props: RenderableProps<P>, context?: any): VNode<any> | null;
-		displayName?: string;
-		defaultProps?: Partial<P>;
-	}
-	interface FunctionalComponent<P = {}> extends FunctionComponent<P> {}
-
-	interface ComponentClass<P = {}, S = {}> {
-		new (props: P, context?: any): Component<P, S>;
-		displayName?: string;
-		defaultProps?: Partial<P>;
-		contextType?: Context<any>;
-		getDerivedStateFromProps?(
-			props: Readonly<P>,
-			state: Readonly<S>
-		): Partial<S> | null;
-		getDerivedStateFromError?(error: any): Partial<S> | null;
-	}
-	interface ComponentConstructor<P = {}, S = {}> extends ComponentClass<P, S> {}
-
-	// Type alias for a component instance considered generally, whether stateless or stateful.
-	type AnyComponent<P = {}, S = {}> = FunctionComponent<P> | Component<P, S>;
-
-	interface Component<P = {}, S = {}> {
-		componentWillMount?(): void;
-		componentDidMount?(): void;
-		componentWillUnmount?(): void;
-		getChildContext?(): object;
-		componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;
-		shouldComponentUpdate?(
-			nextProps: Readonly<P>,
-			nextState: Readonly<S>,
-			nextContext: any
-		): boolean;
-		componentWillUpdate?(
-			nextProps: Readonly<P>,
-			nextState: Readonly<S>,
-			nextContext: any
-		): void;
-		getSnapshotBeforeUpdate?(oldProps: Readonly<P>, oldState: Readonly<S>): any;
-		componentDidUpdate?(
-			previousProps: Readonly<P>,
-			previousState: Readonly<S>,
-			snapshot: any
-		): void;
-		componentDidCatch?(error: any, errorInfo: any): void;
-	}
-
-	abstract class Component<P, S> {
-		constructor(props?: P, context?: any);
-
-		static displayName?: string;
-		static defaultProps?: any;
-		static contextType?: Context<any>;
-
-		// Static members cannot reference class type parameters. This is not
-		// supported in TypeScript. Reusing the same type arguments from `Component`
-		// will lead to an impossible state where one cannot satisfy the type
-		// constraint under no circumstances, see #1356.In general type arguments
-		// seem to be a bit buggy and not supported well at the time of this
-		// writing with TS 3.3.3333.
-		static getDerivedStateFromProps?(
-			props: Readonly<object>,
-			state: Readonly<object>
-		): object | null;
-		static getDerivedStateFromError?(error: any): object | null;
-
-		state: Readonly<S>;
-		props: RenderableProps<P>;
-		context: any;
-		base?: Element | Text;
-
-		// From https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e836acc75a78cf0655b5dfdbe81d69fdd4d8a252/types/react/index.d.ts#L402
-		// // We MUST keep setState() as a unified signature because it allows proper checking of the method return type.
-		// // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
-		setState<K extends keyof S>(
-			state:
-				| ((
-						prevState: Readonly<S>,
-						props: Readonly<P>
-				  ) => Pick<S, K> | Partial<S> | null)
-				| (Pick<S, K> | Partial<S> | null),
-			callback?: () => void
-		): void;
-
-		forceUpdate(callback?: () => void): void;
-
-		abstract render(
-			props?: RenderableProps<P>,
-			state?: Readonly<S>,
-			context?: any
-		): ComponentChild;
-	}
-
-	//
-	// Preact createElement
-	// -----------------------------------
-
-	function createElement(
-		type: string,
-		props:
-			| (JSXInternal.HTMLAttributes &
-					JSXInternal.SVGAttributes &
-					Record<string, any>)
-			| null,
-		...children: ComponentChildren[]
-	): VNode<any>;
-	function createElement<P>(
-		type: ComponentType<P>,
-		props: (Attributes & P) | null,
-		...children: ComponentChildren[]
-	): VNode<any>;
-	namespace createElement {
-		export import JSX = JSXInternal;
-	}
-
-	function h(
-		type: string,
-		props:
-			| (JSXInternal.HTMLAttributes &
-					JSXInternal.SVGAttributes &
-					Record<string, any>)
-			| null,
-		...children: ComponentChildren[]
-	): VNode<any>;
-	function h<P>(
-		type: ComponentType<P>,
-		props: (Attributes & P) | null,
-		...children: ComponentChildren[]
-	): VNode<any>;
-	namespace h {
-		export import JSX = JSXInternal;
-	}
-
-	//
-	// Preact render
-	// -----------------------------------
-
-	function render(
-		vnode: ComponentChild,
-		parent: Element | Document | ShadowRoot | DocumentFragment,
-		replaceNode?: Element | Text
-	): void;
-	function hydrate(
-		vnode: ComponentChild,
-		parent: Element | Document | ShadowRoot | DocumentFragment
-	): void;
-	function cloneElement(
-		vnode: VNode<any>,
-		props?: any,
-		...children: ComponentChildren[]
-	): VNode<any>;
-	function cloneElement<P>(
-		vnode: VNode<P>,
-		props?: any,
-		...children: ComponentChildren[]
-	): VNode<P>;
-
-	//
-	// Preact Built-in Components
-	// -----------------------------------
-
-	// TODO: Revisit what the public type of this is...
-	const Fragment: ComponentClass<{}, {}>;
-
-	//
-	// Preact options
-	// -----------------------------------
-
+export interface VNode<P = {}> {
+	type: ComponentType<P> | string;
+	props: P & { children: ComponentChildren };
+	key: Key;
 	/**
-	 * Global options for preact
+	 * ref is not guaranteed by React.ReactElement, for compatibility reasons
+	 * with popular react libs we define it as optional too
 	 */
-	interface Options {
-		/** Attach a hook that is invoked whenever a VNode is created. */
-		vnode?(vnode: VNode): void;
-		/** Attach a hook that is invoked immediately before a vnode is unmounted. */
-		unmount?(vnode: VNode): void;
-		/** Attach a hook that is invoked after a vnode has rendered. */
-		diffed?(vnode: VNode): void;
-		event?(e: Event): any;
-		requestAnimationFrame?: typeof requestAnimationFrame;
-		debounceRendering?(cb: () => void): void;
-		useDebugValue?(value: string | number): void;
-		_addHookName?(name: string | number): void;
-		__suspenseDidResolve?(vnode: VNode, cb: () => void): void;
-		// __canSuspenseResolve?(vnode: VNode, cb: () => void): void;
-	}
-
-	const options: Options;
-
-	//
-	// Preact helpers
-	// -----------------------------------
-	function createRef<T = any>(): RefObject<T>;
-	function toChildArray(
-		children: ComponentChildren
-	): Array<VNode | string | number>;
-	function isValidElement(vnode: any): vnode is VNode;
-
-	//
-	// Context
-	// -----------------------------------
-	interface Consumer<T>
-		extends FunctionComponent<{
-			children: (value: T) => ComponentChildren;
-		}> {}
-	interface PreactConsumer<T> extends Consumer<T> {}
-
-	interface Provider<T>
-		extends FunctionComponent<{
-			value: T;
-			children: ComponentChildren;
-		}> {}
-	interface PreactProvider<T> extends Provider<T> {}
-
-	interface Context<T> {
-		Consumer: Consumer<T>;
-		Provider: Provider<T>;
-		displayName?: string;
-	}
-	interface PreactContext<T> extends Context<T> {}
-
-	function createContext<T>(defaultValue: T): Context<T>;
+	ref?: Ref<any> | null;
+	/**
+	 * The time this `vnode` started rendering. Will only be set when
+	 * the devtools are attached.
+	 * Default value: `0`
+	 */
+	startTime?: number;
+	/**
+	 * The time that the rendering of this `vnode` was completed. Will only be
+	 * set when the devtools are attached.
+	 * Default value: `-1`
+	 */
+	endTime?: number;
 }
+
+//
+// Preact Component interface
+// -----------------------------------
+
+export type Key = string | number | any;
+
+export type RefObject<T> = { current: T | null };
+export type RefCallback<T> = (instance: T | null) => void;
+export type Ref<T> = RefObject<T> | RefCallback<T>;
+
+export type ComponentChild =
+	| VNode<any>
+	| object
+	| string
+	| number
+	| bigint
+	| boolean
+	| null
+	| undefined;
+export type ComponentChildren = ComponentChild[] | ComponentChild;
+
+export interface Attributes {
+	key?: Key;
+	jsx?: boolean;
+}
+
+export interface ClassAttributes<T> extends Attributes {
+	ref?: Ref<T>;
+}
+
+export interface PreactDOMAttributes {
+	children?: ComponentChildren;
+	dangerouslySetInnerHTML?: {
+		__html: string;
+	};
+}
+
+export type RenderableProps<P, RefType = any> = P &
+	Readonly<Attributes & { children?: ComponentChildren; ref?: Ref<RefType> }>;
+
+export type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
+export type ComponentFactory<P = {}> = ComponentType<P>;
+
+export type ComponentProps<
+	C extends ComponentType<any> | keyof JSXInternal.IntrinsicElements
+> = C extends ComponentType<infer P>
+	? P
+	: C extends keyof JSXInternal.IntrinsicElements
+	? JSXInternal.IntrinsicElements[C]
+	: never;
+
+export interface FunctionComponent<P = {}> {
+	(props: RenderableProps<P>, context?: any): VNode<any> | null;
+	displayName?: string;
+	defaultProps?: Partial<P>;
+}
+export interface FunctionalComponent<P = {}> extends FunctionComponent<P> {}
+
+export interface ComponentClass<P = {}, S = {}> {
+	new (props: P, context?: any): Component<P, S>;
+	displayName?: string;
+	defaultProps?: Partial<P>;
+	contextType?: Context<any>;
+	getDerivedStateFromProps?(
+		props: Readonly<P>,
+		state: Readonly<S>
+	): Partial<S> | null;
+	getDerivedStateFromError?(error: any): Partial<S> | null;
+}
+export interface ComponentConstructor<P = {}, S = {}>
+	extends ComponentClass<P, S> {}
+
+// Type alias for a component instance considered generally, whether stateless or stateful.
+export type AnyComponent<P = {}, S = {}> =
+	| FunctionComponent<P>
+	| Component<P, S>;
+
+export interface Component<P = {}, S = {}> {
+	componentWillMount?(): void;
+	componentDidMount?(): void;
+	componentWillUnmount?(): void;
+	getChildContext?(): object;
+	componentWillReceiveProps?(nextProps: Readonly<P>, nextContext: any): void;
+	shouldComponentUpdate?(
+		nextProps: Readonly<P>,
+		nextState: Readonly<S>,
+		nextContext: any
+	): boolean;
+	componentWillUpdate?(
+		nextProps: Readonly<P>,
+		nextState: Readonly<S>,
+		nextContext: any
+	): void;
+	getSnapshotBeforeUpdate?(oldProps: Readonly<P>, oldState: Readonly<S>): any;
+	componentDidUpdate?(
+		previousProps: Readonly<P>,
+		previousState: Readonly<S>,
+		snapshot: any
+	): void;
+	componentDidCatch?(error: any, errorInfo: any): void;
+}
+
+export abstract class Component<P, S> {
+	constructor(props?: P, context?: any);
+
+	static displayName?: string;
+	static defaultProps?: any;
+	static contextType?: Context<any>;
+
+	// Static members cannot reference class type parameters. This is not
+	// supported in TypeScript. Reusing the same type arguments from `Component`
+	// will lead to an impossible state where one cannot satisfy the type
+	// constraint under no circumstances, see #1356.In general type arguments
+	// seem to be a bit buggy and not supported well at the time of this
+	// writing with TS 3.3.3333.
+	static getDerivedStateFromProps?(
+		props: Readonly<object>,
+		state: Readonly<object>
+	): object | null;
+	static getDerivedStateFromError?(error: any): object | null;
+
+	state: Readonly<S>;
+	props: RenderableProps<P>;
+	context: any;
+	base?: Element | Text;
+
+	// From https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e836acc75a78cf0655b5dfdbe81d69fdd4d8a252/types/react/index.d.ts#L402
+	// // We MUST keep setState() as a unified signature because it allows proper checking of the method return type.
+	// // See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18365#issuecomment-351013257
+	setState<K extends keyof S>(
+		state:
+			| ((
+					prevState: Readonly<S>,
+					props: Readonly<P>
+			  ) => Pick<S, K> | Partial<S> | null)
+			| (Pick<S, K> | Partial<S> | null),
+		callback?: () => void
+	): void;
+
+	forceUpdate(callback?: () => void): void;
+
+	abstract render(
+		props?: RenderableProps<P>,
+		state?: Readonly<S>,
+		context?: any
+	): ComponentChild;
+}
+
+//
+// Preact createElement
+// -----------------------------------
+
+export function createElement(
+	type: string,
+	props:
+		| (JSXInternal.HTMLAttributes &
+				JSXInternal.SVGAttributes &
+				Record<string, any>)
+		| null,
+	...children: ComponentChildren[]
+): VNode<any>;
+export function createElement<P>(
+	type: ComponentType<P>,
+	props: (Attributes & P) | null,
+	...children: ComponentChildren[]
+): VNode<any>;
+export namespace createElement {
+	export import JSX = JSXInternal;
+}
+
+export function h(
+	type: string,
+	props:
+		| (JSXInternal.HTMLAttributes &
+				JSXInternal.SVGAttributes &
+				Record<string, any>)
+		| null,
+	...children: ComponentChildren[]
+): VNode<any>;
+export function h<P>(
+	type: ComponentType<P>,
+	props: (Attributes & P) | null,
+	...children: ComponentChildren[]
+): VNode<any>;
+export namespace h {
+	export import JSX = JSXInternal;
+}
+
+//
+// Preact render
+// -----------------------------------
+
+export function render(
+	vnode: ComponentChild,
+	parent: Element | Document | ShadowRoot | DocumentFragment,
+	replaceNode?: Element | Text
+): void;
+export function hydrate(
+	vnode: ComponentChild,
+	parent: Element | Document | ShadowRoot | DocumentFragment
+): void;
+export function cloneElement(
+	vnode: VNode<any>,
+	props?: any,
+	...children: ComponentChildren[]
+): VNode<any>;
+export function cloneElement<P>(
+	vnode: VNode<P>,
+	props?: any,
+	...children: ComponentChildren[]
+): VNode<P>;
+
+//
+// Preact Built-in Components
+// -----------------------------------
+
+// TODO: Revisit what the public type of this is...
+export const Fragment: ComponentClass<{}, {}>;
+
+//
+// Preact options
+// -----------------------------------
+
+/**
+ * Global options for preact
+ */
+export interface Options {
+	/** Attach a hook that is invoked whenever a VNode is created. */
+	vnode?(vnode: VNode): void;
+	/** Attach a hook that is invoked immediately before a vnode is unmounted. */
+	unmount?(vnode: VNode): void;
+	/** Attach a hook that is invoked after a vnode has rendered. */
+	diffed?(vnode: VNode): void;
+	event?(e: Event): any;
+	requestAnimationFrame?: typeof requestAnimationFrame;
+	debounceRendering?(cb: () => void): void;
+	useDebugValue?(value: string | number): void;
+	_addHookName?(name: string | number): void;
+	__suspenseDidResolve?(vnode: VNode, cb: () => void): void;
+	// __canSuspenseResolve?(vnode: VNode, cb: () => void): void;
+}
+
+export const options: Options;
+
+//
+// Preact helpers
+// -----------------------------------
+export function createRef<T = any>(): RefObject<T>;
+export function toChildArray(
+	children: ComponentChildren
+): Array<VNode | string | number>;
+export function isValidElement(vnode: any): vnode is VNode;
+
+//
+// Context
+// -----------------------------------
+export interface Consumer<T>
+	extends FunctionComponent<{
+		children: (value: T) => ComponentChildren;
+	}> {}
+export interface PreactConsumer<T> extends Consumer<T> {}
+
+export interface Provider<T>
+	extends FunctionComponent<{
+		value: T;
+		children: ComponentChildren;
+	}> {}
+export interface PreactProvider<T> extends Provider<T> {}
+
+export interface Context<T> {
+	Consumer: Consumer<T>;
+	Provider: Provider<T>;
+	displayName?: string;
+}
+export interface PreactContext<T> extends Context<T> {}
+
+export function createContext<T>(defaultValue: T): Context<T>;

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1,38 +1,44 @@
 // Users who only use Preact for SSR might not specify "dom" in their lib in tsconfig.json
 /// <reference lib="dom" />
 
+import {
+	ClassAttributes,
+	Component,
+	PreactDOMAttributes,
+	VNode
+} from './index';
+
 type Defaultize<Props, Defaults> =
 	// Distribute over unions
 	Props extends any // Make any properties included in Default optional
-		? Partial<Pick<Props, Extract<keyof Props, keyof Defaults>>> &
-				// Include the remaining properties from Props
+		? Partial<Pick<Props, Extract<keyof Props, keyof Defaults>>> & // Include the remaining properties from Props
 				Pick<Props, Exclude<keyof Props, keyof Defaults>>
 		: never;
 
 export namespace JSXInternal {
-	type LibraryManagedAttributes<Component, Props> = Component extends {
+	export type LibraryManagedAttributes<Component, Props> = Component extends {
 		defaultProps: infer Defaults;
 	}
 		? Defaultize<Props, Defaults>
 		: Props;
 
-	interface IntrinsicAttributes {
+	export interface IntrinsicAttributes {
 		key?: any;
 	}
 
-	interface Element extends preact.VNode<any> {}
+	export interface Element extends VNode<any> {}
 
-	interface ElementClass extends preact.Component<any, any> {}
+	export interface ElementClass extends Component<any, any> {}
 
-	interface ElementAttributesProperty {
+	export interface ElementAttributesProperty {
 		props: any;
 	}
 
-	interface ElementChildrenAttribute {
+	export interface ElementChildrenAttribute {
 		children: any;
 	}
 
-	type DOMCSSProperties = {
+	export type DOMCSSProperties = {
 		[key in keyof Omit<
 			CSSStyleDeclaration,
 			| 'item'
@@ -42,14 +48,14 @@ export namespace JSXInternal {
 			| 'getPropertyPriority'
 		>]?: string | number | null | undefined;
 	};
-	type AllCSSProperties = {
+	export type AllCSSProperties = {
 		[key: string]: string | number | null | undefined;
 	};
-	interface CSSProperties extends AllCSSProperties, DOMCSSProperties {
+	export interface CSSProperties extends AllCSSProperties, DOMCSSProperties {
 		cssText?: string | null;
 	}
 
-	interface SVGAttributes<Target extends EventTarget = SVGElement>
+	export interface SVGAttributes<Target extends EventTarget = SVGElement>
 		extends HTMLAttributes<Target> {
 		accentHeight?: number | string;
 		accumulate?: 'none' | 'sum';
@@ -305,67 +311,63 @@ export namespace JSXInternal {
 		zoomAndPan?: string;
 	}
 
-	interface PathAttributes {
+	export interface PathAttributes {
 		d: string;
 	}
 
-	type TargetedEvent<
+	export type TargetedEvent<
 		Target extends EventTarget = EventTarget,
 		TypedEvent extends Event = Event
 	> = Omit<TypedEvent, 'currentTarget'> & {
 		readonly currentTarget: Target;
 	};
 
-	type TargetedAnimationEvent<Target extends EventTarget> = TargetedEvent<
-		Target,
-		AnimationEvent
-	>;
-	type TargetedClipboardEvent<Target extends EventTarget> = TargetedEvent<
-		Target,
-		ClipboardEvent
-	>;
-	type TargetedCompositionEvent<Target extends EventTarget> = TargetedEvent<
-		Target,
-		CompositionEvent
-	>;
-	type TargetedDragEvent<Target extends EventTarget> = TargetedEvent<
+	export type TargetedAnimationEvent<
+		Target extends EventTarget
+	> = TargetedEvent<Target, AnimationEvent>;
+	export type TargetedClipboardEvent<
+		Target extends EventTarget
+	> = TargetedEvent<Target, ClipboardEvent>;
+	export type TargetedCompositionEvent<
+		Target extends EventTarget
+	> = TargetedEvent<Target, CompositionEvent>;
+	export type TargetedDragEvent<Target extends EventTarget> = TargetedEvent<
 		Target,
 		DragEvent
 	>;
-	type TargetedFocusEvent<Target extends EventTarget> = TargetedEvent<
+	export type TargetedFocusEvent<Target extends EventTarget> = TargetedEvent<
 		Target,
 		FocusEvent
 	>;
-	type TargetedKeyboardEvent<Target extends EventTarget> = TargetedEvent<
+	export type TargetedKeyboardEvent<Target extends EventTarget> = TargetedEvent<
 		Target,
 		KeyboardEvent
 	>;
-	type TargetedMouseEvent<Target extends EventTarget> = TargetedEvent<
+	export type TargetedMouseEvent<Target extends EventTarget> = TargetedEvent<
 		Target,
 		MouseEvent
 	>;
-	type TargetedPointerEvent<Target extends EventTarget> = TargetedEvent<
+	export type TargetedPointerEvent<Target extends EventTarget> = TargetedEvent<
 		Target,
 		PointerEvent
 	>;
-	type TargetedTouchEvent<Target extends EventTarget> = TargetedEvent<
+	export type TargetedTouchEvent<Target extends EventTarget> = TargetedEvent<
 		Target,
 		TouchEvent
 	>;
-	type TargetedTransitionEvent<Target extends EventTarget> = TargetedEvent<
-		Target,
-		TransitionEvent
-	>;
-	type TargetedUIEvent<Target extends EventTarget> = TargetedEvent<
+	export type TargetedTransitionEvent<
+		Target extends EventTarget
+	> = TargetedEvent<Target, TransitionEvent>;
+	export type TargetedUIEvent<Target extends EventTarget> = TargetedEvent<
 		Target,
 		UIEvent
 	>;
-	type TargetedWheelEvent<Target extends EventTarget> = TargetedEvent<
+	export type TargetedWheelEvent<Target extends EventTarget> = TargetedEvent<
 		Target,
 		WheelEvent
 	>;
 
-	interface EventHandler<E extends TargetedEvent> {
+	export interface EventHandler<E extends TargetedEvent> {
 		/**
 		 * The `this` keyword always points to the DOM element the event handler
 		 * was invoked on. See: https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Event_handlers#Event_handlers_parameters_this_binding_and_the_return_value
@@ -373,48 +375,48 @@ export namespace JSXInternal {
 		(this: E['currentTarget'], event: E): void;
 	}
 
-	type AnimationEventHandler<Target extends EventTarget> = EventHandler<
+	export type AnimationEventHandler<Target extends EventTarget> = EventHandler<
 		TargetedAnimationEvent<Target>
 	>;
-	type ClipboardEventHandler<Target extends EventTarget> = EventHandler<
+	export type ClipboardEventHandler<Target extends EventTarget> = EventHandler<
 		TargetedClipboardEvent<Target>
 	>;
-	type CompositionEventHandler<Target extends EventTarget> = EventHandler<
-		TargetedCompositionEvent<Target>
-	>;
-	type DragEventHandler<Target extends EventTarget> = EventHandler<
+	export type CompositionEventHandler<
+		Target extends EventTarget
+	> = EventHandler<TargetedCompositionEvent<Target>>;
+	export type DragEventHandler<Target extends EventTarget> = EventHandler<
 		TargetedDragEvent<Target>
 	>;
-	type FocusEventHandler<Target extends EventTarget> = EventHandler<
+	export type FocusEventHandler<Target extends EventTarget> = EventHandler<
 		TargetedFocusEvent<Target>
 	>;
-	type GenericEventHandler<Target extends EventTarget> = EventHandler<
+	export type GenericEventHandler<Target extends EventTarget> = EventHandler<
 		TargetedEvent<Target>
 	>;
-	type KeyboardEventHandler<Target extends EventTarget> = EventHandler<
+	export type KeyboardEventHandler<Target extends EventTarget> = EventHandler<
 		TargetedKeyboardEvent<Target>
 	>;
-	type MouseEventHandler<Target extends EventTarget> = EventHandler<
+	export type MouseEventHandler<Target extends EventTarget> = EventHandler<
 		TargetedMouseEvent<Target>
 	>;
-	type PointerEventHandler<Target extends EventTarget> = EventHandler<
+	export type PointerEventHandler<Target extends EventTarget> = EventHandler<
 		TargetedPointerEvent<Target>
 	>;
-	type TouchEventHandler<Target extends EventTarget> = EventHandler<
+	export type TouchEventHandler<Target extends EventTarget> = EventHandler<
 		TargetedTouchEvent<Target>
 	>;
-	type TransitionEventHandler<Target extends EventTarget> = EventHandler<
+	export type TransitionEventHandler<Target extends EventTarget> = EventHandler<
 		TargetedTransitionEvent<Target>
 	>;
-	type UIEventHandler<Target extends EventTarget> = EventHandler<
+	export type UIEventHandler<Target extends EventTarget> = EventHandler<
 		TargetedUIEvent<Target>
 	>;
-	type WheelEventHandler<Target extends EventTarget> = EventHandler<
+	export type WheelEventHandler<Target extends EventTarget> = EventHandler<
 		TargetedWheelEvent<Target>
 	>;
 
-	interface DOMAttributes<Target extends EventTarget>
-		extends preact.PreactDOMAttributes {
+	export interface DOMAttributes<Target extends EventTarget>
+		extends PreactDOMAttributes {
 		// Image Events
 		onLoad?: GenericEventHandler<Target>;
 		onLoadCapture?: GenericEventHandler<Target>;
@@ -611,8 +613,8 @@ export namespace JSXInternal {
 		onTransitionEndCapture?: TransitionEventHandler<Target>;
 	}
 
-	interface HTMLAttributes<RefType extends EventTarget = EventTarget>
-		extends preact.ClassAttributes<RefType>,
+	export interface HTMLAttributes<RefType extends EventTarget = EventTarget>
+		extends ClassAttributes<RefType>,
 			DOMAttributes<RefType> {
 		// Standard HTML Attributes
 		accept?: string;
@@ -769,7 +771,7 @@ export namespace JSXInternal {
 		itemRef?: string;
 	}
 
-	interface HTMLMarqueeElement extends HTMLElement {
+	export interface HTMLMarqueeElement extends HTMLElement {
 		behavior?: 'scroll' | 'slide' | 'alternate';
 		bgColor?: string;
 		direction?: 'left' | 'right' | 'up' | 'down';
@@ -783,7 +785,7 @@ export namespace JSXInternal {
 		width?: number | string;
 	}
 
-	interface IntrinsicElements {
+	export interface IntrinsicElements {
 		// HTML
 		a: HTMLAttributes<HTMLAnchorElement>;
 		abbr: HTMLAttributes<HTMLElement>;

--- a/test/ts/preact-global-test.tsx
+++ b/test/ts/preact-global-test.tsx
@@ -1,0 +1,6 @@
+import { createElement } from '../../src';
+
+// Test that preact types are available via the global `preact` namespace.
+
+let component: preact.ComponentChild;
+component = <div>Hello World</div>;


### PR DESCRIPTION
This commit changes the types to use ESM d.ts files intead of UMD/global
files. Added an additional test to validate that the global `preact`
Typescript namespace is still present.

Fixes #3075
