### PR TITLE
Move render callbacks to Internals

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -61,13 +61,13 @@ options.diffed = internal => {
 options._commit = (internal, commitQueue) => {
 	commitQueue.some(component => {
 		try {
-			component._renderCallbacks.forEach(invokeCleanup);
-			component._renderCallbacks = component._renderCallbacks.filter(cb =>
+			component._commitCallbacks.forEach(invokeCleanup);
+			component._commitCallbacks = component._commitCallbacks.filter(cb =>
 				cb._value ? invokeEffect(cb) : true
 			);
 		} catch (e) {
 			commitQueue.some(c => {
-				if (c._renderCallbacks) c._renderCallbacks = [];
+				if (c._commitCallbacks) c._commitCallbacks = [];
 			});
 			commitQueue = [];
 			options._catchError(e, component._internal);
@@ -183,7 +183,7 @@ export function useLayoutEffect(callback, args) {
 		state._value = callback;
 		state._args = args;
 
-		currentComponent._renderCallbacks.push(state);
+		currentComponent._commitCallbacks.push(state);
 	}
 }
 

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -59,18 +59,18 @@ options.diffed = internal => {
 };
 
 options._commit = (internal, commitQueue) => {
-	commitQueue.some(component => {
+	commitQueue.some(internal => {
 		try {
-			component._commitCallbacks.forEach(invokeCleanup);
-			component._commitCallbacks = component._commitCallbacks.filter(cb =>
+			internal._commitCallbacks.forEach(invokeCleanup);
+			internal._commitCallbacks = internal._commitCallbacks.filter(cb =>
 				cb._value ? invokeEffect(cb) : true
 			);
 		} catch (e) {
-			commitQueue.some(c => {
-				if (c._commitCallbacks) c._commitCallbacks = [];
+			commitQueue.some(i => {
+				if (i._commitCallbacks) i._commitCallbacks = [];
 			});
 			commitQueue = [];
-			options._catchError(e, component._internal);
+			options._catchError(e, internal);
 		}
 	});
 
@@ -183,7 +183,10 @@ export function useLayoutEffect(callback, args) {
 		state._value = callback;
 		state._args = args;
 
-		currentComponent._commitCallbacks.push(state);
+		if (currentComponent._internal._commitCallbacks == null) {
+			currentComponent._internal._commitCallbacks = [];
+		}
+		currentComponent._internal._commitCallbacks.push(state);
 	}
 }
 

--- a/mangle.json
+++ b/mangle.json
@@ -37,7 +37,7 @@
       "$_depth": "__b",
       "$_detachOnNextRender": "__b",
       "$_nextState": "__s",
-      "$_renderCallbacks": "__h",
+      "$_commitCallbacks": "__h",
       "$_children": "__k",
       "$_pendingSuspensionCount": "__u",
       "$_childDidSuspend": "__c",

--- a/mangle.json
+++ b/mangle.json
@@ -44,7 +44,6 @@
       "$_onResolve": "__R",
       "$_suspended": "__e",
       "$_dom": "__e",
-      "$_hydrating": "__h",
       "$_flags": "__f",
       "$_component": "__c",
       "$__html": "__html",

--- a/src/component.js
+++ b/src/component.js
@@ -56,7 +56,7 @@ Component.prototype.setState = function(update, callback) {
 	if (update == null) return;
 
 	if (this._internal) {
-		if (callback) this._renderCallbacks.push(callback);
+		if (callback) this._commitCallbacks.push(callback);
 		enqueueRender(this);
 	}
 };
@@ -73,7 +73,7 @@ Component.prototype.forceUpdate = function(callback) {
 		// is coming from. We need this because forceUpdate should never call
 		// shouldComponentUpdate
 		this._internal._flags |= FORCE_UPDATE;
-		if (callback) this._renderCallbacks.push(callback);
+		if (callback) this._commitCallbacks.push(callback);
 		enqueueRender(this);
 	}
 };

--- a/src/component.js
+++ b/src/component.js
@@ -1,5 +1,5 @@
 import { assign } from './util';
-import { commitRoot } from './diff/commit';
+import { addCommitCallback, commitRoot } from './diff/commit';
 import options from './options';
 import { createVNode, Fragment } from './create-element';
 import { patch } from './diff/patch';
@@ -56,7 +56,7 @@ Component.prototype.setState = function(update, callback) {
 	if (update == null) return;
 
 	if (this._internal) {
-		if (callback) this._commitCallbacks.push(callback);
+		if (callback) addCommitCallback(this._internal, () => callback.call(this));
 		enqueueRender(this);
 	}
 };
@@ -73,7 +73,7 @@ Component.prototype.forceUpdate = function(callback) {
 		// is coming from. We need this because forceUpdate should never call
 		// shouldComponentUpdate
 		this._internal._flags |= FORCE_UPDATE;
-		if (callback) this._commitCallbacks.push(callback);
+		if (callback) addCommitCallback(this._internal, () => callback.call(this));
 		enqueueRender(this);
 	}
 };

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -23,7 +23,7 @@ import { createInternal, getDomSibling, getChildDom } from '../tree';
  * @param {object} globalContext The current context object - modified by
  * getChildContext
  * @param {boolean} isSvg Whether or not this DOM node is an SVG node
- * @param {Array<import('../internal').Component>} commitQueue List of
+ * @param {import('../internal').CommitQueue} commitQueue List of
  * components which have callbacks to invoke in commitRoot
  * @param {import('../internal').PreactElement} startDom The dom node
  * diffChildren should begin diffing with.

--- a/src/diff/commit.js
+++ b/src/diff/commit.js
@@ -1,15 +1,7 @@
 import options from '../options';
 
-export function addCommitCallback(internal, callback) {
-	if (internal._commitCallbacks == null) {
-		internal._commitCallbacks = [];
-	}
-
-	internal._commitCallbacks.push(callback);
-}
-
 /**
- * @param {Array<import('../internal').Component>} commitQueue List of components
+ * @param {import('../internal').CommitQueue} commitQueue List of components
  * which have callbacks to invoke in commitRoot
  * @param {import('../internal').Internal} rootInternal
  */

--- a/src/diff/commit.js
+++ b/src/diff/commit.js
@@ -1,5 +1,13 @@
 import options from '../options';
 
+export function addCommitCallback(internal, callback) {
+	if (internal._commitCallbacks == null) {
+		internal._commitCallbacks = [];
+	}
+
+	internal._commitCallbacks.push(callback);
+}
+
 /**
  * @param {Array<import('../internal').Component>} commitQueue List of components
  * which have callbacks to invoke in commitRoot
@@ -11,8 +19,8 @@ export function commitRoot(commitQueue, rootInternal) {
 	commitQueue.some(c => {
 		try {
 			// @ts-ignore Reuse the commitQueue variable here so the type changes
-			commitQueue = c._renderCallbacks;
-			c._renderCallbacks = [];
+			commitQueue = c._commitCallbacks;
+			c._commitCallbacks = [];
 			commitQueue.some(cb => {
 				// @ts-ignore See above ts-ignore on commitQueue
 				cb.call(c);

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -80,7 +80,7 @@ export function renderComponent(
 		c._globalContext = globalContext;
 		isNew = true;
 		internal._flags |= DIRTY_BIT;
-		c._renderCallbacks = [];
+		c._commitCallbacks = [];
 	}
 
 	// Invoke getDerivedStateFromProps
@@ -106,7 +106,7 @@ export function renderComponent(
 			// If the component was constructed, queue up componentDidMount so the
 			// first time this internal commits (regardless of suspense or not) it
 			// will be called
-			c._renderCallbacks.push(c.componentDidMount);
+			c._commitCallbacks.push(c.componentDidMount);
 		}
 	} else {
 		if (
@@ -133,7 +133,7 @@ export function renderComponent(
 			}
 
 			c._internal = internal;
-			if (c._renderCallbacks.length) {
+			if (c._commitCallbacks.length) {
 				commitQueue.push(c);
 			}
 
@@ -175,7 +175,7 @@ export function renderComponent(
 
 		// Only schedule componentDidUpdate if the component successfully rendered
 		if (c.componentDidUpdate != null) {
-			c._renderCallbacks.push(() => {
+			c._commitCallbacks.push(() => {
 				c.componentDidUpdate(oldProps, oldState, snapshot);
 			});
 		}
@@ -209,7 +209,7 @@ export function renderComponent(
 		);
 	}
 
-	if (c._renderCallbacks.length) {
+	if (c._commitCallbacks.length) {
 		commitQueue.push(c);
 	}
 

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -10,6 +10,7 @@ import {
 	MODE_PENDING_ERROR,
 	MODE_RERENDERING_ERROR
 } from '../constants';
+import { addCommitCallback } from './commit';
 
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
@@ -80,7 +81,6 @@ export function renderComponent(
 		c._globalContext = globalContext;
 		isNew = true;
 		internal._flags |= DIRTY_BIT;
-		c._commitCallbacks = [];
 	}
 
 	// Invoke getDerivedStateFromProps
@@ -106,7 +106,7 @@ export function renderComponent(
 			// If the component was constructed, queue up componentDidMount so the
 			// first time this internal commits (regardless of suspense or not) it
 			// will be called
-			c._commitCallbacks.push(c.componentDidMount);
+			addCommitCallback(internal, () => c.componentDidMount());
 		}
 	} else {
 		if (
@@ -133,8 +133,11 @@ export function renderComponent(
 			}
 
 			c._internal = internal;
-			if (c._commitCallbacks.length) {
-				commitQueue.push(c);
+			if (
+				internal._commitCallbacks != null &&
+				internal._commitCallbacks.length
+			) {
+				commitQueue.push(internal);
 			}
 
 			// TODO: Returning undefined here (i.e. return;) passes all tests. That seems
@@ -175,7 +178,7 @@ export function renderComponent(
 
 		// Only schedule componentDidUpdate if the component successfully rendered
 		if (c.componentDidUpdate != null) {
-			c._commitCallbacks.push(() => {
+			addCommitCallback(internal, () => {
 				c.componentDidUpdate(oldProps, oldState, snapshot);
 			});
 		}
@@ -209,8 +212,8 @@ export function renderComponent(
 		);
 	}
 
-	if (c._commitCallbacks.length) {
-		commitQueue.push(c);
+	if (internal._commitCallbacks != null && internal._commitCallbacks.length) {
+		commitQueue.push(internal);
 	}
 
 	return nextDomSibling;

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -18,7 +18,7 @@ import {
  * @param {import('../internal').Internal} internal The component's backing Internal node
  * @param {object} globalContext The current context object. Modified by getChildContext
  * @param {boolean} isSvg Whether or not this element is an SVG node
- * @param {Array<import('../internal').Component>} commitQueue List of components
+ * @param {import('../internal').CommitQueue} commitQueue List of components
  * which have callbacks to invoke in commitRoot
  * @param {import('../internal').PreactNode} startDom
  * @returns {import('../internal').PreactNode} pointer to the next DOM node (in order) to be rendered (or null)

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -24,7 +24,7 @@ import { removeNode } from '../util';
  * @param {import('../internal').Internal} internal The Internal node to mount
  * @param {object} globalContext The current context object. Modified by getChildContext
  * @param {boolean} isSvg Whether or not this element is an SVG node
- * @param {Array<import('../internal').Component>} commitQueue List of components
+ * @param {import('../internal').CommitQueue} commitQueue List of components
  * which have callbacks to invoke in commitRoot
  * @param {import('../internal').PreactElement} startDom
  * @returns {import('../internal').PreactElement | null} pointer to the next DOM node to be hydrated (or null)
@@ -117,7 +117,7 @@ export function mount(
  * @param {import('../internal').Internal} internal The Internal node to mount
  * @param {object} globalContext The current context object
  * @param {boolean} isSvg Whether or not this DOM node is an SVG node
- * @param {Array<import('../internal').Component>} commitQueue List of components
+ * @param {import('../internal').CommitQueue} commitQueue List of components
  * which have callbacks to invoke in commitRoot
  * @returns {import('../internal').PreactElement}
  */
@@ -246,7 +246,7 @@ function mountDOMElement(dom, internal, globalContext, isSvg, commitQueue) {
  * @param {import('../internal').Internal} parentInternal The parent Internal of the given children
  * @param {object} globalContext The current context object - modified by getChildContext
  * @param {boolean} isSvg Whether or not this DOM node is an SVG node
- * @param {Array<import('../internal').Component>} commitQueue List of components
+ * @param {import('../internal').CommitQueue} commitQueue List of components
  * which have callbacks to invoke in commitRoot
  * @param {import('../internal').PreactElement} startDom
  */

--- a/src/diff/patch.js
+++ b/src/diff/patch.js
@@ -19,7 +19,7 @@ import { getChildDom, getDomSibling } from '../tree';
  * @param {import('../internal').Internal} internal The Internal node to patch
  * @param {object} globalContext The current context object. Modified by getChildContext
  * @param {boolean} isSvg Whether or not this element is an SVG node
- * @param {Array<import('../internal').Component>} commitQueue List of components
+ * @param {import('../internal').CommitQueue} commitQueue List of components
  * which have callbacks to invoke in commitRoot
  * @param {import('../internal').PreactNode} startDom
  */
@@ -148,7 +148,7 @@ export function patch(
  * @param {import('../internal').Internal} internal The Internal node to patch
  * @param {object} globalContext The current context object
  * @param {boolean} isSvg Whether or not this DOM node is an SVG node
- * @param {Array<import('../internal').Component>} commitQueue List of components
+ * @param {import('../internal').CommitQueue} commitQueue List of components
  * which have callbacks to invoke in commitRoot
  * @returns {import('../internal').PreactElement}
  */

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -46,7 +46,7 @@ export interface Options extends preact.Options {
 	_internal(internal: Internal, vnode: VNode | string): void;
 }
 
-export type CommitQueue = Component[];
+export type CommitQueue = Internal[];
 
 // Redefine ComponentFactory using our new internal FunctionalComponent interface above
 export type ComponentFactory<P> =
@@ -142,6 +142,8 @@ export interface Internal<P = {}> {
 	_flags: number;
 	/** This Internal's distance from the tree root */
 	_depth: number | null;
+	/** Callbacks to invoke when this internal commits */
+	_commitCallbacks: Array<() => void>;
 }
 
 export interface Component<P = {}, S = {}> extends preact.Component<P, S> {
@@ -149,7 +151,6 @@ export interface Component<P = {}, S = {}> extends preact.Component<P, S> {
 	constructor: ComponentType<P>;
 	state: S; // Override Component["state"] to not be readonly for internal use, specifically Hooks
 	/** @TODO this should be moved to internal.data */
-	_commitCallbacks: Array<() => void>; // Only class components
 	_globalContext?: any;
 	_internal?: Internal<P> | null;
 	_nextState?: S | null; // Only class components

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -147,7 +147,7 @@ export interface Component<P = {}, S = {}> extends preact.Component<P, S> {
 	constructor: ComponentType<P>;
 	state: S; // Override Component["state"] to not be readonly for internal use, specifically Hooks
 	/** @TODO this should be moved to internal.data */
-	_renderCallbacks: Array<() => void>; // Only class components
+	_commitCallbacks: Array<() => void>; // Only class components
 	_globalContext?: any;
 	_internal?: Internal<P> | null;
 	_nextState?: S | null; // Only class components

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -34,7 +34,7 @@ export interface Options extends preact.Options {
 	/** Attach a hook that is invoked before a vnode is diffed. */
 	_diff?(internal: Internal, vnode?: VNode): void;
 	/** Attach a hook that is invoked after a tree was mounted or was updated. */
-	_commit?(internal: Internal, commitQueue: Component[]): void;
+	_commit?(internal: Internal, commitQueue: CommitQueue): void;
 	/** Attach a hook that is invoked before a vnode has rendered. */
 	_render?(internal: Internal): void;
 	/** Attach a hook that is invoked before a hook's state is queried. */
@@ -45,6 +45,8 @@ export interface Options extends preact.Options {
 	_catchError(error: any, internal: Internal): void;
 	_internal(internal: Internal, vnode: VNode | string): void;
 }
+
+export type CommitQueue = Component[];
 
 // Redefine ComponentFactory using our new internal FunctionalComponent interface above
 export type ComponentFactory<P> =


### PR DESCRIPTION
... and rename to `commitCallbacks`.

This change is a step to further separate the core diff from a specific Component implementation. Though I suspect that `_commitCallbacks` won't forever stay on Internal (depends on how we implement an extensible component API), I figured I'd move it to Internals for now so we can start to peel away other parts of the codebase.