### PR TITLE
Add preact/dom package

### DIFF
--- a/config/node-13-exports.js
+++ b/config/node-13-exports.js
@@ -1,6 +1,14 @@
 const fs = require('fs');
 
-const subRepositories = ['compat', 'debug', 'devtools', 'hooks', 'jsx-runtime', 'test-utils'];
+const subRepositories = [
+	'compat',
+	'debug',
+	'devtools',
+	'dom',
+	'hooks',
+	'jsx-runtime',
+	'test-utils'
+];
 const snakeCaseToCamelCase = str =>
 	str.replace(/([-_][a-z])/g, group => group.toUpperCase().replace('-', ''));
 

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -4,6 +4,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const preact = path.join(__dirname, '..', 'src');
 const compat = path.join(__dirname, '..', 'compat', 'src');
+const dom = path.join(__dirname, '..', 'dom', 'src');
 
 module.exports = {
 	context: __dirname,
@@ -18,7 +19,7 @@ module.exports = {
 			['preact/hooks']: path.join(__dirname, '..', 'hooks', 'src'),
 			preact: preact,
 			react: compat,
-			'react-dom': compat
+			'react-dom': dom
 		},
 		extensions: ['.tsx', '.ts', '.js']
 	},

--- a/dom/LICENSE
+++ b/dom/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-present Jason Miller
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dom/package.json
+++ b/dom/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "preact-dom",
+  "amdName": "preactDom",
+  "version": "0.1.0",
+  "private": true,
+  "description": "DOM addon for Preact to mirror react-dom",
+  "main": "dist/dom.js",
+  "module": "dist/dom.module.js",
+  "umd:main": "dist/dom.umd.js",
+  "source": "src/index.js",
+  "license": "MIT",
+  "types": "src/index.d.ts",
+  "scripts": {
+    "build": "microbundle build --raw",
+    "dev": "microbundle watch --raw --format cjs"
+  },
+  "peerDependencies": {
+    "preact": "^10.0.0"
+  }
+}

--- a/dom/src/index.d.ts
+++ b/dom/src/index.d.ts
@@ -1,0 +1,6 @@
+export { render, hydrate } from '../..';
+export {
+	unmountComponentAtNode,
+	findDOMNode,
+	createPortal
+} from '../../compat';

--- a/dom/src/index.js
+++ b/dom/src/index.js
@@ -1,0 +1,6 @@
+export { render, hydrate } from 'preact';
+export {
+	unmountComponentAtNode,
+	findDOMNode,
+	createPortal
+} from 'preact/compat';

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -123,6 +123,7 @@ function createEsbuildPlugin() {
 		'preact/debug': subPkgPath('./debug/'),
 		'preact/devtools': subPkgPath('./devtools/'),
 		'preact/compat': subPkgPath('./compat/'),
+		'preact/dom': subPkgPath('./dom/'),
 		'preact/hooks': subPkgPath('./hooks/'),
 		'preact/test-utils': subPkgPath('./test-utils/'),
 		'preact/jsx-runtime': subPkgPath('./jsx-runtime/'),
@@ -142,8 +143,16 @@ function createEsbuildPlugin() {
 				};
 			});
 
-			build.onResolve({ filter: /^(react|react-dom)$/ }, args => {
+			build.onResolve({ filter: /^react$/ }, args => {
 				const pkg = alias['preact/compat'];
+				return {
+					path: pkg,
+					namespace: 'preact'
+				};
+			});
+
+			build.onResolve({ filter: /^react-dom$/ }, args => {
+				const pkg = alias['preact/dom'];
 				return {
 					path: pkg,
 					namespace: 'preact'
@@ -278,7 +287,7 @@ module.exports = function(config) {
 			{
 				pattern:
 					config.grep ||
-					'{debug,devtools,hooks,compat,test-utils,jsx-runtime,}/test/{browser,shared}/**/*.test.js',
+					'{debug,devtools,hooks,compat,dom,test-utils,jsx-runtime,}/test/{browser,shared}/**/*.test.js',
 				watched: false,
 				type: 'js'
 			}
@@ -289,7 +298,7 @@ module.exports = function(config) {
 		},
 
 		preprocessors: {
-			'{debug,devtools,hooks,compat,test-utils,jsx-runtime,}/test/**/*': [
+			'{debug,devtools,hooks,compat,dom,test-utils,jsx-runtime,}/test/**/*': [
 				'esbuild',
 				'sourcemap'
 			]

--- a/package.json
+++ b/package.json
@@ -40,6 +40,12 @@
 			"require": "./hooks/dist/hooks.js",
 			"import": "./hooks/dist/hooks.mjs"
 		},
+		"./dom": {
+			"browser": "./dom/dist/dom.module.js",
+			"umd": "./dom/dist/dom.umd.js",
+			"require": "./dom/dist/dom.js",
+			"import": "./dom/dist/dom.mjs"
+		},
 		"./test-utils": {
 			"browser": "./test-utils/dist/testUtils.module.js",
 			"umd": "./test-utils/dist/testUtils.umd.js",
@@ -80,12 +86,14 @@
 		"build:devtools": "microbundle build --raw --cwd devtools",
 		"build:hooks": "microbundle build --raw --cwd hooks",
 		"build:test-utils": "microbundle build --raw --cwd test-utils",
-		"build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks'",
+		"build:compat": "microbundle build --raw --cwd compat --globals 'preact/cmp=preactHooks'",
+		"build:dom": "microbundle build --raw --cwd dom --globals 'preact/compat=preactCompat'",
 		"build:jsx": "microbundle build --raw --cwd jsx-runtime",
 		"postbuild": "node ./config/node-13-exports.js && node ./config/compat-entries.js",
 		"dev": "microbundle watch --raw --format cjs",
 		"dev:hooks": "microbundle watch --raw --format cjs --cwd hooks",
 		"dev:compat": "microbundle watch --raw --format cjs --cwd compat --globals 'preact/hooks=preactHooks'",
+		"dev:dom": "microbundle watch --raw --format cjs --cwd dom --globals 'preact/compat=preactCompat'",
 		"test": "npm-run-all build lint test:unit",
 		"test:unit": "run-p test:mocha test:karma:minify test:ts",
 		"test:ts": "run-p test:ts:*",
@@ -100,7 +108,7 @@
 		"test:karma:test-utils": "cross-env PERFORMANCE=false COVERAGE=false BABEL_NO_MODULES=true karma start karma.conf.js --grep=test-utils/test/shared/**.js --no-single-run",
 		"test:karma:bench": "cross-env PERFORMANCE=true COVERAGE=false BABEL_NO_MODULES=true karma start karma.conf.js --grep=test/benchmarks/**.js --single-run",
 		"benchmark": "npm run test:karma:bench -- no-single-run",
-		"lint": "eslint src test debug compat hooks test-utils"
+		"lint": "eslint src test debug compat dom hooks test-utils"
 	},
 	"eslintConfig": {
 		"extends": [
@@ -183,6 +191,9 @@
 		"devtools/dist",
 		"devtools/src",
 		"devtools/package.json",
+		"dom/dist",
+		"dom/src",
+		"dom/package.json",
 		"hooks/dist",
 		"hooks/src",
 		"hooks/package.json",

--- a/sizereport.config.js
+++ b/sizereport.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	repo: 'preactjs/preact',
-	path: ['./{compat,debug,hooks,}/dist/**/!(*.map)'],
+	path: ['./{compat,debug,dom,hooks,}/dist/**/!(*.map)'],
 	branch: 'master'
 };


### PR DESCRIPTION
AMP is attempting to ship npm modules containing both preact and react variants of our components. One of the sticking points was how do we easily remap from our preact imports into the equivalent react import. For `createElement`, it's easy. But for `render` and `hydrate`, it's very difficult to remap from `preact` to `react-dom`.

Because `preact` (or `preact/compat`) has mixed `react` and `react-dom` APIs, we have to inspect both the import source and the specifiers in order to remap. That's not easily supported, and would essentially require us to write a custom Babel plugin to transform.

Instead, I opted to create a placeholder `preact/dom` package (we patch our `node_modules` directory during builds). This file just exports the needed functions from `preact` package. Now, I can easily remap `preact/dom` to `react-dom` without inspecting what specifiers are imported.