### PR TITLE
Add The Guardian as a Github backer

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Support us with a monthly donation and help us continue our activities. [[Become
 <a href="https://opencollective.com/preact/backer/27/website" target="_blank"><img src="https://opencollective.com/preact/backer/27/avatar.svg"></a>
 <a href="https://opencollective.com/preact/backer/28/website" target="_blank"><img src="https://opencollective.com/preact/backer/28/avatar.svg"></a>
 <a href="https://opencollective.com/preact/backer/29/website" target="_blank"><img src="https://opencollective.com/preact/backer/29/avatar.svg"></a>
+<a href="https://github.com/guardian" target="_blank"><img src="https://avatars.githubusercontent.com/u/164318?s=60&v=4"></a>
+
 
 
 ## Sponsors

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Support us with a monthly donation and help us continue our activities. [[Become
 <a href="https://opencollective.com/preact/backer/27/website" target="_blank"><img src="https://opencollective.com/preact/backer/27/avatar.svg"></a>
 <a href="https://opencollective.com/preact/backer/28/website" target="_blank"><img src="https://opencollective.com/preact/backer/28/avatar.svg"></a>
 <a href="https://opencollective.com/preact/backer/29/website" target="_blank"><img src="https://opencollective.com/preact/backer/29/avatar.svg"></a>
-<a href="https://github.com/guardian" target="_blank"><img src="https://avatars.githubusercontent.com/u/164318?s=60&v=4"></a>
+<a href="https://github.com/guardian" target="_blank"><img src="https://github.com/guardian.png?size=64"></a>
 
 
 


### PR DESCRIPTION
Hi,

We are now supporting `preact` through [Github sponsor](https://github.com/sponsors), as [you can see in sponsoring](https://github.com/orgs/guardian/sponsoring). 
We use `preact` notably on the [frontend code](https://github.com/guardian/support-frontend) of our [support website](https://www.theguardian.com), and you are actually the first open-source project we decided to financially support 🎉.

The associated changes add us as a backer in the `README.md` file. I noticed all the others comes from `opencollective` support, but I don't think asking to be included in that list would be unfair.

Hope you agreed and thank you for your work!

 