### PR TITLE
Invoke commitQueue callbacks with their component as the context

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -56,7 +56,7 @@ Component.prototype.setState = function(update, callback) {
 	if (update == null) return;
 
 	if (this._internal) {
-		if (callback) addCommitCallback(this._internal, () => callback.call(this));
+		if (callback) addCommitCallback(this._internal, callback);
 		enqueueRender(this);
 	}
 };
@@ -73,7 +73,7 @@ Component.prototype.forceUpdate = function(callback) {
 		// is coming from. We need this because forceUpdate should never call
 		// shouldComponentUpdate
 		this._internal._flags |= FORCE_UPDATE;
-		if (callback) addCommitCallback(this._internal, () => callback.call(this));
+		if (callback) addCommitCallback(this._internal, callback);
 		enqueueRender(this);
 	}
 };

--- a/src/diff/commit.js
+++ b/src/diff/commit.js
@@ -26,7 +26,7 @@ export function commitRoot(commitQueue, rootInternal) {
 			commitQueue = internal._commitCallbacks;
 			internal._commitCallbacks = [];
 			commitQueue.some(cb => {
-				cb();
+				cb.call(internal._component);
 			});
 		} catch (e) {
 			options._catchError(e, internal);

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -106,7 +106,7 @@ export function renderComponent(
 			// If the component was constructed, queue up componentDidMount so the
 			// first time this internal commits (regardless of suspense or not) it
 			// will be called
-			addCommitCallback(internal, () => c.componentDidMount());
+			addCommitCallback(internal, c.componentDidMount);
 		}
 	} else {
 		if (


### PR DESCRIPTION
This is an optimization of #3080. It turns out all of the commit queue callbacks we currently use either don't care about `this`, or expect it to be the Component instance associated with an internal, so we can just call the callbacks on `internal._component`.