### PR TITLE
Fix option focus bug caused by IE11 option value workaround.

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -159,6 +159,7 @@ export function diffChildren(
 				firstChildDom = newDom;
 			}
 
+			const parentDomValueBeforeChildPlaced = parentDom.value;
 			if (
 				typeof childVNode.type == 'function' &&
 				childVNode._children != null && // Can be null if childVNode suspended
@@ -190,7 +191,11 @@ export function diffChildren(
 			//
 			// To fix it we make sure to reset the inferred value, so that our own
 			// value check in `diff()` won't be skipped.
-			if (!isHydrating && newParentVNode.type === 'option') {
+			if (
+				!isHydrating &&
+				newParentVNode.type === 'option' &&
+				parentDom.value !== parentDomValueBeforeChildPlaced
+			) {
 				// @ts-ignore We have validated that the type of parentDOM is 'option'
 				// in the above check
 				parentDom.value = '';


### PR DESCRIPTION
Whenever children of an <option> element are changed Preact resets the value to an empty string. This is a hack for an IE11 bug triggered whenever option value field is inferred from the text inside the element.

This hack breaks the behaviour of \<select\> element on other browsers: if you click on the dropdown, mouse over another option (but don't click) and rendering happens at this moment, the focus will go back to the current element. This is caused by setting the value attribute on <option> elements even though it isn't necessary (the value didn't change since the last time but Preact forces it to be set anyway).

To resolve the issue, we save the value dom attribute before we place children and then check if it has changed afterwards, as a way to detect whether we need to activate the hack.

I'm not sure that this is the best solution to the problem - please let me know if you have a better one in mind!

[Here's a link for reproducing the issue](https://tinyurl.com/9xtp68j8) (at least on Firefox 86.0.1 on Windows 10). To reproduce, click on the dropdown, hover on any element other than the first one, wait for the callback to fire - you should see the focus moving to the first element.