### PR TITLE
fix: should override children if null is provided as an argument

### DIFF
--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -25,7 +25,7 @@ export function cloneElement(vnode, props, children) {
 			children.push(arguments[i]);
 		}
 	}
-	if (children != null) {
+	if (arguments.length > 2) {
 		normalizedProps.children = children;
 	}
 

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -26,7 +26,7 @@ export function createElement(type, props, children) {
 			children.push(arguments[i]);
 		}
 	}
-	if (children != null) {
+	if (arguments.length > 2) {
 		normalizedProps.children = children;
 	}
 

--- a/test/browser/cloneElement.test.js
+++ b/test/browser/cloneElement.test.js
@@ -38,6 +38,17 @@ describe('cloneElement', () => {
 		expect(clone.props.children).to.deep.equal(['world', '!']);
 	});
 
+	it('should override children if null is provided as an argument', () => {
+		function Foo() {}
+		const instance = <Foo>foo</Foo>;
+		const clone = cloneElement(instance, { children: 'bar' }, null);
+
+		expect(clone.prototype).to.equal(instance.prototype);
+		expect(clone.type).to.equal(instance.type);
+		expect(clone.props).not.to.equal(instance.props);
+		expect(clone.props.children).to.be.null;
+	});
+
 	it('should override key if specified', () => {
 		function Foo() {}
 		const instance = <Foo key="1">hello</Foo>;

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -867,10 +867,10 @@ describe('Components', () => {
 			expect(scratch.innerHTML).to.equal('<div></div>');
 		});
 
-		it('should be undefined with null as a child', () => {
+		it('should be null with null as a child', () => {
 			render(<Foo>{null}</Foo>, scratch);
 
-			expect(children).to.be.undefined;
+			expect(children).to.be.null;
 			expect(scratch.innerHTML).to.equal('<div></div>');
 		});
 

--- a/test/shared/createElement.test.js
+++ b/test/shared/createElement.test.js
@@ -161,13 +161,15 @@ describe('createElement(jsx)', () => {
 			.that.equals('textstuff');
 	});
 
-	it('should NOT set children prop when null', () => {
-		let r = h('foo', { foo: 'bar' }, null);
+	it('should override children if null is provided as an argument', () => {
+		let r = h('foo', { foo: 'bar', children: 'baz' }, null);
 
 		expect(r)
 			.to.be.an('object')
-			.to.have.nested.property('props.foo')
-			.not.to.have.nested.property('props.children');
+			.to.deep.nested.include({
+				'props.foo': 'bar',
+				'props.children': null
+			});
 	});
 
 	it('should NOT set children prop when unspecified', () => {


### PR DESCRIPTION
https://github.com/facebook/react/blob/v17.0.2/packages/react/src/__tests__/ReactElement-test.js#L264-L273

React overrides children if null is provided as an argument, but preact doesn't.