### PR TITLE
Add flushSync to preact-compat

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -101,6 +101,17 @@ function findDOMNode(component) {
 // eslint-disable-next-line camelcase
 const unstable_batchedUpdates = (callback, arg) => callback(arg);
 
+/** 
+ * In React, `flushSync` flushes the entire tree and forces a rerender. It's
+ * implmented here as a no-op.
+ * @template Arg
+ * @template Result
+ * @param {(arg: Arg) => Result} callback function that runs before the flush
+ * @param {Arg} [arg] Optional arugment that can be passed to the callback
+ * @returns 
+ */
+const flushSync = (callback, arg) => callback(arg)
+
 /**
  * Strict Mode is not implemented in Preact, so we provide a stand-in for it
  * that just renders its children without imposing any restrictions.
@@ -127,6 +138,7 @@ export {
 	PureComponent,
 	memo,
 	forwardRef,
+	flushSync,
 	// eslint-disable-next-line camelcase
 	unstable_batchedUpdates,
 	StrictMode,
@@ -166,6 +178,7 @@ export default {
 	PureComponent,
 	memo,
 	forwardRef,
+	flushSync,
 	unstable_batchedUpdates,
 	StrictMode,
 	Suspense,


### PR DESCRIPTION
This PR is my attempt to address #2636. I ran into the issue of `flushSync` not being available when upgrading to the latest version of chakra UI which was added in [this PR](https://github.com/chakra-ui/chakra-ui/pull/3165) and was added to address https://github.com/facebook/react/issues/18591#issuecomment-697999763. Hopefully the latter isn't an issue for us. 

Always the possibility that this doesn't work as expected and we need to enhance it in someway. Without it though, it _certainly_ doesn't work, ha.

Let me know if I need to update anything else. 