### PR TITLE
Avoid leaking internal vnodes

### DIFF
--- a/src/create-element.js
+++ b/src/create-element.js
@@ -78,7 +78,8 @@ export function createVNode(type, props, key, ref, original) {
 		_original: original == null ? ++options._vnodeId : original
 	};
 
-	if (options.vnode != null) options.vnode(vnode);
+	// Only invoke the vnode hook if this was *not* a direct copy:
+	if (original == null && options.vnode != null) options.vnode(vnode);
 
 	return vnode;
 }


### PR DESCRIPTION
We started calling `options.vnode()` for internal "text" VNodes and copied VNodes at some point, as best as I can tell it was unintentional. We don't officially support the Text VNode shape, and copied VNodes shouldn't be passed through `options.vnode` again because they've already been processed.

This should be good for performance, though it likely won't show up in benchmarks because it primarily affects `preact/compat`.