### PR TITLE
Ignore undefined children in createElement 3rd arg

### DIFF
--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -25,7 +25,7 @@ export function cloneElement(vnode, props, children) {
 			children.push(arguments[i]);
 		}
 	}
-	if (arguments.length > 2) {
+	if (children !== undefined) {
 		normalizedProps.children = children;
 	}
 

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -26,7 +26,7 @@ export function createElement(type, props, children) {
 			children.push(arguments[i]);
 		}
 	}
-	if (arguments.length > 2) {
+	if (children !== undefined) {
 		normalizedProps.children = children;
 	}
 


### PR DESCRIPTION
I believe #3091 may have introduced a bug where `h('div', { children: 'foo' }, undefined)` would produce `{ children: undefined }`. This fixes that bug, if it is a bug.

I've left this as a draft because I actually don't know which is the more desirable behavior here. From an implementation standpoint, I actually think the `arguments.length > 2` approach is best, because it allows us to seamlessly transition to rest parameters since the semantics are then the same:

```
function createElement(type, props, ...children) {
  if (children.length !== 0) props.children = children;
}
```