### PR TITLE
Inline lifecycle handling into `internal._component` check

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -31,12 +31,12 @@ options.unmount = function(internal) {
 	}
 
 	// If a component suspended while it was hydrating and is now being unmounted,
-	// update it's _flags so it appears to be of TYPE_ELEMENT, causing `unmount`
+	// update it's flags so it appears to be of TYPE_ELEMENT, causing `unmount`
 	// to remove the DOM nodes that were awaiting hydration (which are stored on
 	// this internal's _dom property).
-	const wasHydrating = (internal._flags & MODE_HYDRATE) === MODE_HYDRATE;
+	const wasHydrating = (internal.flags & MODE_HYDRATE) === MODE_HYDRATE;
 	if (component && wasHydrating) {
-		internal._flags |= TYPE_ELEMENT;
+		internal.flags |= TYPE_ELEMENT;
 	}
 
 	if (oldUnmount) oldUnmount(internal);
@@ -116,7 +116,7 @@ Suspense.prototype._childDidSuspend = function(promise, suspendingInternal) {
 	 * While in non-hydration cases the usual fallback -> component flow would occur.
 	 */
 	const wasHydrating =
-		(suspendingInternal._flags & MODE_HYDRATE) === MODE_HYDRATE;
+		(suspendingInternal.flags & MODE_HYDRATE) === MODE_HYDRATE;
 
 	if (!c._pendingSuspensionCount++ && !wasHydrating) {
 		this._parentDom = document.createElement('div');

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -374,7 +374,7 @@ Component.prototype.setState = function(update, callback) {
 					)}`
 			);
 		}
-	} else if (this._internal._flags & MODE_UNMOUNTING) {
+	} else if (this._internal.flags & MODE_UNMOUNTING) {
 		console.warn(
 			`Can't call "this.setState" on an unmounted component. This is a no-op, ` +
 				`but it indicates a memory leak in your application. To fix, cancel all ` +
@@ -397,7 +397,7 @@ Component.prototype.forceUpdate = function(callback) {
 					getCurrentInternal()
 				)}`
 		);
-	} else if (this._internal._flags & MODE_UNMOUNTING) {
+	} else if (this._internal.flags & MODE_UNMOUNTING) {
 		console.warn(
 			`Can't call "this.forceUpdate" on an unmounted component. This is a no-op, ` +
 				`but it indicates a memory leak in your application. To fix, cancel all ` +

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -8,15 +8,21 @@
 
 ## Component plugin prep follow ups
 
-- Consider exposing flags to replace various bools in `rendererState`
-	- Move setting COMMIT_FLAG to `setState`/`forceUpdate`
-- Consider adding TYPE_ERROR_BOUNDARY
-
+- Consider how we expect component plugins to interact with the flags field?
+  - Should we expose the relevant flag constants through a `preact/core` package?
+  - Should we expose helper functions and make flags internal (e.g. `markForCommit(internal)`, `setSkipChildren(internal)`, `setForceUpdate(internal)`, etc.)
+- Evaluate if using the `SKIP_CHILDREN` flag is the API we want to signal to not diff a component's children.
+  - Consider if there is a way we could reuse the VNodeID/VNode equality logic here.
+  - Or return something like `internal._children` to signal that these children should be skipped.
+- Add test that asserts the COMMIT flag is unset before committing a component (what's the observable failure if we don't do this?)
 - Re-evaluate how components interact with context.
-	- Should each component plugin have its own "namespaced" property off of `globalContext`
-	- How should components update context? Update `rendererState`? Set it directly on `internal._context`?
+  - Do we still need the `rendererState` if context is the only thing in it?
+  - Should each component plugin have its own "namespaced" property off of `globalContext`
+  - How should components update context? Update `rendererState`? Set it directly on `internal._context`?
 - Rework compat's `readContext` to use future updated `render` plugin
 - Explore if we are missing a test for `.nextSibling` call in VNode equality check in patch
+
+- Consider how component plugins can plug into devtools, SSR, HMR
 
 ## Root node follow ups
 

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -1,5 +1,5 @@
 import { options } from 'preact';
-import { MODE_UNMOUNTING } from '../../src/constants';
+import { MODE_UNMOUNTING, TYPE_ERROR_BOUNDARY } from '../../src/constants';
 
 /** @type {number} */
 let currentIndex;
@@ -278,6 +278,7 @@ export function useErrorBoundary(cb) {
 	const errState = useState();
 	state._value = cb;
 	if (!currentComponent.componentDidCatch) {
+		currentComponent._internal.flags |= TYPE_ERROR_BOUNDARY;
 		currentComponent.componentDidCatch = err => {
 			if (state._value) state._value(err);
 			errState[1](err);

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -296,7 +296,7 @@ export function useErrorBoundary(cb) {
  */
 function flushAfterPaintEffects() {
 	afterPaintEffects.forEach(component => {
-		if (~component._internal._flags & MODE_UNMOUNTING) {
+		if (~component._internal.flags & MODE_UNMOUNTING) {
 			try {
 				component.__hooks._pendingEffects.forEach(invokeCleanup);
 				component.__hooks._pendingEffects.forEach(invokeEffect);

--- a/hooks/test/browser/useErrorBoundary.test.js
+++ b/hooks/test/browser/useErrorBoundary.test.js
@@ -5,7 +5,7 @@ import { setupRerender } from 'preact/test-utils';
 
 /** @jsx createElement */
 
-describe('errorBoundary', () => {
+describe('useErrorBoundary', () => {
 	/** @type {HTMLDivElement} */
 	let scratch, rerender;
 

--- a/mangle.json
+++ b/mangle.json
@@ -44,7 +44,6 @@
       "$_onResolve": "__R",
       "$_suspended": "__e",
       "$_dom": "__e",
-      "$_flags": "__f",
       "$_component": "__c",
       "$__html": "__html",
       "$_parent": "__",

--- a/src/component.js
+++ b/src/component.js
@@ -4,6 +4,7 @@ import options from './options';
 import { createVNode, Fragment } from './create-element';
 import { patch } from './diff/patch';
 import {
+	COMMIT_COMPONENT,
 	DIRTY_BIT,
 	FORCE_UPDATE,
 	MODE_HYDRATE,
@@ -58,7 +59,10 @@ Component.prototype.setState = function(update, callback) {
 	if (update == null) return;
 
 	if (this._internal) {
-		if (callback) addCommitCallback(this, callback);
+		if (callback) {
+			this._internal.flags |= COMMIT_COMPONENT;
+			addCommitCallback(this, callback);
+		}
 		enqueueRender(this);
 	}
 };
@@ -75,7 +79,10 @@ Component.prototype.forceUpdate = function(callback) {
 		// is coming from. We need this because forceUpdate should never call
 		// shouldComponentUpdate
 		this._internal.flags |= FORCE_UPDATE;
-		if (callback) addCommitCallback(this, callback);
+		if (callback) {
+			this._internal.flags |= COMMIT_COMPONENT;
+			addCommitCallback(this, callback);
+		}
 		enqueueRender(this);
 	}
 };

--- a/src/component.js
+++ b/src/component.js
@@ -74,7 +74,7 @@ Component.prototype.forceUpdate = function(callback) {
 		// Set render mode so that we can differentiate where the render request
 		// is coming from. We need this because forceUpdate should never call
 		// shouldComponentUpdate
-		this._internal._flags |= FORCE_UPDATE;
+		this._internal.flags |= FORCE_UPDATE;
 		if (callback) addCommitCallback(this, callback);
 		enqueueRender(this);
 	}
@@ -99,10 +99,10 @@ Component.prototype.render = Fragment;
 function rerenderComponent(component) {
 	let internal = component._internal;
 
-	if (~internal._flags & MODE_UNMOUNTING && internal._flags & DIRTY_BIT) {
+	if (~internal.flags & MODE_UNMOUNTING && internal.flags & DIRTY_BIT) {
 		let parentDom = getParentDom(internal);
 		let startDom =
-			(internal._flags & (MODE_HYDRATE | MODE_SUSPENDED)) ===
+			(internal.flags & (MODE_HYDRATE | MODE_SUSPENDED)) ===
 			(MODE_HYDRATE | MODE_SUSPENDED)
 				? internal._dom
 				: getDomSibling(internal, 0);
@@ -156,8 +156,8 @@ let prevDebounce;
  */
 export function enqueueRender(c) {
 	if (
-		(!(c._internal._flags & DIRTY_BIT) &&
-			(c._internal._flags |= DIRTY_BIT) &&
+		(!(c._internal.flags & DIRTY_BIT) &&
+			(c._internal.flags |= DIRTY_BIT) &&
 			rerenderQueue.push(c) &&
 			!process._rerenderCount++) ||
 		prevDebounce !== options.debounceRendering

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,8 +1,8 @@
 // Internal.flags bitfield constants
 export const TYPE_TEXT = 1 << 0;
 export const TYPE_ELEMENT = 1 << 1;
-export const TYPE_CLASS = 1 << 2;
-export const TYPE_FUNCTION = 1 << 3;
+export const TYPE_FUNCTION = 1 << 2;
+export const TYPE_ERROR_BOUNDARY = 1 << 3;
 /** Signals this internal has a _parentDom prop that should change the parent
  * DOM node of it's children */
 export const TYPE_ROOT = 1 << 4;
@@ -10,7 +10,7 @@ export const TYPE_ROOT = 1 << 4;
 /** Any type of internal representing DOM */
 export const TYPE_DOM = TYPE_TEXT | TYPE_ELEMENT;
 /** Any type of component */
-export const TYPE_COMPONENT = TYPE_CLASS | TYPE_FUNCTION | TYPE_ROOT;
+export const TYPE_COMPONENT = TYPE_FUNCTION | TYPE_ROOT | TYPE_ERROR_BOUNDARY;
 
 // Modes of rendering
 /** Normal hydration that attaches to a DOM tree but does not diff it. */

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-// Internal._flags bitfield constants
+// Internal.flags bitfield constants
 export const TYPE_TEXT = 1 << 0;
 export const TYPE_ELEMENT = 1 << 1;
 export const TYPE_CLASS = 1 << 2;

--- a/src/constants.js
+++ b/src/constants.js
@@ -45,6 +45,9 @@ export const FORCE_UPDATE = 1 << 13;
 /** Signifies that a node needs to be updated */
 export const DIRTY_BIT = 1 << 14;
 
+/** Signifies a component has lifecycles to commit */
+export const COMMIT_COMPONENT = 1 << 15;
+
 /** Reset all mode flags */
 export const RESET_MODE = ~(
 	MODE_HYDRATE |

--- a/src/constants.js
+++ b/src/constants.js
@@ -44,9 +44,10 @@ export const MODE_SVG = 1 << 12;
 export const FORCE_UPDATE = 1 << 13;
 /** Signifies that a node needs to be updated */
 export const DIRTY_BIT = 1 << 14;
+export const SKIP_CHILDREN = 1 << 15;
 
 /** Signifies a component has lifecycles to commit */
-export const COMMIT_COMPONENT = 1 << 15;
+export const COMMIT_COMPONENT = 1 << 16;
 
 /** Reset all mode flags */
 export const RESET_MODE = ~(
@@ -55,7 +56,8 @@ export const RESET_MODE = ~(
 	MODE_SUSPENDED |
 	MODE_ERRORED |
 	MODE_RERENDERING_ERROR |
-	FORCE_UPDATE
+	FORCE_UPDATE |
+	SKIP_CHILDREN
 );
 
 /** Modes a child internal inherits from their parent */

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -1,6 +1,6 @@
 import { enqueueRender } from './component';
 
-export let i = 0;
+let i = 0;
 
 export function createContext(defaultValue, contextId) {
 	contextId = '__cC' + i++;

--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -25,9 +25,6 @@ export function _catchError(error, internal) {
 			try {
 				handleErrorReact(handler, error, internal);
 
-				// NOTE: We're checking that any component in the stack got marked as dirty, even if it did so prior to this loop,
-				// which is technically incorrect. However, there is no way for a component to mark itself as dirty during rendering.
-				// The only way for a component to falsely intercept error bubbling would be to manually sets its internal dirty flag.
 				if (handler.flags & DIRTY_BIT) {
 					handler.flags |= MODE_PENDING_ERROR;
 					return;

--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -2,8 +2,9 @@ import {
 	DIRTY_BIT,
 	MODE_RERENDERING_ERROR,
 	MODE_PENDING_ERROR,
-	TYPE_COMPONENT
+	TYPE_ERROR_BOUNDARY
 } from '../constants';
+import { handleErrorReact } from './reactComponents';
 
 /**
  * Find the closest error boundary to a thrown error and call it
@@ -13,29 +14,22 @@ import {
  * is the highest parent that was being unmounted)
  */
 export function _catchError(error, internal) {
-	// TODO: If we introduce a TYPE_ERROR_BOUNDARY, then we could simplify this to
-	// (internal.flags & (TYPE_ERROR_BOUNDARY | MODE_RERENDERING_ERROR)) == TYPE_ERROR_BOUNDARY
-	while ((internal = internal._parent)) {
+	let handler = internal;
+	// The following condition could also be the following if it is smaller:
+	// (handler.flags & (TYPE_ERROR_BOUNDARY | MODE_RERENDERING_ERROR)) == TYPE_ERROR_BOUNDARY
+	while ((handler = handler._parent)) {
 		if (
-			internal.flags & TYPE_COMPONENT &&
-			~internal.flags & MODE_RERENDERING_ERROR
+			handler.flags & TYPE_ERROR_BOUNDARY &&
+			~handler.flags & MODE_RERENDERING_ERROR
 		) {
 			try {
-				if (internal.type.getDerivedStateFromError != null) {
-					internal._component.setState(
-						internal.type.getDerivedStateFromError(error)
-					);
-				}
-
-				if (internal._component.componentDidCatch != null) {
-					internal._component.componentDidCatch(error);
-				}
+				handleErrorReact(handler, error, internal);
 
 				// NOTE: We're checking that any component in the stack got marked as dirty, even if it did so prior to this loop,
 				// which is technically incorrect. However, there is no way for a component to mark itself as dirty during rendering.
 				// The only way for a component to falsely intercept error bubbling would be to manually sets its internal dirty flag.
-				if (internal.flags & DIRTY_BIT) {
-					internal.flags |= MODE_PENDING_ERROR;
+				if (handler.flags & DIRTY_BIT) {
+					handler.flags |= MODE_PENDING_ERROR;
 					return;
 				}
 			} catch (e) {

--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -14,11 +14,11 @@ import {
  */
 export function _catchError(error, internal) {
 	// TODO: If we introduce a TYPE_ERROR_BOUNDARY, then we could simplify this to
-	// (internal._flags & (TYPE_ERROR_BOUNDARY | MODE_RERENDERING_ERROR)) == TYPE_ERROR_BOUNDARY
+	// (internal.flags & (TYPE_ERROR_BOUNDARY | MODE_RERENDERING_ERROR)) == TYPE_ERROR_BOUNDARY
 	while ((internal = internal._parent)) {
 		if (
-			internal._flags & TYPE_COMPONENT &&
-			~internal._flags & MODE_RERENDERING_ERROR
+			internal.flags & TYPE_COMPONENT &&
+			~internal.flags & MODE_RERENDERING_ERROR
 		) {
 			try {
 				if (internal.type.getDerivedStateFromError != null) {
@@ -34,8 +34,8 @@ export function _catchError(error, internal) {
 				// NOTE: We're checking that any component in the stack got marked as dirty, even if it did so prior to this loop,
 				// which is technically incorrect. However, there is no way for a component to mark itself as dirty during rendering.
 				// The only way for a component to falsely intercept error bubbling would be to manually sets its internal dirty flag.
-				if (internal._flags & DIRTY_BIT) {
-					internal._flags |= MODE_PENDING_ERROR;
+				if (internal.flags & DIRTY_BIT) {
+					internal.flags |= MODE_PENDING_ERROR;
 					return;
 				}
 			} catch (e) {

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -80,7 +80,7 @@ export function diffChildren(
 		// If this node suspended during hydration, and no other flags are set:
 		// @TODO: might be better to explicitly check for MODE_ERRORED here.
 		else if (
-			(childInternal._flags & (MODE_HYDRATE | MODE_SUSPENDED)) ===
+			(childInternal.flags & (MODE_HYDRATE | MODE_SUSPENDED)) ===
 			(MODE_HYDRATE | MODE_SUSPENDED)
 		) {
 			// We are resuming the hydration of a VNode
@@ -119,7 +119,7 @@ export function diffChildren(
 			);
 		}
 
-		if (childInternal._flags & TYPE_COMPONENT) {
+		if (childInternal.flags & TYPE_COMPONENT) {
 			startDom = nextDomSibling;
 		} else if (newDom && newDom == startDom) {
 			// If the newDom and the dom we are expecting to be there are the same, then
@@ -146,10 +146,9 @@ export function diffChildren(
 	for (i = oldChildrenLength; i--; ) {
 		if (oldChildren[i] != null) {
 			if (
-				parentInternal._flags & TYPE_COMPONENT &&
+				parentInternal.flags & TYPE_COMPONENT &&
 				startDom != null &&
-				((oldChildren[i]._flags & TYPE_DOM &&
-					oldChildren[i]._dom == startDom) ||
+				((oldChildren[i].flags & TYPE_DOM && oldChildren[i]._dom == startDom) ||
 					getChildDom(oldChildren[i]) == startDom)
 			) {
 				// If the startDom points to a dom node that is about to be unmounted,
@@ -187,7 +186,7 @@ function findMatchingInternal(childVNode, oldChildren, i, oldChildrenLength) {
 
 	if (typeof childVNode === 'string') {
 		// We never move Text nodes, so we only check for an in-place match:
-		if (childInternal && childInternal._flags & TYPE_TEXT) {
+		if (childInternal && childInternal.flags & TYPE_TEXT) {
 			oldChildren[i] = undefined;
 		} else {
 			// We're looking for a Text node, but this wasn't one: ignore it
@@ -241,7 +240,7 @@ export function reorderChildren(internal, startDom, parentDom) {
 			// (childVNode here).
 			childInternal._parent = internal;
 
-			if (childInternal._flags & TYPE_COMPONENT) {
+			if (childInternal.flags & TYPE_COMPONENT) {
 				startDom = reorderChildren(childInternal, startDom, parentDom);
 			} else if (childInternal._dom == startDom) {
 				startDom = startDom.nextSibling;

--- a/src/diff/commit.js
+++ b/src/diff/commit.js
@@ -1,3 +1,4 @@
+import { COMMIT_COMPONENT } from '../constants';
 import options from '../options';
 import { commitReactComponent } from './reactComponents';
 
@@ -10,6 +11,9 @@ export function commitRoot(commitQueue, rootInternal) {
 	if (options._commit) options._commit(rootInternal, commitQueue);
 
 	commitQueue.some(internal => {
+		// TODO: Need to add a test that asserts this... Thinking something along
+		// the lines of if a commit queues up another commit...
+		internal.flags &= ~COMMIT_COMPONENT;
 		try {
 			commitReactComponent(internal);
 		} catch (e) {

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -1,6 +1,7 @@
 import { mountChildren } from './mount';
 import { diffChildren, reorderChildren } from './children';
 import {
+	COMMIT_COMPONENT,
 	DIRTY_BIT,
 	MODE_PENDING_ERROR,
 	MODE_RERENDERING_ERROR
@@ -10,8 +11,7 @@ import { renderReactComponent } from './reactComponents';
 /** @type {import('../internal').RendererState} */
 export const rendererState = {
 	context: {},
-	skip: false,
-	commit: false
+	skip: false
 };
 
 /**
@@ -41,12 +41,10 @@ export function renderComponent(
 
 	let prevContext = rendererState.context;
 	rendererState.skip = false;
-	rendererState.commit = false;
 
 	const renderResult = renderReactComponent(newVNode, internal, rendererState);
 
 	internal.props = newVNode.props;
-	let committed = rendererState.commit;
 	if (prevContext != rendererState.context) {
 		internal._context = rendererState.context;
 	}
@@ -75,7 +73,7 @@ export function renderComponent(
 		);
 	}
 
-	if (committed) {
+	if (internal.flags & COMMIT_COMPONENT) {
 		commitQueue.push(internal);
 	}
 

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -33,18 +33,18 @@ export function renderComponent(
 	commitQueue,
 	startDom
 ) {
-	internal._flags &= ~DIRTY_BIT;
-	if (internal._flags & MODE_PENDING_ERROR) {
+	internal.flags &= ~DIRTY_BIT;
+	if (internal.flags & MODE_PENDING_ERROR) {
 		// Toggle the MODE_PENDING_ERROR and MODE_RERENDERING_ERROR flags. In
 		// actuality, this should turn off the MODE_PENDING_ERROR flag and turn on
 		// the MODE_RERENDERING_ERROR flag.
-		internal._flags ^= MODE_PENDING_ERROR | MODE_RERENDERING_ERROR;
+		internal.flags ^= MODE_PENDING_ERROR | MODE_RERENDERING_ERROR;
 	}
 
 	let prevContext = rendererState.context;
 	rendererState.skip = false;
 	rendererState.commit = false;
-	rendererState.force = (internal._flags & FORCE_UPDATE) == FORCE_UPDATE;
+	rendererState.force = (internal.flags & FORCE_UPDATE) == FORCE_UPDATE;
 
 	const renderResult = renderReactComponent(newVNode, internal, rendererState);
 

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -10,6 +10,7 @@ import {
 import { renderReactComponent } from './reactComponents';
 
 /** @type {import('../internal').RendererState} */
+// TODO: Now that context is the only thing in rendererState, do we really need it?
 export const rendererState = { context: {} };
 
 /**

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -2,7 +2,6 @@ import { mountChildren } from './mount';
 import { diffChildren, reorderChildren } from './children';
 import {
 	DIRTY_BIT,
-	FORCE_UPDATE,
 	MODE_PENDING_ERROR,
 	MODE_RERENDERING_ERROR
 } from '../constants';
@@ -12,7 +11,6 @@ import { renderReactComponent } from './reactComponents';
 export const rendererState = {
 	context: {},
 	skip: false,
-	force: false,
 	commit: false
 };
 
@@ -44,7 +42,6 @@ export function renderComponent(
 	let prevContext = rendererState.context;
 	rendererState.skip = false;
 	rendererState.commit = false;
-	rendererState.force = (internal.flags & FORCE_UPDATE) == FORCE_UPDATE;
 
 	const renderResult = renderReactComponent(newVNode, internal, rendererState);
 

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -4,15 +4,13 @@ import {
 	COMMIT_COMPONENT,
 	DIRTY_BIT,
 	MODE_PENDING_ERROR,
-	MODE_RERENDERING_ERROR
+	MODE_RERENDERING_ERROR,
+	SKIP_CHILDREN
 } from '../constants';
 import { renderReactComponent } from './reactComponents';
 
 /** @type {import('../internal').RendererState} */
-export const rendererState = {
-	context: {},
-	skip: false
-};
+export const rendererState = { context: {} };
 
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
@@ -40,7 +38,6 @@ export function renderComponent(
 	}
 
 	let prevContext = rendererState.context;
-	rendererState.skip = false;
 
 	const renderResult = renderReactComponent(newVNode, internal, rendererState);
 
@@ -50,7 +47,7 @@ export function renderComponent(
 	}
 
 	let nextDomSibling;
-	if (rendererState.skip) {
+	if (internal.flags & SKIP_CHILDREN) {
 		// TODO: Returning undefined here (i.e. return;) passes all tests. That seems
 		// like a bug. Should validate that we have test coverage for sCU that
 		// returns Fragments with multiple DOM children

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -35,13 +35,13 @@ export function mount(parentDom, newVNode, internal, commitQueue, startDom) {
 	let nextDomSibling;
 
 	try {
-		if (internal._flags & TYPE_COMPONENT) {
+		if (internal.flags & TYPE_COMPONENT) {
 			// Root nodes signal that an attempt to render into a specific DOM node on
 			// the page. Root nodes can occur anywhere in the tree and not just at the
 			// top.
 			let prevStartDom = startDom;
 			let prevParentDom = parentDom;
-			if (internal._flags & TYPE_ROOT) {
+			if (internal.flags & TYPE_ROOT) {
 				parentDom = newVNode.props._parentDom;
 
 				if (parentDom !== prevParentDom) {
@@ -57,7 +57,7 @@ export function mount(parentDom, newVNode, internal, commitQueue, startDom) {
 				startDom
 			);
 
-			if (internal._flags & TYPE_ROOT && prevParentDom !== parentDom) {
+			if (internal.flags & TYPE_ROOT && prevParentDom !== parentDom) {
 				// If we just mounted a root node/Portal, and it changed the parentDom
 				// of it's children, then we need to resume the diff from it's previous
 				// startDom element, which could be null if we are mounting an entirely
@@ -67,7 +67,7 @@ export function mount(parentDom, newVNode, internal, commitQueue, startDom) {
 			}
 		} else {
 			let hydrateDom =
-				internal._flags & (MODE_HYDRATE | MODE_MUTATIVE_HYDRATE)
+				internal.flags & (MODE_HYDRATE | MODE_MUTATIVE_HYDRATE)
 					? startDom
 					: null;
 
@@ -77,12 +77,12 @@ export function mount(parentDom, newVNode, internal, commitQueue, startDom) {
 		if (options.diffed) options.diffed(internal);
 
 		// We successfully rendered this VNode, unset any stored hydration/bailout state:
-		internal._flags &= RESET_MODE;
+		internal.flags &= RESET_MODE;
 	} catch (e) {
 		internal._vnodeId = 0;
-		internal._flags |= e.then ? MODE_SUSPENDED : MODE_ERRORED;
+		internal.flags |= e.then ? MODE_SUSPENDED : MODE_ERRORED;
 
-		if (internal._flags & MODE_HYDRATE) {
+		if (internal.flags & MODE_HYDRATE) {
 			// @ts-ignore Trust me TS, nextSibling is a PreactElement
 			nextDomSibling = startDom && startDom.nextSibling;
 			internal._dom = startDom; // Save our current DOM position to resume later
@@ -108,10 +108,10 @@ function mountDOMElement(dom, internal, commitQueue) {
 	/** @type {any} */
 	let i;
 
-	let isHydrating = internal._flags & MODE_HYDRATE;
+	let isHydrating = internal.flags & MODE_HYDRATE;
 
 	// if hydrating (hydrate() or render() with replaceNode), find the matching child:
-	if (internal._flags & (MODE_HYDRATE | MODE_MUTATIVE_HYDRATE)) {
+	if (internal.flags & (MODE_HYDRATE | MODE_MUTATIVE_HYDRATE)) {
 		while (
 			dom &&
 			(nodeType ? dom.localName !== nodeType : dom.nodeType !== 3)
@@ -120,7 +120,7 @@ function mountDOMElement(dom, internal, commitQueue) {
 		}
 	}
 
-	if (internal._flags & TYPE_TEXT) {
+	if (internal.flags & TYPE_TEXT) {
 		if (dom == null) {
 			// @ts-ignore createTextNode returns Text, we expect PreactElement
 			dom = document.createTextNode(newProps);
@@ -131,10 +131,10 @@ function mountDOMElement(dom, internal, commitQueue) {
 		internal._dom = dom;
 	} else {
 		// Tracks entering and exiting SVG namespace when descending through the tree.
-		// if (nodeType === 'svg') internal._flags |= MODE_SVG;
+		// if (nodeType === 'svg') internal.flags |= MODE_SVG;
 
 		if (dom == null) {
-			if (internal._flags & MODE_SVG) {
+			if (internal.flags & MODE_SVG) {
 				dom = document.createElementNS(
 					'http://www.w3.org/2000/svg',
 					// @ts-ignore We know `newVNode.type` is a string
@@ -150,13 +150,13 @@ function mountDOMElement(dom, internal, commitQueue) {
 
 			// we are creating a new node, so we can assume this is a new subtree (in case we are hydrating), this deopts the hydrate
 			isHydrating = 0;
-			internal._flags &= RESET_MODE;
+			internal.flags &= RESET_MODE;
 		}
 
 		// @TODO: Consider removing and instructing users to instead set the desired
 		// prop for removal to undefined/null. During hydration, props are not
 		// diffed at all (including dangerouslySetInnerHTML)
-		if (internal._flags & MODE_MUTATIVE_HYDRATE) {
+		if (internal.flags & MODE_MUTATIVE_HYDRATE) {
 			// But, if we are in a situation where we are using existing DOM (e.g. replaceNode)
 			// we should read the existing DOM attributes to diff them
 			for (i = 0; i < dom.attributes.length; i++) {
@@ -180,7 +180,7 @@ function mountDOMElement(dom, internal, commitQueue) {
 				(!isHydrating || typeof newProps[i] == 'function') &&
 				newProps[i] != null
 			) {
-				setProperty(dom, i, newProps[i], null, internal._flags & MODE_SVG);
+				setProperty(dom, i, newProps[i], null, internal.flags & MODE_SVG);
 			}
 		}
 
@@ -261,7 +261,7 @@ export function mountChildren(
 
 		newDom = childInternal._dom;
 
-		if (childInternal._flags & TYPE_COMPONENT || newDom == startDom) {
+		if (childInternal.flags & TYPE_COMPONENT || newDom == startDom) {
 			// If the child is a Fragment-like or if it is DOM VNode and its _dom
 			// property matches the dom we are diffing (i.e. startDom), just
 			// continue with the mountedNextChild
@@ -284,8 +284,8 @@ export function mountChildren(
 
 	// Remove children that are not part of any vnode.
 	if (
-		parentInternal._flags & (MODE_HYDRATE | MODE_MUTATIVE_HYDRATE) &&
-		parentInternal._flags & TYPE_ELEMENT
+		parentInternal.flags & (MODE_HYDRATE | MODE_MUTATIVE_HYDRATE) &&
+		parentInternal.flags & TYPE_ELEMENT
 	) {
 		// TODO: Would it be simpler to just clear the pre-existing DOM in top-level
 		// render if render is called with no oldVNode & existing children & no

--- a/src/diff/patch.js
+++ b/src/diff/patch.js
@@ -23,7 +23,7 @@ import { getChildDom, getDomSibling } from '../tree';
  * @param {import('../internal').PreactNode} startDom
  */
 export function patch(parentDom, newVNode, internal, commitQueue, startDom) {
-	if (internal._flags & TYPE_TEXT) {
+	if (internal.flags & TYPE_TEXT) {
 		if (newVNode !== internal.props) {
 			internal._dom.data = newVNode;
 			internal.props = newVNode;
@@ -45,7 +45,7 @@ export function patch(parentDom, newVNode, internal, commitQueue, startDom) {
 	// top.
 	let prevStartDom = startDom;
 	let prevParentDom = parentDom;
-	if (internal._flags & TYPE_ROOT) {
+	if (internal.flags & TYPE_ROOT) {
 		parentDom = newVNode.props._parentDom;
 
 		if (parentDom !== prevParentDom) {
@@ -65,14 +65,14 @@ export function patch(parentDom, newVNode, internal, commitQueue, startDom) {
 	try {
 		if (internal._vnodeId == newVNode._vnodeId) {
 			internal.props = newVNode.props;
-			if (internal._flags & TYPE_COMPONENT) {
+			if (internal.flags & TYPE_COMPONENT) {
 				nextDomSibling = reorderChildren(internal, startDom, parentDom);
 			} else {
 				// TODO: No test fails if I comment the line below. We are likely
 				// missing a test for this, probably around asserting DOM operations.
 				nextDomSibling = internal._dom.nextSibling;
 			}
-		} else if (internal._flags & TYPE_COMPONENT) {
+		} else if (internal.flags & TYPE_COMPONENT) {
 			nextDomSibling = renderComponent(
 				parentDom,
 				/** @type {import('../internal').VNode} */
@@ -90,7 +90,7 @@ export function patch(parentDom, newVNode, internal, commitQueue, startDom) {
 			);
 		}
 
-		if (internal._flags & TYPE_ROOT && prevParentDom !== parentDom) {
+		if (internal.flags & TYPE_ROOT && prevParentDom !== parentDom) {
 			// If this is a root node/Portal, and it changed the parentDom it's
 			// children, then we need to determine which dom node the diff should
 			// continue with.
@@ -114,13 +114,13 @@ export function patch(parentDom, newVNode, internal, commitQueue, startDom) {
 		if (options.diffed) options.diffed(internal);
 
 		// We successfully rendered this VNode, unset any stored hydration/bailout state:
-		internal._flags &= RESET_MODE;
+		internal.flags &= RESET_MODE;
 		// Once we have successfully rendered the new VNode, copy it's ID over
 		internal._vnodeId = newVNode._vnodeId;
 	} catch (e) {
 		// @TODO: assign a new VNode ID here? Or NaN?
 		// newVNode._vnodeId = 0;
-		internal._flags |= e.then ? MODE_SUSPENDED : MODE_ERRORED;
+		internal.flags |= e.then ? MODE_SUSPENDED : MODE_ERRORED;
 		options._catchError(e, internal);
 	}
 
@@ -159,7 +159,7 @@ function patchDOMElement(dom, newVNode, internal, commitQueue) {
 
 	internal.props = newProps;
 
-	diffProps(dom, newProps, oldProps, internal._flags & MODE_SVG);
+	diffProps(dom, newProps, oldProps, internal.flags & MODE_SVG);
 
 	internal._dom = dom;
 

--- a/src/diff/reactComponents.js
+++ b/src/diff/reactComponents.js
@@ -1,5 +1,6 @@
 import { Fragment, Component, options } from '../index';
 import { assign } from '../util';
+import { FORCE_UPDATE } from '../constants';
 
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
@@ -87,7 +88,7 @@ export function renderReactComponent(newVNode, internal, rendererState) {
 		}
 
 		if (
-			!rendererState.force &&
+			~internal.flags & FORCE_UPDATE &&
 			c.shouldComponentUpdate != null &&
 			c.shouldComponentUpdate(newProps, c._nextState, componentContext) ===
 				false

--- a/src/diff/reactComponents.js
+++ b/src/diff/reactComponents.js
@@ -7,6 +7,13 @@ import {
 	TYPE_ERROR_BOUNDARY
 } from '../constants';
 
+/*
+What about:
+- Hooking into devtools (e.g. _hook, useDebugValue)?
+- SSR (e.g. skipEffects)?
+- HMR (e.g. Prefresh)
+*/
+
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
  * @param {import('../internal').VNode} newVNode The new virtual node

--- a/src/diff/reactComponents.js
+++ b/src/diff/reactComponents.js
@@ -1,6 +1,6 @@
 import { Fragment, Component, options } from '../index';
 import { assign } from '../util';
-import { FORCE_UPDATE } from '../constants';
+import { COMMIT_COMPONENT, FORCE_UPDATE } from '../constants';
 
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
@@ -95,13 +95,6 @@ export function renderReactComponent(newVNode, internal, rendererState) {
 		) {
 			c.props = newProps;
 			c.state = c._nextState;
-			if (c._commitCallbacks != null && c._commitCallbacks.length) {
-				// TODO: We could avoid this check if setState could set a COMMIT flag
-				// on the internal whenever it is called with a callback. This check is
-				// to ensure the setState callback is invoked even when sCU blocks
-				// rerendering.
-				rendererState.commit = true;
-			}
 			rendererState.skip = true;
 			return;
 		}
@@ -150,7 +143,7 @@ export function renderReactComponent(newVNode, internal, rendererState) {
 	}
 
 	if (c._commitCallbacks != null && c._commitCallbacks.length) {
-		rendererState.commit = true;
+		internal.flags |= COMMIT_COMPONENT;
 	}
 
 	let isTopLevelFragment =

--- a/src/diff/reactComponents.js
+++ b/src/diff/reactComponents.js
@@ -1,6 +1,6 @@
 import { Fragment, Component, options } from '../index';
 import { assign } from '../util';
-import { COMMIT_COMPONENT, FORCE_UPDATE } from '../constants';
+import { COMMIT_COMPONENT, FORCE_UPDATE, SKIP_CHILDREN } from '../constants';
 
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
@@ -95,7 +95,12 @@ export function renderReactComponent(newVNode, internal, rendererState) {
 		) {
 			c.props = newProps;
 			c.state = c._nextState;
-			rendererState.skip = true;
+
+			// TODO: Evaluate if using the SKIP_CHILDREN flag is the API we want.
+			// Consider if there is a way we could reuse the VNodeID/VNode equality
+			// logic here. Or return something like `internal._children` to signal
+			// that these children should be skipped.
+			internal.flags |= SKIP_CHILDREN;
 			return;
 		}
 

--- a/src/diff/unmount.js
+++ b/src/diff/unmount.js
@@ -21,14 +21,14 @@ export function unmount(internal, parentInternal, skipRemove) {
 	let r,
 		i = 0;
 	if (options.unmount) options.unmount(internal);
-	internal._flags |= MODE_UNMOUNTING;
+	internal.flags |= MODE_UNMOUNTING;
 
 	if ((r = internal.ref)) {
 		if (!r.current || r.current === internal._dom)
 			applyRef(r, null, parentInternal);
 	}
 
-	if (internal._flags & TYPE_COMPONENT) {
+	if (internal.flags & TYPE_COMPONENT) {
 		try {
 			unmountReactComponent(internal);
 		} catch (e) {
@@ -42,13 +42,13 @@ export function unmount(internal, parentInternal, skipRemove) {
 				unmount(
 					r[i],
 					parentInternal,
-					skipRemove ? ~internal._flags & TYPE_ROOT : internal._flags & TYPE_DOM
+					skipRemove ? ~internal.flags & TYPE_ROOT : internal.flags & TYPE_DOM
 				);
 			}
 		}
 	}
 
-	if (!skipRemove && internal._flags & TYPE_DOM) {
+	if (!skipRemove && internal.flags & TYPE_DOM) {
 		removeNode(internal._dom);
 	}
 

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -53,9 +53,6 @@ export interface RendererState {
 	context: Record<string, any>;
 	/** Set to true when this component's children do not need to be diffed */
 	skip: boolean;
-	/** Indicates this component should be added to the commit queue and should
-	 * have the commit option invoked on it */
-	commit: boolean;
 }
 
 // Redefine ComponentFactory using our new internal FunctionalComponent interface above

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -137,6 +137,8 @@ export interface Internal<P = {}> {
 	props: (P & { children: ComponentChildren }) | string | number;
 	key: any;
 	ref: Ref<any> | null;
+	/** Bitfield containing information about the Internal or its component. */
+	flags: number;
 	/** children Internal nodes */
 	_children: Internal[];
 	/** next sibling Internal node */
@@ -150,8 +152,6 @@ export interface Internal<P = {}> {
 	_dom: PreactNode;
 	/** The component instance for which this is a backing Internal node */
 	_component: Component | null;
-	/** Bitfield containing information about the Internal or its component. */
-	_flags: number;
 	/** This Internal's distance from the tree root */
 	_depth: number | null;
 	_context: any;

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -53,8 +53,6 @@ export interface RendererState {
 	context: Record<string, any>;
 	/** Set to true when this component's children do not need to be diffed */
 	skip: boolean;
-	/** Indicates that this component must rerender and skip anything like memo or sCU */
-	force: boolean;
 	/** Indicates this component should be added to the commit queue and should
 	 * have the commit option invoked on it */
 	commit: boolean;

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -51,8 +51,6 @@ export type CommitQueue = Internal[];
 export interface RendererState {
 	/** The current shared global context for this sub tree */
 	context: Record<string, any>;
-	/** Set to true when this component's children do not need to be diffed */
-	skip: boolean;
 }
 
 // Redefine ComponentFactory using our new internal FunctionalComponent interface above

--- a/src/render.js
+++ b/src/render.js
@@ -34,12 +34,12 @@ export function render(vnode, parentDom) {
 		rootInternal._context = {};
 
 		if (parentDom.ownerSVGElement !== undefined) {
-			rootInternal._flags |= MODE_SVG;
+			rootInternal.flags |= MODE_SVG;
 		}
 
 		// Calling `render` on a container with existing DOM elements puts the diff into mutative hydrate mode:
 		if (parentDom.firstChild) {
-			rootInternal._flags |= MODE_MUTATIVE_HYDRATE;
+			rootInternal.flags |= MODE_MUTATIVE_HYDRATE;
 		}
 
 		mount(
@@ -69,11 +69,11 @@ export function hydrate(vnode, parentDom) {
 	vnode = createElement(Fragment, { _parentDom: parentDom }, [vnode]);
 	const rootInternal = createInternal(vnode);
 	rootInternal._context = {};
-	rootInternal._flags |= MODE_HYDRATE;
+	rootInternal.flags |= MODE_HYDRATE;
 	parentDom._children = rootInternal;
 
 	if (parentDom.ownerSVGElement !== undefined) {
-		rootInternal._flags |= MODE_SVG;
+		rootInternal.flags |= MODE_SVG;
 	}
 
 	const commitQueue = [];

--- a/src/tree.js
+++ b/src/tree.js
@@ -24,7 +24,7 @@ export function createInternal(vnode, parentInternal) {
 		ref;
 
 	/** @type {number} */
-	let flags = parentInternal ? parentInternal._flags & INHERITED_MODES : 0;
+	let flags = parentInternal ? parentInternal.flags & INHERITED_MODES : 0;
 
 	// Text VNodes/Internals use NaN as an ID so that two are never equal.
 	let vnodeId = NaN;
@@ -69,7 +69,7 @@ export function createInternal(vnode, parentInternal) {
 			flags |= MODE_SVG;
 		} else if (
 			parentInternal &&
-			parentInternal._flags & MODE_SVG &&
+			parentInternal.flags & MODE_SVG &&
 			parentInternal.type === 'foreignObject'
 		) {
 			flags &= ~MODE_SVG;
@@ -82,12 +82,12 @@ export function createInternal(vnode, parentInternal) {
 		props,
 		key,
 		ref,
+		flags,
 		_children: null,
 		_parent: parentInternal,
 		_vnodeId: vnodeId,
 		_dom: null,
 		_component: null,
-		_flags: flags,
 		_depth: parentInternal ? parentInternal._depth + 1 : 0,
 		_context: null
 	};
@@ -99,8 +99,8 @@ export function createInternal(vnode, parentInternal) {
 
 /** @type {(internal: import('./internal').Internal) => boolean} */
 const shouldSearchComponent = internal =>
-	internal._flags & TYPE_COMPONENT &&
-	(!(internal._flags & TYPE_ROOT) ||
+	internal.flags & TYPE_COMPONENT &&
+	(!(internal.flags & TYPE_ROOT) ||
 		internal.props._parentDom == getParentDom(internal._parent));
 
 /**
@@ -146,7 +146,7 @@ export function getChildDom(internal, i) {
 	for (i = i || 0; i < internal._children.length; i++) {
 		let child = internal._children[i];
 		if (child != null) {
-			if (child._flags & TYPE_DOM) {
+			if (child.flags & TYPE_DOM) {
 				return child._dom;
 			}
 
@@ -167,14 +167,13 @@ export function getChildDom(internal, i) {
  * @returns {import('./internal').PreactElement}
  */
 export function getParentDom(internal) {
-	let parentDom =
-		internal._flags & TYPE_ROOT ? internal.props._parentDom : null;
+	let parentDom = internal.flags & TYPE_ROOT ? internal.props._parentDom : null;
 
 	let parent = internal._parent;
 	while (parentDom == null && parent) {
-		if (parent._flags & TYPE_ROOT) {
+		if (parent.flags & TYPE_ROOT) {
 			parentDom = parent.props._parentDom;
-		} else if (parent._flags & TYPE_ELEMENT) {
+		} else if (parent.flags & TYPE_ELEMENT) {
 			parentDom = parent._dom;
 		}
 

--- a/src/tree.js
+++ b/src/tree.js
@@ -3,7 +3,6 @@ import {
 	TYPE_FUNCTION,
 	TYPE_ELEMENT,
 	TYPE_TEXT,
-	TYPE_CLASS,
 	TYPE_ROOT,
 	INHERITED_MODES,
 	TYPE_COMPONENT,
@@ -58,9 +57,7 @@ export function createInternal(vnode, parentInternal) {
 		// flags = typeof type === 'function' ? COMPONENT_NODE : ELEMENT_NODE;
 		flags |=
 			typeof type === 'function'
-				? type.prototype && 'render' in type.prototype
-					? TYPE_CLASS
-					: props._parentDom
+				? props._parentDom
 					? TYPE_ROOT
 					: TYPE_FUNCTION
 				: TYPE_ELEMENT;

--- a/test/browser/lifecycles/componentDidCatch.test.js
+++ b/test/browser/lifecycles/componentDidCatch.test.js
@@ -655,49 +655,6 @@ describe('Lifecycle methods', () => {
 			expect(scratch).to.have.property('textContent', 'Error: Error!');
 		});
 
-		it('should bubble through already-dirty components', () => {
-			let middle;
-			class Middle extends Component {
-				render({ children }) {
-					middle = this;
-					// This component marks itself as dirty during rendering.
-					// The fact that it is marked as dirty should not prevent propagation of the error through this component.
-					if (this.state.a !== 1) {
-						this.setState({ a: 1 });
-					}
-					const markDirty = () => {
-						if (this.state.b !== 1) {
-							this.setState({ b: 1 });
-						}
-					};
-					// NOTE: the above avoids setting the DIRTY flag during rendering, circumventing the propagation issue.
-					// However, manually marking a component as dirty during rendering *will* prevent error propagation:
-					// this._internal.flags |= DIRTY
-					return [<Fragment ref={markDirty} />, children];
-				}
-			}
-			sinon.spy(Middle.prototype, 'render');
-
-			ThrowErr.prototype.render = throwExpectedError;
-
-			render(
-				<Receiver>
-					<Middle>
-						<ThrowErr />
-					</Middle>
-				</Receiver>,
-				scratch
-			);
-			rerender();
-
-			expect(middle)
-				.to.haveOwnProperty('state')
-				.that.deep.equals({ a: 1, b: 1 });
-			expect(Receiver.prototype.componentDidCatch).to.have.been.calledWith(
-				expectedError
-			);
-		});
-
 		it('should be called through non-component parent elements', () => {
 			ThrowErr.prototype.render = throwExpectedError;
 			render(

--- a/test/browser/lifecycles/componentDidCatch.test.js
+++ b/test/browser/lifecycles/componentDidCatch.test.js
@@ -672,7 +672,7 @@ describe('Lifecycle methods', () => {
 					};
 					// NOTE: the above avoids setting the DIRTY flag during rendering, circumventing the propagation issue.
 					// However, manually marking a component as dirty during rendering *will* prevent error propagation:
-					// this._internal._flags |= DIRTY
+					// this._internal.flags |= DIRTY
 					return [<Fragment ref={markDirty} />, children];
 				}
 			}


### PR DESCRIPTION
This change removes the `isNew` variable

Dependent on #3107 for now

Great catch by @developit 