### PR TITLE
Rely directly on performance.now

### DIFF
--- a/compat/scheduler.js
+++ b/compat/scheduler.js
@@ -1,0 +1,15 @@
+// see scheduler.mjs
+
+function unstable_runWithPriority(priority, callback) {
+	return callback();
+}
+
+module.exports = {
+	unstable_ImmediatePriority: 1,
+	unstable_UserBlockingPriority: 2,
+	unstable_NormalPriority: 3,
+	unstable_LowPriority: 4,
+	unstable_IdlePriority: 5,
+	unstable_runWithPriority,
+	unstable_now: performance.now.bind(performance)
+};

--- a/compat/scheduler.mjs
+++ b/compat/scheduler.mjs
@@ -1,14 +1,16 @@
+/* eslint-disable */
+
 // This file includes experimental React APIs exported from the "scheduler"
 // npm package. Despite being explicitely marked as unstable some libraries
 // already make use of them. This file is not a full replacement for the
 // scheduler package, but includes the necessary shims to make those libraries
 // work with Preact.
 
-export const unstable_ImmediatePriority = 1;
-export const unstable_UserBlockingPriority = 2;
-export const unstable_NormalPriority = 3;
-export const unstable_LowPriority = 4;
-export const unstable_IdlePriority = 5;
+export var unstable_ImmediatePriority = 1;
+export var unstable_UserBlockingPriority = 2;
+export var unstable_NormalPriority = 3;
+export var unstable_LowPriority = 4;
+export var unstable_IdlePriority = 5;
 
 /**
  * @param {number} priority
@@ -18,4 +20,4 @@ export function unstable_runWithPriority(priority, callback) {
 	return callback();
 }
 
-export const unstable_now = () => performance.now();
+export var unstable_now = performance.now.bind(performance);

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -100,16 +100,16 @@ function findDOMNode(component) {
 // eslint-disable-next-line camelcase
 const unstable_batchedUpdates = (callback, arg) => callback(arg);
 
-/** 
+/**
  * In React, `flushSync` flushes the entire tree and forces a rerender. It's
  * implmented here as a no-op.
  * @template Arg
  * @template Result
  * @param {(arg: Arg) => Result} callback function that runs before the flush
  * @param {Arg} [arg] Optional arugment that can be passed to the callback
- * @returns 
+ * @returns
  */
-const flushSync = (callback, arg) => callback(arg)
+const flushSync = (callback, arg) => callback(arg);
 
 /**
  * Strict Mode is not implemented in Preact, so we provide a stand-in for it

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -32,7 +32,6 @@ import {
 	REACT_ELEMENT_TYPE,
 	__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
 } from './render';
-export * from './scheduler';
 
 const version = '16.8.0'; // trick libraries to think we are react
 

--- a/compat/src/scheduler.js
+++ b/compat/src/scheduler.js
@@ -18,7 +18,4 @@ export function unstable_runWithPriority(priority, callback) {
 	return callback();
 }
 
-export const unstable_now =
-	typeof performance === 'object' && typeof performance.now === 'function'
-		? performance.now.bind(performance)
-		: () => Date.now();
+export const unstable_now = () => performance.now();

--- a/compat/test/browser/scheduler.test.js
+++ b/compat/test/browser/scheduler.test.js
@@ -6,7 +6,7 @@ import {
 	unstable_UserBlockingPriority,
 	unstable_ImmediatePriority,
 	unstable_now
-} from 'preact/compat';
+} from 'preact/compat/scheduler';
 
 describe('scheduler', () => {
 	describe('runWithPriority', () => {

--- a/compat/test/browser/scheduler.test.js
+++ b/compat/test/browser/scheduler.test.js
@@ -6,7 +6,7 @@ import {
 	unstable_UserBlockingPriority,
 	unstable_ImmediatePriority,
 	unstable_now
-} from '../../src/scheduler';
+} from 'preact/compat/scheduler';
 
 describe('scheduler', () => {
 	describe('runWithPriority', () => {

--- a/compat/test/browser/scheduler.test.js
+++ b/compat/test/browser/scheduler.test.js
@@ -6,7 +6,7 @@ import {
 	unstable_UserBlockingPriority,
 	unstable_ImmediatePriority,
 	unstable_now
-} from 'preact/compat/scheduler';
+} from '../../src/scheduler';
 
 describe('scheduler', () => {
 	describe('runWithPriority', () => {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 		"build:devtools": "microbundle build --raw --cwd devtools",
 		"build:hooks": "microbundle build --raw --cwd hooks",
 		"build:test-utils": "microbundle build --raw --cwd test-utils",
-		"build:compat": "microbundle build --raw --cwd compat --globals 'preact/hooks=preactHooks'",
+		"build:compat": "microbundle build src/index.js src/scheduler.js --raw --cwd compat --globals 'preact/hooks=preactHooks'",
 		"build:jsx": "microbundle build --raw --cwd jsx-runtime",
 		"postbuild": "node ./config/node-13-exports.js && node ./config/compat-entries.js",
 		"dev": "microbundle watch --raw --format cjs",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,10 @@
 			"require": "./compat/server.js",
 			"import": "./compat/server.mjs"
 		},
+		"./compat/scheduler": {
+			"require": "./compat/dist/scheduler.js",
+			"import": "./compat/dist/scheduler.mjs"
+		},
 		"./package.json": "./package.json",
 		"./": "./"
 	},

--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
 			"import": "./compat/server.mjs"
 		},
 		"./compat/scheduler": {
-			"require": "./compat/dist/scheduler.js",
-			"import": "./compat/dist/scheduler.mjs"
+			"require": "./compat/scheduler.js",
+			"import": "./compat/scheduler.mjs"
 		},
 		"./package.json": "./package.json",
 		"./": "./"
@@ -175,6 +175,8 @@
 		"compat/src",
 		"compat/server.js",
 		"compat/server.mjs",
+		"compat/scheduler.js",
+		"compat/scheduler.mjs",
 		"compat/test-utils.js",
 		"compat/jsx-runtime.js",
 		"compat/jsx-runtime.mjs",


### PR DESCRIPTION
React doesn't export the scheduler methods or constants from `react` or `react-dom`.