### PR TITLE
Move VNode matching logic into its own function

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -35,7 +35,7 @@ export function diffChildren(
 	commitQueue,
 	startDom
 ) {
-	let i, j, newDom, refs;
+	let i, newDom, refs;
 
 	/** @type {import('../internal').Internal} */
 	let childInternal;
@@ -58,45 +58,12 @@ export function diffChildren(
 			continue;
 		}
 
-		// Check if we find a corresponding element in oldChildren.
-		// If found, delete the array item by setting to `undefined`.
-		// We use `undefined`, as `null` is reserved for empty placeholders
-		// (holes).
-		childInternal = oldChildren[i];
-
-		if (typeof childVNode === 'string') {
-			// We never move Text nodes, so we only check for an in-place match:
-			if (childInternal && childInternal._flags & TYPE_TEXT) {
-				oldChildren[i] = undefined;
-			} else {
-				// We're looking for a Text node, but this wasn't one: ignore it
-				childInternal = undefined;
-			}
-		} else if (
-			childInternal === null ||
-			(childInternal &&
-				childVNode.key == childInternal.key &&
-				childVNode.type === childInternal.type)
-		) {
-			oldChildren[i] = undefined;
-		} else {
-			// Either oldVNode === undefined or oldChildrenLength > 0,
-			// so after this loop oldVNode == null or oldVNode is a valid value.
-			for (j = 0; j < oldChildrenLength; j++) {
-				childInternal = oldChildren[j];
-				// If childVNode is unkeyed, we only match similarly unkeyed nodes, otherwise we match by key.
-				// We always match by type (in either case).
-				if (
-					childInternal &&
-					childVNode.key == childInternal.key &&
-					childVNode.type === childInternal.type
-				) {
-					oldChildren[j] = undefined;
-					break;
-				}
-				childInternal = null;
-			}
-		}
+		childInternal = findMatchingInternal(
+			childVNode,
+			oldChildren,
+			i,
+			oldChildrenLength
+		);
 
 		let prevDom;
 		let oldVNodeRef;
@@ -213,6 +180,57 @@ export function diffChildren(
 	}
 
 	return startDom;
+}
+
+/**
+ * @param {import('../internal').VNode | string} childVNode
+ * @param {import('../internal').Internal[]} oldChildren
+ * @param {number} i
+ * @param {number} oldChildrenLength
+ * @returns {import('../internal').Internal}
+ */
+function findMatchingInternal(childVNode, oldChildren, i, oldChildrenLength) {
+	// Check if we find a corresponding element in oldChildren.
+	// If found, delete the array item by setting to `undefined`.
+	// We use `undefined`, as `null` is reserved for empty placeholders
+	// (holes).
+	let childInternal = oldChildren[i];
+
+	if (typeof childVNode === 'string') {
+		// We never move Text nodes, so we only check for an in-place match:
+		if (childInternal && childInternal._flags & TYPE_TEXT) {
+			oldChildren[i] = undefined;
+		} else {
+			// We're looking for a Text node, but this wasn't one: ignore it
+			childInternal = undefined;
+		}
+	} else if (
+		childInternal === null ||
+		(childInternal &&
+			childVNode.key == childInternal.key &&
+			childVNode.type === childInternal.type)
+	) {
+		oldChildren[i] = undefined;
+	} else {
+		// Either oldVNode === undefined or oldChildrenLength > 0,
+		// so after this loop oldVNode == null or oldVNode is a valid value.
+		for (let j = 0; j < oldChildrenLength; j++) {
+			childInternal = oldChildren[j];
+			// If childVNode is unkeyed, we only match similarly unkeyed nodes, otherwise we match by key.
+			// We always match by type (in either case).
+			if (
+				childInternal &&
+				childVNode.key == childInternal.key &&
+				childVNode.type === childInternal.type
+			) {
+				oldChildren[j] = undefined;
+				break;
+			}
+			childInternal = null;
+		}
+	}
+
+	return childInternal;
 }
 
 /**


### PR DESCRIPTION
While doing some child diffing investigations, I noticed locally that moving our VNode matching logic into its own function and improve some of the run times on 02_replace1k benchmark. The final duration doesn't change too much but locally it appears to remove some of the main-thread optimizations that occured in the early runs of 02_replace1k