### PR TITLE
Remove unused reorder call in patch

### DIFF
--- a/src/diff/patch.js
+++ b/src/diff/patch.js
@@ -1,4 +1,4 @@
-import { diffChildren, reorderChildren } from './children';
+import { diffChildren } from './children';
 import { diffProps, setProperty } from './props';
 import options from '../options';
 import { renderComponent } from './component';
@@ -122,12 +122,6 @@ export function patch(
 		// Once we have successfully rendered the new VNode, copy it's ID over
 		internal._vnodeId = newVNode._vnodeId;
 	} catch (e) {
-		if (e.then) {
-			// If a promise was thrown, reorderChildren in case this component is
-			// being hidden or moved
-			reorderChildren(internal, startDom, parentDom);
-		}
-
 		// @TODO: assign a new VNode ID here? Or NaN?
 		// newVNode._vnodeId = 0;
 		internal._flags |= e.then ? MODE_SUSPENDED : MODE_ERRORED;


### PR DESCRIPTION
In #3072, we no longer rerender all of Suspense's children when rendering the fallback. As such, we no longer need to reorder children that might've thrown during this fallback render. This PR removes that logic since it is no longer needed (I forgot to do this in #3072).