### PR TITLE
Update signature of `lazy` to reflect behavior

### DIFF
--- a/compat/src/suspense.d.ts
+++ b/compat/src/suspense.d.ts
@@ -3,7 +3,7 @@ import { Component, ComponentChild } from '../../src';
 //
 // Suspense/lazy
 // -----------------------------------
-export function lazy<T>(loader: () => Promise<{ default: T }>): T;
+export function lazy<T>(loader: () => Promise<{ default: T } | T>): T;
 
 export interface SuspenseProps {
 	children?: preact.ComponentChildren;


### PR DESCRIPTION
The `lazy` function of `preach/compat` accepts the promise to either return a `{ default: T }` (as `import()` would) or just `T`. This was missing in the typescript declaration however and this PR dresses that.