### PR TITLE
Improve typing of forwardRef

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -105,7 +105,7 @@ declare namespace React {
 
 	export function forwardRef<R, P = {}>(
 		fn: ForwardFn<P, R>
-	): preact.FunctionalComponent<P>;
+	): preact.FunctionalComponent<Omit<P, 'ref'> & { ref?: preact.RefObject<R> }>;
 
 	export function unstable_batchedUpdates(
 		callback: (arg?: any) => void,


### PR DESCRIPTION
The specified ref type is now included in the typing of the functional component returned by `forwardRef`.

This is similar to the corresponding React typings, which currently look like [this](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e293a5bb95e4c77482da1d91dde77d4a1d6e397c/types/react/index.d.ts#L800):

```ts
function forwardRef<T, P = {}>(
  render: ForwardRefRenderFunction<T, P>
): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
```