### PR TITLE
[restructure] Use signed ints for VNode ID generation

### DIFF
--- a/jsx-runtime/src/index.js
+++ b/jsx-runtime/src/index.js
@@ -2,6 +2,8 @@ import { options, Fragment } from 'preact';
 
 /** @typedef {import('preact').VNode} VNode */
 
+let vnodeId = 0;
+
 /**
  * @fileoverview
  * This file exports various methods that implement Babel's "automatic" JSX runtime API:
@@ -38,6 +40,7 @@ function createVNode(type, props, key, __source, __self) {
 		key,
 		ref: props && props.ref,
 		constructor: undefined,
+		_vnodeId: --vnodeId,
 		__source,
 		__self
 	};

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -1,5 +1,7 @@
 import options from './options';
 
+let vnodeId = 0;
+
 /**
  * Create an virtual node (used for JSX)
  * @param {import('./internal').VNode["type"]} type The node name or Component
@@ -64,7 +66,7 @@ export function createVNode(type, props, key, ref, original) {
 		key,
 		ref,
 		constructor: undefined,
-		_vnodeId: original === 0 ? ++options._vnodeId : original
+		_vnodeId: original || ++vnodeId
 	};
 
 	if (options.vnode != null) options.vnode(vnode);

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -21,7 +21,6 @@ export interface DevSource {
 }
 
 export interface Options extends preact.Options {
-	_vnodeId: number;
 	/** Attach a hook that is invoked immediately before a vnode is unmounted. */
 	unmount?(internal: Internal): void;
 	/** Attach a hook that is invoked after a vnode has rendered. */
@@ -42,8 +41,8 @@ export interface Options extends preact.Options {
 	/** Bypass effect execution. Currenty only used in devtools for hooks inspection */
 	_skipEffects?: boolean;
 	/** Attach a hook that is invoked after an error is caught in a component but before calling lifecycle hooks */
-	_catchError(error: any, internal: Internal): void;
-	_internal(internal: Internal, vnode: VNode | string): void;
+	_catchError?(error: any, internal: Internal): void;
+	_internal?(internal: Internal, vnode: VNode | string): void;
 }
 
 export type CommitQueue = Internal[];
@@ -112,6 +111,11 @@ export interface VNode<P = {}> extends preact.VNode<P> {
 	// Redefine type here using our internal ComponentType type
 	type: string | ComponentType<P>;
 	props: P & { children: ComponentChildren };
+	/**
+	 * Internal GUID for this VNode, used for fast equality checks.
+	 * Note: h() allocates monotonic positive integer IDs, jsx() allocates negative.
+	 * @private
+	 */
 	_vnodeId: number;
 }
 

--- a/src/options.js
+++ b/src/options.js
@@ -10,8 +10,7 @@ import { _catchError } from './diff/catch-error';
  * @type {import('./internal').Options}
  */
 const options = {
-	_catchError,
-	_vnodeId: 1
+	_catchError
 };
 
 export default options;


### PR DESCRIPTION
This brings the changes from #2978 to restructure.