### PR TITLE
iteration on #3152: inline unmount hook and use global subscriptions

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -254,7 +254,7 @@ export function useContext(context) {
 	// This is probably not safe to convert to "!"
 	if (state._value == null) {
 		state._value = true;
-		provider.sub(currentComponent);
+		provider._subs.add(currentComponent);
 	}
 	return provider.props.value;
 }

--- a/hooks/test/browser/useContext.test.js
+++ b/hooks/test/browser/useContext.test.js
@@ -193,7 +193,7 @@ describe('useContext', () => {
 			</Context.Provider>,
 			scratch
 		);
-		subSpy = sinon.spy(provider, 'sub');
+		subSpy = sinon.spy(provider._subs, 'add');
 
 		render(
 			<Context.Provider value={69}>

--- a/mangle.json
+++ b/mangle.json
@@ -68,7 +68,9 @@
       "$_owner": "__o",
       "$_skipEffects": "__s",
       "$_rerenderCount": "__r",
-      "$_forwarded": "__f"
+      "$_forwarded": "__f",
+      "$_subs": "s",
+      "$_prev": "p"
     }
   }
 }

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -29,7 +29,8 @@ export const createContext = (defaultValue, contextId) => {
 			// initial setup:
 			if (!this._subs) {
 				this._subs = new Set();
-				ctx = { [contextId]: this };
+				ctx = {};
+				ctx[contextId] = this;
 				this.getChildContext = () => ctx;
 			}
 			// re-render subscribers in response to value change

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -1,10 +1,18 @@
 import { enqueueRender } from './component';
-import options from './options';
 
-export let i = 0;
+export let nextContextId = 0;
 
-export function createContext(defaultValue, contextId) {
-	contextId = '__cC' + i++;
+const providers = new Set();
+
+export const unsubscribeFromContext = component => {
+	// if this was a context provider, delete() returns true and we exit:
+	if (providers.delete(component)) return;
+	// ... otherwise, unsubscribe from any contexts:
+	providers.forEach(p => p._subs.delete(component));
+};
+
+export const createContext = (defaultValue, contextId) => {
+	contextId = '__cC' + nextContextId++;
 
 	const context = {
 		_id: contextId,
@@ -17,45 +25,18 @@ export function createContext(defaultValue, contextId) {
 			return props.children(contextValue);
 		},
 		/** @type {import('./internal').FunctionComponent} */
-		Provider(props) {
-			if (!this.getChildContext) {
-				let subs = new Set();
-				let ctx = {};
-				ctx[contextId] = this;
-
-				const oldUnmount = options.unmount;
-				options.unmount = internal => {
-					subs.delete(internal._component);
-
-					if (oldUnmount) oldUnmount(internal)
-				}
-
+		Provider(props, ctx) {
+			// initial setup:
+			if (!this._subs) {
+				this._subs = new Set();
+				ctx = { [contextId]: this };
 				this.getChildContext = () => ctx;
-
-				this.shouldComponentUpdate = function(_props) {
-					if (this.props.value !== _props.value) {
-						// I think the forced value propagation here was only needed when `options.debounceRendering` was being bypassed:
-						// https://github.com/preactjs/preact/commit/4d339fb803bea09e9f198abf38ca1bf8ea4b7771#diff-54682ce380935a717e41b8bfc54737f6R358
-						// In those cases though, even with the value corrected, we're double-rendering all nodes.
-						// It might be better to just tell folks not to use force-sync mode.
-						// Currently, using `useContext()` in a class component will overwrite its `this.context` value.
-						// subs.some(c => {
-						// 	c.context = _props.value;
-						// 	enqueueRender(c);
-						// });
-
-						// subs.some(c => {
-						// 	c.context[contextId] = _props.value;
-						// 	enqueueRender(c);
-						// });
-						subs.forEach(enqueueRender);
-					}
-				};
-
-				this.sub = c => {
-					subs.add(c);
-				};
 			}
+			// re-render subscribers in response to value change
+			else if (props.value !== this._prev) {
+				this._subs.forEach(enqueueRender);
+			}
+			this._prev = props.value;
 
 			return props.children;
 		}
@@ -68,4 +49,4 @@ export function createContext(defaultValue, contextId) {
 	// https://reactjs.org/docs/context.html#contextdisplayname
 
 	return (context.Provider._contextRef = context.Consumer.contextType = context);
-}
+};

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -71,7 +71,7 @@ export function renderComponent(
 			c.constructor = type;
 			c.render = doRender;
 		}
-		if (provider) provider.sub(c);
+		if (provider) provider._subs.add(c);
 
 		c.props = newProps;
 		if (!c.state) c.state = {};

--- a/src/diff/unmount.js
+++ b/src/diff/unmount.js
@@ -1,4 +1,5 @@
 import { MODE_UNMOUNTING, TYPE_DOM, TYPE_ROOT } from '../constants';
+import { unsubscribeFromContext } from '../create-context';
 import options from '../options';
 import { removeNode } from '../util';
 import { applyRef } from './refs';
@@ -23,6 +24,8 @@ export function unmount(internal, parentInternal, skipRemove) {
 	}
 
 	if ((r = internal._component) != null) {
+		unsubscribeFromContext(r);
+
 		if (r.componentWillUnmount) {
 			try {
 				r.componentWillUnmount();


### PR DESCRIPTION
(note: this is slightly better for filesize when the babel config from `remove-ie11` is applied, because of the arrow functions and computed object property. Locally, `npm run dev` reports `preact.js.gz:  4524b`)