### PR TITLE
Use Brotli instead of gzip

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -15,3 +15,4 @@ jobs:
       - uses: preactjs/compressed-size-action@v1
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          compression: 'brotli'


### PR DESCRIPTION
Let's optimize for Brotli size:
- It's supported by most modern browsers (and not IE 11).
- It performs better than gzip.