### PR TITLE
[restructure] Simplify normalizeToVNode() so all new types are treated as text by default

### DIFF
--- a/src/create-element.js
+++ b/src/create-element.js
@@ -79,20 +79,17 @@ export function createVNode(type, props, key, ref, original) {
  * @returns {import('./internal').VNode | string | null}
  */
 export function normalizeToVNode(childVNode) {
-	if (childVNode == null || childVNode === true || childVNode === false) {
-		return null;
+	switch (typeof childVNode) {
+		case 'boolean':
+			return null;
+		case 'object':
+		case 'function':
+			if (Array.isArray(childVNode)) {
+				return createVNode(Fragment, { children: childVNode }, null, null, 0);
+			}
+			return childVNode;
 	}
-	const type = typeof childVNode;
-	if (type === 'string' || type === 'function') {
-		return childVNode;
-	}
-	if (type !== 'object') {
-		return childVNode + '';
-	}
-	if (Array.isArray(childVNode)) {
-		return createVNode(Fragment, { children: childVNode }, null, null, 0);
-	}
-	return childVNode;
+	return childVNode + '';
 }
 
 export function createRef() {

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -79,22 +79,19 @@ export function createVNode(type, props, key, ref, original) {
  * @returns {import('./internal').VNode | string | null}
  */
 export function normalizeToVNode(childVNode) {
-	if (childVNode == null || typeof childVNode == 'boolean') {
+	if (childVNode == null || childVNode === true || childVNode === false) {
 		return null;
 	}
-	// If this newVNode is being reused (e.g. <div>{reuse}{reuse}</div>) in the same diff,
-	// or we are rendering a component (e.g. setState) copy the oldVNodes so it can have
-	// it's own DOM & etc. pointers
-	else if (
-		typeof childVNode == 'number' ||
-		// eslint-disable-next-line valid-typeof
-		typeof childVNode == 'bigint'
-	) {
+	const type = typeof childVNode;
+	if (type === 'string' || type === 'function') {
+		return childVNode;
+	}
+	if (type !== 'object') {
 		return childVNode + '';
-	} else if (Array.isArray(childVNode)) {
+	}
+	if (Array.isArray(childVNode)) {
 		return createVNode(Fragment, { children: childVNode }, null, null, 0);
 	}
-
 	return childVNode;
 }
 


### PR DESCRIPTION
This just inverts the type checks in `normalizeToVNode` so that the default case (for types we don't track or use) is to convert things to a String. 