### PR TITLE
Fix react-spring error caused by augmented function contexts

### DIFF
--- a/mangle.json
+++ b/mangle.json
@@ -55,7 +55,7 @@
       "$_pendingError": "__E",
       "$_processingException": "__",
       "$_globalContext": "__n",
-      "$_context": "__c",
+      "$_context": "c",
       "$_defaultValue": "__",
       "$_id": "__c",
       "$_contextRef": "__",


### PR DESCRIPTION
React-spring provides its own [custom context wrapper](https://github.com/pmndrs/react-spring/blob/d5d8271656f3f3c464a47ad9d39941250ce588b6/packages/core/src/SpringContext.tsx#L33), which effectively does `Object.assign(function SpringContext, createContext(defaultValue))`. This breaks `preact/hooks` because it causes the hook state for `useContext()` to have a `.__c` property that contains a `function`. We mangle both `_cleanup` and `_context` to `__c`, which collides. Normally this is not an issue because `createContext()` returns an Object.