### PR TITLE
(restructure) Tighten benchmark measured time

### DIFF
--- a/benches/src/02_replace1k.html
+++ b/benches/src/02_replace1k.html
@@ -6,6 +6,9 @@
 		<title>replace all rows</title>
 		<meta name="description" content="updating all 1,000 rows" />
 		<style>
+			table {
+				table-layout: fixed;
+			}
 			.preloadicon {
 				display: none;
 			}
@@ -25,8 +28,7 @@
 				afterFrameAsync,
 				markRunStart,
 				markRunEnd,
-				forceLayout,
-				tick,
+				mutateAndLayout,
 				raf
 			} from './util.js';
 			import * as framework from 'framework';
@@ -52,12 +54,10 @@
 
 				markRunStart('final');
 				performance.mark('start');
-				run();
-				await tick();
-				await forceLayout();
+				await mutateAndLayout(run);
+				performance.mark('stop');
 				await markRunEnd('final');
 				testElementText(elementSelector, WARMUP_COUNT + '001');
-				performance.mark('stop');
 				performance.measure(measureName, 'start', 'stop');
 
 				await raf();

--- a/benches/src/02_replace1k.html
+++ b/benches/src/02_replace1k.html
@@ -24,7 +24,10 @@
 				afterFrame,
 				afterFrameAsync,
 				markRunStart,
-				markRunEnd
+				markRunEnd,
+				forceLayout,
+				tick,
+				raf
 			} from './util.js';
 			import * as framework from 'framework';
 			import { render } from '../src/keyed-children/index.js';
@@ -47,18 +50,18 @@
 
 				await afterFrameAsync();
 
-				afterFrame(function () {
-					testElementText(elementSelector, WARMUP_COUNT + '001');
-					performance.mark('stop');
-					performance.measure(measureName, 'start', 'stop');
-
-					measureMemory();
-				});
-
 				markRunStart('final');
 				performance.mark('start');
 				run();
+				await tick();
+				await forceLayout();
 				await markRunEnd('final');
+				testElementText(elementSelector, WARMUP_COUNT + '001');
+				performance.mark('stop');
+				performance.measure(measureName, 'start', 'stop');
+
+				await raf();
+				measureMemory();
 			}
 
 			afterFrame(main);

--- a/benches/src/03_update10th1k_x16.html
+++ b/benches/src/03_update10th1k_x16.html
@@ -13,7 +13,7 @@
 				display: none;
 			}
 			.glyphicon-remove:before {
-				content: "⨯";
+				content: '⨯';
 			}
 		</style>
 	</head>
@@ -27,7 +27,9 @@
 				afterFrameAsync,
 				getRowLinkSel,
 				testElement,
-				testElementTextContains
+				testElementTextContains,
+				forceLayout,
+				tick
 			} from './util.js';
 			import * as framework from 'framework';
 			import { render } from '../src/keyed-children/index.js';
@@ -63,8 +65,8 @@
 			async function run() {
 				performance.mark('start');
 				update();
-
-				await afterFrameAsync();
+				await tick();
+				await forceLayout();
 				testElementTextContains(getRowLinkSel(991), repeat(' !!!', 3 + 1));
 				performance.mark('stop');
 				performance.measure(measureName, 'start', 'stop');

--- a/benches/src/03_update10th1k_x16.html
+++ b/benches/src/03_update10th1k_x16.html
@@ -9,6 +9,9 @@
 			content="updating every 10th row for 1,000 rows (3 warmup runs). 16x CPU slowdown."
 		/>
 		<style>
+			table {
+				table-layout: fixed;
+			}
 			.preloadicon {
 				display: none;
 			}
@@ -28,8 +31,8 @@
 				getRowLinkSel,
 				testElement,
 				testElementTextContains,
-				forceLayout,
-				tick
+				mutateAndLayout,
+				raf
 			} from './util.js';
 			import * as framework from 'framework';
 			import { render } from '../src/keyed-children/index.js';
@@ -63,14 +66,16 @@
 			}
 
 			async function run() {
+				await afterFrameAsync();
+
+				const REPEAT = 50;
 				performance.mark('start');
-				update();
-				await tick();
-				await forceLayout();
-				testElementTextContains(getRowLinkSel(991), repeat(' !!!', 3 + 1));
+				await mutateAndLayout(update, REPEAT);
+				testElementTextContains(getRowLinkSel(991), repeat(' !!!', 3 + REPEAT));
 				performance.mark('stop');
 				performance.measure(measureName, 'start', 'stop');
 
+				await raf();
 				measureMemory();
 			}
 

--- a/benches/src/07_create10k.html
+++ b/benches/src/07_create10k.html
@@ -6,6 +6,9 @@
 		<title>create many rows</title>
 		<meta name="description" content="creating 10,000 rows" />
 		<style>
+			table {
+				table-layout: fixed;
+			}
 			.preloadicon {
 				display: none;
 			}
@@ -21,10 +24,9 @@
 				measureName,
 				measureMemory,
 				testElementText,
-				afterFrame,
-				forceLayout,
-				raf,
-				tick
+				afterFrameAsync,
+				mutateAndLayout,
+				raf
 			} from './util.js';
 			import * as framework from 'framework';
 			import { render } from '../src/keyed-children/index.js';
@@ -32,16 +34,16 @@
 			const { runLots } = render(framework, document.getElementById('main'));
 
 			async function main() {
+				await afterFrameAsync();
+
 				const elementSelector = 'tr:last-child > td:first-child';
 
 				performance.mark('start');
-				runLots();
-				await tick();
-				await forceLayout();
-
-				testElementText(elementSelector, '10000');
+				await mutateAndLayout(runLots);
 				performance.mark('stop');
 				performance.measure(measureName, 'start', 'stop');
+
+				testElementText(elementSelector, '10000');
 
 				await raf();
 				measureMemory();

--- a/benches/src/07_create10k.html
+++ b/benches/src/07_create10k.html
@@ -21,7 +21,10 @@
 				measureName,
 				measureMemory,
 				testElementText,
-				afterFrame
+				afterFrame,
+				forceLayout,
+				raf,
+				tick
 			} from './util.js';
 			import * as framework from 'framework';
 			import { render } from '../src/keyed-children/index.js';
@@ -33,14 +36,15 @@
 
 				performance.mark('start');
 				runLots();
+				await tick();
+				await forceLayout();
 
-				afterFrame(() => {
-					testElementText(elementSelector, '10000');
-					performance.mark('stop');
-					performance.measure(measureName, 'start', 'stop');
+				testElementText(elementSelector, '10000');
+				performance.mark('stop');
+				performance.measure(measureName, 'start', 'stop');
 
-					measureMemory();
-				});
+				await raf();
+				measureMemory();
 			}
 
 			main();

--- a/benches/src/filter_list.html
+++ b/benches/src/filter_list.html
@@ -28,7 +28,13 @@
 	<body>
 		<div id="app"></div>
 		<script type="module">
-			import { measureName, measureMemory } from './util.js';
+			import {
+				measureName,
+				measureMemory,
+				forceLayout,
+				raf,
+				tick
+			} from './util.js';
 			import { createRoot, createElement as h, Component } from 'framework';
 
 			function Row(props) {
@@ -69,24 +75,34 @@
 				root.render(h(App, { items }));
 			}
 
-			async function warmup() {
-				const count = 25;
+			function warmup() {
+				const count = 10;
 
 				for (let i = 0; i < count; i++) {
 					runPatch();
-					await new Promise(r => requestAnimationFrame(r));
 				}
 			}
 
-			warmup().then(async () => {
+			(async () => {
+				for (let i = 5; i--; ) {
+					warmup();
+					await raf();
+					await forceLayout();
+				}
+
+				await raf();
+
 				performance.mark('start');
 				runPatch();
-				await new Promise(r => requestAnimationFrame(r));
+				await tick();
+				await forceLayout();
 				performance.mark('stop');
 				performance.measure(measureName, 'start', 'stop');
 
+				await raf();
+
 				measureMemory();
-			});
+			})();
 		</script>
 	</body>
 </html>

--- a/benches/src/filter_list.html
+++ b/benches/src/filter_list.html
@@ -31,9 +31,9 @@
 			import {
 				measureName,
 				measureMemory,
-				forceLayout,
-				raf,
-				tick
+				afterFrameAsync,
+				mutateAndLayout,
+				raf
 			} from './util.js';
 			import { createRoot, createElement as h, Component } from 'framework';
 
@@ -75,32 +75,19 @@
 				root.render(h(App, { items }));
 			}
 
-			function warmup() {
-				const count = 10;
-
-				for (let i = 0; i < count; i++) {
-					runPatch();
-				}
-			}
-
 			(async () => {
 				for (let i = 5; i--; ) {
-					warmup();
-					await raf();
-					await forceLayout();
+					await mutateAndLayout(runPatch, 10);
 				}
 
-				await raf();
+				await afterFrameAsync();
 
 				performance.mark('start');
-				runPatch();
-				await tick();
-				await forceLayout();
+				await mutateAndLayout(runPatch, 50);
 				performance.mark('stop');
 				performance.measure(measureName, 'start', 'stop');
 
 				await raf();
-
 				measureMemory();
 			})();
 		</script>

--- a/benches/src/hydrate1k.html
+++ b/benches/src/hydrate1k.html
@@ -22,7 +22,8 @@
 				measureMemory,
 				testElementText,
 				afterFrame,
-				afterFrameAsync
+				afterFrameAsync,
+				forceLayout
 			} from './util.js';
 			import * as framework from 'framework';
 			import { getComponents } from '../src/keyed-children/components.js';
@@ -112,19 +113,18 @@
 			}
 
 			function timedRun() {
-				afterFrame(function () {
-					performance.mark('stop');
-					performance.measure(measureName, 'start', 'stop');
-
-					measureMemory();
-				});
-
 				const hydrateRoot = setupHydrateRoot();
 				const store = new Store();
 				store.data = baseStore.data.slice();
 
 				performance.mark('start');
 				createRoot(hydrateRoot).hydrate(createElement(Main, { store }));
+				forceLayout();
+				performance.mark('stop');
+				performance.measure(measureName, 'start', 'stop');
+				afterFrame(function() {
+					measureMemory();
+				});
 			}
 
 			async function main() {

--- a/benches/src/hydrate1k.html
+++ b/benches/src/hydrate1k.html
@@ -6,6 +6,9 @@
 		<title>hydrate 1k table rows</title>
 		<meta name="description" content="hydrating 1,000 rows" />
 		<style>
+			table {
+				table-layout: fixed;
+			}
 			.preloadicon {
 				display: none;
 			}
@@ -23,7 +26,7 @@
 				testElementText,
 				afterFrame,
 				afterFrameAsync,
-				forceLayout
+				mutateAndLayout
 			} from './util.js';
 			import * as framework from 'framework';
 			import { getComponents } from '../src/keyed-children/components.js';
@@ -112,31 +115,28 @@
 				await clickRemove(hydrateRoot, `WARMUP ${i} - posthydrate`, 1000, 999);
 			}
 
-			function timedRun() {
+			async function timedRun() {
 				const hydrateRoot = setupHydrateRoot();
 				const store = new Store();
 				store.data = baseStore.data.slice();
 
 				performance.mark('start');
-				createRoot(hydrateRoot).hydrate(createElement(Main, { store }));
-				forceLayout();
+				await mutateAndLayout(() => {
+					createRoot(hydrateRoot).hydrate(createElement(Main, { store }));
+				});
 				performance.mark('stop');
 				performance.measure(measureName, 'start', 'stop');
-				afterFrame(function() {
-					measureMemory();
-				});
 			}
 
 			async function main() {
-				// const WARMUP_COUNT = 5;
-				const WARMUP_COUNT = 5;
-				for (let i = 0; i < WARMUP_COUNT; i++) {
-					await warmupRun(i);
-				}
+				await mutateAndLayout(warmupRun, 5);
 
 				await afterFrameAsync();
 
-				timedRun();
+				await timedRun();
+
+				await raf();
+				measureMemory();
 			}
 
 			initializeTemplate().then(main);

--- a/benches/src/many_updates.html
+++ b/benches/src/many_updates.html
@@ -17,7 +17,13 @@
 	<body>
 		<div id="root"></div>
 		<script type="module">
-			import { measureName, measureMemory } from './util.js';
+			import {
+				measureName,
+				measureMemory,
+				raf,
+				tick,
+				forceLayout
+			} from './util.js';
 			import { createRoot, createElement as h } from 'framework';
 
 			const state = {
@@ -77,13 +83,12 @@
 				// patchResults.push(performance.now() - s);
 			}
 
-			async function warmup() {
+			function warmup() {
 				// const count = 100;
-				const count = 25;
+				const count = 10;
 
 				for (let i = 0; i < count; i++) {
 					runPatch();
-					await new Promise(r => requestAnimationFrame(r));
 				}
 
 				// let fastest = Infinity;
@@ -98,15 +103,26 @@
 				// console.log(`fastest run: ${fastest.toFixed(2)}ms`);
 			}
 
-			warmup().then(async () => {
+			(async () => {
+				for (let i = 5; i--; ) {
+					warmup();
+					await raf();
+					await forceLayout();
+				}
+
+				await raf();
+
 				performance.mark('start');
 				runPatch();
-				await new Promise(r => requestAnimationFrame(r));
+				await tick();
+				await forceLayout();
 				performance.mark('stop');
 				performance.measure(measureName, 'start', 'stop');
 
+				await raf();
+
 				measureMemory();
-			});
+			})();
 		</script>
 	</body>
 </html>

--- a/benches/src/many_updates.html
+++ b/benches/src/many_updates.html
@@ -20,9 +20,9 @@
 			import {
 				measureName,
 				measureMemory,
-				raf,
-				tick,
-				forceLayout
+				afterFrameAsync,
+				mutateAndLayout,
+				raf
 			} from './util.js';
 			import { createRoot, createElement as h } from 'framework';
 
@@ -83,44 +83,19 @@
 				// patchResults.push(performance.now() - s);
 			}
 
-			function warmup() {
-				// const count = 100;
-				const count = 10;
-
-				for (let i = 0; i < count; i++) {
-					runPatch();
-				}
-
-				// let fastest = Infinity;
-				// const total = patchResults.reduce((all, cur) => {
-				// 	if (cur < fastest) {
-				// 		fastest = cur;
-				// 	}
-				// 	return all + cur;
-				// }, 0);
-
-				// console.log(`${count} runs average: ${(total / count).toFixed(2)}ms`);
-				// console.log(`fastest run: ${fastest.toFixed(2)}ms`);
-			}
-
 			(async () => {
 				for (let i = 5; i--; ) {
-					warmup();
-					await raf();
-					await forceLayout();
+					await mutateAndLayout(runPatch, 10);
 				}
 
-				await raf();
+				await afterFrameAsync();
 
 				performance.mark('start');
-				runPatch();
-				await tick();
-				await forceLayout();
+				await mutateAndLayout(runPatch, 11);
 				performance.mark('stop');
 				performance.measure(measureName, 'start', 'stop');
 
 				await raf();
-
 				measureMemory();
 			})();
 		</script>

--- a/benches/src/text_update.html
+++ b/benches/src/text_update.html
@@ -8,7 +8,13 @@
 	<body>
 		<div id="root"></div>
 		<script type="module">
-			import { measureName, measureMemory } from './util.js';
+			import {
+				measureName,
+				measureMemory,
+				forceLayout,
+				tick,
+				raf
+			} from './util.js';
 			import { createRoot, createElement } from 'framework';
 
 			const root = createRoot(document.getElementById('root'));
@@ -22,13 +28,18 @@
 
 			let result;
 
-			performance.mark('start');
-			for (let i = 0; i < 100; i++) {
-				root.render(createElement(component, { randomValue: i }));
-			}
-			performance.mark('stop');
-			performance.measure(measureName, 'start', 'stop');
-			measureMemory();
+			(async () => {
+				performance.mark('start');
+				for (let i = 0; i < 100; i++) {
+					root.render(createElement(component, { randomValue: i }));
+				}
+				await tick();
+				await forceLayout();
+				performance.mark('stop');
+				performance.measure(measureName, 'start', 'stop');
+				await raf();
+				measureMemory();
+			})();
 		</script>
 	</body>
 </html>

--- a/benches/src/text_update.html
+++ b/benches/src/text_update.html
@@ -11,8 +11,8 @@
 			import {
 				measureName,
 				measureMemory,
-				forceLayout,
-				tick,
+				afterFrameAsync,
+				mutateAndLayout,
 				raf
 			} from './util.js';
 			import { createRoot, createElement } from 'framework';
@@ -28,15 +28,23 @@
 
 			let result;
 
+			let i = 0;
+			function runPatch() {
+				root.render(createElement(component, { randomValue: ++i }));
+			}
+
 			(async () => {
+				await mutateAndLayout(runPatch, 1000);
+
+				await afterFrameAsync();
+
 				performance.mark('start');
-				for (let i = 0; i < 100; i++) {
-					root.render(createElement(component, { randomValue: i }));
+				for (let i = 19; i--; ) {
+					await mutateAndLayout(runPatch, 1000);
 				}
-				await tick();
-				await forceLayout();
 				performance.mark('stop');
 				performance.measure(measureName, 'start', 'stop');
+
 				await raf();
 				measureMemory();
 			})();

--- a/benches/src/util.js
+++ b/benches/src/util.js
@@ -19,6 +19,11 @@ export function afterFrameAsync() {
 	return promise;
 }
 
+export const raf = () => new Promise(requestAnimationFrame);
+export const forceLayout = () =>
+	(document.body._height = document.body.getBoundingClientRect().height);
+export const tick = () => new Promise(resolve => setTimeout(resolve, 0));
+
 export function measureMemory() {
 	if ('gc' in window && 'memory' in performance) {
 		// Report results in MBs

--- a/benches/src/util.js
+++ b/benches/src/util.js
@@ -22,7 +22,16 @@ export function afterFrameAsync() {
 export const raf = () => new Promise(requestAnimationFrame);
 export const forceLayout = () =>
 	(document.body._height = document.body.getBoundingClientRect().height);
-export const tick = () => new Promise(resolve => setTimeout(resolve, 0));
+export const tick = () => new Promise(r => Promise.resolve().then(r));
+
+export async function mutateAndLayout(mutation, times = 1) {
+	// await afterFrameAsync();
+	for (let i = 0; i < times; i++) {
+		await mutation(i);
+	}
+	await tick();
+	await forceLayout();
+}
 
 export function measureMemory() {
 	if ('gc' in window && 'memory' in performance) {


### PR DESCRIPTION
This switches from using rAF to measure async/layout work after rendering:
    `start(), doWork(), await raf(), stop()`
... to using setTimeout(0) followed by a force layout (requesting the bounding box for body):
    `start(), doWork(), await timeout(0), layout(), stop()`

This should considerably reduce the amount of idle time being measured during benchmarks, while ensuring deferred updates (via Promise/microtasks) are included in measured time.