### PR TITLE
(restrcuture) run benches when they're changed

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,12 +7,16 @@ on:
       - '**'
     paths:
       - 'src/**.js'
+      - 'benches/**.html'
+      - 'mangle.json'
   push:
     branches:
       - master
       - restructure
     paths:
       - 'src/**.js'
+      - 'benches/**.html'
+      - 'mangle.json'
 
 jobs:
   prepare:


### PR DESCRIPTION
This runs benchmarks in CI not just for `src/**.js` changes, but also when the benchmarks themselves are modified, as well as for any `mangle.json` changes, which play an important role in performance.