### PR TITLE
Change the signature of options.requestAnimationFrame

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -265,7 +265,7 @@ export interface Options {
 	/** Attach a hook that is invoked after a vnode has rendered. */
 	diffed?(vnode: VNode): void;
 	event?(e: Event): any;
-	requestAnimationFrame?(cb: () => void): void;
+	requestAnimationFrame?(cb: () => any): any;
 	debounceRendering?(cb: () => void): void;
 	useDebugValue?(value: string | number): void;
 	_addHookName?(name: string | number): void;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -265,7 +265,7 @@ export interface Options {
 	/** Attach a hook that is invoked after a vnode has rendered. */
 	diffed?(vnode: VNode): void;
 	event?(e: Event): any;
-	requestAnimationFrame?: typeof requestAnimationFrame;
+	requestAnimationFrame?(cb: () => void): void;
 	debounceRendering?(cb: () => void): void;
 	useDebugValue?(value: string | number): void;
 	_addHookName?(name: string | number): void;


### PR DESCRIPTION
The type signature of **options.requestAnimationFrame** has been change to reflect the guide and to make it easier to use according to #3160. 