### PR TITLE
Fix type definitions

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -755,8 +755,8 @@ export namespace JSXInternal {
 		wrap?: string;
 
 		// Non-standard Attributes
-		autocapitalize?: string;
-		autoCapitalize?: string;
+		autocapitalize?: 'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters';
+		autoCapitalize?: 'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters';
 
 		// RDFa Attributes
 		about?: string;

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -733,6 +733,7 @@ export namespace JSXInternal {
 		slot?: string;
 		span?: number;
 		spellcheck?: boolean;
+		spellCheck?: boolean;
 		src?: string;
 		srcset?: string;
 		srcDoc?: string;

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -754,6 +754,10 @@ export namespace JSXInternal {
 		wmode?: string;
 		wrap?: string;
 
+		// Non-standard Attributes
+		autocapitalize?: string;
+		autoCapitalize?: string;
+
 		// RDFa Attributes
 		about?: string;
 		datatype?: string;


### PR DESCRIPTION
This PR adds attribute typings for HTMLAttributes

* adds camel case version of `spellCheck`
* adds non-standard attribute `autoCapitalize` and `autocapitalize`