### PR TITLE
refactor(catch-error): use `while` will reduce the volume of output MAP files (-16b)

### DIFF
--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -9,7 +9,7 @@ export function _catchError(error, vnode) {
 	/** @type {import('../internal').Component} */
 	let component, ctor, handled;
 
-	for (; (vnode = vnode._parent); ) {
+	while (vnode = vnode._parent) {
 		if ((component = vnode._component) && !component._processingException) {
 			try {
 				ctor = component.constructor;


### PR DESCRIPTION
- I found it here replace `for` for `while`, will reduce the volume of MAP file volumes
- The output `dist` folder will be reduced by 16b
![84561623829598_ pic](https://user-images.githubusercontent.com/47778908/122182817-39469580-cebd-11eb-90c0-2f1a704699e4.jpg)

I am not sure if this is helpful😅