### PR TITLE
Remove unecessary assignment

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -87,7 +87,7 @@ export function diffChildren(
 				childVNode._original
 			);
 		} else {
-			childVNode = newParentVNode._children[i] = childVNode;
+			newParentVNode._children[i] = childVNode;
 		}
 
 		// Terser removes the `continue` here and wraps the loop body


### PR DESCRIPTION
Checked in this way in Firefox console:
```
var a = 5, b = 6;
a = b = a;
a // shows 5
b // shows 5
```
If the leftmost assignment doesn't change the value of the variable then it can be safely removed
![image](https://user-images.githubusercontent.com/16450547/122649543-f2fc6b00-d136-11eb-8662-242ee96ece0d.png)
