### PR TITLE
Fix ref typing of forwardRef

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -105,7 +105,7 @@ declare namespace React {
 
 	export function forwardRef<R, P = {}>(
 		fn: ForwardFn<P, R>
-	): preact.FunctionalComponent<Omit<P, 'ref'> & { ref?: preact.RefObject<R> }>;
+	): preact.FunctionalComponent<Omit<P, 'ref'> & { ref?: preact.Ref<R> }>;
 
 	export function unstable_batchedUpdates(
 		callback: (arg?: any) => void,


### PR DESCRIPTION
`forwardRef` accpets `RefCallback` as well as `RefObject`. To accept `RefCallback`, use `Ref` instead of `RefObject` .