### PR TITLE
fix bug in chrome where select values continuously rerender

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -180,21 +180,7 @@ export function diffChildren(
 				);
 			}
 
-			// Browsers will infer an option's `value` from `textContent` when
-			// no value is present. This essentially bypasses our code to set it
-			// later in `diff()`. It works fine in all browsers except for IE11
-			// where it breaks setting `select.value`. There it will be always set
-			// to an empty string. Re-applying an options value will fix that, so
-			// there are probably some internal data structures that aren't
-			// updated properly.
-			//
-			// To fix it we make sure to reset the inferred value, so that our own
-			// value check in `diff()` won't be skipped.
-			if (!isHydrating && newParentVNode.type === 'option') {
-				// @ts-ignore We have validated that the type of parentDOM is 'option'
-				// in the above check
-				parentDom.value = '';
-			} else if (typeof newParentVNode.type == 'function') {
+			if (typeof newParentVNode.type == 'function') {
 				// Because the newParentVNode is Fragment-like, we need to set it's
 				// _nextDom property to the nextSibling of its last child DOM node.
 				//


### PR DESCRIPTION
Resolves https://github.com/preactjs/preact/issues/3171

If this poses issues in IE11:

```js
import { options } from 'preact';
options.diffed = vnode => {
  if (vnode.type === 'option') {
    const props = vnode.props;
    if (!('value' in props)) {
      vnode.dom.value = vnode.dom.textContent;
    }
  }
}
```