### PR TITLE
[compat] Skip rendering <noscript> contents on the client

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -12,6 +12,8 @@ export const REACT_ELEMENT_TYPE =
 
 const CAMEL_PROPS = /^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|fill|flood|font|glyph(?!R)|horiz|marker(?!H|W|U)|overline|paint|stop|strikethrough|stroke|text(?!L)|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/;
 
+const IS_DOM = typeof document !== 'undefined';
+
 // Input types for which onchange should not be converted to oninput.
 // type="file|checkbox|radio", plus "range" in IE11.
 // (IE11 doesn't support Symbol, which we use here to turn `rad` into `ra` which matches "range")
@@ -117,7 +119,11 @@ options.vnode = vnode => {
 		for (let i in props) {
 			let value = props[i];
 
-			if (i === 'value' && 'defaultValue' in props && value == null) {
+			if (i === 'children' && type === 'noscript') {
+				// Emulate React's behavior of not rendering the contents of noscript tags on the client.
+				continue;
+			}
+			else if (i === 'value' && 'defaultValue' in props && value == null) {
 				// Skip applying value if it is null/undefined and we already set
 				// a default value
 				continue;


### PR DESCRIPTION
This fixes the issue from #2797, and [this issue](https://zenn.dev/d_suke/scraps/f7013c4554ac43) using Next.js's `<Image>` component with Preact.