### PR TITLE
Add onBeforeInput attribute to type definitions

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -453,6 +453,8 @@ export namespace JSXInternal {
 		onChangeCapture?: GenericEventHandler<Target>;
 		onInput?: GenericEventHandler<Target>;
 		onInputCapture?: GenericEventHandler<Target>;
+		onBeforeInput?: GenericEventHandler<Target>;
+		onBeforeInputCapture?: GenericEventHandler<Target>;
 		onSearch?: GenericEventHandler<Target>;
 		onSearchCapture?: GenericEventHandler<Target>;
 		onSubmit?: GenericEventHandler<Target>;
@@ -663,7 +665,14 @@ export namespace JSXInternal {
 		decoding?: 'sync' | 'async' | 'auto';
 		draggable?: boolean;
 		encType?: string;
-		enterkeyhint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send';
+		enterkeyhint?:
+			| 'enter'
+			| 'done'
+			| 'go'
+			| 'next'
+			| 'previous'
+			| 'search'
+			| 'send';
 		form?: string;
 		formAction?: string;
 		formEncType?: string;
@@ -721,7 +730,15 @@ export namespace JSXInternal {
 		radioGroup?: string;
 		readonly?: boolean;
 		readOnly?: boolean;
-		referrerpolicy?: 'no-referrer' | 'no-referrer-when-downgrade' | 'origin' | 'origin-when-cross-origin' | 'same-origin' | 'strict-origin' | 'strict-origin-when-cross-origin' | 'unsafe-url';
+		referrerpolicy?:
+			| 'no-referrer'
+			| 'no-referrer-when-downgrade'
+			| 'origin'
+			| 'origin-when-cross-origin'
+			| 'same-origin'
+			| 'strict-origin'
+			| 'strict-origin-when-cross-origin'
+			| 'unsafe-url';
 		rel?: string;
 		required?: boolean;
 		reversed?: boolean;
@@ -762,8 +779,20 @@ export namespace JSXInternal {
 		wrap?: string;
 
 		// Non-standard Attributes
-		autocapitalize?: 'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters';
-		autoCapitalize?: 'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters';
+		autocapitalize?:
+			| 'off'
+			| 'none'
+			| 'on'
+			| 'sentences'
+			| 'words'
+			| 'characters';
+		autoCapitalize?:
+			| 'off'
+			| 'none'
+			| 'on'
+			| 'sentences'
+			| 'words'
+			| 'characters';
 		disablePictureInPicture?: boolean;
 		results?: number;
 		translate?: 'yes' | 'no';


### PR DESCRIPTION
Hi, Preact team.

I'm excited to read [the slide about the future of Preact](https://docs.google.com/presentation/d/1sZyETbDiacqAznlEGEpfyPz0q37Q-12bOB5Mq3OtyKQ/edit#slide=id.p) (especially about the removal of deopts). I'm really looking forward to the release. Thank you for all your continuous efforts!

This PR adds typedefs for `onBeforeInput` and `onBeforeInputCapture`. There are a few other changes, but they are due to prettier on the pre-commit hook.


---
Before:
![image](https://user-images.githubusercontent.com/34891695/131548056-a6bff912-e230-4abb-bf69-5e37bf220d58.png)


After:
![image](https://user-images.githubusercontent.com/34891695/131548124-4f8d4201-b6d6-4e96-a5e4-495e23f534f7.png)


