### PR TITLE
Add focusin/focusout to type definitions

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -445,6 +445,10 @@ export namespace JSXInternal {
 		// Focus Events
 		onFocus?: FocusEventHandler<Target>;
 		onFocusCapture?: FocusEventHandler<Target>;
+		onfocusin?: FocusEventHandler<Target>;
+		onfocusinCapture?: FocusEventHandler<Target>;
+		onfocusout?: FocusEventHandler<Target>;
+		onfocusoutCapture?: FocusEventHandler<Target>;
 		onBlur?: FocusEventHandler<Target>;
 		onBlurCapture?: FocusEventHandler<Target>;
 


### PR DESCRIPTION
Resolves #3186.
Added onfocusin/onfocusout attributes, all lowercased according to the comments on #1611.

---
Before:
![image](https://user-images.githubusercontent.com/34891695/132391439-c3027382-cdaf-44a8-b059-bafaf7984510.png)

After:
![image](https://user-images.githubusercontent.com/34891695/132391520-0ede3f6c-ef28-476b-a3ee-31d45de472d9.png)

