### PR TITLE
types: use FunctionComponent instead of FunctionalComponent

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -87,10 +87,10 @@ declare namespace React {
 	}
 
 	export function memo<P = {}>(
-		component: preact.FunctionalComponent<P>,
+		component: preact.FunctionComponent<P>,
 		comparer?: (prev: P, next: P) => boolean
 	): preact.FunctionComponent<P>;
-	export function memo<C extends preact.FunctionalComponent<any>>(
+	export function memo<C extends preact.FunctionComponent<any>>(
 		component: C,
 		comparer?: (
 			prev: preact.ComponentProps<C>,
@@ -105,7 +105,7 @@ declare namespace React {
 
 	export function forwardRef<R, P = {}>(
 		fn: ForwardFn<P, R>
-	): preact.FunctionalComponent<Omit<P, 'ref'> & { ref?: preact.RefObject<R> }>;
+	): preact.FunctionComponent<Omit<P, 'ref'> & { ref?: preact.RefObject<R> }>;
 
 	export function unstable_batchedUpdates(
 		callback: (arg?: any) => void,


### PR DESCRIPTION
A type error occurred when using FunctionComponent using `forwardRef`, so this part was changed to use FunctionComponent.
Please let me know if you have any additional corrections to make!