### PR TITLE
refactor(types): Allow Promise<void> for useEffect callback

### DIFF
--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -62,7 +62,7 @@ export function useRef<T>(initialValue: null): RefObject<T>;
 export function useRef<T>(initialValue: T): Ref<T>;
 export function useRef<T>(): Ref<T | undefined>;
 
-type EffectCallback = () => void | (() => void);
+type EffectCallback = () => void | Promise<void> | (() => void);
 /**
  * Accepts a function that contains imperative, possibly effectful code.
  * The effects run after browser paint, without blocking it.


### PR DESCRIPTION
Closes #3239

Allows for behavior like the following, without TS throwing an error:

```
const [data, setData] = useState<null | Data>(null);

useEffect(async () => {
  const newData = await downloadData();
  setData(newData);
}, []);
```