### PR TITLE
fix className leak

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -184,7 +184,7 @@ options.vnode = vnode => {
 		vnode.props = normalizedProps;
 	}
 
-	if (type && props.class != props.className) {
+	if (type && typeof type === 'string' && props.class != props.className) {
 		classNameDescriptor.enumerable = 'className' in props;
 		if (props.className != null) normalizedProps.class = props.className;
 		Object.defineProperty(normalizedProps, 'className', classNameDescriptor);

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -99,6 +99,13 @@ function isDefaultPrevented() {
 	return this.defaultPrevented;
 }
 
+let classNameDescriptor = {
+	configurable: true,
+	get() {
+		return this.class;
+	}
+};
+
 let oldVNodeHook = options.vnode;
 options.vnode = vnode => {
 	let type = vnode.type;
@@ -181,6 +188,12 @@ options.vnode = vnode => {
 		}
 
 		vnode.props = normalizedProps;
+
+		if (props.class != props.className) {
+			classNameDescriptor.enumerable = 'className' in props;
+			if (props.className != null) normalizedProps.class = props.className;
+			Object.defineProperty(normalizedProps, 'className', classNameDescriptor);
+		}
 	}
 
 	vnode.$$typeof = REACT_ELEMENT_TYPE;

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -190,12 +190,6 @@ options.vnode = vnode => {
 		vnode.props = normalizedProps;
 	}
 
-	if (type && typeof type === 'string' && props.class != props.className) {
-		classNameDescriptor.enumerable = 'className' in props;
-		if (props.className != null) normalizedProps.class = props.className;
-		Object.defineProperty(normalizedProps, 'className', classNameDescriptor);
-	}
-
 	vnode.$$typeof = REACT_ELEMENT_TYPE;
 
 	if (oldVNodeHook) oldVNodeHook(vnode);

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -99,13 +99,6 @@ function isDefaultPrevented() {
 	return this.defaultPrevented;
 }
 
-let classNameDescriptor = {
-	configurable: true,
-	get() {
-		return this.class;
-	}
-};
-
 let oldVNodeHook = options.vnode;
 options.vnode = vnode => {
 	let type = vnode.type;

--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -229,6 +229,21 @@ describe('compat render', () => {
 		);
 	});
 
+	it('should correctly allow for "className"', () => {
+		const Foo = props => {
+			const { className, ...rest } = props;
+			return (
+				<div class={className}>
+					<p {...rest}>Foo</p>
+				</div>
+			);
+		};
+
+		render(<Foo className="foo" />, scratch);
+		expect(scratch.firstChild.className).to.equal('foo');
+		expect(scratch.firstChild.firstChild.className).to.equal('');
+	});
+
 	it('should normalize class+className even on components', () => {
 		function Foo(props) {
 			return (


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/3159
Fixes https://github.com/preactjs/preact/issues/2582

I honestly think it's highly indeterministic to alter the props passed into a component, generally in React (compat) people will pas in either `class` or `className` and won't expect this to be changed. Introducing an additional prop is only going to confuse people. Note that we did not do this before