### PR TITLE
(restructure) - fix Suspense(list) tests

### DIFF
--- a/compat/src/suspense-list.js
+++ b/compat/src/suspense-list.js
@@ -22,7 +22,7 @@ const resolve = (list, child, node) => {
 		// mark the child as completely resolved by deleting it from ._map.
 		// This is used to figure out when *all* children have been completely
 		// resolved when revealOrder is 'together'.
-		list._map.delete(child._vnodeId);
+		list._map.delete(child.props);
 	}
 
 	// If revealOrder is falsy then we can do an early exit, as the
@@ -61,7 +61,7 @@ SuspenseList.prototype._suspended = function(child) {
 	const component = list._internal._parent._component;
 	const delegated =
 		component && component._suspended && component._suspended(list._internal);
-	const node = list._map.get(child._vnodeId);
+	const node = list._map.get(child.props);
 	node[SUSPENDED_COUNT]++;
 
 	return unsuspend => {
@@ -108,7 +108,7 @@ SuspenseList.prototype.render = function(props) {
 		//
 		// Pending callbacks are added to the end of the node:
 		// 	[suspended_count, resolved_count, next_node, callback_0, callback_1, ...]
-		this._map.set(children[i]._vnodeId, (this._next = [1, 0, this._next]));
+		this._map.set(children[i].props, (this._next = [1, 0, this._next]));
 	}
 	return props.children;
 };

--- a/compat/test/browser/suspense-list.test.js
+++ b/compat/test/browser/suspense-list.test.js
@@ -39,7 +39,7 @@ function getSuspendableComponent(text) {
 	return LifecycleSuspender;
 }
 
-describe.skip('suspense-list', () => {
+describe('suspense-list', () => {
 	/** @type {HTMLDivElement} */
 	let scratch,
 		rerender,
@@ -302,7 +302,7 @@ describe.skip('suspense-list', () => {
 		);
 	});
 
-	it('should make components appear together if revealOrder=together and first one resolves others', async () => {
+	it.skip('should make components appear together if revealOrder=together and first one resolves others', async () => {
 		const [resolver1, resolver2, resolver3] = getSuspenseList('together');
 
 		rerender(); // Re-render with fallback cuz lazy threw
@@ -329,7 +329,7 @@ describe.skip('suspense-list', () => {
 		);
 	});
 
-	it('should make components appear together if revealOrder=together and second one resolves before others', async () => {
+	it.skip('should make components appear together if revealOrder=together and second one resolves before others', async () => {
 		const [resolver1, resolver2, resolver3] = getSuspenseList('together');
 
 		rerender(); // Re-render with fallback cuz lazy threw
@@ -461,7 +461,7 @@ describe.skip('suspense-list', () => {
 		);
 	});
 
-	it('should make sure nested SuspenseList works with together', async () => {
+	it.skip('should make sure nested SuspenseList works with together', async () => {
 		const [resolveA, resolveB, resolveC, resolveD] = getNestedSuspenseList(
 			'together',
 			'forwards'
@@ -519,7 +519,7 @@ describe.skip('suspense-list', () => {
 		expect(scratch.innerHTML).to.eql(`<div></div><span>A</span>`);
 	});
 
-	it('should work with together even when a <Suspense> child does not suspend', async () => {
+	it.skip('should work with together even when a <Suspense> child does not suspend', async () => {
 		const Component = getSuspendableComponent('A');
 
 		render(
@@ -542,7 +542,7 @@ describe.skip('suspense-list', () => {
 		expect(scratch.innerHTML).to.eql(`<div></div><span>A</span>`);
 	});
 
-	it('should not suspend resolved children if a new suspense comes in between', async () => {
+	it.skip('should not suspend resolved children if a new suspense comes in between', async () => {
 		const ComponentA = getSuspendableComponent('A');
 		const ComponentB = getSuspendableComponent('B');
 

--- a/compat/test/browser/suspense-list.test.js
+++ b/compat/test/browser/suspense-list.test.js
@@ -302,7 +302,7 @@ describe('suspense-list', () => {
 		);
 	});
 
-	it.skip('should make components appear together if revealOrder=together and first one resolves others', async () => {
+	it('should make components appear together if revealOrder=together and first one resolves others', async () => {
 		const [resolver1, resolver2, resolver3] = getSuspenseList('together');
 
 		rerender(); // Re-render with fallback cuz lazy threw
@@ -329,7 +329,7 @@ describe('suspense-list', () => {
 		);
 	});
 
-	it.skip('should make components appear together if revealOrder=together and second one resolves before others', async () => {
+	it('should make components appear together if revealOrder=together and second one resolves before others', async () => {
 		const [resolver1, resolver2, resolver3] = getSuspenseList('together');
 
 		rerender(); // Re-render with fallback cuz lazy threw
@@ -461,7 +461,7 @@ describe('suspense-list', () => {
 		);
 	});
 
-	it.skip('should make sure nested SuspenseList works with together', async () => {
+	it('should make sure nested SuspenseList works with together', async () => {
 		const [resolveA, resolveB, resolveC, resolveD] = getNestedSuspenseList(
 			'together',
 			'forwards'

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -1173,7 +1173,7 @@ describe('suspense', () => {
 			});
 	});
 
-	it.skip('should correctly render nested Suspense components without intermediate DOM #2747', () => {
+	it('should correctly render nested Suspense components without intermediate DOM #2747', () => {
 		const [ProfileDetails, resolveDetails] = createLazy();
 		const [ProfileTimeline, resolveTimeline] = createLazy();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "preact",
 			"version": "10.5.13",
 			"license": "MIT",
 			"devDependencies": {


### PR DESCRIPTION
The main issue seemed to be that we have no solid way to identify `Suspense` boundaries within our map I've leveraged `_vnodeId` which seemed to unstable in the `revealOrder="together"` mode as multiple unsuspensions (read: rerenders) lead to new `_vnodeIds` and `child-nodes`. Hence leveraging `Suspense.props` which remains stable across renders.

Currently there are two failing tests left that I can't seem to figure out