### PR TITLE
(restructure) - suspense correctness

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -13,17 +13,18 @@ options._catchError = function(error, internal) {
 
 		internal._commitCallbacks = []
 		if (!internal._dom) {
-			internal._component.__hooks = undefined;
+			internal._component = undefined;
 		}
 		for (; (handler = handler._parent); ) {
+			component = handler._component
 			if (typeof handler.type === 'function') {
 				handler._commitCallbacks = []
-				if (!handler._dom) {
-					internal._component.__hooks = undefined;
+				if (!handler._dom && component && !component._childDidSuspend) {
+					handler._component = undefined;
 				}
 			}
 
-			if ((component = handler._component) && component._childDidSuspend) {
+			if (component && component._childDidSuspend) {
 				// Don't call oldCatchError if we found a Suspense
 				return component._childDidSuspend(error, internal);
 			}

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -11,7 +11,18 @@ options._catchError = function(error, internal) {
 		let component;
 		let handler = internal;
 
+		internal._commitCallbacks = []
+		if (!internal._dom) {
+			internal._component.__hooks = undefined;
+		}
 		for (; (handler = handler._parent); ) {
+			if (typeof handler.type === 'function') {
+				handler._commitCallbacks = []
+				if (!handler._dom) {
+					internal._component.__hooks = undefined;
+				}
+			}
+
 			if ((component = handler._component) && component._childDidSuspend) {
 				// Don't call oldCatchError if we found a Suspense
 				return component._childDidSuspend(error, internal);


### PR DESCRIPTION
[Sandbox with experiments](https://codesandbox.io/s/awesome-river-wvx3d?file=/src/App.js)

How current Suspense seems to work:
- clear hookState on first render
- keep hookState on subsequent render

I think we'll have to rewrite Suspense to operate on the internal rather than the component if we want to make proper clearing work like in the above demo