### PR TITLE
(restructure) - remove _component from our hooks implementation

### DIFF
--- a/compat/src/memo.js
+++ b/compat/src/memo.js
@@ -1,4 +1,4 @@
-import { createElement } from 'preact';
+import { createElement, Component } from 'preact';
 import { shallowDiffers } from './util';
 
 /**
@@ -9,7 +9,16 @@ import { shallowDiffers } from './util';
  * @returns {import('./internal').FunctionComponent}
  */
 export function memo(c, comparer) {
-	function shouldUpdate(nextProps) {
+	function Memoed() {}
+
+	Memoed.prototype = new Component();
+	Memoed.displayName = 'Memo(' + (c.displayName || c.name) + ')';
+	// eslint-disable-next-line
+	Memoed.prototype.render = function(props) {
+		return createElement(c, props);
+	};
+
+	Memoed.prototype.shouldComponentUpdate = function(nextProps) {
 		let ref = this.props.ref;
 		let updateRef = ref == nextProps.ref;
 		if (!updateRef && ref) {
@@ -21,13 +30,8 @@ export function memo(c, comparer) {
 		}
 
 		return !comparer(this.props, nextProps) || !updateRef;
-	}
+	};
 
-	function Memoed(props) {
-		this.shouldComponentUpdate = shouldUpdate;
-		return createElement(c, props);
-	}
-	Memoed.displayName = 'Memo(' + (c.displayName || c.name) + ')';
 	Memoed.prototype.isReactComponent = true;
 	Memoed._forwarded = true;
 	return Memoed;

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -181,7 +181,7 @@ describe('suspense', () => {
 
 		return resolve(LazyResult).then(() => {
 			rerender();
-			expect(ref.current.constructor).to.equal(LazyResult);
+			expect(ref.current._internal.type).to.equal(LazyResult);
 		});
 	});
 

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -282,12 +282,12 @@ export function initDebug() {
 		if (oldBeforeDiff) oldBeforeDiff(internal, vnode);
 	};
 
-	options._hook = (comp, index, type) => {
-		if (!comp || !hooksAllowed) {
+	options._hook = (internal, index, type) => {
+		if (!internal || !hooksAllowed) {
 			throw new Error('Hook can only be invoked from render methods.');
 		}
 
-		if (oldHook) oldHook(comp, index, type);
+		if (oldHook) oldHook(internal, index, type);
 	};
 
 	// Ideally we'd want to print a warning once per component, but we

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -43,7 +43,6 @@ PR's that weren't backported yet, do they work?
 
 - Address many TODOs
 - Move refs to internal renderCallbacks
-- Rewrite rerender loop to operate on internals, not components
 - Consider converting Fragment (and other special nodes, e.g. root, Portal,
   context?) to be numbers instead of functions with special diff handling
 

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -9,6 +9,7 @@
 - `[MAJOR]` Forward ref by default on functional components (this is not the case for compat)
 - `[MINOR]` Add truely controlled components
 - `[MINOR]` Add `createRoot` API
+- `[MAJOR]` Change `options._hook` to get an internal passed in (devtools)
 
 ## To verify
 

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -34,10 +34,10 @@ options._render = internal => {
 	currentInternal = internal;
 	currentIndex = 0;
 
-	if (currentInternal.data) {
-		currentInternal.data._pendingEffects.forEach(invokeCleanup);
-		currentInternal.data._pendingEffects.forEach(invokeEffect);
-		currentInternal.data._pendingEffects = [];
+	if (currentInternal.data && currentInternal.data.__hooks) {
+		currentInternal.data.__hooks._pendingEffects.forEach(invokeCleanup);
+		currentInternal.data.__hooks._pendingEffects.forEach(invokeEffect);
+		currentInternal.data.__hooks._pendingEffects = [];
 	}
 };
 

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -142,7 +142,7 @@ export function useReducer(reducer, initialState, init) {
 					hookState._value = [nextValue, hookState._value[1]];
 
 					// TODO: this needs to change to a rerender mechanism not on "_component"
-					hookState._internal._component.setState({});
+					hookState._internal.rerender();
 				}
 			}
 		];

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -41,7 +41,7 @@ options._render = internal => {
 	currentInternal = internal;
 	currentIndex = 0;
 
-	const hooks = currentInternal.data.__hooks;
+	const hooks = currentInternal.data && currentInternal.data.__hooks;
 	if (hooks) {
 		hooks._pendingEffects.forEach(invokeCleanup);
 		hooks._pendingEffects.forEach(invokeEffect);
@@ -53,7 +53,7 @@ options.diffed = internal => {
 	if (oldAfterDiff) oldAfterDiff(internal);
 
 	const data = internal.data;
-	if (data.__hooks && data.__hooks._pendingEffects.length) {
+	if (data && data.__hooks && data.__hooks._pendingEffects.length) {
 		afterPaint(afterPaintEffects.push(internal));
 	}
 	currentInternal = previousInternal;

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -99,11 +99,7 @@ options.unmount = internal => {
  */
 function getHookState(index, type) {
 	if (options._hook) {
-		options._hook(
-			currentInternal && currentInternal._component,
-			index,
-			currentHook || type
-		);
+		options._hook(currentInternal, index, currentHook || type);
 	}
 	currentHook = 0;
 

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -257,7 +257,7 @@ export function useContext(context) {
 	// This is probably not safe to convert to "!"
 	if (state._value == null) {
 		state._value = true;
-		provider._subs.add(currentInternal._component);
+		provider._subs.add(currentInternal);
 	}
 	return provider.props.value;
 }

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -140,7 +140,7 @@ export function useReducer(reducer, initialState, init) {
 				const nextValue = hookState._reducer(hookState._value[0], action);
 				if (hookState._value[0] !== nextValue) {
 					hookState._value = [nextValue, hookState._value[1]];
-					hookState._internal.rerender();
+					hookState._internal.rerender(hookState._internal);
 				}
 			}
 		];

--- a/hooks/test/browser/useEffect.test.js
+++ b/hooks/test/browser/useEffect.test.js
@@ -75,6 +75,8 @@ describe('useEffect', () => {
 			return <p>Test</p>;
 		};
 		act(() => render(<App i={0} />, scratch));
+		expect(executionOrder).to.deep.equal(['action1', 'action2']);
+
 		act(() => render(<App i={2} />, scratch));
 		expect(executionOrder).to.deep.equal([
 			'cleanup1',

--- a/src/component.js
+++ b/src/component.js
@@ -56,7 +56,7 @@ Component.prototype.setState = function(update, callback) {
 
 	if (this._internal) {
 		if (callback) addCommitCallback(this._internal, callback.bind(this));
-		this._internal.rerender();
+		this._internal.rerender(this._internal);
 	}
 };
 
@@ -73,7 +73,7 @@ Component.prototype.forceUpdate = function(callback) {
 		// shouldComponentUpdate
 		this._internal.flags |= FORCE_UPDATE;
 		if (callback) addCommitCallback(this._internal, callback.bind(this));
-		this._internal.rerender();
+		this._internal.rerender(this._internal);
 	}
 };
 

--- a/src/component.js
+++ b/src/component.js
@@ -56,7 +56,7 @@ Component.prototype.setState = function(update, callback) {
 
 	if (this._internal) {
 		if (callback) addCommitCallback(this._internal, callback.bind(this));
-		enqueueRender(this._internal);
+		this._internal.rerender();
 	}
 };
 
@@ -73,7 +73,7 @@ Component.prototype.forceUpdate = function(callback) {
 		// shouldComponentUpdate
 		this._internal.flags |= FORCE_UPDATE;
 		if (callback) addCommitCallback(this._internal, callback.bind(this));
-		enqueueRender(this._internal);
+		this._internal.rerender();
 	}
 };
 
@@ -92,7 +92,7 @@ Component.prototype.render = Fragment;
 /**
  * @param {import('./internal').Component} internal The internal to rerender
  */
-function rerenderComponent(internal) {
+function rerender(internal) {
 	if (~internal.flags & MODE_UNMOUNTING && internal.flags & DIRTY_BIT) {
 		let parentDom = getParentDom(internal);
 		let startDom =
@@ -156,7 +156,7 @@ function process() {
 	while ((len = process._rerenderCount = rerenderQueue.length)) {
 		rerenderQueue.sort((a, b) => a._depth - b._depth);
 		while (len--) {
-			rerenderComponent(rerenderQueue.shift());
+			rerender(rerenderQueue.shift());
 		}
 	}
 }

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -35,9 +35,7 @@ export const createContext = (defaultValue, contextId) => {
 			}
 			// re-render subscribers in response to value change
 			else if (props.value !== this._prev) {
-				this._subs.forEach(internal => {
-					enqueueRender(internal._component);
-				});
+				this._subs.forEach(enqueueRender);
 			}
 			this._prev = props.value;
 

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -4,11 +4,12 @@ let nextContextId = 0;
 
 const providers = new Set();
 
-export const unsubscribeFromContext = component => {
+export const unsubscribeFromContext = internal => {
+	console.log(providers);
 	// if this was a context provider, delete() returns true and we exit:
-	if (providers.delete(component)) return;
+	if (providers.delete(internal)) return;
 	// ... otherwise, unsubscribe from any contexts:
-	providers.forEach(p => p._subs.delete(component));
+	providers.forEach(p => p._component._subs.delete(internal));
 };
 
 export const createContext = (defaultValue, contextId) => {
@@ -32,6 +33,7 @@ export const createContext = (defaultValue, contextId) => {
 				ctx = {};
 				ctx[contextId] = this;
 				this.getChildContext = () => ctx;
+				providers.add(this._internal);
 			}
 			// re-render subscribers in response to value change
 			else if (props.value !== this._prev) {

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -35,7 +35,9 @@ export const createContext = (defaultValue, contextId) => {
 			}
 			// re-render subscribers in response to value change
 			else if (props.value !== this._prev) {
-				this._subs.forEach(enqueueRender);
+				this._subs.forEach(internal => {
+					enqueueRender(internal._component);
+				});
 			}
 			this._prev = props.value;
 

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -5,11 +5,12 @@ let nextContextId = 0;
 const providers = new Set();
 
 export const unsubscribeFromContext = internal => {
-	console.log(providers);
 	// if this was a context provider, delete() returns true and we exit:
 	if (providers.delete(internal)) return;
 	// ... otherwise, unsubscribe from any contexts:
-	providers.forEach(p => p._component._subs.delete(internal));
+	providers.forEach(p => {
+		p._component._subs.delete(internal);
+	});
 };
 
 export const createContext = (defaultValue, contextId) => {

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -41,7 +41,7 @@ export function renderFunctionComponent(
 		internal._component = c = {
 			props: newProps,
 			context: componentContext,
-			forceUpdate: internal.rerender
+			forceUpdate: internal.rerender.bind(null, internal)
 		};
 
 		if (provider) provider._subs.add(internal);

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -1,6 +1,5 @@
 import { Fragment } from '../create-element';
 import options from '../options';
-import { Component } from '../component';
 import { mountChildren } from './mount';
 import { diffChildren, reorderChildren } from './children';
 import {
@@ -51,11 +50,14 @@ export function renderFunctionComponent(
 	if (internal && internal._component) {
 		c = internal._component;
 	} else {
-		internal._component = c = new Component(newProps, componentContext);
+		internal._component = c = {
+			props: newProps,
+			context: componentContext,
+			forceUpdate: internal.rerender
+		};
 
 		if (provider) provider._subs.add(internal);
 
-		c.props = newProps;
 		internal.flags |= DIRTY_BIT;
 		isNew = true;
 	}
@@ -184,7 +186,6 @@ export function renderClassComponent(
 
 		if (provider) provider._subs.add(internal);
 
-		c.props = newProps;
 		if (!c.state) c.state = {};
 		isNew = true;
 		internal.flags |= DIRTY_BIT;

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -56,9 +56,6 @@ export function renderFunctionComponent(
 		if (provider) provider._subs.add(internal);
 
 		c.props = newProps;
-		c.context = componentContext;
-		c.constructor = type;
-		c.render = doRender;
 		internal.flags |= DIRTY_BIT;
 		isNew = true;
 	}
@@ -66,9 +63,9 @@ export function renderFunctionComponent(
 	if (
 		(!isNew &&
 			!(internal.flags & FORCE_UPDATE) &&
-				c.shouldComponentUpdate != null &&
-				c.shouldComponentUpdate(newProps, c._nextState, componentContext) ===
-					false) ||
+			c.shouldComponentUpdate != null &&
+			c.shouldComponentUpdate(newProps, c._nextState, componentContext) ===
+				false) ||
 		(newVNode && newVNode._vnodeId === internal._vnodeId)
 	) {
 		internal.props = c.props = newProps;
@@ -96,7 +93,7 @@ export function renderFunctionComponent(
 	internal.flags &= ~DIRTY_BIT;
 	c._internal = internal;
 
-	tmp = c.render(c.props, c.state, c.context);
+	tmp = type.call(c, c.props, c.context);
 
 	if (c.getChildContext != null) {
 		internal._context = Object.assign({}, context, c.getChildContext());
@@ -189,7 +186,6 @@ export function renderClassComponent(
 
 		c.props = newProps;
 		if (!c.state) c.state = {};
-		c.context = componentContext;
 		isNew = true;
 		internal.flags |= DIRTY_BIT;
 	}
@@ -324,9 +320,4 @@ export function renderClassComponent(
 	}
 
 	return nextDomSibling;
-}
-
-/** The `.render()` method for a PFC backing instance. */
-function doRender(props, state, context) {
-	return this.constructor(props, context);
 }

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -15,7 +15,7 @@ export function renderFunctionComponent(
 ) {
 	/** @type {import('../internal').Component} */
 	let c;
-	let tmp, isNew;
+	let tmp;
 
 	/** @type {import('../internal').ComponentType} */
 	let type = (internal.type);
@@ -47,25 +47,11 @@ export function renderFunctionComponent(
 		if (provider) provider._subs.add(internal);
 
 		internal.flags |= DIRTY_BIT;
-		isNew = true;
 	}
 
-	if (
-		(!isNew &&
-			!(internal.flags & FORCE_UPDATE) &&
-			c.shouldComponentUpdate != null &&
-			c.shouldComponentUpdate(newProps, c._nextState, componentContext) ===
-				false) ||
-		(newVNode && newVNode._vnodeId === internal._vnodeId)
-	) {
+	if (newVNode && newVNode._vnodeId === internal._vnodeId) {
 		internal.props = c.props = newProps;
-		// More info about this here: https://gist.github.com/JoviDeCroock/bec5f2ce93544d2e6070ef8e0036e4e8
-		if (newVNode && newVNode._vnodeId !== internal._vnodeId) {
-			internal.flags &= ~DIRTY_BIT;
-		}
-
 		c._internal = internal;
-
 		// TODO: Returning undefined here (i.e. return;) passes all tests. That seems
 		// like a bug. Should validate that we have test coverage for sCU that
 		// returns Fragments with multiple DOM children

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -72,7 +72,7 @@ export function renderComponent(
 			c.constructor = type;
 			c.render = doRender;
 		}
-		if (provider) provider._subs.add(c);
+		if (provider) provider._subs.add(internal);
 
 		c.props = newProps;
 		if (!c.state) c.state = {};

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -2,12 +2,7 @@ import { Fragment } from '../create-element';
 import options from '../options';
 import { mountChildren } from './mount';
 import { diffChildren, reorderChildren } from './children';
-import {
-	DIRTY_BIT,
-	FORCE_UPDATE,
-	MODE_PENDING_ERROR,
-	MODE_RERENDERING_ERROR
-} from '../constants';
+import { DIRTY_BIT, FORCE_UPDATE } from '../constants';
 import { addCommitCallback } from './commit';
 import { getParentContext } from '../tree';
 
@@ -27,13 +22,6 @@ export function renderFunctionComponent(
 
 	// @TODO split update + mount?
 	let newProps = newVNode ? newVNode.props : internal.props;
-
-	if (internal.flags & MODE_PENDING_ERROR) {
-		// Toggle the MODE_PENDING_ERROR and MODE_RERENDERING_ERROR flags. In
-		// actuality, this should turn off the MODE_PENDING_ERROR flag and turn on
-		// the MODE_RERENDERING_ERROR flag.
-		internal.flags ^= MODE_PENDING_ERROR | MODE_RERENDERING_ERROR;
-	}
 
 	const context = getParentContext(internal);
 
@@ -77,9 +65,6 @@ export function renderFunctionComponent(
 		}
 
 		c._internal = internal;
-		if (internal._commitCallbacks != null && internal._commitCallbacks.length) {
-			commitQueue.push(internal);
-		}
 
 		// TODO: Returning undefined here (i.e. return;) passes all tests. That seems
 		// like a bug. Should validate that we have test coverage for sCU that
@@ -125,10 +110,6 @@ export function renderFunctionComponent(
 		);
 	}
 
-	if (internal._commitCallbacks != null && internal._commitCallbacks.length) {
-		commitQueue.push(internal);
-	}
-
 	return nextDomSibling;
 }
 
@@ -158,13 +139,6 @@ export function renderClassComponent(
 
 	// @TODO split update + mount?
 	let newProps = newVNode ? newVNode.props : internal.props;
-
-	if (internal.flags & MODE_PENDING_ERROR) {
-		// Toggle the MODE_PENDING_ERROR and MODE_RERENDERING_ERROR flags. In
-		// actuality, this should turn off the MODE_PENDING_ERROR flag and turn on
-		// the MODE_RERENDERING_ERROR flag.
-		internal.flags ^= MODE_PENDING_ERROR | MODE_RERENDERING_ERROR;
-	}
 
 	const context = getParentContext(internal);
 
@@ -243,12 +217,6 @@ export function renderClassComponent(
 			}
 
 			c._internal = internal;
-			if (
-				internal._commitCallbacks != null &&
-				internal._commitCallbacks.length
-			) {
-				commitQueue.push(internal);
-			}
 
 			// TODO: Returning undefined here (i.e. return;) passes all tests. That seems
 			// like a bug. Should validate that we have test coverage for sCU that
@@ -314,10 +282,6 @@ export function renderClassComponent(
 			commitQueue,
 			startDom
 		);
-	}
-
-	if (internal._commitCallbacks != null && internal._commitCallbacks.length) {
-		commitQueue.push(internal);
 	}
 
 	return nextDomSibling;

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -67,6 +67,13 @@ export function mount(parentDom, newVNode, internal, commitQueue, startDom) {
 				);
 			}
 
+			if (
+				internal._commitCallbacks != null &&
+				internal._commitCallbacks.length
+			) {
+				commitQueue.push(internal);
+			}
+
 			if (internal.flags & TYPE_ROOT && prevParentDom !== parentDom) {
 				// If we just mounted a root node/Portal, and it changed the parentDom
 				// of it's children, then we need to resume the diff from it's previous

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -7,13 +7,14 @@ import {
 	MODE_SUSPENDED,
 	RESET_MODE,
 	TYPE_TEXT,
+	TYPE_CLASS,
 	MODE_ERRORED,
 	TYPE_ROOT,
 	MODE_SVG
 } from '../constants';
 import { normalizeToVNode } from '../create-element';
 import { setProperty } from './props';
-import { renderComponent } from './component';
+import { renderClassComponent, renderFunctionComponent } from './component';
 import { createInternal } from '../tree';
 import options from '../options';
 
@@ -48,13 +49,23 @@ export function mount(parentDom, newVNode, internal, commitQueue, startDom) {
 				}
 			}
 
-			nextDomSibling = renderComponent(
-				parentDom,
-				null,
-				internal,
-				commitQueue,
-				startDom
-			);
+			if (internal.flags & TYPE_CLASS) {
+				nextDomSibling = renderClassComponent(
+					parentDom,
+					null,
+					internal,
+					commitQueue,
+					startDom
+				);
+			} else {
+				nextDomSibling = renderFunctionComponent(
+					parentDom,
+					null,
+					internal,
+					commitQueue,
+					startDom
+				);
+			}
 
 			if (internal.flags & TYPE_ROOT && prevParentDom !== parentDom) {
 				// If we just mounted a root node/Portal, and it changed the parentDom

--- a/src/diff/patch.js
+++ b/src/diff/patch.js
@@ -1,7 +1,7 @@
 import { diffChildren } from './children';
 import { setProperty } from './props';
 import options from '../options';
-import { renderComponent } from './component';
+import { renderClassComponent, renderFunctionComponent } from './component';
 import {
 	RESET_MODE,
 	TYPE_TEXT,
@@ -9,6 +9,7 @@ import {
 	MODE_SUSPENDED,
 	MODE_ERRORED,
 	TYPE_ROOT,
+	TYPE_CLASS,
 	MODE_SVG,
 	UNDEFINED
 } from '../constants';
@@ -81,14 +82,23 @@ export function patch(parentDom, newVNode, internal, commitQueue, startDom) {
 	}
 
 	try {
-		nextDomSibling = renderComponent(
-			parentDom,
-			/** @type {import('../internal').VNode} */
-			(newVNode),
-			internal,
-			commitQueue,
-			startDom
-		);
+		if (internal.flags & TYPE_CLASS) {
+			nextDomSibling = renderClassComponent(
+				parentDom,
+				newVNode,
+				internal,
+				commitQueue,
+				startDom
+			);
+		} else {
+			nextDomSibling = renderFunctionComponent(
+				parentDom,
+				newVNode,
+				internal,
+				commitQueue,
+				startDom
+			);
+		}
 	} catch (e) {
 		// @TODO: assign a new VNode ID here? Or NaN?
 		// newVNode._vnodeId = 0;

--- a/src/diff/unmount.js
+++ b/src/diff/unmount.js
@@ -23,7 +23,7 @@ export function unmount(internal, parentInternal, skipRemove) {
 	}
 
 	if ((r = internal._component)) {
-		unsubscribeFromContext(r);
+		unsubscribeFromContext(internal);
 
 		if (r.componentWillUnmount) {
 			try {

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -129,6 +129,14 @@ export interface Internal<P = {}> {
 	props: (P & { children: ComponentChildren }) | string | number;
 	key: any;
 	ref: Ref<any> | null;
+
+	/** Bitfield containing information about the Internal or its component. */
+	flags: number;
+	/** Polymorphic property to store extensions like hooks on */
+	data: object;
+	/** The function that triggers in-place re-renders for an internal */
+	rerender: () => void;
+
 	/** children Internal nodes */
 	_children: Internal[];
 	/** next sibling Internal node */
@@ -142,8 +150,6 @@ export interface Internal<P = {}> {
 	_dom: PreactNode;
 	/** The component instance for which this is a backing Internal node */
 	_component: Component | null;
-	/** Bitfield containing information about the Internal or its component. */
-	flags: number;
 	/** This Internal's distance from the tree root */
 	_depth: number | null;
 	/** Callbacks to invoke when this internal commits */

--- a/src/tree.js
+++ b/src/tree.js
@@ -83,12 +83,13 @@ export function createInternal(vnode, parentInternal) {
 		props,
 		key,
 		ref,
+		data: {},
+		flags,
 		_children: null,
 		_parent: parentInternal,
 		_vnodeId: vnodeId,
 		_dom: null,
 		_component: null,
-		flags,
 		_context: null,
 		_depth: parentInternal ? parentInternal._depth + 1 : 0
 	};

--- a/src/tree.js
+++ b/src/tree.js
@@ -83,7 +83,7 @@ export function createInternal(vnode, parentInternal) {
 		props,
 		key,
 		ref,
-		data: {},
+		data: typeof type === 'function' ? {} : undefined,
 		flags,
 		_children: null,
 		_parent: parentInternal,

--- a/src/tree.js
+++ b/src/tree.js
@@ -83,7 +83,8 @@ export function createInternal(vnode, parentInternal) {
 		props,
 		key,
 		ref,
-		data: {},
+		// TODO: we can probably do better by selectively initializing this
+		data: typeof type == 'function' ? {} : null,
 		flags,
 		_children: null,
 		_parent: parentInternal,

--- a/src/tree.js
+++ b/src/tree.js
@@ -83,7 +83,7 @@ export function createInternal(vnode, parentInternal) {
 		props,
 		key,
 		ref,
-		data: typeof type === 'function' ? {} : undefined,
+		data: {},
 		flags,
 		_children: null,
 		_parent: parentInternal,

--- a/src/tree.js
+++ b/src/tree.js
@@ -11,6 +11,7 @@ import {
 	MODE_SVG,
 	UNDEFINED
 } from './constants';
+import { enqueueRender } from './component';
 
 /**
  * Create an internal tree node
@@ -83,7 +84,8 @@ export function createInternal(vnode, parentInternal) {
 		props,
 		key,
 		ref,
-		data: typeof type == 'function' ? {} : null,
+		data: null,
+		rerender: null,
 		flags,
 		_children: null,
 		_parent: parentInternal,
@@ -93,6 +95,11 @@ export function createInternal(vnode, parentInternal) {
 		_context: null,
 		_depth: parentInternal ? parentInternal._depth + 1 : 0
 	};
+
+	if (typeof type == 'function') {
+		internal.rerender = enqueueRender.bind(null, internal);
+		internal.data = {};
+	}
 
 	if (options._internal) options._internal(internal, vnode);
 

--- a/src/tree.js
+++ b/src/tree.js
@@ -83,7 +83,6 @@ export function createInternal(vnode, parentInternal) {
 		props,
 		key,
 		ref,
-		// TODO: we can probably do better by selectively initializing this
 		data: typeof type == 'function' ? {} : null,
 		flags,
 		_children: null,

--- a/src/tree.js
+++ b/src/tree.js
@@ -84,8 +84,8 @@ export function createInternal(vnode, parentInternal) {
 		props,
 		key,
 		ref,
-		data: null,
-		rerender: null,
+		data: typeof type == 'function' ? {} : null,
+		rerender: enqueueRender,
 		flags,
 		_children: null,
 		_parent: parentInternal,
@@ -95,11 +95,6 @@ export function createInternal(vnode, parentInternal) {
 		_context: null,
 		_depth: parentInternal ? parentInternal._depth + 1 : 0
 	};
-
-	if (typeof type == 'function') {
-		internal.rerender = enqueueRender.bind(null, internal);
-		internal.data = {};
-	}
 
 	if (options._internal) options._internal(internal, vnode);
 

--- a/test/browser/createContext.test.js
+++ b/test/browser/createContext.test.js
@@ -815,7 +815,7 @@ describe('createContext', () => {
 			expect(spy.getCall(0).args[0]).to.equal(instance);
 		});
 
-		it.only('should order updates correctly', () => {
+		it('should order updates correctly', () => {
 			const events = [];
 			let update;
 			const Store = createContext();

--- a/test/browser/createContext.test.js
+++ b/test/browser/createContext.test.js
@@ -815,7 +815,7 @@ describe('createContext', () => {
 			expect(spy.getCall(0).args[0]).to.equal(instance);
 		});
 
-		it('should order updates correctly', () => {
+		it.only('should order updates correctly', () => {
 			const events = [];
 			let update;
 			const Store = createContext();


### PR DESCRIPTION
This is a run-up to removing `Component` from our core, this PR also splits up functional from class components