### PR TITLE
(restructure) - allow for tree shaking out component

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -11,6 +11,8 @@ import {
 } from './constants';
 import { getDomSibling, getParentDom } from './tree';
 
+export let ENABLE_CLASSES = false;
+
 /**
  * Base Component class. Provides `setState()` and `forceUpdate()`, which
  * trigger rendering
@@ -19,6 +21,7 @@ import { getDomSibling, getParentDom } from './tree';
  * getChildContext
  */
 export function Component(props, context) {
+	ENABLE_CLASSES = true;
 	this.props = props;
 	this.context = context;
 }

--- a/src/component.js
+++ b/src/component.js
@@ -11,7 +11,7 @@ import {
 } from './constants';
 import { getDomSibling, getParentDom } from './tree';
 
-export let ENABLE_CLASSES = false;
+export let ENABLE_CLASSES;
 
 /**
  * Base Component class. Provides `setState()` and `forceUpdate()`, which

--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -1,3 +1,4 @@
+import { ENABLE_CLASSES } from '../component';
 import {
 	DIRTY_BIT,
 	MODE_RERENDERING_ERROR,
@@ -13,31 +14,33 @@ import {
  * is the highest parent that was being unmounted)
  */
 export function _catchError(error, internal) {
-	while ((internal = internal._parent)) {
-		if (
-			internal.flags & TYPE_COMPONENT &&
-			~internal.flags & MODE_RERENDERING_ERROR
-		) {
-			try {
-				if (internal.type.getDerivedStateFromError) {
-					internal._component.setState(
-						internal.type.getDerivedStateFromError(error)
-					);
-				}
+	if (ENABLE_CLASSES) {
+		while ((internal = internal._parent)) {
+			if (
+				internal.flags & TYPE_COMPONENT &&
+				~internal.flags & MODE_RERENDERING_ERROR
+			) {
+				try {
+					if (internal.type.getDerivedStateFromError) {
+						internal._component.setState(
+							internal.type.getDerivedStateFromError(error)
+						);
+					}
 
-				if (internal._component.componentDidCatch) {
-					internal._component.componentDidCatch(error);
-				}
+					if (internal._component.componentDidCatch) {
+						internal._component.componentDidCatch(error);
+					}
 
-				// NOTE: We're checking that any component in the stack got marked as dirty, even if it did so prior to this loop,
-				// which is technically incorrect. However, there is no way for a component to mark itself as dirty during rendering.
-				// The only way for a component to falsely intercept error bubbling would be to manually sets its internal dirty flag.
-				if (internal.flags & DIRTY_BIT) {
-					internal.flags |= MODE_PENDING_ERROR;
-					return;
+					// NOTE: We're checking that any component in the stack got marked as dirty, even if it did so prior to this loop,
+					// which is technically incorrect. However, there is no way for a component to mark itself as dirty during rendering.
+					// The only way for a component to falsely intercept error bubbling would be to manually sets its internal dirty flag.
+					if (internal.flags & DIRTY_BIT) {
+						internal.flags |= MODE_PENDING_ERROR;
+						return;
+					}
+				} catch (e) {
+					error = e;
 				}
-			} catch (e) {
-				error = e;
 			}
 		}
 	}

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -17,6 +17,7 @@ import { setProperty } from './props';
 import { renderClassComponent, renderFunctionComponent } from './component';
 import { createInternal, getParentContext } from '../tree';
 import options from '../options';
+import { ENABLE_CLASSES } from '../component';
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
  * @param {import('../internal').PreactElement} parentDom The parent of the DOM element
@@ -62,7 +63,7 @@ export function mount(parentDom, newVNode, internal, commitQueue, startDom) {
 
 			if (provider) provider._subs.add(internal);
 
-			if (internal.flags & TYPE_CLASS) {
+			if (ENABLE_CLASSES && internal.flags & TYPE_CLASS) {
 				nextDomSibling = renderClassComponent(
 					parentDom,
 					null,

--- a/src/diff/patch.js
+++ b/src/diff/patch.js
@@ -20,6 +20,7 @@ import {
 import { getChildDom, getDomSibling, getParentContext } from '../tree';
 import { mountChildren } from './mount';
 import { Fragment } from '../create-element';
+import { ENABLE_CLASSES } from '../component';
 
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
@@ -107,7 +108,7 @@ export function patch(parentDom, newVNode, internal, commitQueue, startDom) {
 				: tmp._defaultValue
 			: context;
 
-		if (internal.flags & TYPE_CLASS) {
+		if (ENABLE_CLASSES && internal.flags & TYPE_CLASS) {
 			nextDomSibling = renderClassComponent(
 				parentDom,
 				newVNode,


### PR DESCRIPTION
## Tests

We leverage a pattern that initializes a variable when an import occurs, this will allow rollup/terser to tree shake out

Rollup without component (still copies in)
![image](https://user-images.githubusercontent.com/17125876/141614207-727a90bc-402b-4f9d-9722-523e02b6ce6d.png)


Rollup with component
![image](https://user-images.githubusercontent.com/17125876/141614181-184f340b-b1f0-4318-a1cb-517156594b15.png)

Terser seems to result in similar scenario's where leveraging `render` will already include it, wondering if we bail out in comparison to [this experiment](https://rollupjs.org/repl/?version=2.60.0&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmltcG9ydCUyMCU3QiUyMGglMkMlMjBDb21wb25lbnQlMkMlMjByZW5kZXIlMjAlN0QlMjBmcm9tJTIwJy4lMkZwcmVhY3QuanMnJTNCJTVDbiU1Q25mdW5jdGlvbiUyMEZvbyhwcm9wcyklMjAlN0IlNUNuJTVDdHJldHVybiUyMGgoJ2gxJyUyQyUyMG51bGwlMkMlMjAnSGVsbG8nKSUzQiU1Q24lN0QlNUNuJTVDbnJlbmRlcihoKEZvbykpJTNCJTVDbiU1Q25jbGFzcyUyMEJhciUyMGV4dGVuZHMlMjBDb21wb25lbnQlMjAlN0IlNUNuJTVDdHJlbmRlcigpJTIwJTdCJTVDbiU1Q3QlNUN0cmV0dXJuJTIwaChGb28pJTNCJTVDbiU1Q3QlN0QlNUNuJTdEJTVDbiU1Q24lMkYlMkYlMjBERU1PJTNBJTIwdW4tY29tbWVudCUyMHRoaXMlMjBsaW5lJTIwdG8lMjBzZWUlMjBDb21wb25lbnQlMjBnZXQlMjBpbmNsdWRlZCU1Q24lMkYlMkZyZW5kZXIoaChCYXIpKSUzQiU1Q24lMjIlMkMlMjJpc0VudHJ5JTIyJTNBdHJ1ZSU3RCUyQyU3QiUyMm5hbWUlMjIlM0ElMjJwcmVhY3QuanMlMjIlMkMlMjJjb2RlJTIyJTNBJTIyZXhwb3J0JTIwJTdCJTIwaCUyMCU3RCUyMGZyb20lMjAnLiUyRnNyYyUyRmguanMnJTNCJTVDbmV4cG9ydCUyMCU3QiUyMHJlbmRlciUyMCU3RCUyMGZyb20lMjAnLiUyRnNyYyUyRnJlbmRlci5qcyclM0IlNUNuZXhwb3J0JTIwJTdCJTIwQ29tcG9uZW50JTIwJTdEJTIwZnJvbSUyMCcuJTJGc3JjJTJGY29tcG9uZW50LmpzJyUzQiUyMiUyQyUyMmlzRW50cnklMjIlM0FmYWxzZSU3RCUyQyU3QiUyMm5hbWUlMjIlM0ElMjJzcmMlMkZjb21wb25lbnQuanMlMjIlMkMlMjJjb2RlJTIyJTNBJTIyaW1wb3J0JTIwJTdCJTIwTU9ERV9GT1JDRV9VUERBVEUlMjAlN0QlMjBmcm9tJTIwJy4lMkZyZW5kZXIuanMnJTNCJTVDbiU1Q25leHBvcnQlMjBsZXQlMjBFTkFCTEVfQ0xBU1NFUyUzQiU1Q24lNUNuZXhwb3J0JTIwZnVuY3Rpb24lMjBDb21wb25lbnQocHJvcHMlMkMlMjBjb250ZXh0KSUyMCU3QiU1Q24lNUN0RU5BQkxFX0NMQVNTRVMlMjAlM0QlMjB0cnVlJTNCJTVDbiU1Q3R0aGlzLnByb3BzJTIwJTNEJTIwcHJvcHMlM0IlNUNuJTVDdHRoaXMuY29udGV4dCUyMCUzRCUyMGNvbnRleHQlM0IlNUNuJTVDdHRoaXMuX2NhbGxiYWNrcyUyMCUzRCUyMCU1QiU1RCUzQiU1Q24lN0QlNUNuQ29tcG9uZW50LnByb3RvdHlwZS5zZXRTdGF0ZSUyMCUzRCUyMGZ1bmN0aW9uKHN0YXRlJTJDJTIwY2IpJTIwJTdCJTVDbiU1Q3R0aGlzLnN0YXRlJTIwJTNEJTIwc3RhdGUlM0IlNUNuJTVDdGlmJTIwKGNiKSUyMHRoaXMuX2NhbGxiYWNrcy5wdXNoKGNiKSUzQiU1Q24lNUN0ZW5xdWV1ZVJlbmRlcih0aGlzLl9pbnRlcm5hbCklM0IlNUNuJTdEJTNCJTVDbkNvbXBvbmVudC5wcm90b3R5cGUuZm9yY2VVcGRhdGUlMjAlM0QlMjBmdW5jdGlvbihjYiklMjAlN0IlNUNuJTVDdGlmJTIwKGNiKSUyMHRoaXMuX2NhbGxiYWNrcy5wdXNoKGNiKSUzQiU1Q24lNUN0ZW5xdWV1ZVJlbmRlcih0aGlzLl9pbnRlcm5hbCUyQyUyME1PREVfRk9SQ0VfVVBEQVRFKSUzQiU1Q24lN0QlM0IlNUNuJTVDbmZ1bmN0aW9uJTIwZW5xdWV1ZVJlbmRlcihpbnRlcm5hbCUyQyUyMHNldEZsYWdzKSUyMCU3QiU1Q24lNUN0aWYlMjAoaW50ZXJuYWwlMjAlM0QlM0QlMjBudWxsKSUyMHJldHVybiUzQiU1Q24lNUN0bGV0JTIwZmxhZ3MlMjAlM0QlMjBpbnRlcm5hbC5mbGFncyUyMCU3QyUzRCUyMChzZXRGbGFncyUyMCU3QyU3QyUyMDApJTNCJTVDbiU1Q3RpZiUyMChmbGFncyUyMCUyNiUyMERJUlRZX0JJVCUyMCUzRCUzRCUzRCUyMDAlMjAlMjYlMjYlMjBxdWV1ZS5wdXNoKGludGVybmFsKSklMjAlN0IlNUNuJTVDdCU1Q3RzZXRUaW1lb3V0KHByb2Nlc3NRdWV1ZSklM0IlNUNuJTVDdCU3RCU1Q24lN0QlNUNubGV0JTIwcXVldWUlMjAlM0QlMjAlNUIlNUQlM0IlNUNuZnVuY3Rpb24lMjBwcm9jZXNzUXVldWUoKSUyMCU3QiU1Q24lNUN0bGV0JTIwY291bnQlMjAlM0QlMjBxdWV1ZS5sZW5ndGglM0IlNUNuJTVDdHdoaWxlJTIwKGNvdW50LS0pJTIwcmVuZGVyKHF1ZXVlLnNoaWZ0KCkpJTNCJTVDbiU3RCU1Q24lMjIlN0QlMkMlN0IlMjJuYW1lJTIyJTNBJTIyc3JjJTJGcmVuZGVyLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmltcG9ydCUyMCU3QiUyMEVOQUJMRV9DTEFTU0VTJTIwJTdEJTIwZnJvbSUyMCcuJTJGY29tcG9uZW50LmpzJyUzQiU1Q24lNUNuZXhwb3J0JTIwY29uc3QlMjBNT0RFX0ZPUkNFX1VQREFURSUyMCUzRCUyMDElM0IlNUNuJTVDbmV4cG9ydCUyMGZ1bmN0aW9uJTIwcmVuZGVyKHZub2RlJTJDJTIwcGFyZW50JTJDJTIwY29udGV4dCklMjAlN0IlNUNuJTVDdGlmJTIwKHR5cGVvZiUyMHZub2RlJTIwISUzRCUzRCUyMCdvYmplY3QnKSUyMCU3QiU1Q24lNUN0JTVDdGxldCUyMGQlMjAlM0QlMjB2bm9kZS5pbnN0JTIwJTNEJTIwbmV3JTIwVGV4dCh2bm9kZSUyMCU3QyU3QyUyMCcnKSUzQiU1Q24lNUN0JTVDdGlmJTIwKHBhcmVudCklMjBwYXJlbnQuYXBwZW5kQ2hpbGQoZCklM0IlNUNuJTVDdCU1Q3RyZXR1cm4lMjBkJTNCJTVDbiU1Q3QlN0QlNUNuJTVDdGxldCUyMHR5cGUlMjAlM0QlMjB2bm9kZS50eXBlJTNCJTVDbiU1Q3RsZXQlMjBwcm9wcyUyMCUzRCUyMHZub2RlLnByb3BzJTNCJTVDbiU1Q3RpZiUyMCh0eXBlb2YlMjB0eXBlJTIwJTNEJTNEJTNEJTIwJ2Z1bmN0aW9uJyklMjAlN0IlNUNuJTVDdCU1Q3RsZXQlMjBjJTNCJTVDbiU1Q3QlNUN0bGV0JTIwYXJnMiUyMCUzRCUyMGNvbnRleHQlM0IlNUNuJTVDdCU1Q3RsZXQlMjBhcmczJTNCJTVDbiU1Q3QlNUN0aWYlMjAodHlwZS5wcm90b3R5cGUlMjAlMjYlMjYlMjB0eXBlLnByb3RvdHlwZS5yZW5kZXIpJTIwJTdCJTVDbiU1Q3QlNUN0JTVDdGMlMjAlM0QlMjBuZXclMjB0eXBlKHByb3BzJTJDJTIwY29udGV4dCklM0IlNUNuJTVDdCU1Q3QlNUN0aWYlMjAoRU5BQkxFX0NMQVNTRVMpJTIwJTdCJTVDbiU1Q3QlNUN0JTVDdCU1Q3QlMkYlMkYlMjB0aGlzJTIwZW50aXJlJTIwYmxvY2slMjBpcyUyMG9taXR0ZWQlMjBpZiUyMG5vdGhpbmclMjBpbXBvcnRzJTIwQ29tcG9uZW50JTVDbiU1Q3QlNUN0JTVDdCU1Q3RjLl9pbnRlcm5hbCUyMCUzRCUyMHZub2RlJTNCJTVDbiU1Q3QlNUN0JTVDdCU1Q3RpZiUyMChjLmNvbXBvbmVudFdpbGxNb3VudCklMjBjLmNvbXBvbmVudFdpbGxNb3VudCgpJTNCJTVDbiU1Q3QlNUN0JTVDdCU1Q3RpZiUyMChjLmdldENoaWxkQ29udGV4dCklMjBjb250ZXh0JTIwJTNEJTIwYy5nZXRDaGlsZENvbnRleHQoKSUzQiU1Q24lNUN0JTVDdCU1Q3QlNUN0YXJnMyUyMCUzRCUyMGFyZzIlM0IlNUNuJTVDdCU1Q3QlNUN0JTVDdGFyZzIlMjAlM0QlMjBjLnN0YXRlJTNCJTVDbiU1Q3QlNUN0JTVDdCU3RCU1Q24lNUN0JTVDdCU3RCUyMGVsc2UlMjAlN0IlNUNuJTVDdCU1Q3QlNUN0YyUyMCUzRCUyMCU3QiUyMGNvbnRleHQlMkMlMjBzZXRTdGF0ZSUzQSUyMGRvUmVuZGVyJTJDJTIwZm9yY2VVcGRhdGUlM0ElMjBkb0ZvcmNlVXBkYXRlJTJDJTIwcmVuZGVyJTNBJTIwdHlwZSUyQyUyMF9pbnRlcm5hbCUzQSUyMHZub2RlJTIwJTdEJTNCJTVDbiU1Q3QlNUN0JTdEJTVDbiU1Q3QlNUN0bGV0JTIwcmVzdWx0JTIwJTNEJTIwYy5yZW5kZXIocHJvcHMlMkMlMjBhcmcyJTJDJTIwYXJnMyklM0IlNUNuJTVDdCU1Q3RyZXR1cm4lMjByZW5kZXIocmVzdWx0JTJDJTIwcGFyZW50JTJDJTIwY29udGV4dCklM0IlNUNuJTVDdCU3RCUyMGVsc2UlMjAlN0IlNUNuJTVDdCU1Q3RsZXQlMjBkJTIwJTNEJTIwdm5vZGUuaW5zdCUyMCUzRCUyMGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQodHlwZSklM0IlNUNuJTVDdCU1Q3RsZXQlMjBjJTIwJTNEJTIwcHJvcHMlMjAlMjYlMjYlMjBwcm9wcy5jaGlsZHJlbiUzQiU1Q24lNUN0JTVDdGlmJTIwKGMpJTIwZm9yJTIwKGMlMjBvZiUyMCU1QmMlNUQuZmxhdCg5KSklMjByZW5kZXIoYyUyQyUyMGQlMkMlMjBjb250ZXh0KSUzQiU1Q24lNUN0JTVDdGlmJTIwKHBhcmVudCklMjBwYXJlbnQuYXBwZW5kQ2hpbGQoZCklM0IlNUNuJTVDdCU1Q3RyZXR1cm4lMjBkJTNCJTVDbiU1Q3QlN0QlNUNuJTdEJTVDbiUyMiU3RCUyQyU3QiUyMm5hbWUlMjIlM0ElMjJzcmMlMkZoLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmV4cG9ydCUyMGZ1bmN0aW9uJTIwaCh0eXBlJTJDJTIwcHJvcHMlMkMlMjBjaGlsZHJlbiklMjAlN0IlNUNuJTVDdGlmJTIwKGFyZ3VtZW50cy5sZW5ndGglMjAlM0UlMjAyKSUyMCU3QiU1Q24lNUN0JTVDdGlmJTIwKGFyZ3VtZW50cy5sZW5ndGglMjAlM0UlMjAzKSUyMGNoaWxkcmVuJTIwJTNEJTIwJTVCJTVELnNsaWNlLmNhbGwoYXJndW1lbnRzJTJDJTIwMiklM0IlNUNuJTVDdCU1Q3QocHJvcHMlMjAlN0MlN0MlMjAocHJvcHMlMjAlM0QlMjAlN0IlN0QpKS5jaGlsZHJlbiUyMCUzRCUyMGNoaWxkcmVuJTNCJTVDbiU1Q3QlN0QlNUNuJTVDdHJldHVybiUyMCU3QiUyMHR5cGUlMkMlMjBwcm9wcyUyMCU3RCUzQiU1Q24lN0QlMjIlN0QlNUQlMkMlMjJvcHRpb25zJTIyJTNBJTdCJTIyZm9ybWF0JTIyJTNBJTIyZXMlMjIlMkMlMjJuYW1lJTIyJTNBJTIybXlCdW5kbGUlMjIlMkMlMjJhbWQlMjIlM0ElN0IlMjJpZCUyMiUzQSUyMiUyMiU3RCUyQyUyMmdsb2JhbHMlMjIlM0ElN0IlN0QlN0QlMkMlMjJleGFtcGxlJTIyJTNBbnVsbCU3RA==)

The bailout mainly seems to occur when it's a big file... Do note that the tests seem very much affected :joy:

## Potential savings

> These sizes are tentative for restructure as we haven't golfed too much yet

With component

```
Build "preact" to dist:
       4672 B: preact.js.gz
       4252 B: preact.js.br
       4839 B: preact.mjs.gz
       4412 B: preact.mjs.br
       4761 B: preact.umd.js.gz
       4316 B: preact.umd.js.br
```

Without component

```
Build "preact" to dist:
       4213 B: preact.js.gz
       3836 B: preact.js.br
       4327 B: preact.mjs.gz
       3944 B: preact.mjs.br
       4302 B: preact.umd.js.gz
       3906 B: preact.umd.js.br
```

This would mean that someone not leveraging the `Component` import could save 450'ish bytes, now that `useErrorBoundary` works without attaching itself to `componentDidCatch` I think we're in a good spot to search for a solution here.