### PR TITLE
undo change to lazy typings to reduce type ambiguity

### DIFF
--- a/compat/src/suspense.d.ts
+++ b/compat/src/suspense.d.ts
@@ -3,7 +3,7 @@ import { Component, ComponentChild, ComponentChildren } from '../../src';
 //
 // Suspense/lazy
 // -----------------------------------
-export function lazy<T>(loader: () => Promise<{ default: T } | T>): T;
+export function lazy<T>(loader: () => Promise<{ default: T }>): T;
 
 export interface SuspenseProps {
 	children?: ComponentChildren;


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/3219

First introduced in #3139 

this change will result in

```
const MyComponent = lazy(() =>
  import('./my-component').then((m) => {
    return {
      default: m.MyComponent,
    };
  })
);
```

Not working as it can't derive the type