### PR TITLE
adjust raf types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -265,7 +265,7 @@ export interface Options {
 	/** Attach a hook that is invoked after a vnode has rendered. */
 	diffed?(vnode: VNode): void;
 	event?(e: Event): any;
-	requestAnimationFrame?: typeof requestAnimationFrame;
+	requestAnimationFrame?: (callback: () => any) => any;
 	debounceRendering?(cb: () => void): void;
 	useDebugValue?(value: string | number): void;
 	_addHookName?(name: string | number): void;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -265,7 +265,7 @@ export interface Options {
 	/** Attach a hook that is invoked after a vnode has rendered. */
 	diffed?(vnode: VNode): void;
 	event?(e: Event): any;
-	requestAnimationFrame?: (callback: () => any) => any;
+	requestAnimationFrame?(callback: () => void): void;
 	debounceRendering?(cb: () => void): void;
 	useDebugValue?(value: string | number): void;
 	_addHookName?(name: string | number): void;


### PR DESCRIPTION
`typeof raf` results in the type being `(time: number) => ...` which isn't correct as we don't pass this in

resolves https://github.com/preactjs/preact/issues/3160