### PR TITLE
Optimization: use replaceChild where possible

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -175,7 +175,8 @@ export function diffChildren(
 					oldVNode,
 					oldChildren,
 					newDom,
-					oldDom
+					oldDom,
+					i === renderResult.length - 1
 				);
 			}
 
@@ -284,7 +285,8 @@ function placeChild(
 	oldVNode,
 	oldChildren,
 	newDom,
-	oldDom
+	oldDom,
+	replace
 ) {
 	let nextDom;
 	if (childVNode._nextDom !== undefined) {
@@ -306,21 +308,23 @@ function placeChild(
 		outer: if (oldDom == null || oldDom.parentNode !== parentDom) {
 			parentDom.appendChild(newDom);
 			nextDom = null;
+		} else if (replace) {
+			parentDom.replaceChild(newDom, oldDom);
+			nextDom = null;
 		} else {
 			// `j<oldChildrenLength; j+=2` is an alternative to `j++<oldChildrenLength/2`
-			let sibDom = oldDom, j = 0;
-			for ( ; (sibDom = sibDom.nextSibling) && j < oldChildren.length; j += 2) {
+			
+			for (
+				let sibDom = oldDom, j = 0;
+				(sibDom = sibDom.nextSibling) && j < oldChildren.length;
+				j += 2
+			) {
 				if (sibDom == newDom) {
 					break outer;
 				}
 			}
-			if (j === 0) {
-				parentDom.replaceChild(newDom, oldDom);
-				nextDom = null;
-			} else {
-				parentDom.insertBefore(newDom, oldDom);
-				nextDom = oldDom;
-			}
+			parentDom.insertBefore(newDom, oldDom);
+			nextDom = oldDom;
 		}
 	}
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -168,7 +168,7 @@ export function diffChildren(
 					oldDom,
 					parentDom
 				);
-			} else if (i === renderResult.length - 1) {
+			} else if (oldDom != null && i === renderResult.length - 1) {
 				parentDom.replaceChild(newDom, oldDom);
 				oldDom = newDom.nextSibling;
 			} else {

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -176,7 +176,7 @@ export function diffChildren(
 					oldChildren,
 					newDom,
 					oldDom,
-					i === renderResult.length - 1
+					!isHydrating && i === renderResult.length - 1
 				);
 			}
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -168,6 +168,9 @@ export function diffChildren(
 					oldDom,
 					parentDom
 				);
+			} else if (i === renderResult.length - 1) {
+				parentDom.replaceChild(newDom, oldDom);
+				oldDom = newDom.nextSibling;
 			} else {
 				oldDom = placeChild(
 					parentDom,

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -313,7 +313,6 @@ function placeChild(
 			nextDom = null;
 		} else {
 			// `j<oldChildrenLength; j+=2` is an alternative to `j++<oldChildrenLength/2`
-			
 			for (
 				let sibDom = oldDom, j = 0;
 				(sibDom = sibDom.nextSibling) && j < oldChildren.length;

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -168,9 +168,6 @@ export function diffChildren(
 					oldDom,
 					parentDom
 				);
-			} else if (oldDom != null && i === renderResult.length - 1) {
-				parentDom.replaceChild(newDom, oldDom);
-				oldDom = newDom.nextSibling;
 			} else {
 				oldDom = placeChild(
 					parentDom,
@@ -311,17 +308,19 @@ function placeChild(
 			nextDom = null;
 		} else {
 			// `j<oldChildrenLength; j+=2` is an alternative to `j++<oldChildrenLength/2`
-			for (
-				let sibDom = oldDom, j = 0;
-				(sibDom = sibDom.nextSibling) && j < oldChildren.length;
-				j += 2
-			) {
+			let sibDom = oldDom, j = 0;
+			for ( ; (sibDom = sibDom.nextSibling) && j < oldChildren.length; j += 2) {
 				if (sibDom == newDom) {
 					break outer;
 				}
 			}
-			parentDom.insertBefore(newDom, oldDom);
-			nextDom = oldDom;
+			if (j === 0) {
+				parentDom.replaceChild(newDom, oldDom);
+				nextDom = null;
+			} else {
+				parentDom.insertBefore(newDom, oldDom);
+				nextDom = oldDom;
+			}
 		}
 	}
 


### PR DESCRIPTION
This uses `ParentNode.replaceChild()` in the case where insertion is happening at the last index in a list, since it is not possible for an old DOM node to be left in-position after the inserted node. It does not avoid the `.removeChild()` call for the old DOM node, since that is a cheap noop for already-removed nodes.