### PR TITLE
Hydrate HTML Comments: part 3

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -342,7 +342,7 @@ module.exports = function(config) {
 			singleBundle: false,
 
 			// esbuild options
-			target: 'es5',
+			target: downlevel ? 'es5' : 'es2015',
 			define: {
 				COVERAGE: coverage,
 				'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || ''),

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -244,14 +244,7 @@ function reorderChildren(childVNode, oldDom, parentDom) {
 			if (typeof vnode.type == 'function') {
 				oldDom = reorderChildren(vnode, oldDom, parentDom);
 			} else {
-				oldDom = placeChild(
-					parentDom,
-					vnode,
-					vnode,
-					c,
-					vnode._dom,
-					oldDom
-				);
+				oldDom = placeChild(parentDom, vnode, vnode, c, vnode._dom, oldDom);
 			}
 		}
 	}
@@ -310,7 +303,7 @@ function placeChild(
 			// `j<oldChildrenLength; j+=2` is an alternative to `j++<oldChildrenLength/2`
 			for (
 				let sibDom = oldDom, j = 0;
-				(sibDom = sibDom.nextSibling) && j < oldChildren.length;
+				(sibDom = getNextDomSibling(sibDom)) && j < oldChildren.length;
 				j += 2
 			) {
 				if (sibDom == newDom) {
@@ -328,8 +321,17 @@ function placeChild(
 	if (nextDom !== undefined) {
 		oldDom = nextDom;
 	} else {
-		oldDom = newDom.nextSibling;
+		oldDom = getNextDomSibling(newDom);
 	}
 
 	return oldDom;
+}
+
+/**
+ * Get the next Text or Element sibling for a given node.
+ */
+function getNextDomSibling(node) {
+	// skip past comment/cdata/doctype/etc nodes
+	while ((node = node.nextSibling) && node.nodeType > 3);
+	return node;
 }

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -332,6 +332,10 @@ function placeChild(
  */
 function getNextDomSibling(node) {
 	// skip past comment/cdata/doctype/etc nodes
-	while ((node = node.nextSibling) && node.nodeType > 3);
+	while ((node = node.nextSibling)) {
+		if ('localName' in node || node.nodeType === 3) {
+			break;
+		}
+	}
 	return node;
 }

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -318,11 +318,7 @@ function diffElementNodes(
 			// if newVNode matches an element in excessDomChildren or the `dom`
 			// argument matches an element in excessDomChildren, remove it from
 			// excessDomChildren so it isn't later removed in diffChildren
-			if (
-				child &&
-				'localName' in child === !!nodeType &&
-				(nodeType ? child.localName === nodeType : child.nodeType === 3)
-			) {
+			if (child && child.localName == nodeType) {
 				dom = child;
 				excessDomChildren[i] = null;
 				break;
@@ -363,7 +359,9 @@ function diffElementNodes(
 		}
 	} else {
 		// If excessDomChildren was not null, repopulate it with the current element's children:
-		excessDomChildren = excessDomChildren && slice.call(dom.childNodes);
+		excessDomChildren =
+			excessDomChildren &&
+			slice.call(dom.childNodes).filter(n => n.nodeType <= 3);
 
 		oldProps = oldVNode.props || EMPTY_OBJ;
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -311,15 +311,6 @@ function diffElementNodes(
 	// Tracks entering and exiting SVG namespace when descending through the tree.
 	if (nodeType === 'svg') isSvg = true;
 
-	if (isHydrating) {
-		while (
-			dom &&
-			(nodeType ? dom.localName !== nodeType : dom.nodeType !== 3)
-		) {
-			dom = dom.nextSibling;
-		}
-	}
-
 	if (excessDomChildren != null) {
 		for (; i < excessDomChildren.length; i++) {
 			const child = excessDomChildren[i];
@@ -329,8 +320,7 @@ function diffElementNodes(
 			// excessDomChildren so it isn't later removed in diffChildren
 			if (
 				child &&
-				(child === dom ||
-					(nodeType ? child.localName == nodeType : child.nodeType == 3))
+				(nodeType ? child.localName == nodeType : child.nodeType == 3)
 			) {
 				dom = child;
 				excessDomChildren[i] = null;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -320,7 +320,8 @@ function diffElementNodes(
 			// excessDomChildren so it isn't later removed in diffChildren
 			if (
 				child &&
-				(nodeType ? child.localName == nodeType : child.nodeType == 3)
+				'localName' in child === !!nodeType &&
+				(nodeType ? child.localName === nodeType : child.nodeType === 3)
 			) {
 				dom = child;
 				excessDomChildren[i] = null;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -3,7 +3,7 @@ import { Component, getDomSibling } from '../component';
 import { Fragment } from '../create-element';
 import { diffChildren } from './children';
 import { diffProps, setProperty } from './props';
-import { assign, removeNode, slice } from '../util';
+import { assign, removeNode } from '../util';
 import options from '../options';
 
 /**
@@ -361,7 +361,10 @@ function diffElementNodes(
 		// If excessDomChildren was not null, repopulate it with the current element's children:
 		excessDomChildren =
 			excessDomChildren &&
-			slice.call(dom.childNodes).filter(n => n.nodeType <= 3);
+			excessDomChildren.filter.call(
+				dom.childNodes,
+				n => 'localName' in n || n.nodeType === 3
+			);
 
 		oldProps = oldVNode.props || EMPTY_OBJ;
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -311,6 +311,15 @@ function diffElementNodes(
 	// Tracks entering and exiting SVG namespace when descending through the tree.
 	if (nodeType === 'svg') isSvg = true;
 
+	if (isHydrating) {
+		while (
+			dom &&
+			(nodeType ? dom.localName !== nodeType : dom.nodeType !== 3)
+		) {
+			dom = dom.nextSibling;
+		}
+	}
+
 	if (excessDomChildren != null) {
 		for (; i < excessDomChildren.length; i++) {
 			const child = excessDomChildren[i];

--- a/src/render.js
+++ b/src/render.js
@@ -49,7 +49,7 @@ export function render(vnode, parentDom, replaceNode) {
 			: oldVNode
 			? null
 			: parentDom.firstChild
-			? slice.call(parentDom.childNodes)
+			? slice.call(parentDom.childNodes).filter(n => n.nodeType <= 3)
 			: null,
 		commitQueue,
 		!isHydrating && replaceNode

--- a/src/render.js
+++ b/src/render.js
@@ -2,7 +2,6 @@ import { EMPTY_OBJ } from './constants';
 import { commitRoot, diff } from './diff/index';
 import { createElement, Fragment } from './create-element';
 import options from './options';
-import { slice } from './util';
 
 /**
  * Render a Preact virtual node into a DOM element
@@ -49,7 +48,10 @@ export function render(vnode, parentDom, replaceNode) {
 			: oldVNode
 			? null
 			: parentDom.firstChild
-			? slice.call(parentDom.childNodes).filter(n => n.nodeType <= 3)
+			? commitQueue.filter.call(
+					parentDom.childNodes,
+					n => 'localName' in n || n.nodeType === 3
+			  )
 			: null,
 		commitQueue,
 		!isHydrating && replaceNode

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -82,6 +82,18 @@ describe('hydrate()', () => {
 		expect(onClickSpy).to.have.been.called.calledOnce;
 	});
 
+	it('should skip comment nodes between dom nodes', () => {
+		scratch.innerHTML = '<p><i>0</i><!-- c --><b>1</b></p>';
+		hydrate(
+			<p>
+				<i>0</i>
+				<b>1</b>
+			</p>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal('<p><i>0</i><b>1</b></p>');
+	});
+
 	it('should reuse existing DOM when given components', () => {
 		const onClickSpy = sinon.spy();
 		const html = ul([li('1'), li('2'), li('3')]);

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -83,7 +83,9 @@ describe('hydrate()', () => {
 	});
 
 	it('should skip comment nodes between dom nodes', () => {
-		scratch.innerHTML = '<p><i>0</i><!-- c --><b>1</b></p>';
+		const html = '<p><i>0</i><!-- c --><b>1</b></p>';
+		scratch.innerHTML = html;
+		clearLog();
 		hydrate(
 			<p>
 				<i>0</i>
@@ -91,7 +93,8 @@ describe('hydrate()', () => {
 			</p>,
 			scratch
 		);
-		expect(scratch.innerHTML).to.equal('<p><i>0</i><b>1</b></p>');
+		expect(getLog()).to.deep.equal([]);
+		expect(scratch.innerHTML).to.equal(html);
 	});
 
 	it('should reuse existing DOM when given components', () => {
@@ -459,8 +462,11 @@ describe('hydrate()', () => {
 	});
 
 	it('should skip comment nodes', () => {
-		scratch.innerHTML = '<p>hello <!-- c -->foo</p>';
+		const html = '<p>hello <!-- c -->foo</p>';
+		scratch.innerHTML = html;
+		clearLog();
 		hydrate(<p>hello {'foo'}</p>, scratch);
-		expect(scratch.innerHTML).to.equal('<p>hello foo</p>');
+		expect(getLog()).to.deep.equal([]);
+		expect(scratch.innerHTML).to.equal(html);
 	});
 });


### PR DESCRIPTION
This is an addendum to #3327 that changes how comment/cdata/doctype/etc nodes are handled during hydration.
Instead of skipping over those nodes when performing matching, they are excluded from `exccessDomChildren` entirely.
Also, any insertions performed during diffing will now use the next Element/Text node instead of `.nextSibling`, which could be a comment.