### PR TITLE
Bail on batched useState setter ending in an equal result

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -21,7 +21,7 @@ let oldBeforeUnmount = options.unmount;
 const RAF_TIMEOUT = 100;
 let prevRaf;
 
-options._diff = vnode => {
+options._diff = (vnode, oldVNode) => {
 	currentComponent = null;
 
 	if (vnode._component && vnode._component.__hooks) {
@@ -31,14 +31,11 @@ options._diff = vnode => {
 		let hasBail = false;
 		let hasDiff = false;
 		vnode._component.__hooks._list.forEach(hookState => {
-			console.log(
-				hookState._nextValue && hookState._nextValue[0],
-				hookState._value[0]
-			);
 			if (
 				hookState._nextValue &&
 				hookState._nextValue[0] === hookState._value[0]
 			) {
+				hookState._nextValue = undefined;
 				hasBail = true;
 			} else if (
 				hookState._nextValue &&
@@ -50,15 +47,11 @@ options._diff = vnode => {
 			}
 		});
 
-		console.log('hasBail', hasBail);
-		console.log('hasDiff', hasDiff);
-		console.log('hasNext', hasNextStates);
-		if (hasBail && !hasDiff && hasNextStates) {
-			console.log(vnode._original, vnode._component._vnode._original);
-			vnode._original = vnode._component._vnode._original;
+		if (hasBail && !hasDiff && hasNextStates && oldVNode) {
+			vnode._original = oldVNode._original;
 		}
 	}
-	if (oldBeforeDiff) oldBeforeDiff(vnode);
+	if (oldBeforeDiff) oldBeforeDiff(vnode, oldVNode);
 };
 
 options._render = vnode => {

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -25,29 +25,23 @@ options._diff = (vnode, oldVNode) => {
 	currentComponent = null;
 
 	if (vnode._component && vnode._component.__hooks) {
-		const hasNextStates = vnode._component.__hooks._list.some(
-			hookState => hookState._nextValue
-		);
 		let hasBail = false;
 		let hasDiff = false;
+
 		vnode._component.__hooks._list.forEach(hookState => {
 			if (
 				hookState._nextValue &&
 				hookState._nextValue[0] === hookState._value[0]
 			) {
-				hookState._nextValue = undefined;
 				hasBail = true;
-			} else if (
-				hookState._nextValue &&
-				hookState._nextValue[0] !== hookState._value[0]
-			) {
+			} else if (hookState._nextValue) {
 				hookState._value = hookState._nextValue;
-				hookState._nextValue = undefined;
 				hasDiff = true;
 			}
+			hookState._nextValue = undefined;
 		});
 
-		if (hasBail && !hasDiff && hasNextStates && oldVNode) {
+		if (hasBail && !hasDiff && oldVNode) {
 			vnode._original = oldVNode._original;
 		}
 	}
@@ -233,7 +227,7 @@ export function useImperativeHandle(ref, createHandle, args) {
 				return () => ref(null);
 			} else if (ref) {
 				ref.current = createHandle();
-				return () => ref.current = null;
+				return () => (ref.current = null);
 			}
 		},
 		args == null ? args : args.concat(ref)

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -29,13 +29,12 @@ options._diff = (vnode, oldVNode) => {
 		let hasDiff = false;
 
 		vnode._component.__hooks._list.forEach(hookState => {
-			if (
-				hookState._nextValue &&
-				hookState._nextValue[0] === hookState._value[0]
-			) {
+			let nextValue = hookState._nextValue;
+			if (!nextValue) return;
+			if (nextValue[0] === hookState._value[0]) {
 				hasBail = true;
-			} else if (hookState._nextValue) {
-				hookState._value = hookState._nextValue;
+			} else {
+				hookState._value = nextValue;
 				hasDiff = true;
 			}
 			hookState._nextValue = undefined;

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -60,6 +60,7 @@ export interface MemoHookState {
 
 export interface ReducerHookState {
 	_value?: any;
+	_nextValue?: any;
 	_component?: Component;
 	_reducer?: Reducer<any, any>;
 }

--- a/hooks/test/browser/useState.test.js
+++ b/hooks/test/browser/useState.test.js
@@ -1,7 +1,8 @@
 import { setupRerender } from 'preact/test-utils';
-import { createElement, render } from 'preact';
+import { createContext, createElement, render } from 'preact';
+import { useContext, useEffect, useState } from 'preact/hooks';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { useState } from 'preact/hooks';
+import { act } from 'preact/test-utils/dist/testUtils.module';
 
 /** @jsx createElement */
 
@@ -211,4 +212,67 @@ describe('useState', () => {
 		rerender();
 		expect(scratch.innerHTML).to.equal('');
 	});
+
+	// TODO: this is currently resulting in a loop
+	// it.only('does not loop when states are equal after batches', () => {
+	// 	const mountSpy = sinon.spy()
+	// 	const unmountSpy = sinon.spy()
+	// 	const renderSpy = sinon.spy()
+	// 	const Context = createContext(null);
+
+	// 	function ModalProvider(props) {
+	// 		let [modalCount, setModalCount] = useState(0);
+	// 		console.log('render', modalCount)
+	// 		renderSpy(modalCount)
+	// 		let context = {
+	// 			modalCount,
+	// 			addModal() {
+	// 				console.log('add')
+	// 				setModalCount((count) => count + 1);
+	// 			},
+	// 			removeModal() {
+	// 				console.log('remove')
+	// 				setModalCount((count) => count - 1);
+	// 			}
+	// 		};
+
+	// 		return <Context.Provider value={context}>{props.children}</Context.Provider>;
+	// 	}
+
+	// 	function useModal() {
+	// 		let context = useContext(Context);
+	// 		useEffect(() => {
+	// 			console.log('mount')
+	// 			mountSpy()
+
+	// 			context.addModal();
+	// 			return () => {
+	// 				console.log('unmount')
+	// 				unmountSpy();
+	// 				context.removeModal();
+	// 			};
+	// 		}, [context]);
+	// 	}
+
+	// 	function Popover() {
+	// 		useModal();
+	// 		return <div>Popover</div>;
+	// 	}
+
+	// 	function App() {
+	// 		return (
+	// 			<ModalProvider>
+	// 				<Popover />
+	// 			</ModalProvider>
+	// 		);
+	// 	}
+
+	// 	act(() => {
+	// 		render(<App />, scratch)
+	// 	})
+
+	// 	expect(mountSpy).to.be.calledOnce
+	// 	expect(unmountSpy).to.be.calledOnce
+	// 	expect(renderSpy).to.be.calledOnce
+	// })
 });

--- a/mangle.json
+++ b/mangle.json
@@ -40,6 +40,7 @@
       "$_detachOnNextRender": "__b",
       "$_force": "__e",
       "$_nextState": "__s",
+      "$_nextValue": "__s",
       "$_renderCallbacks": "__h",
       "$_vnode": "__v",
       "$_children": "__k",

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -49,6 +49,10 @@ export function diff(
 		excessDomChildren = [oldDom];
 	}
 
+	if (typeof newType === 'function' && oldVNode._component) {
+		newVNode._component = oldVNode._component;
+	}
+
 	if ((tmp = options._diff)) tmp(newVNode);
 
 	try {
@@ -130,6 +134,7 @@ export function diff(
 					c.componentWillReceiveProps(newProps, componentContext);
 				}
 
+				console.log(newVNode.type, newVNode._original === oldVNode._original);
 				if (
 					(!c._force &&
 						c.shouldComponentUpdate != null &&

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -53,7 +53,7 @@ export function diff(
 		newVNode._component = oldVNode._component;
 	}
 
-	if ((tmp = options._diff)) tmp(newVNode);
+	if ((tmp = options._diff)) tmp(newVNode, oldVNode);
 
 	try {
 		outer: if (typeof newType == 'function') {
@@ -134,7 +134,6 @@ export function diff(
 					c.componentWillReceiveProps(newProps, componentContext);
 				}
 
-				console.log(newVNode.type, newVNode._original === oldVNode._original);
 				if (
 					(!c._force &&
 						c.shouldComponentUpdate != null &&

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -34,6 +34,7 @@ export function diff(
 	isHydrating
 ) {
 	let tmp,
+		c,
 		newType = newVNode.type;
 
 	// When passing through createElement it assigns the object
@@ -49,15 +50,15 @@ export function diff(
 		excessDomChildren = [oldDom];
 	}
 
-	if (typeof newType === 'function' && oldVNode._component) {
-		newVNode._component = oldVNode._component;
+	if (oldVNode._component) {
+		c = newVNode._component = oldVNode._component;
 	}
 
 	if ((tmp = options._diff)) tmp(newVNode, oldVNode);
 
 	try {
 		outer: if (typeof newType == 'function') {
-			let c, isNew, oldProps, oldState, snapshot, clearProcessingException;
+			let isNew, oldProps, oldState, snapshot, clearProcessingException;
 			let newProps = newVNode.props;
 
 			// Necessary for createContext api. Setting this property will pass
@@ -72,7 +73,6 @@ export function diff(
 
 			// Get component and set it to `c`
 			if (oldVNode._component) {
-				c = newVNode._component = oldVNode._component;
 				clearProcessingException = c._processingException = c._pendingError;
 			} else {
 				// Instantiate the new component

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -34,7 +34,7 @@ export function diff(
 	isHydrating
 ) {
 	let tmp,
-		c,
+		c = oldVNode._component,
 		newType = newVNode.type;
 
 	// When passing through createElement it assigns the object

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -50,8 +50,8 @@ export function diff(
 		excessDomChildren = [oldDom];
 	}
 
-	if (oldVNode._component) {
-		c = newVNode._component = oldVNode._component;
+	if (c) {
+		newVNode._component = c;
 	}
 
 	if ((tmp = options._diff)) tmp(newVNode, oldVNode);

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -31,7 +31,7 @@ export interface Options extends preact.Options {
 		parent: Element | Document | ShadowRoot | DocumentFragment
 	): void;
 	/** Attach a hook that is invoked before a vnode is diffed. */
-	_diff?(vnode: VNode): void;
+	_diff?(vnode: VNode, oldVNode: VNode): void;
 	/** Attach a hook that is invoked after a tree was mounted or was updated. */
 	_commit?(vnode: VNode, commitQueue: Component[]): void;
 	/** Attach a hook that is invoked before a vnode has rendered. */


### PR DESCRIPTION
When we batch state updates from `useState` it can end up in an equal result, this is a micro-optimization that a lot of UI-libraries seem to rely on.

In the case of https://github.com/preactjs/preact/issues/2715 we can see that we have an effect that does +1 --> unmount -1 --> remounts +1 which ends up in the same Number value for our `useState` meaning we can bailout of this state update which also relieves us from the infinite loop that follows

Fixes: https://github.com/preactjs/preact/issues/2715

To verify:

- https://github.com/preactjs/preact/issues/3297 (EDIT: does not get fixed)
- https://github.com/chakra-ui/chakra-ui/issues/4397