### PR TITLE
Always invoke useEffect callbacks in reverse depth order

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -288,19 +288,18 @@ export function useErrorBoundary(cb) {
  * After paint effects consumer.
  */
 function flushAfterPaintEffects() {
-	afterPaintEffects.forEach(component => {
-		if (component._parentDom) {
-			try {
-				component.__hooks._pendingEffects.forEach(invokeCleanup);
-				component.__hooks._pendingEffects.forEach(invokeEffect);
-				component.__hooks._pendingEffects = [];
-			} catch (e) {
-				component.__hooks._pendingEffects = [];
-				options._catchError(e, component._vnode);
-			}
+	let component;
+	while (component = afterPaintEffects.pop()) {
+		if (!component._parentDom) continue;
+		try {
+			component.__hooks._pendingEffects.forEach(invokeCleanup);
+			component.__hooks._pendingEffects.forEach(invokeEffect);
+			component.__hooks._pendingEffects = [];
+		} catch (e) {
+			component.__hooks._pendingEffects = [];
+			options._catchError(e, component._vnode);
 		}
-	});
-	afterPaintEffects = [];
+	}
 }
 
 let HAS_RAF = typeof requestAnimationFrame == 'function';

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -289,6 +289,8 @@ export function useErrorBoundary(cb) {
  */
 function flushAfterPaintEffects() {
 	let component;
+	// sort the queue by depth (outermost to innermost)
+	afterPaintEffects.sort((a, b) => a._vnode._depth - b._vnode._depth);
 	while (component = afterPaintEffects.pop()) {
 		if (!component._parentDom) continue;
 		try {


### PR DESCRIPTION
(created a new PR for #3354 to get benchmarks running)

<blockquote>

This changes the ordering of useEffect callbacks so that they fire ~~roughly~~deterministically in order of reverse tree depth (innermost to outermost). Callbacks will still fire in-order for multiple useEffect()'s within a single component, but the callbacks for a child component will always fire before those of a parent.

We already invoked useEffect() callbacks in reverse-depth-order for normal/full tree updates, since they were pushed into the queue from `options.diffed()` which fires inner-to-outer.  With this PR, that ordering of useEffect callbacks is now also used when a parent subtree and child subtree are both enqueued for rendering, and the parent update does not descend to the child/grandchild (due to sCU/memo). In that case, we always render the parent component/tree before the child, but will now fire the child's useEffect callbacks before those of the parent.

h/t @wonderful-panda for uncovering this: https://twitter.com/wonderful_panda/status/1467015985672892416

We don't have specific timing that we state these calls will adhere to, so it seems like aligning with React makes the most sense here. React fires in-order within a component, but inner-to-outer between components ([demo](https://codesandbox.io/s/dazzling-snowflake-es4fh?file=/src/App.js)):

<img width="200" alt="Screen Shot 2021-12-06 at 12 31 32 PM" src="https://user-images.githubusercontent.com/105127/144893644-87a83e0f-cf80-4cba-aacd-b828e1d4af3a.png">

</blockquote>