### PR TITLE
Automate building npm package for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - restructure
+  workflow_call:
 
 jobs:
   build_test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+on: create
+
+jobs:
+  build:
+    if: github.ref_type == 'tag'
+    uses: preactjs/preact/.github/workflows/ci.yml@master
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: npm-package
+      - name: Create draft release
+        id: create-release
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const script = require('./scripts/release/create-gh-release.cjs')
+            return script({ github, context })
+      - name: Upload release artifact
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const script = require('./scripts/release/upload-gh-asset.cjs')
+            return script({ require, github, context, glob, release: ${{ steps.create-release.outputs.result }} })

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,12 +177,12 @@ rights to publish new releases on npm.
 	1. `git tag 10.0.0`
 	2. `git push --tags`
 5. Wait for the Release workflow to complete
-	- It'll create a draft release and upload the npm package to publish as an asset to the release
+	- It'll create a draft release and upload the built npm package as an asset to the release
 6. [Fill in the release notes](#writing-release-notes) in GitHub and publish them
 7. Run the publish script with the tag you created
 	1. `node ./scripts/release/publish.mjs 10.0.0`
-   1. Make sure you have 2FA enabled in npm, otherwise the above command will fail.
-   2. If you're doing a pre-release add `--tag next` to the `publish.mjs` command to publish it under a different tag (default is `latest`)
+   2. Make sure you have 2FA enabled in npm, otherwise the above command will fail.
+   3. If you're doing a pre-release add `--tag next` to the `publish.mjs` command to publish it under a different tag (default is `latest`)
 8. Tweet it out
 
 ## Legacy Releases (8.x)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,6 +170,27 @@ We closely watch our issues and have a pretty active [Slack workspace](https://c
 This guide is intended for core team members that have the necessary
 rights to publish new releases on npm.
 
+1. Make a PR where **only** the version number is incremented in `package.json` (note: We follow `SemVer` conventions)
+2. Wait until the PR is approved and merged.
+3. Switch back to the `master` branch and pull the merged PR
+4. Create and push a tag for the new version you want to publish:
+	1. `git tag 10.0.0`
+	2. `git push --tags`
+5. Wait for the Release workflow to complete
+	- It'll create a draft release and upload the npm package to publish as an asset to the release
+6. [Fill in the release notes](#writing-release-notes) in GitHub and publish them
+7. Run the publish script with the tag you created
+	1. `node ./scripts/release/publish.mjs 10.0.0`
+   1. Make sure you have 2FA enabled in npm, otherwise the above command will fail.
+   2. If you're doing a pre-release add `--tag next` to the `publish.mjs` command to publish it under a different tag (default is `latest`)
+8. Tweet it out
+
+## Legacy Releases (8.x)
+
+> **ATTENTION:** Make sure that you've cleared the project correctly
+> when switching from a 10.x branch.
+
+0. Run `rm -rf dist node_modules && npm i` to make sure to have the correct dependencies.
 1. [Write the release notes](#writing-release-notes) and keep them as a draft in GitHub
    1. I'd recommend writing them in an offline editor because each edit to a draft will change the URL in GitHub.
 2. Make a PR where **only** the version number is incremented in `package.json` (note: We follow `SemVer` conventions)
@@ -180,15 +201,6 @@ rights to publish new releases on npm.
    2. If you're doing a pre-release add `--tag next` to the `npm publish` command to publish it under a different tag (default is `latest`)
 6. Publish the release notes and create the correct git tag.
 7. Tweet it out
-
-## Legacy Releases (8.x)
-
-> **ATTENTION:** Make sure that you've cleared the project correctly
-> when switching from a 10.x branch.
-
-0. Run `rm -rf dist node_modules && npm i` to make sure to have the correct dependencies.
-
-Apart from that it's the same as above.
 
 ## Writing release notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "10.6.4",
 			"license": "MIT",
 			"devDependencies": {
+				"@actions/github": "^5.0.0",
+				"@actions/glob": "^0.2.0",
 				"@babel/core": "^7.7.0",
 				"@babel/plugin-proposal-object-rest-spread": "^7.6.2",
 				"@babel/plugin-transform-react-jsx": "^7.7.0",
@@ -54,13 +56,55 @@
 				"npm-run-all": "^4.0.0",
 				"prettier": "^1.18.2",
 				"prop-types": "^15.7.2",
+				"sade": "^1.7.4",
 				"sinon": "^9.2.3",
 				"sinon-chai": "^3.5.0",
-				"typescript": "4.4.2"
+				"typescript": "4.4.2",
+				"undici": "^4.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/preact"
+			}
+		},
+		"node_modules/@actions/core": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
+			"integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+			"dev": true,
+			"dependencies": {
+				"@actions/http-client": "^1.0.11"
+			}
+		},
+		"node_modules/@actions/github": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.0.tgz",
+			"integrity": "sha512-QvE9eAAfEsS+yOOk0cylLBIO/d6WyWIOvsxxzdrPFaud39G6BOkUwScXZn1iBzQzHyu9SBkkLSWlohDWdsasAQ==",
+			"dev": true,
+			"dependencies": {
+				"@actions/http-client": "^1.0.11",
+				"@octokit/core": "^3.4.0",
+				"@octokit/plugin-paginate-rest": "^2.13.3",
+				"@octokit/plugin-rest-endpoint-methods": "^5.1.1"
+			}
+		},
+		"node_modules/@actions/glob": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@actions/glob/-/glob-0.2.0.tgz",
+			"integrity": "sha512-mqE2a7I66kxcvsdwxs/filQwZsq25IfktMaviGfDB51v6Q3bvxnV7mFsZnvYtLhqGZbPxwBnH8AD3UYaOWb//w==",
+			"dev": true,
+			"dependencies": {
+				"@actions/core": "^1.2.6",
+				"minimatch": "^3.0.4"
+			}
+		},
+		"node_modules/@actions/http-client": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+			"integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+			"dev": true,
+			"dependencies": {
+				"tunnel": "0.0.6"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -1704,6 +1748,135 @@
 			"integrity": "sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==",
 			"dev": true
 		},
+		"node_modules/@octokit/auth-token": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+			"integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/types": "^6.0.3"
+			}
+		},
+		"node_modules/@octokit/core": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
+			"integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/auth-token": "^2.4.4",
+				"@octokit/graphql": "^4.5.8",
+				"@octokit/request": "^5.6.0",
+				"@octokit/request-error": "^2.0.5",
+				"@octokit/types": "^6.0.3",
+				"before-after-hook": "^2.2.0",
+				"universal-user-agent": "^6.0.0"
+			}
+		},
+		"node_modules/@octokit/endpoint": {
+			"version": "6.0.12",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+			"integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/types": "^6.0.3",
+				"is-plain-object": "^5.0.0",
+				"universal-user-agent": "^6.0.0"
+			}
+		},
+		"node_modules/@octokit/endpoint/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@octokit/graphql": {
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+			"integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/request": "^5.6.0",
+				"@octokit/types": "^6.0.3",
+				"universal-user-agent": "^6.0.0"
+			}
+		},
+		"node_modules/@octokit/openapi-types": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
+			"integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==",
+			"dev": true
+		},
+		"node_modules/@octokit/plugin-paginate-rest": {
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
+			"integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/types": "^6.34.0"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=2"
+			}
+		},
+		"node_modules/@octokit/plugin-rest-endpoint-methods": {
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
+			"integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/types": "^6.34.0",
+				"deprecation": "^2.3.1"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=3"
+			}
+		},
+		"node_modules/@octokit/request": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
+			"integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/endpoint": "^6.0.1",
+				"@octokit/request-error": "^2.1.0",
+				"@octokit/types": "^6.16.1",
+				"is-plain-object": "^5.0.0",
+				"node-fetch": "^2.6.1",
+				"universal-user-agent": "^6.0.0"
+			}
+		},
+		"node_modules/@octokit/request-error": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+			"integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/types": "^6.0.3",
+				"deprecation": "^2.0.0",
+				"once": "^1.4.0"
+			}
+		},
+		"node_modules/@octokit/request/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@octokit/types": {
+			"version": "6.34.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
+			"integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/openapi-types": "^11.2.0"
+			}
+		},
 		"node_modules/@sindresorhus/is": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz",
@@ -2769,6 +2942,12 @@
 			"dependencies": {
 				"tweetnacl": "^0.14.3"
 			}
+		},
+		"node_modules/before-after-hook": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+			"integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
+			"dev": true
 		},
 		"node_modules/benchmark": {
 			"version": "2.1.4",
@@ -5136,6 +5315,12 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/deprecation": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+			"dev": true
 		},
 		"node_modules/detect-libc": {
 			"version": "1.0.3",
@@ -17524,6 +17709,15 @@
 				"through": "^2.3.8"
 			}
 		},
+		"node_modules/undici": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-4.12.0.tgz",
+			"integrity": "sha512-sJ4CyO3ZPaoxWpLQTJpH/gWD+tCIra2OJ9UPvrX1siyJkgh8NOAybRejJ/g2xHyOdAuoSE0lPRJwRl8AZSXYJQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.18"
+			}
+		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -17574,6 +17768,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
 			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+			"dev": true
+		},
+		"node_modules/universal-user-agent": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+			"integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
 			"dev": true
 		},
 		"node_modules/universalify": {
@@ -18261,6 +18461,46 @@
 		}
 	},
 	"dependencies": {
+		"@actions/core": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
+			"integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+			"dev": true,
+			"requires": {
+				"@actions/http-client": "^1.0.11"
+			}
+		},
+		"@actions/github": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.0.tgz",
+			"integrity": "sha512-QvE9eAAfEsS+yOOk0cylLBIO/d6WyWIOvsxxzdrPFaud39G6BOkUwScXZn1iBzQzHyu9SBkkLSWlohDWdsasAQ==",
+			"dev": true,
+			"requires": {
+				"@actions/http-client": "^1.0.11",
+				"@octokit/core": "^3.4.0",
+				"@octokit/plugin-paginate-rest": "^2.13.3",
+				"@octokit/plugin-rest-endpoint-methods": "^5.1.1"
+			}
+		},
+		"@actions/glob": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@actions/glob/-/glob-0.2.0.tgz",
+			"integrity": "sha512-mqE2a7I66kxcvsdwxs/filQwZsq25IfktMaviGfDB51v6Q3bvxnV7mFsZnvYtLhqGZbPxwBnH8AD3UYaOWb//w==",
+			"dev": true,
+			"requires": {
+				"@actions/core": "^1.2.6",
+				"minimatch": "^3.0.4"
+			}
+		},
+		"@actions/http-client": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+			"integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+			"dev": true,
+			"requires": {
+				"tunnel": "0.0.6"
+			}
+		},
 		"@babel/code-frame": {
 			"version": "7.14.5",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
@@ -19405,6 +19645,127 @@
 			"integrity": "sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==",
 			"dev": true
 		},
+		"@octokit/auth-token": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+			"integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+			"dev": true,
+			"requires": {
+				"@octokit/types": "^6.0.3"
+			}
+		},
+		"@octokit/core": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
+			"integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
+			"dev": true,
+			"requires": {
+				"@octokit/auth-token": "^2.4.4",
+				"@octokit/graphql": "^4.5.8",
+				"@octokit/request": "^5.6.0",
+				"@octokit/request-error": "^2.0.5",
+				"@octokit/types": "^6.0.3",
+				"before-after-hook": "^2.2.0",
+				"universal-user-agent": "^6.0.0"
+			}
+		},
+		"@octokit/endpoint": {
+			"version": "6.0.12",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+			"integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+			"dev": true,
+			"requires": {
+				"@octokit/types": "^6.0.3",
+				"is-plain-object": "^5.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"dependencies": {
+				"is-plain-object": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+					"dev": true
+				}
+			}
+		},
+		"@octokit/graphql": {
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+			"integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+			"dev": true,
+			"requires": {
+				"@octokit/request": "^5.6.0",
+				"@octokit/types": "^6.0.3",
+				"universal-user-agent": "^6.0.0"
+			}
+		},
+		"@octokit/openapi-types": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
+			"integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==",
+			"dev": true
+		},
+		"@octokit/plugin-paginate-rest": {
+			"version": "2.17.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
+			"integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
+			"dev": true,
+			"requires": {
+				"@octokit/types": "^6.34.0"
+			}
+		},
+		"@octokit/plugin-rest-endpoint-methods": {
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
+			"integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+			"dev": true,
+			"requires": {
+				"@octokit/types": "^6.34.0",
+				"deprecation": "^2.3.1"
+			}
+		},
+		"@octokit/request": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
+			"integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+			"dev": true,
+			"requires": {
+				"@octokit/endpoint": "^6.0.1",
+				"@octokit/request-error": "^2.1.0",
+				"@octokit/types": "^6.16.1",
+				"is-plain-object": "^5.0.0",
+				"node-fetch": "^2.6.1",
+				"universal-user-agent": "^6.0.0"
+			},
+			"dependencies": {
+				"is-plain-object": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+					"dev": true
+				}
+			}
+		},
+		"@octokit/request-error": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+			"integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+			"dev": true,
+			"requires": {
+				"@octokit/types": "^6.0.3",
+				"deprecation": "^2.0.0",
+				"once": "^1.4.0"
+			}
+		},
+		"@octokit/types": {
+			"version": "6.34.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
+			"integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+			"dev": true,
+			"requires": {
+				"@octokit/openapi-types": "^11.2.0"
+			}
+		},
 		"@sindresorhus/is": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz",
@@ -20235,6 +20596,12 @@
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
+		},
+		"before-after-hook": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+			"integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
+			"dev": true
 		},
 		"benchmark": {
 			"version": "2.1.4",
@@ -22147,6 +22514,12 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
 			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+			"dev": true
+		},
+		"deprecation": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
 			"dev": true
 		},
 		"detect-libc": {
@@ -32050,6 +32423,12 @@
 				"through": "^2.3.8"
 			}
 		},
+		"undici": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-4.12.0.tgz",
+			"integrity": "sha512-sJ4CyO3ZPaoxWpLQTJpH/gWD+tCIra2OJ9UPvrX1siyJkgh8NOAybRejJ/g2xHyOdAuoSE0lPRJwRl8AZSXYJQ==",
+			"dev": true
+		},
 		"unicode-canonical-property-names-ecmascript": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -32088,6 +32467,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
 			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+			"dev": true
+		},
+		"universal-user-agent": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+			"integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
 			"dev": true
 		},
 		"universalify": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 			"require": "./jsx-runtime/dist/jsxRuntime.js",
 			"import": "./jsx-runtime/dist/jsxRuntime.mjs"
 		},
-    "./compat/server": {
+		"./compat/server": {
 			"require": "./compat/server.js",
 			"import": "./compat/server.mjs"
 		},
@@ -66,7 +66,7 @@
 			"require": "./compat/jsx-runtime.js",
 			"import": "./compat/jsx-runtime.mjs"
 		},
-    "./compat/jsx-dev-runtime": {
+		"./compat/jsx-dev-runtime": {
 			"require": "./compat/jsx-dev-runtime.js",
 			"import": "./compat/jsx-dev-runtime.mjs"
 		},
@@ -235,6 +235,8 @@
 	"bugs": "https://github.com/preactjs/preact/issues",
 	"homepage": "https://preactjs.com",
 	"devDependencies": {
+		"@actions/github": "^5.0.0",
+		"@actions/glob": "^0.2.0",
 		"@babel/core": "^7.7.0",
 		"@babel/plugin-proposal-object-rest-spread": "^7.6.2",
 		"@babel/plugin-transform-react-jsx": "^7.7.0",
@@ -280,8 +282,10 @@
 		"npm-run-all": "^4.0.0",
 		"prettier": "^1.18.2",
 		"prop-types": "^15.7.2",
+		"sade": "^1.7.4",
 		"sinon": "^9.2.3",
 		"sinon-chai": "^3.5.0",
-		"typescript": "4.4.2"
+		"typescript": "4.4.2",
+		"undici": "^4.12.0"
 	}
 }

--- a/scripts/release/create-gh-release.js
+++ b/scripts/release/create-gh-release.js
@@ -1,0 +1,59 @@
+/**
+ * @typedef {import('@octokit/openapi-types').components["schemas"]["release"]} Release
+ *
+ * @typedef Params
+ * @property {ReturnType<typeof import("@actions/github").getOctokit>} github
+ * @property {typeof import("@actions/github").context} context
+ *
+ * @param {Params} params
+ * @returns {Promise<Release>}
+ */
+async function create({ github, context }) {
+	const commitSha = process.env.GITHUB_SHA;
+	const tag_name = process.env.GITHUB_REF_NAME;
+	console.log('tag:', tag_name);
+
+	let releaseResult;
+
+	let releasePages = github.paginate.iterator(
+		github.rest.repos.listReleases,
+		context.repo
+	);
+
+	for await (const page of releasePages) {
+		for (let release of page.data) {
+			if (release.tag_name == tag_name) {
+				console.log('Existing release found:', release);
+				releaseResult = release;
+				break;
+			}
+		}
+	}
+
+	if (!releaseResult) {
+		console.log('No existing release found. Creating a new draft...');
+
+		// No existing release for this tag found so let's create a release
+		// API Documentation: https://docs.github.com/en/rest/reference/repos#create-a-release
+		// Octokit Documentation: https://octokit.github.io/rest.js/v18#repos-create-release
+		const createReleaseRes = await github.rest.repos.createRelease({
+			...context.repo,
+			tag_name,
+			name: tag_name,
+			body: '', // TODO: Maybe run changelogged and prefill the body?
+			draft: true,
+			prerelease: tag_name.includes('-'),
+			target_commitish: commitSha
+		});
+
+		console.log('Created release:', createReleaseRes.data);
+		releaseResult = createReleaseRes.data;
+	} else if (!releaseResult.draft) {
+		console.error('Found existing release but it was not in draft mode');
+		process.exit(1);
+	}
+
+	return releaseResult;
+}
+
+module.exports = create;

--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -1,0 +1,140 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import { fetch, stream } from 'undici';
+import sade from 'sade';
+
+let DEBUG = false;
+const log = {
+	debug: (...msgs) => DEBUG && console.log(...msgs),
+	info: (...msgs) => console.log(...msgs),
+	error: (...msgs) => console.error(...msgs)
+};
+
+/**
+ * Parse HTTP Link headers into an array of [rel_name, uri] tuples.
+ * This implementation only looks for one parameter named "rel".
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link
+ * @param {string} linkHeader
+ * @returns {Array<[string, string]>}
+ */
+function parseLinkHeader(linkHeader) {
+	log.debug('raw link:', linkHeader);
+
+	/** @type {Array<[string, string]>} */
+	const result = [];
+	const uris = linkHeader.split(/,\s*</);
+
+	for (let uri of uris) {
+		// We assume each link uri only has one param and the param key is "rel"
+		// The first "<" may get stripped off by the split call above
+		const match = uri.match(/<?([^>]*)>\s*;\s*rel="?([^"]*)"?/);
+
+		// 1st group: URI, 2nd group: rel name
+		result.push([match[2], match[1]]);
+	}
+
+	log.debug('parsed:', result);
+	return result;
+}
+
+/**
+ * AsyncGenerator for all GitHub releases in this repo, yielding each page of results
+ * @typedef {import('@octokit/openapi-types').components["schemas"]["release"]} Release
+ * @returns {AsyncGenerator<Release[]>}
+ */
+async function* getReleases() {
+	let nextUrl = 'https://api.github.com/repos/preactjs/preact/releases';
+	while (nextUrl) {
+		log.debug('Fetching', nextUrl);
+
+		const response = await fetch(nextUrl);
+		const linkHeader = response.headers.get('Link');
+		const links = linkHeader ? parseLinkHeader(linkHeader) : null;
+
+		nextUrl = links?.find(link => link[0] == 'next')?.[1];
+		yield /** @type {Release[]} */ (await response.json());
+	}
+}
+
+async function main(tag, opts) {
+	DEBUG = opts.debug;
+
+	log.debug('Git tag:', tag);
+	log.debug('Options:', opts);
+
+	// 1. Find a release with the matching tag
+	/** @type {Release} */
+	let release;
+
+	for await (let releasePage of getReleases()) {
+		release = releasePage.find(release => release.tag_name == tag);
+		if (release) {
+			break;
+		}
+	}
+
+	log.debug('Release:', release);
+	if (release) {
+		log.info('Found release', release.id, 'at', release.html_url);
+	} else {
+		log.error(
+			`Could not find a release with the tag ${tag}. Please publish that tag, wait for the release workflow to complete. Then publish the release, and re-run this script.`
+		);
+		process.exit(1);
+	}
+
+	// 2. Find npm package release asset
+	/** @type {Release["assets"][0]} */
+	let packageAsset = null;
+	const artifactRegex = /^preact-.+\.tgz$/;
+	for (let asset of release.assets) {
+		if (artifactRegex.test(asset.name)) {
+			packageAsset = asset;
+		}
+	}
+
+	if (packageAsset) {
+		log.info(`Found npm package asset: ${packageAsset.name}`);
+	} else {
+		log.error(
+			'Could not find asset matching package regex:',
+			artifactRegex,
+			'\nPlease wait for release workflow to complete and upload npm package.'
+		);
+		process.exit(1);
+	}
+
+	// 3. Download release asset
+	log.info(`\nDownloading ${packageAsset.name}...`);
+	await stream(
+		packageAsset.browser_download_url,
+		{
+			method: 'GET',
+			maxRedirections: 30
+		},
+		() => fs.createWriteStream(packageAsset.name)
+	);
+
+	// 3. Run npm publish
+	const args = ['publish', packageAsset.name];
+	if (opts['npm-tag']) {
+		args.push('--tag', opts['npm-tag']);
+	}
+
+	log.info(`Executing \`npm ${args.join(' ')}\``);
+	if (!opts['dry-run']) {
+		execFileSync('npm', args, { encoding: 'utf8', stdio: 'inherit' });
+	}
+}
+
+sade('publish <git-tag>', true)
+	.describe('Publish a tagged version of this package')
+	.option('--npm-tag', 'The npm tag to publish this package under', '')
+	.option(
+		'--dry-run',
+		"Prepare the package for publishing but don't actually publish it",
+		false
+	)
+	.option('--debug -d', 'Log debugging information', false)
+	.action(main)
+	.parse(process.argv);

--- a/scripts/release/upload-gh-asset.js
+++ b/scripts/release/upload-gh-asset.js
@@ -1,0 +1,65 @@
+/**
+ * @typedef {import('@octokit/openapi-types').components["schemas"]["release"]} Release
+ *
+ * @typedef Params
+ * @property {typeof require} require
+ * @property {ReturnType<typeof import("@actions/github").getOctokit>} github
+ * @property {typeof import("@actions/github").context} context
+ * @property {typeof import("@actions/glob")} glob
+ * @property {Release} release
+ *
+ * @param {Params} params
+ */
+async function upload({ require, github, context, glob, release }) {
+	const fs = require('fs');
+
+	// Find artifact to upload
+	const artifactPattern = 'preact.tgz';
+	const globber = await glob.create(artifactPattern, {
+		matchDirectories: false
+	});
+
+	const results = await globber.glob();
+	if (results.length == 0) {
+		throw new Error(
+			`No release artifact found matching pattern: ${artifactPattern}`
+		);
+	} else if (results.length > 1) {
+		throw new Error(
+			`More than one artifact matching pattern found. Expected only one. Found ${results.length}.`
+		);
+	}
+
+	const assetPath = results[0];
+	const assetName = `preact-${release.tag_name.replace(/^v/, '')}.tgz`;
+	const assetRegex = /^preact-.+\.tgz$/;
+
+	for (let asset of release.assets) {
+		if (assetRegex.test(asset.name)) {
+			console.log(
+				`Found existing asset matching asset pattern: ${asset.name}. Removing...`
+			);
+			await github.rest.repos.deleteReleaseAsset({
+				...context.repo,
+				asset_id: asset.id
+			});
+		}
+	}
+
+	console.log(`Uploading ${assetName} from ${assetPath}...`);
+
+	// Upload a release asset
+	// API Documentation: https://docs.github.com/en/rest/reference/repos#upload-a-release-asset
+	// Octokit Documentation: https://octokit.github.io/rest.js/v18#repos-upload-release-asset
+	const uploadAssetResponse = await github.rest.repos.uploadReleaseAsset({
+		...context.repo,
+		release_id: release.id,
+		name: assetName,
+		data: fs.readFileSync(assetPath)
+	});
+
+	console.log('Asset:', uploadAssetResponse.data);
+	return uploadAssetResponse.data;
+}
+
+module.exports = upload;


### PR DESCRIPTION
This PR adds a new Release workflow that runs whenever a new tag is created. Upon new tag creation, it'll run a build which produces as an artifact the built npm package for the commit the tag was created on. It then creates a draft release and uploads the built npm package as an asset to the npm package.

This PR also adds a script that will download the npm package from a release and publish it to NPM.

See the changes to our CONTRIBUTING guide to understand how our publish process will change.

NOTE: 2FA is still required for npm publishes. This PR does not automate the publishing a new package, just the building of the repo to create the npm package that still must be manually published.

Unfortunately, I can only test this after this PR is completed so there might be a couple of fast follows after this one to fix bugs 😅