### PR TITLE
Move `createPortal` to core

### DIFF
--- a/.changeset/little-melons-crash.md
+++ b/.changeset/little-melons-crash.md
@@ -1,0 +1,5 @@
+---
+'preact': minor
+---
+
+Move `createPortal` to the core package 

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -6,7 +6,8 @@ import {
 	Component,
 	createContext,
 	Fragment,
-	createRoot
+	createRoot,
+	createPortal
 } from 'preact';
 import {
 	useState,
@@ -26,7 +27,6 @@ import { forwardRef } from './forwardRef';
 import { Children } from './Children';
 import { Suspense, lazy } from './suspense';
 import { SuspenseList } from './suspense-list';
-import { createPortal } from './portals';
 import {
 	hydrate,
 	render,

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -1,7 +1,6 @@
-import { Component, createElement, options, Fragment } from 'preact';
+import { Component, createElement, options, Fragment, createPortal } from 'preact';
 import { TYPE_ELEMENT, MODE_HYDRATE } from '../../src/constants';
 import { getParentDom } from '../../src/tree';
-import { createPortal } from './portals';
 
 const oldCatchError = options._catchError;
 /** @type {(error: any, internal: import('./internal').Internal) => void} */

--- a/src/create-portal.js
+++ b/src/create-portal.js
@@ -1,4 +1,4 @@
-import { createElement } from 'preact';
+import { createElement } from './create-element';
 
 /**
  * Portal component

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -101,6 +101,11 @@ export interface ComponentClass<P = {}, S = {}> {
 export interface ComponentConstructor<P = {}, S = {}>
 	extends ComponentClass<P, S> {}
 
+export function createPortal(
+	vnode: VNode,
+	container: Element
+): VNode<any>;
+
 // Type alias for a component instance considered generally, whether stateless or stateful.
 export type AnyComponent<P = {}, S = {}> =
 	| FunctionComponent<P>

--- a/src/index.js
+++ b/src/index.js
@@ -12,3 +12,4 @@ export { cloneElement } from './clone-element';
 export { createContext } from './create-context';
 export { toChildArray } from './diff/children';
 export { default as options } from './options';
+export { createPortal } from './create-portal';

--- a/test/browser/portals.test.js
+++ b/test/browser/portals.test.js
@@ -9,7 +9,7 @@ import { setupRerender, act } from 'preact/test-utils';
 import { setupScratch, teardown } from '../_util/helpers';
 import { getLog, clearLog } from '../_util/logCall';
 
-/* eslint-disable react/jsx-boolean-value, react/display-name, prefer-arrow-callback */
+/** @jsx createElement */
 
 describe('Portal', () => {
 	/** @type {HTMLDivElement} */

--- a/test/browser/portals.test.js
+++ b/test/browser/portals.test.js
@@ -1,13 +1,13 @@
-import React, {
+import {
 	createElement,
 	render,
 	createPortal,
-	useState,
 	Component
-} from 'preact/compat';
-import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { getLog, clearLog } from '../../../test/_util/logCall';
+} from 'preact';
+import { useState } from 'preact/hooks';
 import { setupRerender, act } from 'preact/test-utils';
+import { setupScratch, teardown } from '../_util/helpers';
+import { getLog, clearLog } from '../_util/logCall';
 
 /* eslint-disable react/jsx-boolean-value, react/display-name, prefer-arrow-callback */
 


### PR DESCRIPTION
The implementation has grown to a very minimal amount of code so it seems worth moving this to Preact so importing `createPortal` doesn't require all the compat side-effects