### PR TITLE
Benchmark Tightening

### DIFF
--- a/benches/package-lock.json
+++ b/benches/package-lock.json
@@ -20,7 +20,7 @@
 				"prompts": "^2.4.0",
 				"sade": "^1.7.3",
 				"strip-ansi": "^6.0.0",
-				"tachometer": "^0.5.10",
+				"tachometer": "^0.5.7",
 				"v8-deopt-viewer": "^0.2.1"
 			}
 		},
@@ -365,24 +365,15 @@
 			}
 		},
 		"node_modules/ansi-escape-sequences": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-6.2.0.tgz",
-			"integrity": "sha512-tDwbanmlgu4wVCNM75YvwugiDn7iZtCewniuxZgLBbdVy/li7ufZhNpqPR7ZJgJVI2TzRcElDKBNlLaI+RSzbQ==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-5.1.2.tgz",
+			"integrity": "sha512-JcpoVp1W1bl1Qn4cVuiXEhD6+dyXKSOgCn2zlzE8inYgCJCBy1aPnUhlz6I4DFum8D4ovb9Qi/iAjUcGvG2lqw==",
 			"dev": true,
 			"dependencies": {
-				"array-back": "^6.2.0"
+				"array-back": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=12.17"
-			}
-		},
-		"node_modules/ansi-escape-sequences/node_modules/array-back": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.0.tgz",
-			"integrity": "sha512-mixVv03GOOn/ubHE4STQ+uevX42ETdk0JoMVEjNkSOCT7WgERh7C8/+NyhWYNpE3BN69pxFyJIBcF7CxWz/+4A==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.17"
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -437,6 +428,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4.0.0"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -1241,17 +1241,18 @@
 			"dev": true
 		},
 		"node_modules/fs-extra": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
 			"dev": true,
 			"dependencies": {
+				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=10"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -1686,9 +1687,9 @@
 			}
 		},
 		"node_modules/jsonschema": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
-			"integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==",
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.11.tgz",
+			"integrity": "sha512-XNZHs3N1IOa3lPKm//npxMhOdaoPw+MvEV0NIgxcER83GTJcG13rehtWmpBCfEt8DrtYwIkMTs8bdXoYs4fvnQ==",
 			"dev": true,
 			"engines": {
 				"node": "*"
@@ -3043,9 +3044,9 @@
 			}
 		},
 		"node_modules/systeminformation": {
-			"version": "5.9.17",
-			"resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.9.17.tgz",
-			"integrity": "sha512-hbJtPsG63PCst4PLXFq8hycbkeR5oGDquRowfLK0gNX7nJ1qx3tCbsWu83OL4GP1dkcLMKsVooLUn5x2K1Epgg==",
+			"version": "4.34.23",
+			"resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-4.34.23.tgz",
+			"integrity": "sha512-33+lQwlLxXoxy0o9WLOgw8OjbXeS3Jv+pSl+nxKc2AOClBI28HsdRPpH0u9Xa9OVjHLT9vonnOMw1ug7YXI0dA==",
 			"dev": true,
 			"os": [
 				"darwin",
@@ -3060,7 +3061,7 @@
 				"systeminformation": "lib/cli.js"
 			},
 			"engines": {
-				"node": ">=8.0.0"
+				"node": ">=4.0.0"
 			},
 			"funding": {
 				"type": "Buy me a coffee",
@@ -3107,23 +3108,22 @@
 			}
 		},
 		"node_modules/tachometer": {
-			"version": "0.5.10",
-			"resolved": "https://registry.npmjs.org/tachometer/-/tachometer-0.5.10.tgz",
-			"integrity": "sha512-2FbP+uA4Pcx0IbcfKP15IXhqueq73E5U1NWOsD9m3j5mtHqMSMtNXDJ1CpegZcDuYd2Dg+L2Nu3+e40Q+X8t7w==",
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/tachometer/-/tachometer-0.5.7.tgz",
+			"integrity": "sha512-fam/Esl2Ly/2/UtgdMKvYXU56vkdMnUY1od0FhThtyUOOcDUvRFOF+2Ia2Re5JM3nTpyqs5E2rGStuI3uxj5KA==",
 			"dev": true,
-			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@types/command-line-usage": "^5.0.1",
 				"@types/selenium-webdriver": "^4.0.11",
 				"@types/table": "^6.0.0",
-				"ansi-escape-sequences": "^6.0.1",
+				"ansi-escape-sequences": "^5.0.0",
 				"command-line-args": "^5.0.2",
 				"command-line-usage": "^6.1.0",
 				"csv-stringify": "^5.3.0",
-				"fs-extra": "^10.0.0",
+				"fs-extra": "^9.0.1",
 				"get-stream": "^6.0.0",
 				"got": "^11.5.0",
-				"jsonschema": "^1.4.0",
+				"jsonschema": "~1.2.11",
 				"jsonwebtoken": "^8.5.1",
 				"jstat": "^1.9.2",
 				"koa": "^2.11.0",
@@ -3140,7 +3140,7 @@
 				"semver": "^7.1.1",
 				"source-map-support": "^0.5.16",
 				"strip-ansi": "^6.0.0",
-				"systeminformation": "^5.3.3",
+				"systeminformation": "^4.32.0",
 				"table": "^6.0.7",
 				"ua-parser-js": "^0.7.19"
 			},
@@ -3762,20 +3762,12 @@
 			}
 		},
 		"ansi-escape-sequences": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-6.2.0.tgz",
-			"integrity": "sha512-tDwbanmlgu4wVCNM75YvwugiDn7iZtCewniuxZgLBbdVy/li7ufZhNpqPR7ZJgJVI2TzRcElDKBNlLaI+RSzbQ==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-5.1.2.tgz",
+			"integrity": "sha512-JcpoVp1W1bl1Qn4cVuiXEhD6+dyXKSOgCn2zlzE8inYgCJCBy1aPnUhlz6I4DFum8D4ovb9Qi/iAjUcGvG2lqw==",
 			"dev": true,
 			"requires": {
-				"array-back": "^6.2.0"
-			},
-			"dependencies": {
-				"array-back": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.0.tgz",
-					"integrity": "sha512-mixVv03GOOn/ubHE4STQ+uevX42ETdk0JoMVEjNkSOCT7WgERh7C8/+NyhWYNpE3BN69pxFyJIBcF7CxWz/+4A==",
-					"dev": true
-				}
+				"array-back": "^4.0.0"
 			}
 		},
 		"ansi-regex": {
@@ -3815,6 +3807,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
 			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+			"dev": true
+		},
+		"at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
 			"dev": true
 		},
 		"balanced-match": {
@@ -4502,11 +4500,12 @@
 			"dev": true
 		},
 		"fs-extra": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
 			"dev": true,
 			"requires": {
+				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"
@@ -4855,9 +4854,9 @@
 			}
 		},
 		"jsonschema": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
-			"integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==",
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.11.tgz",
+			"integrity": "sha512-XNZHs3N1IOa3lPKm//npxMhOdaoPw+MvEV0NIgxcER83GTJcG13rehtWmpBCfEt8DrtYwIkMTs8bdXoYs4fvnQ==",
 			"dev": true
 		},
 		"jsonwebtoken": {
@@ -5991,9 +5990,9 @@
 			}
 		},
 		"systeminformation": {
-			"version": "5.9.17",
-			"resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.9.17.tgz",
-			"integrity": "sha512-hbJtPsG63PCst4PLXFq8hycbkeR5oGDquRowfLK0gNX7nJ1qx3tCbsWu83OL4GP1dkcLMKsVooLUn5x2K1Epgg==",
+			"version": "4.34.23",
+			"resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-4.34.23.tgz",
+			"integrity": "sha512-33+lQwlLxXoxy0o9WLOgw8OjbXeS3Jv+pSl+nxKc2AOClBI28HsdRPpH0u9Xa9OVjHLT9vonnOMw1ug7YXI0dA==",
 			"dev": true
 		},
 		"table": {
@@ -6029,22 +6028,22 @@
 			}
 		},
 		"tachometer": {
-			"version": "0.5.10",
-			"resolved": "https://registry.npmjs.org/tachometer/-/tachometer-0.5.10.tgz",
-			"integrity": "sha512-2FbP+uA4Pcx0IbcfKP15IXhqueq73E5U1NWOsD9m3j5mtHqMSMtNXDJ1CpegZcDuYd2Dg+L2Nu3+e40Q+X8t7w==",
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/tachometer/-/tachometer-0.5.7.tgz",
+			"integrity": "sha512-fam/Esl2Ly/2/UtgdMKvYXU56vkdMnUY1od0FhThtyUOOcDUvRFOF+2Ia2Re5JM3nTpyqs5E2rGStuI3uxj5KA==",
 			"dev": true,
 			"requires": {
 				"@types/command-line-usage": "^5.0.1",
 				"@types/selenium-webdriver": "^4.0.11",
 				"@types/table": "^6.0.0",
-				"ansi-escape-sequences": "^6.0.1",
+				"ansi-escape-sequences": "^5.0.0",
 				"command-line-args": "^5.0.2",
 				"command-line-usage": "^6.1.0",
 				"csv-stringify": "^5.3.0",
-				"fs-extra": "^10.0.0",
+				"fs-extra": "^9.0.1",
 				"get-stream": "^6.0.0",
 				"got": "^11.5.0",
-				"jsonschema": "^1.4.0",
+				"jsonschema": "~1.2.11",
 				"jsonwebtoken": "^8.5.1",
 				"jstat": "^1.9.2",
 				"koa": "^2.11.0",
@@ -6061,7 +6060,7 @@
 				"semver": "^7.1.1",
 				"source-map-support": "^0.5.16",
 				"strip-ansi": "^6.0.0",
-				"systeminformation": "^5.3.3",
+				"systeminformation": "^4.32.0",
 				"table": "^6.0.7",
 				"ua-parser-js": "^0.7.19"
 			}

--- a/benches/package-lock.json
+++ b/benches/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"afterframe": "^1.0.1"
+				"afterframe": "^1.0.2"
 			},
 			"devDependencies": {
 				"@kristoferbaxter/async": "^1.0.0",
@@ -20,7 +20,7 @@
 				"prompts": "^2.4.0",
 				"sade": "^1.7.3",
 				"strip-ansi": "^6.0.0",
-				"tachometer": "^0.5.7",
+				"tachometer": "^0.5.10",
 				"v8-deopt-viewer": "^0.2.1"
 			}
 		},
@@ -326,9 +326,9 @@
 			}
 		},
 		"node_modules/afterframe": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/afterframe/-/afterframe-1.0.1.tgz",
-			"integrity": "sha512-0AOAf3V8eplIEx7WCTwL6aMhVuW4OPWMUiIV8DB5nvdjutGQcG+EyRXVgCjSXyVE7wIXu3O+KS+eFcf7XTwanA=="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/afterframe/-/afterframe-1.0.2.tgz",
+			"integrity": "sha512-0JeMZI7dIfVs5guqLgidQNV7c6jBC2HO0QNSekAUB82Hr7PdU9QXNAF3kpFkvATvHYDDTGto7FPsRu1ey+aKJQ=="
 		},
 		"node_modules/agent-base": {
 			"version": "5.1.1",
@@ -365,15 +365,24 @@
 			}
 		},
 		"node_modules/ansi-escape-sequences": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-5.1.2.tgz",
-			"integrity": "sha512-JcpoVp1W1bl1Qn4cVuiXEhD6+dyXKSOgCn2zlzE8inYgCJCBy1aPnUhlz6I4DFum8D4ovb9Qi/iAjUcGvG2lqw==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-6.2.0.tgz",
+			"integrity": "sha512-tDwbanmlgu4wVCNM75YvwugiDn7iZtCewniuxZgLBbdVy/li7ufZhNpqPR7ZJgJVI2TzRcElDKBNlLaI+RSzbQ==",
 			"dev": true,
 			"dependencies": {
-				"array-back": "^4.0.0"
+				"array-back": "^6.2.0"
 			},
 			"engines": {
-				"node": ">=8.0.0"
+				"node": ">=12.17"
+			}
+		},
+		"node_modules/ansi-escape-sequences/node_modules/array-back": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.0.tgz",
+			"integrity": "sha512-mixVv03GOOn/ubHE4STQ+uevX42ETdk0JoMVEjNkSOCT7WgERh7C8/+NyhWYNpE3BN69pxFyJIBcF7CxWz/+4A==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.17"
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -428,15 +437,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 4.0.0"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -1241,18 +1241,17 @@
 			"dev": true
 		},
 		"node_modules/fs-extra": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-			"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
 			"dev": true,
 			"dependencies": {
-				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
-				"universalify": "^1.0.0"
+				"universalify": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -1675,19 +1674,21 @@
 			"dev": true
 		},
 		"node_modules/jsonfile": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-			"integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
 			"dev": true,
 			"dependencies": {
-				"graceful-fs": "^4.1.6",
-				"universalify": "^1.0.0"
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
 			}
 		},
 		"node_modules/jsonschema": {
-			"version": "1.2.11",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.11.tgz",
-			"integrity": "sha512-XNZHs3N1IOa3lPKm//npxMhOdaoPw+MvEV0NIgxcER83GTJcG13rehtWmpBCfEt8DrtYwIkMTs8bdXoYs4fvnQ==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
+			"integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==",
 			"dev": true,
 			"engines": {
 				"node": "*"
@@ -3042,9 +3043,9 @@
 			}
 		},
 		"node_modules/systeminformation": {
-			"version": "4.34.9",
-			"resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-4.34.9.tgz",
-			"integrity": "sha512-jvc4DlJeXazsen2riPDR97GSaHNCmoL+mgfB8IXxmpNpNd7kv5MfkuihXEmF1/prBFtqzUA2lxnt1qp4maOMQA==",
+			"version": "5.9.17",
+			"resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.9.17.tgz",
+			"integrity": "sha512-hbJtPsG63PCst4PLXFq8hycbkeR5oGDquRowfLK0gNX7nJ1qx3tCbsWu83OL4GP1dkcLMKsVooLUn5x2K1Epgg==",
 			"dev": true,
 			"os": [
 				"darwin",
@@ -3059,7 +3060,11 @@
 				"systeminformation": "lib/cli.js"
 			},
 			"engines": {
-				"node": ">=4.0.0"
+				"node": ">=8.0.0"
+			},
+			"funding": {
+				"type": "Buy me a coffee",
+				"url": "https://www.buymeacoffee.com/systeminfo"
 			}
 		},
 		"node_modules/table": {
@@ -3102,22 +3107,23 @@
 			}
 		},
 		"node_modules/tachometer": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/tachometer/-/tachometer-0.5.7.tgz",
-			"integrity": "sha512-fam/Esl2Ly/2/UtgdMKvYXU56vkdMnUY1od0FhThtyUOOcDUvRFOF+2Ia2Re5JM3nTpyqs5E2rGStuI3uxj5KA==",
+			"version": "0.5.10",
+			"resolved": "https://registry.npmjs.org/tachometer/-/tachometer-0.5.10.tgz",
+			"integrity": "sha512-2FbP+uA4Pcx0IbcfKP15IXhqueq73E5U1NWOsD9m3j5mtHqMSMtNXDJ1CpegZcDuYd2Dg+L2Nu3+e40Q+X8t7w==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@types/command-line-usage": "^5.0.1",
 				"@types/selenium-webdriver": "^4.0.11",
 				"@types/table": "^6.0.0",
-				"ansi-escape-sequences": "^5.0.0",
+				"ansi-escape-sequences": "^6.0.1",
 				"command-line-args": "^5.0.2",
 				"command-line-usage": "^6.1.0",
 				"csv-stringify": "^5.3.0",
-				"fs-extra": "^9.0.1",
+				"fs-extra": "^10.0.0",
 				"get-stream": "^6.0.0",
 				"got": "^11.5.0",
-				"jsonschema": "~1.2.11",
+				"jsonschema": "^1.4.0",
 				"jsonwebtoken": "^8.5.1",
 				"jstat": "^1.9.2",
 				"koa": "^2.11.0",
@@ -3134,7 +3140,7 @@
 				"semver": "^7.1.1",
 				"source-map-support": "^0.5.16",
 				"strip-ansi": "^6.0.0",
-				"systeminformation": "^4.32.0",
+				"systeminformation": "^5.3.3",
 				"table": "^6.0.7",
 				"ua-parser-js": "^0.7.19"
 			},
@@ -3293,9 +3299,9 @@
 			}
 		},
 		"node_modules/universalify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-			"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 			"dev": true,
 			"engines": {
 				"node": ">= 10.0.0"
@@ -3723,9 +3729,9 @@
 			}
 		},
 		"afterframe": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/afterframe/-/afterframe-1.0.1.tgz",
-			"integrity": "sha512-0AOAf3V8eplIEx7WCTwL6aMhVuW4OPWMUiIV8DB5nvdjutGQcG+EyRXVgCjSXyVE7wIXu3O+KS+eFcf7XTwanA=="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/afterframe/-/afterframe-1.0.2.tgz",
+			"integrity": "sha512-0JeMZI7dIfVs5guqLgidQNV7c6jBC2HO0QNSekAUB82Hr7PdU9QXNAF3kpFkvATvHYDDTGto7FPsRu1ey+aKJQ=="
 		},
 		"agent-base": {
 			"version": "5.1.1",
@@ -3756,12 +3762,20 @@
 			}
 		},
 		"ansi-escape-sequences": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-5.1.2.tgz",
-			"integrity": "sha512-JcpoVp1W1bl1Qn4cVuiXEhD6+dyXKSOgCn2zlzE8inYgCJCBy1aPnUhlz6I4DFum8D4ovb9Qi/iAjUcGvG2lqw==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-6.2.0.tgz",
+			"integrity": "sha512-tDwbanmlgu4wVCNM75YvwugiDn7iZtCewniuxZgLBbdVy/li7ufZhNpqPR7ZJgJVI2TzRcElDKBNlLaI+RSzbQ==",
 			"dev": true,
 			"requires": {
-				"array-back": "^4.0.0"
+				"array-back": "^6.2.0"
+			},
+			"dependencies": {
+				"array-back": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.0.tgz",
+					"integrity": "sha512-mixVv03GOOn/ubHE4STQ+uevX42ETdk0JoMVEjNkSOCT7WgERh7C8/+NyhWYNpE3BN69pxFyJIBcF7CxWz/+4A==",
+					"dev": true
+				}
 			}
 		},
 		"ansi-regex": {
@@ -3801,12 +3815,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
 			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-			"dev": true
-		},
-		"at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
 			"dev": true
 		},
 		"balanced-match": {
@@ -4494,15 +4502,14 @@
 			"dev": true
 		},
 		"fs-extra": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-			"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
 			"dev": true,
 			"requires": {
-				"at-least-node": "^1.0.0",
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
-				"universalify": "^1.0.0"
+				"universalify": "^2.0.0"
 			}
 		},
 		"fs.realpath": {
@@ -4838,19 +4845,19 @@
 			"dev": true
 		},
 		"jsonfile": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-			"integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6",
-				"universalify": "^1.0.0"
+				"universalify": "^2.0.0"
 			}
 		},
 		"jsonschema": {
-			"version": "1.2.11",
-			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.11.tgz",
-			"integrity": "sha512-XNZHs3N1IOa3lPKm//npxMhOdaoPw+MvEV0NIgxcER83GTJcG13rehtWmpBCfEt8DrtYwIkMTs8bdXoYs4fvnQ==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
+			"integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==",
 			"dev": true
 		},
 		"jsonwebtoken": {
@@ -5984,9 +5991,9 @@
 			}
 		},
 		"systeminformation": {
-			"version": "4.34.9",
-			"resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-4.34.9.tgz",
-			"integrity": "sha512-jvc4DlJeXazsen2riPDR97GSaHNCmoL+mgfB8IXxmpNpNd7kv5MfkuihXEmF1/prBFtqzUA2lxnt1qp4maOMQA==",
+			"version": "5.9.17",
+			"resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.9.17.tgz",
+			"integrity": "sha512-hbJtPsG63PCst4PLXFq8hycbkeR5oGDquRowfLK0gNX7nJ1qx3tCbsWu83OL4GP1dkcLMKsVooLUn5x2K1Epgg==",
 			"dev": true
 		},
 		"table": {
@@ -6022,22 +6029,22 @@
 			}
 		},
 		"tachometer": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/tachometer/-/tachometer-0.5.7.tgz",
-			"integrity": "sha512-fam/Esl2Ly/2/UtgdMKvYXU56vkdMnUY1od0FhThtyUOOcDUvRFOF+2Ia2Re5JM3nTpyqs5E2rGStuI3uxj5KA==",
+			"version": "0.5.10",
+			"resolved": "https://registry.npmjs.org/tachometer/-/tachometer-0.5.10.tgz",
+			"integrity": "sha512-2FbP+uA4Pcx0IbcfKP15IXhqueq73E5U1NWOsD9m3j5mtHqMSMtNXDJ1CpegZcDuYd2Dg+L2Nu3+e40Q+X8t7w==",
 			"dev": true,
 			"requires": {
 				"@types/command-line-usage": "^5.0.1",
 				"@types/selenium-webdriver": "^4.0.11",
 				"@types/table": "^6.0.0",
-				"ansi-escape-sequences": "^5.0.0",
+				"ansi-escape-sequences": "^6.0.1",
 				"command-line-args": "^5.0.2",
 				"command-line-usage": "^6.1.0",
 				"csv-stringify": "^5.3.0",
-				"fs-extra": "^9.0.1",
+				"fs-extra": "^10.0.0",
 				"get-stream": "^6.0.0",
 				"got": "^11.5.0",
-				"jsonschema": "~1.2.11",
+				"jsonschema": "^1.4.0",
 				"jsonwebtoken": "^8.5.1",
 				"jstat": "^1.9.2",
 				"koa": "^2.11.0",
@@ -6054,7 +6061,7 @@
 				"semver": "^7.1.1",
 				"source-map-support": "^0.5.16",
 				"strip-ansi": "^6.0.0",
-				"systeminformation": "^4.32.0",
+				"systeminformation": "^5.3.3",
 				"table": "^6.0.7",
 				"ua-parser-js": "^0.7.19"
 			}
@@ -6181,9 +6188,9 @@
 			}
 		},
 		"universalify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-			"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 			"dev": true
 		},
 		"unpipe": {

--- a/benches/package.json
+++ b/benches/package.json
@@ -13,7 +13,7 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-		"afterframe": "^1.0.1"
+		"afterframe": "^1.0.2"
 	},
 	"devDependencies": {
 		"@kristoferbaxter/async": "^1.0.0",
@@ -24,7 +24,7 @@
 		"prompts": "^2.4.0",
 		"sade": "^1.7.3",
 		"strip-ansi": "^6.0.0",
-		"tachometer": "^0.5.7",
+		"tachometer": "^0.5.10",
 		"v8-deopt-viewer": "^0.2.1"
 	}
 }

--- a/benches/package.json
+++ b/benches/package.json
@@ -24,7 +24,7 @@
 		"prompts": "^2.4.0",
 		"sade": "^1.7.3",
 		"strip-ansi": "^6.0.0",
-		"tachometer": "^0.5.10",
+		"tachometer": "^0.5.7",
 		"v8-deopt-viewer": "^0.2.1"
 	}
 }

--- a/benches/scripts/bench.js
+++ b/benches/scripts/bench.js
@@ -22,6 +22,7 @@ export const defaultBenchOptions = {
 	timeout: 1,
 	'window-size': '1024,768',
 	framework: IS_CI ? ['preact-master', 'preact-local'] : null,
+	memory: true,
 	trace: false
 };
 

--- a/benches/scripts/config.js
+++ b/benches/scripts/config.js
@@ -307,7 +307,12 @@ function parseBrowserOption(str, options) {
 	const name = str;
 
 	/** @type {BrowserConfigs} */
-	const config = { name, headless };
+	const config = { name };
+
+	if (config.name === 'chrome' || config.name === 'firefox') {
+		config.headless = headless;
+	}
+
 	if (remoteUrl !== undefined) {
 		config.remoteUrl = remoteUrl;
 	}

--- a/benches/scripts/config.js
+++ b/benches/scripts/config.js
@@ -322,16 +322,16 @@ function parseBrowserOption(str, options) {
 		const mem = options.memory !== false;
 		config.addArguments = [
 			`--js-flags="${mem ? '--expose-gc ' : ''}--random-seed=1157259157"`,
-			mem && '--enable-precise-memory-info'
-			// '--disable-ipc-flooding-protection',
-			// '--disable-renderer-backgrounding',
-			// '--disable-background-timer-throttling',
-			// '--disable-backgrounding-occluded-windows',
-			// '--disable-hang-monitor',
-			// '--disable-device-discovery-notifications',
-			// '--disable-extensions',
-			// '--incognito',
-			// '--deterministic-mode',
+			mem && '--enable-precise-memory-info',
+			'--disable-ipc-flooding-protection',
+			'--disable-renderer-backgrounding',
+			'--disable-background-timer-throttling',
+			'--disable-backgrounding-occluded-windows',
+			'--disable-hang-monitor',
+			'--disable-device-discovery-notifications',
+			'--disable-extensions',
+			'--incognito',
+			'--deterministic-mode'
 			// '--no-sandbox'
 		].filter(Boolean);
 	}

--- a/benches/scripts/config.js
+++ b/benches/scripts/config.js
@@ -84,7 +84,7 @@ function getBaseBenchmarkConfig(benchPath, options) {
 	let measurement;
 	if (name == '02_replace1k') {
 		// MUST BE KEPT IN SYNC WITH WARMUP COUNT IN 02_replace1k.html
-		const WARMUP_COUNT = 5;
+		const WARMUP_COUNT = 3;
 
 		// For 02_replace1k, collect additional measurements focusing on the JS
 		// clock time for each warmup and the final duration.

--- a/benches/scripts/config.js
+++ b/benches/scripts/config.js
@@ -322,7 +322,6 @@ function parseBrowserOption(str, options) {
 		const mem = options.memory !== false;
 		config.addArguments = [
 			`--js-flags="${mem ? '--expose-gc ' : ''}--random-seed=1157259157"`,
-			'--disable-extensions',
 			mem && '--enable-precise-memory-info',
 			'--disable-ipc-flooding-protection',
 			'--disable-renderer-backgrounding',
@@ -330,7 +329,8 @@ function parseBrowserOption(str, options) {
 			'--disable-backgrounding-occluded-windows',
 			'--disable-hang-monitor',
 			'--disable-device-discovery-notifications',
-			'--incognito',
+			// '--disable-extensions',
+			// '--incognito',
 			'--deterministic-mode',
 			'--no-sandbox'
 		].filter(Boolean);

--- a/benches/scripts/config.js
+++ b/benches/scripts/config.js
@@ -322,17 +322,17 @@ function parseBrowserOption(str, options) {
 		const mem = options.memory !== false;
 		config.addArguments = [
 			`--js-flags="${mem ? '--expose-gc ' : ''}--random-seed=1157259157"`,
-			mem && '--enable-precise-memory-info',
-			'--disable-ipc-flooding-protection',
-			'--disable-renderer-backgrounding',
-			'--disable-background-timer-throttling',
-			'--disable-backgrounding-occluded-windows',
-			'--disable-hang-monitor',
-			'--disable-device-discovery-notifications',
+			mem && '--enable-precise-memory-info'
+			// '--disable-ipc-flooding-protection',
+			// '--disable-renderer-backgrounding',
+			// '--disable-background-timer-throttling',
+			// '--disable-backgrounding-occluded-windows',
+			// '--disable-hang-monitor',
+			// '--disable-device-discovery-notifications',
 			// '--disable-extensions',
 			// '--incognito',
-			'--deterministic-mode',
-			'--no-sandbox'
+			// '--deterministic-mode',
+			// '--no-sandbox'
 		].filter(Boolean);
 	}
 

--- a/benches/scripts/config.js
+++ b/benches/scripts/config.js
@@ -321,8 +321,18 @@ function parseBrowserOption(str, options) {
 	if (config.name == 'chrome') {
 		const mem = options.memory !== false;
 		config.addArguments = [
-			`--js-flags="${mem ? '--expose-gc' : ''}"`,
-			mem && '--enable-precise-memory-info'
+			`--js-flags="${mem ? '--expose-gc ' : ''}--random-seed=1157259157"`,
+			'--disable-extensions',
+			mem && '--enable-precise-memory-info',
+			'--disable-ipc-flooding-protection',
+			'--disable-renderer-backgrounding',
+			'--disable-background-timer-throttling',
+			'--disable-backgrounding-occluded-windows',
+			'--disable-hang-monitor',
+			'--disable-device-discovery-notifications',
+			'--incognito',
+			'--deterministic-mode',
+			'--no-sandbox'
 		].filter(Boolean);
 	}
 

--- a/benches/scripts/config.js
+++ b/benches/scripts/config.js
@@ -328,10 +328,10 @@ function parseBrowserOption(str, options) {
 			'--disable-background-timer-throttling',
 			'--disable-backgrounding-occluded-windows',
 			'--disable-hang-monitor',
-			'--disable-device-discovery-notifications',
-			'--disable-extensions',
-			'--incognito',
 			'--deterministic-mode'
+			// '--disable-device-discovery-notifications',
+			// '--disable-extensions',
+			// '--incognito',
 			// '--no-sandbox'
 		].filter(Boolean);
 	}

--- a/benches/scripts/config.js
+++ b/benches/scripts/config.js
@@ -327,12 +327,12 @@ function parseBrowserOption(str, options) {
 			'--disable-renderer-backgrounding',
 			'--disable-background-timer-throttling',
 			'--disable-backgrounding-occluded-windows',
-			'--disable-hang-monitor',
-			'--deterministic-mode'
+			// '--disable-hang-monitor',
 			// '--disable-device-discovery-notifications',
-			// '--disable-extensions',
-			// '--incognito',
-			// '--no-sandbox'
+			'--disable-extensions',
+			'--incognito',
+			'--no-sandbox'
+			// '--deterministic-mode'
 		].filter(Boolean);
 	}
 

--- a/benches/scripts/global.d.ts
+++ b/benches/scripts/global.d.ts
@@ -6,6 +6,7 @@ interface TachometerOptions {
 	horizon: string;
 	timeout: number;
 	trace: boolean;
+	memory: boolean;
 }
 
 interface DeoptOptions {

--- a/benches/scripts/index.js
+++ b/benches/scripts/index.js
@@ -63,6 +63,11 @@ prog
 		defaultBenchOptions.framework
 	)
 	.option(
+		'--memory',
+		'Measure and report memory consumption',
+		defaultBenchOptions.memory
+	)
+	.option(
 		'--trace',
 		'Enable perf tracing for browsers that support it',
 		defaultBenchOptions.trace

--- a/benches/src/02_replace1k.html
+++ b/benches/src/02_replace1k.html
@@ -40,7 +40,7 @@
 				const elementSelector = 'tr:first-child > td:first-child';
 
 				// MUST BE KEPT IN SYNC WITH WARMUP COUNT IN benches/scripts/config.js
-				const WARMUP_COUNT = 5;
+				const WARMUP_COUNT = 3;
 				for (let i = 0; i < WARMUP_COUNT; i++) {
 					markRunStart(`warmup-${i}`);
 					run();

--- a/benches/src/03_update10th1k_x16.html
+++ b/benches/src/03_update10th1k_x16.html
@@ -26,12 +26,12 @@
 			import {
 				measureName,
 				measureMemory,
-				afterFrame,
 				afterFrameAsync,
 				getRowLinkSel,
 				testElement,
 				testElementTextContains,
-				mutateAndLayout,
+				mutateAndLayoutAsync,
+				sleep,
 				raf
 			} from './util.js';
 			import * as framework from 'framework';
@@ -66,14 +66,17 @@
 			}
 
 			async function run() {
-				await afterFrameAsync();
+				await sleep(100);
 
 				const REPEAT = 50;
-				performance.mark('start');
-				await mutateAndLayout(update, REPEAT);
-				testElementTextContains(getRowLinkSel(991), repeat(' !!!', 3 + REPEAT));
+				await mutateAndLayoutAsync(iteration => {
+					if (iteration === 0) performance.mark('start');
+					update();
+				}, REPEAT);
 				performance.mark('stop');
 				performance.measure(measureName, 'start', 'stop');
+
+				testElementTextContains(getRowLinkSel(991), repeat(' !!!', 3 + REPEAT));
 
 				await raf();
 				measureMemory();

--- a/benches/src/07_create10k.html
+++ b/benches/src/07_create10k.html
@@ -8,6 +8,8 @@
 		<style>
 			table {
 				table-layout: fixed;
+				border-collapse: collapse;
+				overflow: hidden;
 			}
 			.preloadicon {
 				display: none;
@@ -24,28 +26,49 @@
 				measureName,
 				measureMemory,
 				testElementText,
-				afterFrameAsync,
-				mutateAndLayout,
+				mutateAndLayoutAsync,
+				sleep,
+				tick,
 				raf
 			} from './util.js';
 			import * as framework from 'framework';
 			import { render } from '../src/keyed-children/index.js';
 
-			const { runLots } = render(framework, document.getElementById('main'));
+			const clone = document.getElementById('main').cloneNode(true);
+			const { clear, run, runLots } = render(
+				framework,
+				document.getElementById('main')
+			);
+
+			async function warmup() {
+				for (let i = 5; i--; ) {
+					runLots();
+					await tick();
+					clear();
+					await raf();
+				}
+			}
 
 			async function main() {
-				await afterFrameAsync();
+				document.getElementById('main').replaceWith(clone);
+				const { clear, runLots } = render(framework, clone);
 
 				const elementSelector = 'tr:last-child > td:first-child';
 
+				// Note: unlike the other benches, we *don't* wait for layout here!
+				// Layout for 10000 table rows takes 5x longer than the JS workload
+				// we're trying to benchmark, which buries real performance changes.
+
 				performance.mark('start');
-				await mutateAndLayout(runLots);
+				runLots();
+				await sleep(10); // just long enough for setState to commit, but not layout
 				performance.mark('stop');
 				performance.measure(measureName, 'start', 'stop');
 
 				testElementText(elementSelector, '10000');
-
+				clear();
 				await raf();
+
 				measureMemory();
 			}
 

--- a/benches/src/filter_list.html
+++ b/benches/src/filter_list.html
@@ -31,8 +31,8 @@
 			import {
 				measureName,
 				measureMemory,
-				afterFrameAsync,
-				mutateAndLayout,
+				mutateAndLayoutAsync,
+				sleep,
 				raf
 			} from './util.js';
 			import { createRoot, createElement as h, Component } from 'framework';
@@ -76,14 +76,16 @@
 			}
 
 			(async () => {
-				for (let i = 5; i--; ) {
-					await mutateAndLayout(runPatch, 10);
+				for (let i = 3; i--; ) {
+					await mutateAndLayoutAsync(runPatch, 11);
 				}
 
-				await afterFrameAsync();
+				await sleep(100);
 
-				performance.mark('start');
-				await mutateAndLayout(runPatch, 50);
+				await mutateAndLayoutAsync(iteration => {
+					if (iteration === 0) performance.mark('start');
+					runPatch();
+				}, 111);
 				performance.mark('stop');
 				performance.measure(measureName, 'start', 'stop');
 

--- a/benches/src/many_updates.html
+++ b/benches/src/many_updates.html
@@ -21,7 +21,8 @@
 				measureName,
 				measureMemory,
 				afterFrameAsync,
-				mutateAndLayout,
+				mutateAndLayoutAsync,
+				sleep,
 				raf
 			} from './util.js';
 			import { createRoot, createElement as h } from 'framework';
@@ -84,14 +85,16 @@
 			}
 
 			(async () => {
-				for (let i = 5; i--; ) {
-					await mutateAndLayout(runPatch, 10);
+				for (let i = 3; i--; ) {
+					await mutateAndLayoutAsync(runPatch, 11);
 				}
 
-				await afterFrameAsync();
+				await sleep(100);
 
-				performance.mark('start');
-				await mutateAndLayout(runPatch, 11);
+				await mutateAndLayoutAsync(iteration => {
+					if (iteration === 0) performance.mark('start');
+					runPatch();
+				}, 21);
 				performance.mark('stop');
 				performance.measure(measureName, 'start', 'stop');
 

--- a/benches/src/text_update.html
+++ b/benches/src/text_update.html
@@ -11,8 +11,8 @@
 			import {
 				measureName,
 				measureMemory,
-				afterFrameAsync,
-				mutateAndLayout,
+				mutateAndLayoutAsync,
+				sleep,
 				raf
 			} from './util.js';
 			import { createRoot, createElement } from 'framework';
@@ -34,14 +34,22 @@
 			}
 
 			(async () => {
-				await mutateAndLayout(runPatch, 1000);
-
-				await afterFrameAsync();
-
-				performance.mark('start');
-				for (let i = 19; i--; ) {
-					await mutateAndLayout(runPatch, 1000);
+				for (let i = 5; i--; ) {
+					for (let j = 1000; j--; ) runPatch();
+					await raf();
 				}
+
+				await sleep(200);
+
+				// This triggers a rAF, then runs a synchronous benchmark followed by one "tick",
+				// which should include the cost of layout in all current browsers.
+				await mutateAndLayoutAsync(() => {
+					performance.mark('start');
+					for (let i = 19000; i--; ) {
+						runPatch();
+					}
+				});
+
 				performance.mark('stop');
 				performance.measure(measureName, 'start', 'stop');
 

--- a/benches/src/todo.html
+++ b/benches/src/todo.html
@@ -47,7 +47,12 @@
 	<body>
 		<div id="app"></div>
 		<script type="module">
-			import { measureName, measureMemory } from './util.js';
+			import {
+				mutateAndLayoutAsync,
+				sleep,
+				measureName,
+				measureMemory
+			} from './util.js';
 			import { createRoot, createElement as h, Component } from 'framework';
 
 			// Number of warmup runs of the benchmark to execute before the timed run
@@ -154,7 +159,7 @@
 			}
 			const $ = sel => document.querySelector(sel);
 
-			async function runPatch() {
+			function runPatch() {
 				state = freshState();
 				rerender();
 				const input = $('input');
@@ -224,9 +229,14 @@
 			}
 
 			warmup().then(async () => {
-				performance.mark('start');
-				await runPatch();
-				await new Promise(r => requestAnimationFrame(r));
+				await sleep(200);
+
+				// This triggers a rAF, then runs a synchronous benchmark followed by one "tick",
+				// which should include the cost of layout in all current browsers.
+				await mutateAndLayoutAsync(() => {
+					performance.mark('start');
+					runPatch();
+				});
 				performance.mark('stop');
 				performance.measure(measureName, 'start', 'stop');
 

--- a/benches/src/util.js
+++ b/benches/src/util.js
@@ -19,10 +19,41 @@ export function afterFrameAsync() {
 	return promise;
 }
 
+let count = 0;
+const channel = new MessageChannel();
+const callbacks = new Map();
+channel.port1.onmessage = e => {
+	let id = e.data;
+	let fn = callbacks.get(id);
+	callbacks.delete(id);
+	fn();
+};
+let pm = function(callback) {
+	let id = ++count;
+	callbacks.set(id, callback);
+	this.postMessage(id);
+}.bind(channel.port2);
+
+export function nextTick() {
+	return new Promise(r => pm(r));
+}
+
+export function mutateAndLayoutAsync(mutation, times = 1) {
+	return new Promise(resolve => {
+		requestAnimationFrame(() => {
+			for (let i = 0; i < times; i++) {
+				mutation(i);
+			}
+			pm(resolve);
+		});
+	});
+}
+
 export const raf = () => new Promise(requestAnimationFrame);
 export const forceLayout = () =>
 	(document.body._height = document.body.getBoundingClientRect().height);
 export const tick = () => new Promise(r => Promise.resolve().then(r));
+export const sleep = ms => new Promise(r => setTimeout(r, ms));
 
 export async function mutateAndLayout(mutation, times = 1) {
 	// await afterFrameAsync();


### PR DESCRIPTION
I spent a bunch of time this week digging into our benchmarks, and ended up finding a way to improve repeatability. The key is to run benchmark code _synchronously_ within a requestAnimationFrame callback, then wait one tick (postMessage). By starting the time measurement just before running the synchronous benchmark code and ending the period _after_ the tick, measured time includes the JS being benchmarked and the paint that immediately follows it, without forcing layout.