### PR TITLE
implement currentOwner for emotion/mui

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -123,8 +123,7 @@ options.vnode = vnode => {
 			if (IS_DOM && i === 'children' && type === 'noscript') {
 				// Emulate React's behavior of not rendering the contents of noscript tags on the client.
 				continue;
-			}
-			else if (i === 'value' && 'defaultValue' in props && value == null) {
+			} else if (i === 'value' && 'defaultValue' in props && value == null) {
 				// Skip applying value if it is null/undefined and we already set
 				// a default value
 				continue;
@@ -212,6 +211,8 @@ options._render = function(vnode) {
 	if (oldBeforeRender) {
 		oldBeforeRender(vnode);
 	}
+
+	__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner.current = vnode;
 	currentComponent = vnode._component;
 };
 
@@ -220,6 +221,9 @@ options._render = function(vnode) {
 // only `react-relay` makes use of it. It uses it to read the
 // context value.
 export const __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = {
+	ReactCurrentOwner: {
+		current: null
+	},
 	ReactCurrentDispatcher: {
 		current: {
 			readContext(context) {

--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -478,4 +478,24 @@ describe('compat render', () => {
 
 		expect(scratch.textContent).to.equal('foo');
 	});
+
+	it("should support mui's usage of __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED", () => {
+		const {
+			ReactCurrentOwner
+		} = React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+
+		function Bar() {
+			expect(ReactCurrentOwner.current.type.name).to.equal('Bar');
+			return 'hi';
+		}
+
+		function Foo() {
+			expect(ReactCurrentOwner.current.type.name).to.equal('Foo');
+			return <Bar />;
+		}
+
+		React.render(<Foo />, scratch);
+
+		expect(scratch.textContent).to.equal('hi');
+	});
 });


### PR DESCRIPTION
Emotion uses their own implementation of `jsxDev` that uses currentOwner to wrap the component.

```js
return ReactElement(type, key, ref, self, source, ReactCurrentOwner.current, props);
```

Fixes #3395

Investigating this further this looks like it is because React is inlined https://github.com/facebook/react/blob/main/packages/react/src/jsx/ReactJSXElement.js#L354