### PR TITLE
Normalize CompositionEvent listeners in preact/compat

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -123,8 +123,7 @@ options.vnode = vnode => {
 			if (IS_DOM && i === 'children' && type === 'noscript') {
 				// Emulate React's behavior of not rendering the contents of noscript tags on the client.
 				continue;
-			}
-			else if (i === 'value' && 'defaultValue' in props && value == null) {
+			} else if (i === 'value' && 'defaultValue' in props && value == null) {
 				// Skip applying value if it is null/undefined and we already set
 				// a default value
 				continue;
@@ -154,7 +153,7 @@ options.vnode = vnode => {
 				i = 'onfocusin';
 			} else if (/^onblur$/i.test(i)) {
 				i = 'onfocusout';
-			} else if (/^on(Ani|Tra|Tou|BeforeInp)/.test(i)) {
+			} else if (/^on(Ani|Tra|Tou|BeforeInp|Compo)/.test(i)) {
 				i = i.toLowerCase();
 			} else if (nonCustomElement && CAMEL_PROPS.test(i)) {
 				i = i.replace(/[A-Z0-9]/, '-$&').toLowerCase();

--- a/compat/test/browser/events.test.js
+++ b/compat/test/browser/events.test.js
@@ -275,4 +275,11 @@ describe('preact/compat events', () => {
 		scratch.firstChild.dispatchEvent(createEvent('beforeinput'));
 		expect(spy).to.be.calledOnce;
 	});
+
+	it('should normalize compositionstart event listener', () => {
+		let spy = sinon.spy();
+		render(<input onCompositionStart={spy} />, scratch);
+		scratch.firstChild.dispatchEvent(createEvent('compositionstart'));
+		expect(spy).to.be.calledOnce;
+	});
 });


### PR DESCRIPTION
This PR normalizes `compositionstart`, `compositionupdate` and `compositionend` event listeners in the same way Preact already does for `beforeinput`.

This solves an issue with Slate, where trying to type a character with an accent (like `ú`) causes an exception.

[A similar issue](https://github.com/preactjs/preact/issues/2789) is fixed by this PR (see  https://codesandbox.io/s/pensive-cookies-wpdej). See also https://github.com/ianstormtaylor/slate/issues/3903#issuecomment-887576458
