### PR TITLE
repeat renders that result in a pending state

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -203,7 +203,7 @@ export function useLayoutEffect(callback, args) {
 
 export function useRef(initialValue) {
 	currentHook = 5;
-	return useState({ current: initialValue })[0];
+	return useReducer(invokeEffect, { current: initialValue })[0];
 }
 
 /**

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -8,6 +8,9 @@ let currentIndex;
 /** @type {import('./internal').Internal} */
 let currentInternal;
 
+/** @type {import('./internal').Internal} */
+let previousInternal;
+
 /** @type {number} */
 let currentHook = 0;
 
@@ -35,15 +38,25 @@ options._render = internal => {
 	currentIndex = 0;
 
 	if (currentInternal.data && currentInternal.data.__hooks) {
-		currentInternal.data.__hooks._pendingEffects.forEach(invokeCleanup);
-		currentInternal.data.__hooks._pendingEffects.forEach(invokeEffect);
-		currentInternal.data.__hooks._pendingEffects = [];
+		if (previousInternal === currentInternal) {
+			currentInternal.data.__hooks._pendingEffects = [];
+			currentInternal._commitCallbacks = [];
+			currentInternal.data.__hooks._list.forEach(hookItem => {
+				if (hookItem._args) hookItem._args = undefined;
+			});
+		} else {
+			currentInternal.data.__hooks._pendingEffects.forEach(invokeCleanup);
+			currentInternal.data.__hooks._pendingEffects.forEach(invokeEffect);
+			currentInternal.data.__hooks._pendingEffects = [];
+		}
 	}
+	previousInternal = internal;
 };
 
 options.diffed = internal => {
 	if (oldAfterDiff) oldAfterDiff(internal);
 
+	previousInternal = undefined;
 	if (
 		internal.data &&
 		internal.data.__hooks &&

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -203,7 +203,7 @@ export function useLayoutEffect(callback, args) {
 
 export function useRef(initialValue) {
 	currentHook = 5;
-	return useMemo(() => ({ current: initialValue }), []);
+	return useState({ current: initialValue })[0];
 }
 
 /**

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -7,9 +7,11 @@ import { Reducer } from '.';
 
 export { PreactContext };
 
-export type Internal = PreactInternal & {
-	_component: Component;
-};
+export interface Internal extends PreactInternal {
+	data: PreactInternal.data & {
+		__hooks: ComponentHooks;
+	};
+}
 
 /**
  * The type of arguments passed to a Hook function. While this type is not

--- a/hooks/test/browser/useEffect.test.js
+++ b/hooks/test/browser/useEffect.test.js
@@ -505,4 +505,30 @@ describe('useEffect', () => {
 			'Parent - Effect'
 		]);
 	});
+
+	it('should cancel effects from a disposed render', () => {
+		const calls = [];
+		const App = () => {
+			const [greeting, setGreeting] = useState('bye');
+
+			useEffect(() => {
+				calls.push('doing effect' + greeting);
+				return () => {
+					calls.push('cleaning up' + greeting);
+				};
+			}, [greeting]);
+
+			if (greeting === 'bye') {
+				setGreeting('hi');
+			}
+
+			return <p>{greeting}</p>;
+		};
+
+		act(() => {
+			render(<App />, scratch);
+		});
+		expect(calls.length).to.equal(1);
+		expect(calls).to.deep.equal(['doing effecthi']);
+	});
 });

--- a/hooks/test/browser/useLayoutEffect.test.js
+++ b/hooks/test/browser/useLayoutEffect.test.js
@@ -386,4 +386,30 @@ describe('useLayoutEffect', () => {
 			'Parent - Effect'
 		]);
 	});
+
+	it('should cancel effects from a disposed render', () => {
+		const calls = [];
+		const App = () => {
+			const [greeting, setGreeting] = useState('bye');
+
+			useLayoutEffect(() => {
+				calls.push('doing effect' + greeting);
+				return () => {
+					calls.push('cleaning up' + greeting);
+				};
+			}, [greeting]);
+
+			if (greeting === 'bye') {
+				setGreeting('hi');
+			}
+
+			return <p>{greeting}</p>;
+		};
+
+		act(() => {
+			render(<App />, scratch);
+		});
+		expect(calls.length).to.equal(1);
+		expect(calls).to.deep.equal(['doing effecthi']);
+	});
 });

--- a/hooks/test/browser/useState.test.js
+++ b/hooks/test/browser/useState.test.js
@@ -176,6 +176,26 @@ describe('useState', () => {
 		expect(scratch.innerHTML).to.equal('<p>hi</p>');
 	});
 
+	it('should render a second time when the render function updates state', () => {
+		const calls = [];
+		const App = () => {
+			const [greeting, setGreeting] = useState('bye');
+
+			if (greeting === 'bye') {
+				setGreeting('hi');
+			}
+
+			calls.push(greeting);
+
+			return <p>{greeting}</p>;
+		};
+
+		render(<App />, scratch);
+		expect(calls.length).to.equal(2);
+		expect(calls).to.deep.equal(['bye', 'hi']);
+		expect(scratch.textContent).to.equal('hi');
+	});
+
 	it('should handle queued useState', () => {
 		function Message({ message, onClose }) {
 			const [isVisible, setVisible] = useState(Boolean(message));

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -46,13 +46,14 @@ export function renderFunctionComponent(
 	internal.props = c.props = newProps;
 
 	c._internal = internal;
-	// eslint-disable-next-line
-	while (1) {
+	let counter = 0;
+	while (counter < 25) {
+		counter++;
 		internal.flags &= ~DIRTY_BIT;
 		if ((tmp = options._render)) tmp(internal);
 		tmp = type.call(c, c.props, c.context);
 		if (!(internal.flags & DIRTY_BIT)) {
-			break;
+			counter = 25;
 		}
 	}
 

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -45,12 +45,15 @@ export function renderFunctionComponent(
 	c.context = componentContext;
 	internal.props = c.props = newProps;
 
-	if ((tmp = options._render)) tmp(internal);
-
-	internal.flags &= ~DIRTY_BIT;
 	c._internal = internal;
-
-	tmp = type.call(c, c.props, c.context);
+	while (1) {
+		internal.flags &= ~DIRTY_BIT;
+		if ((tmp = options._render)) tmp(internal);
+		tmp = type.call(c, c.props, c.context);
+		if (!(internal.flags & DIRTY_BIT)) {
+			break;
+		}
+	}
 
 	if (c.getChildContext != null) {
 		internal._context = Object.assign({}, context, c.getChildContext());

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -46,6 +46,7 @@ export function renderFunctionComponent(
 	internal.props = c.props = newProps;
 
 	c._internal = internal;
+	// eslint-disable-next-line
 	while (1) {
 		internal.flags &= ~DIRTY_BIT;
 		if ((tmp = options._render)) tmp(internal);

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -56,6 +56,7 @@ export function renderFunctionComponent(
 			counter = 25;
 		}
 	}
+	internal.flags &= ~DIRTY_BIT;
 
 	if (c.getChildContext != null) {
 		internal._context = Object.assign({}, context, c.getChildContext());


### PR DESCRIPTION
When our render-function has a condition that results in us having to repeat this render (can be seen with the `DIRTY_BIT`) then we can safely just reexecute that render. To do this successfully however we need to also dispose pending effects, memo, ... so these are executed correctly with the updated state and have no duplicate effects for our state.

This PR adds reexecution of render function when we have pending state and also adds a detection for this, when a render is repeated we retain `state` but clear memoization/effects