### PR TITLE
make sure compat is triggered in new jsx runtime

### DIFF
--- a/compat/jsx-dev-runtime.js
+++ b/compat/jsx-dev-runtime.js
@@ -1,1 +1,3 @@
+require('preact/compat');
+
 module.exports = require('preact/jsx-runtime');

--- a/compat/jsx-dev-runtime.mjs
+++ b/compat/jsx-dev-runtime.mjs
@@ -1,1 +1,3 @@
+import 'preact/compat';
+
 export * from 'preact/jsx-runtime';

--- a/compat/jsx-runtime.js
+++ b/compat/jsx-runtime.js
@@ -1,1 +1,3 @@
+require('preact/compat');
+
 module.exports = require('preact/jsx-runtime');

--- a/compat/jsx-runtime.mjs
+++ b/compat/jsx-runtime.mjs
@@ -1,1 +1,3 @@
+import 'preact/compat';
+
 export * from 'preact/jsx-runtime';


### PR DESCRIPTION
`preact` relies on `compat/render` to be required/imported to generate compatible jsx object to react. This is generally enough, however as the current esm/cjs transistion, sometimes two copy of preact will exist in runtime for each kind of module. If `compat` is only imported once, everthing compat related would be broken.

This pr is not enough for compeletely fix this issue, but would make preact working when someone only import the new jsx function is imported. This is part of fix for gatsbyjs/gatsby#34783