### PR TITLE
Fix cursor reset in Safari in input field

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -433,9 +433,9 @@ function diffElementNodes(
 				// despite the attribute not being present. When the attribute
 				// is missing the progress bar is treated as indeterminate.
 				// To fix that we'll always update it when it is 0 for progress elements
-				(i !== oldProps.value ||
-					i !== dom.value ||
-					(nodeType === 'progress' && !i))
+				// - Don't compare with `oldProps` value, otherwise Safari
+				//   resets input cursor position #1502
+				(i !== dom.value || (nodeType === 'progress' && !i))
 			) {
 				setProperty(dom, 'value', i, oldProps.value, false);
 			}


### PR DESCRIPTION
This PR partially reverts 09c30063cb18d0a1f6e2135f5c45381566dfa22b which lead to a regression in Safari. Locally verified in IE11, Safari, Firefox and Chrome.

Fixes #1502 (a second time) .