### PR TITLE
Add back IE11 select fix

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -433,9 +433,12 @@ function diffElementNodes(
 				// despite the attribute not being present. When the attribute
 				// is missing the progress bar is treated as indeterminate.
 				// To fix that we'll always update it when it is 0 for progress elements
-				// - Don't compare with `oldProps` value, otherwise Safari
-				//   resets input cursor position #1502
-				(i !== dom.value || (nodeType === 'progress' && !i))
+				(i !== dom.value ||
+					(nodeType === 'progress' && !i) ||
+					// This is only for IE 11 to fix <select> value not being updated.
+					// To avoid a stale select value we need to set the option.value
+					// again, which triggers IE11 to re-evaluate the select value
+					(nodeType === 'option' && i !== oldProps.value))
 			) {
 				setProperty(dom, 'value', i, oldProps.value, false);
 			}


### PR DESCRIPTION
@developit Turns out that line in https://github.com/preactjs/preact/commit/09c30063cb18d0a1f6e2135f5c45381566dfa22b was a necessary fix for IE11 after all! It's necessary to get `<select>`-elements to behave properly in IE11 🙈 