### PR TITLE
Add support for `errorInfo`

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -2,7 +2,7 @@ import { Component, createElement, options, Fragment } from 'preact';
 import { assign } from './util';
 
 const oldCatchError = options._catchError;
-options._catchError = function(error, newVNode, oldVNode) {
+options._catchError = function(error, newVNode, oldVNode, errorInfo) {
 	if (error.then) {
 		/** @type {import('./internal').Component} */
 		let component;
@@ -19,7 +19,7 @@ options._catchError = function(error, newVNode, oldVNode) {
 			}
 		}
 	}
-	oldCatchError(error, newVNode, oldVNode);
+	oldCatchError(error, newVNode, oldVNode, errorInfo);
 };
 
 const oldUnmount = options.unmount;

--- a/compat/test/browser/componentDidCatch.test.js
+++ b/compat/test/browser/componentDidCatch.test.js
@@ -1,0 +1,50 @@
+import React, { render, Component } from 'preact/compat';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { act } from 'preact/test-utils';
+
+describe('componentDidCatch', () => {
+	let scratch;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('should pass errorInfo in compat', () => {
+		let info;
+		let update;
+		class Receiver extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { error: null, i: 0 };
+				update = this.setState.bind(this);
+			}
+			componentDidCatch(error, errorInfo) {
+				info = errorInfo;
+				this.setState({ error });
+			}
+			render() {
+				if (this.state.error) return <div />;
+				if (this.state.i === 0) return <ThrowErr />;
+				return null;
+			}
+		}
+
+		function ThrowErr() {
+			throw new Error('fail');
+		}
+
+		act(() => {
+			render(<Receiver />, scratch);
+		});
+
+		act(() => {
+			update({ i: 1 });
+		});
+
+		expect(info).to.deep.equal({});
+	});
+});

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -44,7 +44,7 @@ export function initDebug() {
 		  };
 	const deprecations = [];
 
-	options._catchError = (error, vnode, oldVNode) => {
+	options._catchError = (error, vnode, oldVNode, errorInfo) => {
 		let component = vnode && vnode._component;
 		if (component && typeof error.then == 'function') {
 			const promise = error;
@@ -68,7 +68,9 @@ export function initDebug() {
 		}
 
 		try {
-			oldCatchError(error, vnode, oldVNode);
+			errorInfo = errorInfo || {};
+			errorInfo.componentStack = getOwnerStack(vnode);
+			oldCatchError(error, vnode, oldVNode, errorInfo);
 
 			// when an error was handled by an ErrorBoundary we will nontheless emit an error
 			// event on the window object. This is to make up for react compatibility in dev mode

--- a/hooks/test/browser/componentDidCatch.test.js
+++ b/hooks/test/browser/componentDidCatch.test.js
@@ -1,0 +1,60 @@
+import { createElement, render, Component } from 'preact';
+import { act } from 'preact/test-utils';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { useEffect } from 'preact/hooks';
+
+/** @jsx createElement */
+
+describe('errorInfo', () => {
+	/** @type {HTMLDivElement} */
+	let scratch;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('should pass errorInfo on hook unmount error', () => {
+		let info;
+		let update;
+		class Receiver extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { error: null, i: 0 };
+				update = this.setState.bind(this);
+			}
+			componentDidCatch(error, errorInfo) {
+				info = errorInfo;
+				this.setState({ error });
+			}
+			render() {
+				if (this.state.error) return <div />;
+				if (this.state.i === 0) return <ThrowErr />;
+				return null;
+			}
+		}
+
+		function ThrowErr() {
+			useEffect(() => {
+				return () => {
+					throw new Error('fail');
+				};
+			}, []);
+
+			return <h1 />;
+		}
+
+		act(() => {
+			render(<Receiver />, scratch);
+		});
+
+		act(() => {
+			update({ i: 1 });
+		});
+
+		expect(info).to.deep.equal({});
+	});
+});

--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -4,8 +4,10 @@
  * @param {import('../internal').VNode} vnode The vnode that threw
  * the error that was caught (except for unmounting when this parameter
  * is the highest parent that was being unmounted)
+ * @param {import('../internal').VNode} [oldVNode]
+ * @param {import('../internal').ErrorInfo} [errorInfo]
  */
-export function _catchError(error, vnode) {
+export function _catchError(error, vnode, oldVNode, errorInfo) {
 	/** @type {import('../internal').Component} */
 	let component, ctor, handled;
 
@@ -20,7 +22,7 @@ export function _catchError(error, vnode) {
 				}
 
 				if (component.componentDidCatch != null) {
-					component.componentDidCatch(error);
+					component.componentDidCatch(error, errorInfo || {});
 					handled = component._dirty;
 				}
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -68,6 +68,10 @@ export interface PreactDOMAttributes {
 	};
 }
 
+export interface ErrorInfo {
+	componentStack?: string;
+}
+
 export type RenderableProps<P, RefType = any> = P &
 	Readonly<Attributes & { children?: ComponentChildren; ref?: Ref<RefType> }>;
 
@@ -130,7 +134,7 @@ export interface Component<P = {}, S = {}> {
 		previousState: Readonly<S>,
 		snapshot: any
 	): void;
-	componentDidCatch?(error: any, errorInfo: any): void;
+	componentDidCatch?(error: any, errorInfo: ErrorInfo): void;
 }
 
 export abstract class Component<P, S> {

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -20,6 +20,10 @@ export interface DevSource {
 	lineNumber: number;
 }
 
+export interface ErrorInfo {
+	componentStack?: string;
+}
+
 export interface Options extends preact.Options {
 	/** Attach a hook that is invoked before render, mainly to check the arguments. */
 	_root?(
@@ -37,7 +41,12 @@ export interface Options extends preact.Options {
 	/** Bypass effect execution. Currenty only used in devtools for hooks inspection */
 	_skipEffects?: boolean;
 	/** Attach a hook that is invoked after an error is caught in a component but before calling lifecycle hooks */
-	_catchError(error: any, vnode: VNode, oldVNode?: VNode | undefined): void;
+	_catchError(
+		error: any,
+		vnode: VNode,
+		oldVNode: VNode | undefined,
+		errorInfo: ErrorInfo | undefined
+	): void;
 }
 
 export type ComponentChild =

--- a/test/browser/lifecycles/componentDidCatch.test.js
+++ b/test/browser/lifecycles/componentDidCatch.test.js
@@ -668,5 +668,36 @@ describe('Lifecycle methods', () => {
 
 			expect(scratch.innerHTML).to.equal('<div>Error: Error!</div>');
 		});
+
+		it('should pass errorInfo on render error', () => {
+			let info;
+			class Receiver extends Component {
+				constructor(props) {
+					super(props);
+					this.state = { error: null };
+				}
+				componentDidCatch(error, errorInfo) {
+					info = errorInfo;
+					this.setState({ error });
+				}
+				render() {
+					if (this.state.error) return <div />;
+					return this.props.children;
+				}
+			}
+
+			function ThrowErr() {
+				throw new Error('fail');
+			}
+
+			render(
+				<Receiver>
+					<ThrowErr />
+				</Receiver>,
+				scratch
+			);
+
+			expect(info).to.deep.equal({});
+		});
 	});
 });


### PR DESCRIPTION
This PR adds support for the `errorInfo` argument which is the second to `componentDidCatch`. In React it's used to pass the owner tree along. This is often used in combination with [error logging](https://github.com/getsentry/sentry-javascript/blob/d5c3929abc51f05bde1e342cd37274d9aa28c645/packages/react/src/errorboundary.tsx?rgh-link-date=2020-11-18T10%3A51%3A49Z#L70). Note that we'll only collect component traces if `preact/debug` is loaded.

Fixes #2835, #3118  .
Replaces #2836 .