### PR TITLE
Fix test not cleaned up properly

### DIFF
--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -14,15 +14,20 @@ import { setupRerender, act } from 'preact/test-utils';
 describe('Portal', () => {
 	/** @type {HTMLDivElement} */
 	let scratch;
+	/** @type {HTMLDivElement} */
+	let scratch2;
+
 	let rerender;
 
 	beforeEach(() => {
 		scratch = setupScratch();
+		scratch2 = setupScratch('scratch-2');
 		rerender = setupRerender();
 	});
 
 	afterEach(() => {
 		teardown(scratch);
+		teardown(scratch2);
 	});
 
 	it('should render into a different root node', () => {
@@ -690,7 +695,7 @@ describe('Portal', () => {
 				calls.push('Portal');
 			}, []);
 
-			return createPortal(<Parent isPortal>{content}</Parent>, document.body);
+			return createPortal(<Parent isPortal>{content}</Parent>, scratch2);
 		};
 
 		const App = () => {

--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -183,11 +183,12 @@ export function sortCss(cssText) {
 
 /**
  * Setup the test environment
+ * @param {string} [id]
  * @returns {HTMLDivElement}
  */
-export function setupScratch() {
+export function setupScratch(id) {
 	const scratch = document.createElement('div');
-	scratch.id = 'scratch';
+	scratch.id = id || 'scratch';
 	(document.body || document.documentElement).appendChild(scratch);
 	return scratch;
 }


### PR DESCRIPTION
Noticed that the portal test directly renderes into `document.body` and thereby leaving some stray DOM nodes around after the test completed.

This PR creates a sibling scratch element instead that is removed after each test.