### PR TITLE
Fix swapped jsx runtime `__source` and `__self` arguments

### DIFF
--- a/jsx-runtime/src/index.js
+++ b/jsx-runtime/src/index.js
@@ -20,10 +20,10 @@ let vnodeId = 0;
  * @param {VNode['type']} type
  * @param {VNode['props']} props
  * @param {VNode['key']} [key]
- * @param {string} [__source]
  * @param {string} [__self]
+ * @param {string} [__source]
  */
-function createVNode(type, props, key, __source, __self) {
+function createVNode(type, props, key, __self, __source) {
 	// We'll want to preserve `ref` in props to get rid of the need for
 	// forwardRef components in the future, but that should happen via
 	// a separate PR.

--- a/jsx-runtime/test/browser/jsx-runtime.test.js
+++ b/jsx-runtime/test/browser/jsx-runtime.test.js
@@ -66,7 +66,7 @@ describe('Babel jsx/jsxDEV', () => {
 	});
 
 	it('should set __source and __self', () => {
-		const vnode = jsx('div', { class: 'foo' }, 'key', 'source', 'self');
+		const vnode = jsx('div', { class: 'foo' }, 'key', 'self', 'source');
 		expect(vnode.__source).to.equal('source');
 		expect(vnode.__self).to.equal('self');
 	});


### PR DESCRIPTION
While working on https://github.com/preactjs/preset-vite/issues/40 I noticed that our argument order to `jsxDEV` differs from [the argument order babel transpiles to](https://github.com/babel/babel/blob/e498bee10f0123bb208baa228ce6417542a2c3c4/packages/babel-plugin-transform-react-jsx-development/test/fixtures/linux/auto-import-dev/output.mjs#L8). There the `__source` argument comes last and the `__source` is before that. Basically the other way round than what we have.

