### PR TITLE
Add missing defaultValue and defaultChecked typings

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -661,6 +661,8 @@ export namespace JSXInternal {
 		data?: string;
 		dateTime?: string;
 		default?: boolean;
+		defaultChecked?: boolean;
+		defaultValue?: string;
 		defer?: boolean;
 		dir?: 'auto' | 'rtl' | 'ltr';
 		disabled?: boolean;


### PR DESCRIPTION
fixes #2857 

These attributes are necessary for working with uncontrolled forms.
Preact already works correctly with these, but the JSX typings are missing.