### PR TITLE
Bugfix: nested hook state updates return the first state

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -141,7 +141,7 @@ export function useReducer(reducer, initialState, init) {
 			action => {
 				const prevValue = hookState._value[0];
 				const nextValue = hookState._reducer(prevValue, action);
-				hookState._value[0] = nextValue;
+				hookState._value = [nextValue, hookState._value[1]];
 				if (nextValue !== prevValue) {
 					hookState._component.setState({});
 				}

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -139,9 +139,10 @@ export function useReducer(reducer, initialState, init) {
 			!init ? invokeOrReturn(undefined, initialState) : init(initialState),
 
 			action => {
-				const nextValue = hookState._reducer(hookState._value[0], action);
-				if (hookState._value[0] !== nextValue) {
-					hookState._value = [nextValue, hookState._value[1]];
+				const prevValue = hookState._value[0];
+				const nextValue = hookState._reducer(prevValue, action);
+				hookState._value[0] = nextValue;
+				if (nextValue !== prevValue) {
 					hookState._component.setState({});
 				}
 			}


### PR DESCRIPTION
This mostly affects useReducer, where dispatching from within the reducer will drop the resulting state update: https://codepen.io/developit/pen/YzEOWGx?editors=0010