### PR TITLE
Add `preact/reactive` addon

### DIFF
--- a/config/node-13-exports.js
+++ b/config/node-13-exports.js
@@ -1,6 +1,14 @@
 const fs = require('fs');
 
-const subRepositories = ['compat', 'debug', 'devtools', 'hooks', 'jsx-runtime', 'test-utils'];
+const subRepositories = [
+	'compat',
+	'debug',
+	'devtools',
+	'hooks',
+	'jsx-runtime',
+	'test-utils',
+	'reactive'
+];
 const snakeCaseToCamelCase = str =>
 	str.replace(/([-_][a-z])/g, group => group.toUpperCase().replace('-', ''));
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -126,6 +126,7 @@ function createEsbuildPlugin() {
 		'preact/devtools': subPkgPath('./devtools/'),
 		'preact/compat': subPkgPath('./compat/'),
 		'preact/hooks': subPkgPath('./hooks/'),
+		'preact/reactive': subPkgPath('./reactive/'),
 		'preact/test-utils': subPkgPath('./test-utils/'),
 		'preact/jsx-runtime': subPkgPath('./jsx-runtime/'),
 		'preact/jsx-dev-runtime': subPkgPath('./jsx-runtime/'),
@@ -319,7 +320,7 @@ module.exports = function(config) {
 			{
 				pattern:
 					config.grep ||
-					'{debug,devtools,hooks,compat,test-utils,jsx-runtime,}/test/{browser,shared}/**/*.test.js',
+					'{debug,devtools,hooks,compat,reactive,test-utils,jsx-runtime,}/test/{browser,shared}/**/*.test.js',
 				watched: false,
 				type: 'js'
 			}
@@ -330,7 +331,7 @@ module.exports = function(config) {
 		},
 
 		preprocessors: {
-			'{debug,devtools,hooks,compat,test-utils,jsx-runtime,}/test/**/*': [
+			'{debug,devtools,hooks,compat,reactive,test-utils,jsx-runtime,}/test/**/*': [
 				'esbuild'
 			]
 		},

--- a/mangle.json
+++ b/mangle.json
@@ -33,6 +33,8 @@
       "$_value": "__",
       "$_original": "__v",
       "$_args": "__H",
+      "$__reactive": "__R",
+      "$_atom": "__t",
       "$_factory": "__h",
       "$_depth": "__b",
       "$_nextDom": "__d",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,12 @@
 			"require": "./hooks/dist/hooks.js",
 			"import": "./hooks/dist/hooks.mjs"
 		},
+		"./reactive": {
+			"browser": "./reactive/dist/reactive.module.js",
+			"umd": "./reactive/dist/reactive.umd.js",
+			"require": "./reactive/dist/reactive.js",
+			"import": "./reactive/dist/reactive.mjs"
+		},
 		"./test-utils": {
 			"browser": "./test-utils/dist/testUtils.module.js",
 			"umd": "./test-utils/dist/testUtils.umd.js",
@@ -79,6 +85,7 @@
 		"./debug/package.json": "./debug/package.json",
 		"./devtools/package.json": "./devtools/package.json",
 		"./hooks/package.json": "./hooks/package.json",
+		"./reactive/package.json": "./reactive/package.json",
 		"./test-utils/package.json": "./test-utils/package.json",
 		"./jsx-runtime/package.json": "./jsx-runtime/package.json"
 	},
@@ -96,6 +103,7 @@
 		"build:debug": "microbundle build --raw --cwd debug",
 		"build:devtools": "microbundle build --raw --cwd devtools",
 		"build:hooks": "microbundle build --raw --cwd hooks",
+		"build:reactive": "microbundle build --raw --cwd reactive",
 		"build:test-utils": "microbundle build --raw --cwd test-utils",
 		"build:compat": "microbundle build src/index.js src/scheduler.js --raw --cwd compat --globals 'preact/hooks=preactHooks'",
 		"build:jsx": "microbundle build --raw --cwd jsx-runtime",

--- a/reactive/README.md
+++ b/reactive/README.md
@@ -1,0 +1,243 @@
+# Reactive addon
+
+## Summary
+
+This PR adds a new addon called `reactive`, which is an alternative to `hooks` for managing state. It's main purpose is to decouple the rendering phase from state updates to ensure optimal rendering performance by default, even for complex apps. It comes with some DX improvements, such as that dependencies are tracked automatically and don't have to be specified by hand for effects.
+
+## Basic Example
+
+```jsx
+import { signal } from 'preact/reactive';
+
+// Won't re-render despite state being updated. The effect will
+// trigger only when `count.value` changes, not when the component
+// re-renders.
+function App() {
+	const [count, setCount] = signal(0);
+
+	// Look, no dependency args
+	effect(() => {
+		console.log(`count: ${count.value}`);
+	});
+
+	return <NeverReRendered count={count} />;
+}
+
+// Will only render once during mounting, will not re-render
+// when state is updated in <App />
+function NeverReRendered({ count }) {
+	return <Inner count={count} />;
+}
+
+// Whenever the button is clicked, only the <Inner /> component will rerender
+function Inner({ count }) {
+	return (
+		<button onClick={() => setCount(count.value + 1)}>
+			increment {count.value}
+		</button>
+	);
+}
+```
+
+## Motivation
+
+Since the introduction of hooks we've seen more and more developers pick that as their main way to manage state. This works great for smaller applications but becomes complex and can easily lead to performance issues in bigger projects. Hooks tie state updates to rendering itself and thereby cause unnecessary re-renders of large portions of the component tree whenever state is updated. One can avoid most of these issues by manually placing memoized calls at the correct spots, but these are hard to track down.
+
+This has been a frequent source of performance issues in projects I've consulted for over the past few years. In one example just rendering the page took 500ms on my Macbook M1 Air and 2s on a slower Android phone. This is the sole time the framework spent rendering. The layout resembled a product list which displays a few filters and a carousel at the top.
+
+Virtual-DOM-based frameworks typically render top down from the component which holds the state. But often the state is only used in components quite a bit further down the tree which means we'll spent a lot of time comparing components which didn't change.
+
+```jsx
+const MyContext = createContext(null);
+
+function Foo(props) {
+	const [data, setData] = useState(null);
+
+	// Provider and all its children will be re-rendered on state changes,
+	// unless they manually opted out.
+	return (
+		<MyContext.Provider value={{ data }}>{props.children}</MyContext.Provider>
+	);
+}
+```
+
+As applications grow the state of components becomes more intertwined and state often ends up being only triggered to fire an effect.
+
+```jsx
+// Example of where an effect triggers a state update to trigger
+// another effect
+function Foo(props) {
+	const [foo, setFoo] = useState(null);
+	const [bar, setBar] = useState(null);
+
+	useEffect(() => {
+		// Update foo, to trigger the other effect
+		setFoo('foobar');
+	}, []);
+
+	useEffect(() => {
+		console.log(foo);
+	}, [foo]);
+
+	// ...
+}
+```
+
+Whilst memoization can help in improving the performance, it tends to be used incorrectly or is easily defeated by passing a value which changes on each render.
+
+So let's fix that. Let's find a system which avoids these problems by design. A system that only re-renders components that depend on the state that was updated.
+
+A couple of years back when IE11 was still a thing, I've made very good experiences with various reactive libraries that track either or both read and write access to state. One example of that is the excellent [MobX](https://github.com/mobxjs/mobx) library.
+
+Due to the separation of state updates and rendering the framework knows which exact components need to be updated. Instead of passing values down, you're passing descriptions on how to get that value down the tree. Depending on the framework this can be a function, a getter on an object or another kind of "box". That allows frameworks to skip huge portions of the component tree and would not trigger accidental renders caused by state updates to trigger effects.
+
+## Detailed design
+
+One key goal of `preact/reactive` is to have a very lean API, similar to hooks. Frameworks based around observable primitives tend to have a rather large API surface with a lot of new concepts to learn. Our system should be minimal and allow users to compose complex features out of smaller building blocks. It should have a lot of familiar aspects and enough new ones to make the transition to it as beginner friendly as possible.
+
+### Signals
+
+The core primitive of this new system are signals. Signals are very similar to `useState`.
+
+```jsx
+function App() {
+	const [count, setCount] = signal(0);
+	// ...
+}
+```
+
+But instead of `count` being the number `0`, it is an object on which the original value can be accessed via the `count.value`. That object reference stays the same throughout all re-renderings. By ensuring a stable reference we can safely pass it down to components and track which components read its `.value` property. Whenever it's read inside a component, we add this component as a dependency to that signal. When the value changes we can directly update only these components and skip everything else.
+
+### Computed Signals (aka derived values)
+
+Computed signals are a way to derive a single value from other signals. It is automatically updated whenever the signals it depends upon are updated.
+
+```jsx
+function App() {
+	const [name, setName] = signal('Jane Doe');
+	const [age, setAge] = signal(32);
+
+	// Automatically updated whenever `name` or `age` changes.
+	const text = computed(() => {
+		return `Name: ${name.value}, age: ${age.value}`;
+	});
+
+	// ...
+}
+```
+
+This also works for conditional logic where new signals need to be subscribed to on the fly and old subscriptions need to be discarded.
+
+```jsx
+function App() {
+  const [count, setCount] = signal(0);
+  const [foo, setFoo] = signal('foo');
+  const [bar, setBar] = signal('bar');
+
+  // Automatically updated whenever `name` or `age` changes.
+  const text = computed(() => {
+    if (count > 10) {
+      return foo.value;
+    }
+
+    return bar.value;
+  });
+});
+```
+
+### Effects
+
+The way effects are triggered is basically a combination of `useEffect` and the tracking abilities of `computed()`. The effect will only run when the component is mounted or when the effect dependencies changes.
+
+```jsx
+function App() {
+	const [count, setCount] = signal(0);
+
+	effect(() => console.log(count.value));
+
+	// ...
+}
+```
+
+Similar to `useEffect` we can return a cleanup function that is called whenever the effect is updated or the component is unmounted.
+
+```jsx
+function App() {
+	const [userId, setUserId] = signal(1);
+
+	effect(() => {
+		const id = userId.value;
+		api.subscribeUser(id);
+
+		return () => {
+			api.unsubscribeUser(id);
+		};
+	});
+
+	// ...
+}
+```
+
+### Readonly: Reacting to prop changes
+
+Because the `props` of a component are a plain object and not reactive by default, effects or derived signals would not be updated whenever props change. We can use the `readonly()` function to create a readonly signal that always updates when the passed value changes.
+
+```jsx
+function App(props) {
+	// Signal is a stable reference. Value always updates
+	// when `props.name` has changed.
+	const name = readonly(props.name);
+	const text = computed(() => `My name is: ${name.value}`);
+	// ...
+}
+```
+
+### Inject: Subscribing to context
+
+The `inject()` function can be used to subscribe to context. It works similar to `useContext` with the sole difference that the return value is wrapped in a signal.
+
+```jsx
+const ThemeCtx = createContext('light');
+
+function App(props) {
+	const theme = inject(ThemeCtx);
+
+	return <p>Theme: {theme.value}</p>;
+}
+```
+
+### Debugging
+
+Due to the nature of the system of being able to track signal reads, we can better show in devtools why a value was updated and how state relates to each component. This work has not yet started.
+
+## Drawbacks
+
+With hooks developers had to learn about closures in depth. With a reactive system one needs to now about how variables are passed around in JavaScript (pass by value vs by reference).
+
+Similar to hooks the callsite order must be consistent. This means that you cannot conditionally create signals on the fly.
+
+## Adoption Strategy
+
+With the addition of the new addon developers can introduce reactive components on a component bases in their existing projects. Adoption can therefore happen incrementally and the system happily co-exists with all current solutions.
+
+The current plan is to leverage this module in our devtools extension as the first real world project.
+
+## Unresolved questions
+
+This is mostly bikeshedding:
+
+1. Should it be `foo.value` or `foo.$` ?
+
+```jsx
+<button onClick={() => setCount(count.value + 1)}>{count.value}</button>
+```
+
+vs
+
+```jsx
+<button onClick={() => setCount(count.$ + 1)}>{count.$}</button>
+```
+
+2. `inject` is not a good name for reading from context.
+3. Do we have a better name for `readonly`?
+4. How to work with refs?

--- a/reactive/README.md
+++ b/reactive/README.md
@@ -210,6 +210,28 @@ function App(props) {
 
 Due to the nature of the system of being able to track signal reads, we can better show in devtools why a value was updated and how state relates to each component. This work has not yet started.
 
+### Error handling
+
+Errors can be caught via typicall Error boundaries. Since we track the component context a signal was created in, we rethrow the error on that component.
+
+```js
+function Foo() {
+	const [foo, setFoo] = signal('foo');
+
+	const text = computed(() => {
+		if (foo.value !== 'foo') {
+			// Errors thrown inside a computed signal can be caught
+			// with error boundaries
+			throw new Error('fail');
+		}
+
+		return foo.value;
+	});
+
+	// ...
+}
+```
+
 ## Drawbacks
 
 With hooks developers had to learn about closures in depth. With a reactive system one needs to now about how variables are passed around in JavaScript (pass by value vs by reference).

--- a/reactive/mangle.json
+++ b/reactive/mangle.json
@@ -1,0 +1,21 @@
+{
+  "help": {
+    "what is this file?": "It controls protected/private property mangling so that minified builds have consistent property names.",
+    "why are there duplicate minified properties?": "Most properties are only used on one type of objects, so they can have the same name since they will never collide. Doing this reduces size."
+  },
+  "minify": {
+    "mangle": {
+      "properties": {
+        "regex": "^_[^_]",
+        "reserved": [
+          "__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED",
+          "__REACT_DEVTOOLS_GLOBAL_HOOK__",
+          "__PREACT_DEVTOOLS__",
+          "_renderers",
+          "__source",
+          "__self"
+        ]
+      }
+    }
+  }
+}

--- a/reactive/package.json
+++ b/reactive/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "reactive",
+	"amdName": "preactReactive",
+	"version": "0.1.0",
+	"private": true,
+	"description": "Reactive adapter for Preact",
+	"main": "dist/reactive.js",
+	"module": "dist/reactive.module.js",
+	"umd:main": "dist/reactive.umd.js",
+	"source": "src/index.js",
+	"license": "MIT",
+	"types": "src/index.d.ts",
+	"peerDependencies": {
+		"preact": "^10.0.0"
+	},
+	"mangle": {
+		"regex": "^_"
+	}
+}

--- a/reactive/src/index.d.ts
+++ b/reactive/src/index.d.ts
@@ -5,16 +5,20 @@ import {
 	ComponentChildren,
 	FunctionComponent,
 	VNode,
-	Attributes
+	Attributes,
+	ComponentClass
 } from '../../';
-import { JSXInternal } from '../../src/jsx';
 
-export interface Atom<T> {
-	subscribe(fn: (value: T) => void): () => void;
+export interface Reactive<T> {
+	value: T;
 }
-
-export function $<T>(atom: Atom<T>): T;
+export type StateUpdater<S> = (value: S | ((prevState: S) => S)) => void;
+export function signal<T>(
+	initialValue: T,
+	displayName?: string
+): [Reactive<T>, StateUpdater<T>];
+export function computed<T>(fn: () => T): Reactive<T>;
 
 export function component<P = {}>(
-	fn: (initialProps: P, get: <T>(atom: Atom<T>) => T) => FunctionComponent<P>
-): any;
+	fn: (props: P) => () => ComponentChild
+): FunctionComponent<P>;

--- a/reactive/src/index.d.ts
+++ b/reactive/src/index.d.ts
@@ -1,0 +1,20 @@
+export { Fragment } from '../../';
+import {
+	ComponentType,
+	ComponentChild,
+	ComponentChildren,
+	FunctionComponent,
+	VNode,
+	Attributes
+} from '../../';
+import { JSXInternal } from '../../src/jsx';
+
+export interface Atom<T> {
+	subscribe(fn: (value: T) => void): () => void;
+}
+
+export function $<T>(atom: Atom<T>): T;
+
+export function component<P = {}>(
+	fn: (initialProps: P, get: <T>(atom: Atom<T>) => T) => FunctionComponent<P>
+): any;

--- a/reactive/src/index.d.ts
+++ b/reactive/src/index.d.ts
@@ -6,7 +6,8 @@ import {
 	FunctionComponent,
 	VNode,
 	Attributes,
-	ComponentClass
+	ComponentClass,
+	Context
 } from '../../';
 
 export interface Reactive<T> {
@@ -18,6 +19,7 @@ export function signal<T>(
 	displayName?: string
 ): [Reactive<T>, StateUpdater<T>];
 export function computed<T>(fn: () => T, displayName?: string): Reactive<T>;
+export function inject<T>(ctx: Context<T>): Reactive<T>;
 
 export function component<P = {}>(
 	fn: (props: P) => ComponentChild

--- a/reactive/src/index.d.ts
+++ b/reactive/src/index.d.ts
@@ -21,7 +21,3 @@ export function signal<T>(
 export function computed<T>(fn: () => T, displayName?: string): Reactive<T>;
 export function effect(fn: () => T, displayName?: string): void;
 export function inject<T>(ctx: Context<T>): Reactive<T>;
-
-export function component<P = {}>(
-	fn: (props: P) => ComponentChild
-): FunctionComponent<P>;

--- a/reactive/src/index.d.ts
+++ b/reactive/src/index.d.ts
@@ -19,6 +19,7 @@ export function signal<T>(
 	displayName?: string
 ): [Reactive<T>, StateUpdater<T>];
 export function computed<T>(fn: () => T, displayName?: string): Reactive<T>;
+export function effect(fn: () => T, displayName?: string): void;
 export function inject<T>(ctx: Context<T>): Reactive<T>;
 
 export function component<P = {}>(

--- a/reactive/src/index.d.ts
+++ b/reactive/src/index.d.ts
@@ -20,5 +20,5 @@ export function signal<T>(
 export function computed<T>(fn: () => T, displayName?: string): Reactive<T>;
 
 export function component<P = {}>(
-	fn: (props: P) => () => ComponentChild
+	fn: (props: P) => ComponentChild
 ): FunctionComponent<P>;

--- a/reactive/src/index.d.ts
+++ b/reactive/src/index.d.ts
@@ -17,7 +17,7 @@ export function signal<T>(
 	initialValue: T,
 	displayName?: string
 ): [Reactive<T>, StateUpdater<T>];
-export function computed<T>(fn: () => T): Reactive<T>;
+export function computed<T>(fn: () => T, displayName?: string): Reactive<T>;
 
 export function component<P = {}>(
 	fn: (props: P) => () => ComponentChild

--- a/reactive/src/index.d.ts
+++ b/reactive/src/index.d.ts
@@ -21,3 +21,7 @@ export function signal<T>(
 export function computed<T>(fn: () => T, displayName?: string): Reactive<T>;
 export function effect(fn: () => T, displayName?: string): void;
 export function inject<T>(ctx: Context<T>): Reactive<T>;
+
+export function ref<T>(initialValue: T): MutableRef<T>;
+export function ref<T>(initialValue: T | null): Ref<T>;
+export function ref<T = undefined>(): MutableRef<T | undefined>;

--- a/reactive/src/index.d.ts
+++ b/reactive/src/index.d.ts
@@ -19,6 +19,7 @@ export function signal<T>(
 	displayName?: string
 ): [Reactive<T>, StateUpdater<T>];
 export function computed<T>(fn: () => T, displayName?: string): Reactive<T>;
+export function readonly<T>(value: T, displayName?: string): Atom<T>;
 export function effect(fn: () => T, displayName?: string): void;
 export function inject<T>(ctx: Context<T>): Reactive<T>;
 

--- a/reactive/src/index.d.ts
+++ b/reactive/src/index.d.ts
@@ -1,8 +1,9 @@
 export interface Reactive<T> {
 	value: T;
+	setValue: StateUpdater<T>;
 }
 
-export type StateUpdater<S> = (value: S | ((prevState: S) => S)) => void;
+export type StateUpdater<S> = (value: S | ((prevState: S) => S | null)) => void;
 
 /**
  * Returns a signal that holds the value and can be subscribed to in order to

--- a/reactive/src/index.d.ts
+++ b/reactive/src/index.d.ts
@@ -1,28 +1,63 @@
-export { Fragment } from '../../';
-import {
-	ComponentType,
-	ComponentChild,
-	ComponentChildren,
-	FunctionComponent,
-	VNode,
-	Attributes,
-	ComponentClass,
-	Context
-} from '../../';
-
 export interface Reactive<T> {
 	value: T;
 }
+
 export type StateUpdater<S> = (value: S | ((prevState: S) => S)) => void;
+
+/**
+ * Returns a signal that holds the value and can be subscribed to in order to
+ * react to changes.
+ * @param initialValue The initial value
+ * @param displayName Optional: Label for signal to use for debugging
+ */
 export function signal<T>(
 	initialValue: T,
 	displayName?: string
 ): [Reactive<T>, StateUpdater<T>];
+
+/**
+ * Create a derived signal from other signals. It tracks every signal that is
+ * read and updates automatically when they change.
+ * @param fn Function that tracks signal reads
+ * @param displayName Optional: Label for signal to use for debugging
+ */
 export function computed<T>(fn: () => T, displayName?: string): Reactive<T>;
+
+/**
+ * Turn the passed `value` into a signal. Whenever a new value is passed to
+ * `readonly` the signal is updated. This can be used to subscribe to `props`.
+ * @param value
+ * @param displayName Optional: Label for signal to use for debugging
+ */
 export function readonly<T>(value: T, displayName?: string): Atom<T>;
+
+/**
+ * Accepts a function that contains imperative, possibly effectful code.
+ * The effects run after browser paint, without blocking it.
+ *
+ * @param fn Imperative function that can return a cleanup function
+ * @param displayName Optional: Label for signal to use for debugging
+ */
 export function effect(fn: () => T, displayName?: string): void;
+
+/**
+ * Returns the current context value wrapped in a signal, as given by the
+ * nearest context provider for the given context.
+ * When the provider updates, the signal will be updated with the new value.
+ *
+ * @param context The context you want to use
+ */
 export function inject<T>(ctx: Context<T>): Reactive<T>;
 
+/**
+ * Returns a mutable ref object whose `.current` property is initialized to the passed argument
+ * (`initialValue`). The returned object will persist for the full lifetime of the component.
+ *
+ * Note that `ref()` is useful for more than the `ref` attribute. It’s handy for keeping any mutable
+ * value around similar to how you’d use instance fields in classes.
+ *
+ * @param initialValue the initial value to store in the ref object
+ */
 export function ref<T>(initialValue: T): MutableRef<T>;
 export function ref<T>(initialValue: T | null): Ref<T>;
 export function ref<T = undefined>(): MutableRef<T | undefined>;

--- a/reactive/src/index.js
+++ b/reactive/src/index.js
@@ -44,10 +44,11 @@ options.unmount = vnode => {
 
 	/** @type {import('./internal').Component | null} */
 	const c = vnode._component;
-	if (c) {
-		const state = c.__reactive;
-		if (state) {
-			unsubscribe(state._atom);
+	if (c && c.__reactive) {
+		const list = c.__reactive._list;
+		let i = list.length;
+		while (i--) {
+			destroy(list[i]);
 		}
 	}
 };
@@ -158,12 +159,17 @@ function unlinkDep(atom, dep) {
 /**
  * @param {import('./internal').Atom} atom
  */
-function unsubscribe(atom) {
-	console.log('UNSUBSCRIBE', atom);
+function destroy(atom) {
 	const stack = [atom];
 	let item;
 	while ((item = stack.pop()) !== undefined) {
-		// const subs = graph.subs.get(atom)
+		const deps = graph.deps.get(item);
+		if (deps) {
+			deps.forEach(dep => {
+				unlinkDep(item, dep);
+				stack.push(dep);
+			});
+		}
 	}
 }
 

--- a/reactive/src/index.js
+++ b/reactive/src/index.js
@@ -43,7 +43,7 @@ options.unmount = vnode => {
  * @param {string} [displayName]
  * @returns {import('./internal').Atom<T>}
  */
-function getAtomState(index, initialState, kind, displayName) {
+function getAtom(index, initialState, kind, displayName) {
 	const reactive = currentAtom;
 
 	if (index >= reactive._children.length) {
@@ -234,12 +234,7 @@ function isUpdater(x) {
  * @returns {[import('./index').Reactive<T>,import('./index').StateUpdater<T>]}
  */
 export function signal(initialValue, displayName) {
-	const atom = getAtomState(
-		currentIndex++,
-		initialValue,
-		KIND_SOURCE,
-		displayName
-	);
+	const atom = getAtom(currentIndex++, initialValue, KIND_SOURCE, displayName);
 
 	/** @type {import('./index').StateUpdater<T>} */
 	const updater = value => {
@@ -322,14 +317,9 @@ function track(atom, fn) {
  * @returns {import('./internal').Atom<T>}
  */
 export function computed(fn, displayName) {
-	const state = getAtomState(
-		currentIndex++,
-		undefined,
-		KIND_COMPUTED,
-		displayName
-	);
-	state._onUpdate = () => track(state, fn);
-	return state;
+	const atom = getAtom(currentIndex++, undefined, KIND_COMPUTED, displayName);
+	atom._onUpdate = () => track(atom, fn);
+	return atom;
 }
 
 /**
@@ -338,7 +328,7 @@ export function computed(fn, displayName) {
  * @returns {import('./internal').Atom<T>}
  */
 export function inject(context) {
-	const atom = getAtomState(
+	const atom = getAtom(
 		currentIndex++,
 		undefined,
 		KIND_COMPUTED,

--- a/reactive/src/index.js
+++ b/reactive/src/index.js
@@ -99,7 +99,6 @@ function createAtom(initialValue, kind, displayName = '') {
 		displayName: displayName + '_' + String(atomHash++),
 		kind,
 		_onUpdate: NOOP,
-		_onActivate: NOOP,
 		_value: initialValue,
 		get value() {
 			tracking.add(state);

--- a/reactive/src/index.js
+++ b/reactive/src/index.js
@@ -205,6 +205,11 @@ export function signal(initialValue, displayName) {
 
 	/** @type {import('./index').StateUpdater<T>} */
 	const updater = value => {
+		// TODO: Extract to preact/debug?
+		if (currentAtom !== undefined && currentAtom.kind === KIND_COMPUTED) {
+			throw new Error('Must not update signal inside computed.');
+		}
+
 		if (isUpdater(value)) {
 			const res = value(atom._value);
 			if (res !== null && res !== atom._value) {

--- a/reactive/src/index.js
+++ b/reactive/src/index.js
@@ -15,6 +15,13 @@ let oldBeforeRender = options._render;
 let oldAfterDiff = options.diffed;
 let oldBeforeUnmount = options.unmount;
 
+/** @type {import('./internal').AtomKind.SOURCE} */
+const KIND_SOURCE = 1;
+/** @type {import('./internal').AtomKind.COMPUTED} */
+const KIND_COMPUTED = 2;
+/** @type {import('./internal').AtomKind.REACTION} */
+const KIND_REACTION = 3;
+
 options._diff = vnode => {
 	currentComponent = null;
 	if (oldBeforeDiff) oldBeforeDiff(vnode);
@@ -191,7 +198,12 @@ function isUpdater(x) {
  * @returns {[import('./index').Reactive<T>,import('./index').StateUpdater<T>]}
  */
 export function signal(initialValue, displayName) {
-	const atom = getAtomState(currentIndex++, initialValue, 1, displayName);
+	const atom = getAtomState(
+		currentIndex++,
+		initialValue,
+		KIND_SOURCE,
+		displayName
+	);
 
 	/** @type {import('./index').StateUpdater<T>} */
 	const updater = value => {
@@ -250,7 +262,12 @@ function track(atom, fn) {
  * @returns {import('./internal').Atom<T>}
  */
 export function computed(fn, displayName) {
-	const state = getAtomState(currentIndex++, undefined, 2, displayName);
+	const state = getAtomState(
+		currentIndex++,
+		undefined,
+		KIND_COMPUTED,
+		displayName
+	);
 	state._onUpdate = () => track(state, fn);
 	return state;
 }
@@ -263,7 +280,12 @@ export function computed(fn, displayName) {
  * @returns {T}
  */
 function reactive(fn, cb, displayName) {
-	const atom = getAtomState(currentIndex++, undefined, 3, displayName);
+	const atom = getAtomState(
+		currentIndex++,
+		undefined,
+		KIND_REACTION,
+		displayName
+	);
 	atom._onUpdate = () => {
 		track(atom, fn);
 		cb(atom._value);

--- a/reactive/src/index.js
+++ b/reactive/src/index.js
@@ -289,7 +289,7 @@ export function component(fn) {
 		return reactive(
 			view,
 			() => this.setState({}),
-			this.displayName || this.name || 'Component'
+			this.displayName || fn.name || 'ReactiveComponent'
 		);
 	};
 }

--- a/reactive/src/index.js
+++ b/reactive/src/index.js
@@ -283,6 +283,40 @@ export function computed(fn, displayName) {
 }
 
 /**
+ * @template T
+ * @param {import('preact').Context<T>} context
+ * @returns {import('./internal').Atom<T>}
+ */
+export function inject(context) {
+	const atom = getAtomState(
+		currentIndex++,
+		undefined,
+		KIND_COMPUTED,
+		'inject_' + (context.displayName || 'unknown')
+	);
+
+	const provider = currentComponent.context[context._id];
+
+	// The devtools needs access to the context object to
+	// be able to pull of the default value when no provider
+	// is present in the tree.
+	atom._context = context;
+	if (!provider) {
+		atom._value = context._defaultValue;
+		return atom;
+	}
+
+	// This is probably not safe to convert to "!"
+	if (atom._value == null) {
+		provider.sub(currentComponent);
+	}
+
+	atom._value = provider.props.value;
+
+	return atom;
+}
+
+/**
  * @template P
  * @param {(props: P) => () => import('../../src/index').ComponentChild} fn
  * @returns {import('../../src/index').ComponentChild}

--- a/reactive/src/index.js
+++ b/reactive/src/index.js
@@ -216,6 +216,16 @@ function isUpdater(x) {
 }
 
 /**
+ *
+ * @param {*} a
+ * @param {*} b
+ * @returns {boolean}
+ */
+function shouldUpdate(a, b) {
+	return a !== b || (a !== null && typeof a === 'object');
+}
+
+/**
  * @template T
  * @param {T} initialValue
  * @param {string} [displayName]
@@ -242,7 +252,7 @@ export function signal(initialValue, displayName) {
 				atom._value = res;
 				invalidate(atom);
 			}
-		} else {
+		} else if (atom._value !== value) {
 			atom._value = value;
 			invalidate(atom);
 		}

--- a/reactive/src/index.js
+++ b/reactive/src/index.js
@@ -223,10 +223,9 @@ export function signal(initialValue, displayName) {
  * @template T
  * @param {import('./internal').Atom<T>} atom
  * @param {() => T} fn
- * @param {import('./internal').Component} c
  * @returns {T}
  */
-function track(atom, fn, c) {
+function track(atom, fn) {
 	let tmp = tracking;
 	tracking = new Set();
 	let tmpAtom = currentAtom;
@@ -278,7 +277,7 @@ export function computed(fn, displayName) {
 		KIND_COMPUTED,
 		displayName
 	);
-	state._onUpdate = () => track(state, fn, currentComponent);
+	state._onUpdate = () => track(state, fn);
 	return state;
 }
 
@@ -340,7 +339,7 @@ export function component(fn) {
 		};
 
 		try {
-			return track(atom, () => fn(props), this);
+			return track(atom, () => fn(props));
 		} finally {
 			currentComponent = prevCurrentComponent;
 		}

--- a/reactive/src/index.js
+++ b/reactive/src/index.js
@@ -1,0 +1,123 @@
+import { options } from 'preact';
+
+/** @type {import('./internal').Component} */
+let currentComponent;
+
+let oldBeforeDiff = options._diff;
+let oldBeforeRender = options._render;
+let oldAfterDiff = options.diffed;
+let oldBeforeUnmount = options.unmount;
+
+options._diff = vnode => {
+	currentComponent = null;
+	if (oldBeforeDiff) oldBeforeDiff(vnode);
+};
+
+options._render = vnode => {
+	if (oldBeforeRender) oldBeforeRender(vnode);
+	currentComponent = vnode._component;
+};
+
+options.diffed = vnode => {
+	if (oldAfterDiff) oldAfterDiff(vnode);
+	currentComponent = null;
+};
+
+options.unmount = vnode => {
+	if (oldBeforeUnmount) oldBeforeUnmount(vnode);
+
+	/** @type {import('./internal').Component | null} */
+	const c = vnode._component;
+	if (c) {
+		const refs = c.__reactive;
+		if (refs) {
+			refs._atoms.forEach(value => value._unsubscribe());
+			refs._atoms.clear();
+		}
+	}
+};
+
+const NOOP = () => {};
+
+function newSubState(component) {
+	return {
+		_unsubscribe: NOOP,
+		_value: undefined,
+		_component: component
+	};
+}
+
+/**
+ *
+ * @param {*} component
+ * @returns {import('./internal').Component["__reactive"]}
+ */
+function getRefs(component) {
+	return (
+		component.__reactive ||
+		(component.__reactive = { _atoms: new Map(), _prevAtoms: new Map() })
+	);
+}
+
+/**
+ *
+ * @param {import('./internal').Component["__reactive"]} refs
+ * @param {import('./index').Atom<any>} atom
+ * @returns
+ */
+function subscribeToAtom(refs, atom, component) {
+	let sub = refs._prevAtoms.get(atom);
+	if (!sub) {
+		sub = newSubState(component);
+		sub._unsubscribe = atom.subscribe(v => {
+			if (sub._value !== v) {
+				sub._value = v;
+				if (sub._unsubscribe !== NOOP) {
+					sub._component.setState({});
+				}
+			}
+		});
+		refs._atoms.set(atom, sub);
+	}
+
+	return sub._value;
+}
+
+/**
+ * Subscribe to RxJS-style observables
+ * @type {import('./index').$}
+ */
+export function $(atom) {
+	const refs = getRefs(currentComponent);
+	return subscribeToAtom(refs, atom, currentComponent);
+}
+
+function get(component) {
+	const refs = getRefs(component);
+	return atom => subscribeToAtom(refs, atom, component);
+}
+
+/**
+ * @type {import('./index').component}
+ */
+export function component(fn) {
+	return function Reactive(props) {
+		let view =
+			this.__reactiveView || (this.__reactiveView = fn(props, get(this)));
+		const refs = getRefs(this);
+
+		// TODO: Check if memory optimizations are worth it
+		refs._prevAtoms = refs._atoms;
+		refs._atoms = new Map();
+
+		const ui = view(props, this);
+
+		refs._prevAtoms.forEach((s, atom) => {
+			if (!refs._atoms.has(atom)) {
+				s._unsubscribe();
+			}
+		});
+
+		return ui;
+	};
+}

--- a/reactive/src/index.js
+++ b/reactive/src/index.js
@@ -124,9 +124,7 @@ function getReactive(component) {
 
 		component.__reactive._atom._tracking = new Set();
 		component.__reactive._atom._onUpdate = () => {
-			if (component._skipRender) {
-				component._skipRender = false;
-			}
+			component._skipRender = false;
 			component.setState({});
 		};
 	}

--- a/reactive/src/index.js
+++ b/reactive/src/index.js
@@ -212,13 +212,8 @@ function linkDep(atom, dep) {
 
 	subs.add(atom);
 
-	let deps = graph.deps.get(atom);
-	if (!deps) {
-		deps = new Set();
-		graph.deps.set(atom, deps);
-	}
-
-	deps.add(dep);
+	// Deps Set() is created before this function
+	graph.deps.get(atom).add(dep);
 }
 
 /**

--- a/reactive/src/index.js
+++ b/reactive/src/index.js
@@ -562,3 +562,16 @@ export function inject(context) {
 
 	return atom;
 }
+
+/**
+ * @template T
+ * @param {T} initialValue
+ * @returns {{ current: T}}
+ */
+export function ref(initialValue) {
+	const atom = getAtom(currentIndex++, undefined, KIND_SOURCE);
+	if (atom._value === undefined) {
+		atom._value = { current: initialValue };
+	}
+	return atom._value;
+}

--- a/reactive/src/index.js
+++ b/reactive/src/index.js
@@ -24,10 +24,6 @@ const NOOP = () => {};
 
 let atomHash = 0;
 
-// TODO: Process writes in a queue similar to
-// component state updates (would add batching by default)
-// Is this bad for inputs?
-
 /** @type {import('./internal').AtomKind.SOURCE} */
 const KIND_SOURCE = 1;
 /** @type {import('./internal').AtomKind.COMPUTED} */

--- a/reactive/src/index.js
+++ b/reactive/src/index.js
@@ -581,20 +581,21 @@ export function inject(context) {
 		return atom;
 	}
 
+	function InjectedContext(props) {}
+	// @ts-ignore
+	InjectedContext.prototype = new Component();
+	InjectedContext.prototype.render = function() {
+		atom._value = provider.props.value;
+		const subs = graph.subs.get(atom);
+		if (subs && subs.size > 0) {
+			invalidate(atom);
+		}
+		return null;
+	};
+
 	// This is probably not safe to convert to "!"
 	if (atom._value == null) {
 		atom._value = provider.props.value;
-
-		class InjectedContext extends Component {
-			render() {
-				atom._value = provider.props.value;
-				const subs = graph.subs.get(atom);
-				if (subs && subs.size > 0) {
-					invalidate(atom);
-				}
-				return null;
-			}
-		}
 
 		const vnode = h(InjectedContext, {});
 

--- a/reactive/src/index.js
+++ b/reactive/src/index.js
@@ -110,20 +110,22 @@ options.unmount = vnode => {
  */
 function getReactive(component) {
 	if (!component.__reactive) {
+		const atom = createAtom(
+			null,
+			KIND_REACTION,
+			undefined,
+			component.constructor.displayName ||
+				component.constructor.name ||
+				'ReactiveComponent'
+		);
+
 		component.__reactive = {
-			_atom: createAtom(
-				null,
-				KIND_REACTION,
-				undefined,
-				component.constructor.displayName ||
-					component.constructor.name ||
-					'ReactiveComponent'
-			),
+			_atom: atom,
 			_pendingEffects: []
 		};
 
-		component.__reactive._atom._tracking = new Set();
-		component.__reactive._atom._onUpdate = () => {
+		atom._tracking = new Set();
+		atom._onUpdate = () => {
 			component._skipRender = false;
 			component.setState({});
 		};

--- a/reactive/src/index.js
+++ b/reactive/src/index.js
@@ -546,6 +546,23 @@ export function effect(fn, displayName) {
 
 /**
  * @template T
+ * @param {T} value
+ * @param {string} [displayName]
+ * @returns {import('./internal').Atom<T>}
+ */
+export function readonly(value, displayName) {
+	const atom = getAtom(currentIndex++, value, KIND_SOURCE, displayName);
+
+	if (atom._value !== value) {
+		atom._value = value;
+		invalidate(atom);
+	}
+
+	return atom;
+}
+
+/**
+ * @template T
  * @param {import('preact').Context<T>} context
  * @returns {import('./internal').Atom<T>}
  */

--- a/reactive/src/internal.d.ts
+++ b/reactive/src/internal.d.ts
@@ -19,7 +19,6 @@ export interface Atom<T = any> {
 	value: T;
 	_value: T;
 	_onUpdate: () => void;
-	_onActivate: () => void;
 }
 
 export interface Graph {

--- a/reactive/src/internal.d.ts
+++ b/reactive/src/internal.d.ts
@@ -1,5 +1,5 @@
 import { Component as PreactComponent } from '../../src/internal';
-import { Atom } from './index';
+import { Subscribeable } from './index';
 
 export interface Subscription {
 	_unsubscribe: () => void;
@@ -7,9 +7,28 @@ export interface Subscription {
 	_component: Component;
 }
 
+export enum AtomKind {
+	SOURCE = 1,
+	COMPUTED = 2,
+	REACTION = 3
+}
+
+export interface Atom<T = any> {
+	displayName: string;
+	kind: AtomKind;
+	value: T;
+	_value: T;
+	_onUpdate: () => void;
+	_onActivate: () => void;
+}
+
+export interface Graph {
+	deps: Map<Atom, Set<Atom>>;
+	subs: Map<Atom, Set<Atom>>;
+}
+
 export interface Component extends PreactComponent<any, any> {
 	__reactive?: {
-		_atoms: Map<Atom<any>, Subscription>;
-		_prevAtoms: Map<Atom<any>, Subscription>;
+		_list: Atom[];
 	};
 }

--- a/reactive/src/internal.d.ts
+++ b/reactive/src/internal.d.ts
@@ -1,6 +1,5 @@
 import { Component as PreactComponent } from '../../src/internal';
 import { Context } from '../../src/index';
-import { Subscribeable } from './index';
 
 export enum AtomKind {
 	SOURCE = 1,

--- a/reactive/src/internal.d.ts
+++ b/reactive/src/internal.d.ts
@@ -12,6 +12,8 @@ export interface Atom<T = any> {
 	kind: AtomKind;
 	value: T;
 	_value: T;
+	_owner: Atom | null;
+	_children: Atom[];
 	_onUpdate: () => void;
 }
 
@@ -21,7 +23,5 @@ export interface Graph {
 }
 
 export interface Component extends PreactComponent<any, any> {
-	__reactive?: {
-		_list: Atom[];
-	};
+	__reactive?: Atom;
 }

--- a/reactive/src/internal.d.ts
+++ b/reactive/src/internal.d.ts
@@ -1,0 +1,15 @@
+import { Component as PreactComponent } from '../../src/internal';
+import { Atom } from './index';
+
+export interface Subscription {
+	_unsubscribe: () => void;
+	_value: any;
+	_component: Component;
+}
+
+export interface Component extends PreactComponent<any, any> {
+	__reactive?: {
+		_atoms: Map<Atom<any>, Subscription>;
+		_prevAtoms: Map<Atom<any>, Subscription>;
+	};
+}

--- a/reactive/src/internal.d.ts
+++ b/reactive/src/internal.d.ts
@@ -1,4 +1,5 @@
 import { Component as PreactComponent } from '../../src/internal';
+import { Context } from '../../src/index';
 import { Subscribeable } from './index';
 
 export enum AtomKind {
@@ -16,6 +17,7 @@ export interface Atom<T = any> {
 	_children: Atom[];
 	_component: Component | null;
 	_onUpdate: () => void;
+	_context: Context<T> | null;
 }
 
 export interface Graph {

--- a/reactive/src/internal.d.ts
+++ b/reactive/src/internal.d.ts
@@ -11,6 +11,7 @@ export interface Atom<T = any> {
 	displayName: string;
 	kind: AtomKind;
 	value: T;
+	_pending: number;
 	_value: T;
 	_owner: Atom | null;
 	_children: Atom[];

--- a/reactive/src/internal.d.ts
+++ b/reactive/src/internal.d.ts
@@ -13,11 +13,12 @@ export interface Atom<T = any> {
 	value: T;
 	_pending: number;
 	_value: T;
-	_owner: Atom | null;
+	_tracking: Set<Atom> | undefined;
+	_owner: Atom | undefined;
 	_children: Atom[];
-	_component: Component | null;
+	_component: Component | undefined;
 	_onUpdate: () => void;
-	_context: Context<T> | null;
+	_context: Context<T> | undefined;
 }
 
 export interface Graph {

--- a/reactive/src/internal.d.ts
+++ b/reactive/src/internal.d.ts
@@ -1,12 +1,6 @@
 import { Component as PreactComponent } from '../../src/internal';
 import { Subscribeable } from './index';
 
-export interface Subscription {
-	_unsubscribe: () => void;
-	_value: any;
-	_component: Component;
-}
-
 export enum AtomKind {
 	SOURCE = 1,
 	COMPUTED = 2,

--- a/reactive/src/internal.d.ts
+++ b/reactive/src/internal.d.ts
@@ -26,5 +26,8 @@ export interface Graph {
 }
 
 export interface Component extends PreactComponent<any, any> {
-	__reactive?: Atom;
+	__reactive?: {
+		_atom: Atom;
+		_pendingEffects: any[];
+	};
 }

--- a/reactive/src/internal.d.ts
+++ b/reactive/src/internal.d.ts
@@ -14,6 +14,7 @@ export interface Atom<T = any> {
 	_value: T;
 	_owner: Atom | null;
 	_children: Atom[];
+	_component: Component | null;
 	_onUpdate: () => void;
 }
 

--- a/reactive/src/internal.d.ts
+++ b/reactive/src/internal.d.ts
@@ -18,6 +18,7 @@ export interface Atom<T = any> {
 	_children: Atom[];
 	_component: Component | undefined;
 	_onUpdate: () => void;
+	_onCleanup: () => void;
 	_context: Context<T> | undefined;
 }
 
@@ -26,9 +27,14 @@ export interface Graph {
 	subs: Map<Atom, Set<Atom>>;
 }
 
+export interface EffectState {
+	_atom: Atom;
+	_fn: () => (() => void) | undefined;
+}
+
 export interface Component extends PreactComponent<any, any> {
 	__reactive?: {
 		_atom: Atom;
-		_pendingEffects: any[];
+		_pendingEffects: EffectState[];
 	};
 }

--- a/reactive/src/internal.d.ts
+++ b/reactive/src/internal.d.ts
@@ -7,10 +7,13 @@ export enum AtomKind {
 	REACTION = 3
 }
 
+export type UpdateFn<T> = (value: T) => T | null;
+
 export interface Atom<T = any> {
 	displayName: string;
 	kind: AtomKind;
 	value: T;
+	setValue(value: T | UpdateFn<T>): void;
 	_pending: number;
 	_value: T;
 	_tracking: Set<Atom> | undefined;

--- a/reactive/test/browser/reactive.test.js
+++ b/reactive/test/browser/reactive.test.js
@@ -27,7 +27,7 @@ describe('Reactive', () => {
 			let usedProps;
 			const App = component(props => {
 				usedProps = props;
-				return () => <div />;
+				return <div />;
 			});
 
 			render(<App foo="foo" />, scratch);
@@ -41,7 +41,7 @@ describe('Reactive', () => {
 			let count = 0;
 			const App = component(() => {
 				computed(() => count++);
-				return () => <div />;
+				return <div />;
 			});
 
 			render(<App />, scratch);
@@ -64,11 +64,9 @@ describe('Reactive', () => {
 				update = setNum;
 				updateFoo = setFoo;
 
-				return () => {
-					count++;
-					const v = num.value % 2 === 0 ? foo.value : bar.value;
-					return <div>{v}</div>;
-				};
+				count++;
+				const v = num.value % 2 === 0 ? foo.value : bar.value;
+				return <div>{v}</div>;
 			});
 
 			render(<App />, scratch);
@@ -91,10 +89,8 @@ describe('Reactive', () => {
 				const [name, setName] = signal('foo');
 				updateName = setName;
 
-				return () => {
-					count++;
-					return <div>{name.value}</div>;
-				};
+				count++;
+				return <div>{name.value}</div>;
 			});
 
 			let updateOuter;
@@ -127,35 +123,32 @@ describe('Reactive', () => {
 		describe('displayName', () => {
 			it('should set default if none specified', () => {
 				const App = component(() => {
-					return () => <div>foo</div>;
+					return <div>foo</div>;
 				});
 
 				render(<App />, scratch);
-				const atom =
-					scratch._children._children[0]._component.__reactive._list[0];
+				const atom = scratch._children._children[0]._component.__reactive;
 				expect(atom.displayName).to.match(/^ReactiveComponent_\d+$/);
 			});
 
 			it('should use function name', () => {
 				const App = component(function Foo() {
-					return () => <div>foo</div>;
+					return <div>foo</div>;
 				});
 
 				render(<App />, scratch);
-				const atom =
-					scratch._children._children[0]._component.__reactive._list[0];
+				const atom = scratch._children._children[0]._component.__reactive;
 				expect(atom.displayName).to.match(/^Foo_\d+$/);
 			});
 
 			it('should use component displayName', () => {
 				const App = component(function Foo() {
-					return () => <div>foo</div>;
+					return <div>foo</div>;
 				});
 				App.displayName = 'App';
 
 				render(<App />, scratch);
-				const atom =
-					scratch._children._children[0]._component.__reactive._list[0];
+				const atom = scratch._children._children[0]._component.__reactive;
 				expect(atom.displayName).to.match(/^Foo_\d+$/);
 			});
 		});
@@ -165,7 +158,7 @@ describe('Reactive', () => {
 		it('should render signal value', () => {
 			const App = component(() => {
 				const [name] = signal('foo');
-				return () => <div>{name.value}</div>;
+				return <div>{name.value}</div>;
 			});
 
 			render(<App />, scratch);
@@ -178,7 +171,7 @@ describe('Reactive', () => {
 				const App = component(() => {
 					const [name] = signal('foo');
 					atom = name;
-					return () => <div>{name.value}</div>;
+					return <div>{name.value}</div>;
 				});
 
 				render(<App />, scratch);
@@ -190,7 +183,7 @@ describe('Reactive', () => {
 				const App = component(() => {
 					const [name] = signal('foo', 'foo');
 					atom = name;
-					return () => <div>{name.value}</div>;
+					return <div>{name.value}</div>;
 				});
 
 				render(<App />, scratch);
@@ -204,7 +197,7 @@ describe('Reactive', () => {
 				const App = component(() => {
 					const [name, setName] = signal('foo');
 					update = setName;
-					return () => <div>{name.value}</div>;
+					return <div>{name.value}</div>;
 				});
 
 				render(<App />, scratch);
@@ -213,12 +206,37 @@ describe('Reactive', () => {
 				expect(scratch.innerHTML).to.equal('<div>bar</div>');
 			});
 
+			it('should NOT update when signal is not used', () => {
+				let update;
+
+				const Inner = component(props => {
+					return <div>{props.name.value}</div>;
+				});
+
+				let count = 0;
+				const App = component(() => {
+					const [name, setName] = signal('foo');
+					update = setName;
+					count++;
+					return <Inner name={name} />;
+				});
+
+				render(<App />, scratch);
+				expect(scratch.innerHTML).to.equal('<div>foo</div>');
+				expect(count).to.equal(1);
+
+				update('bar');
+				rerender();
+				expect(scratch.innerHTML).to.equal('<div>bar</div>');
+				expect(count).to.equal(1);
+			});
+
 			it('should update signal via updater function', () => {
 				let update;
 				const App = component(() => {
 					const [name, setName] = signal('foo');
 					update = setName;
-					return () => <div>{name.value}</div>;
+					return <div>{name.value}</div>;
 				});
 
 				render(<App />, scratch);
@@ -232,7 +250,7 @@ describe('Reactive', () => {
 				const App = component(() => {
 					const [name, setName] = signal('foo');
 					update = setName;
-					return () => <div>{name.value}</div>;
+					return <div>{name.value}</div>;
 				});
 
 				render(<App />, scratch);
@@ -251,7 +269,7 @@ describe('Reactive', () => {
 					const [name] = signal('foo');
 					const bar = computed(() => name.value);
 					atom = bar;
-					return () => <div>{bar.value}</div>;
+					return <div>{bar.value}</div>;
 				});
 
 				render(<App />, scratch);
@@ -264,7 +282,7 @@ describe('Reactive', () => {
 					const [name] = signal('foo');
 					const bar = computed(() => name.value, 'bar');
 					atom = bar;
-					return () => <div>{bar.value}</div>;
+					return <div>{bar.value}</div>;
 				});
 
 				render(<App />, scratch);

--- a/reactive/test/browser/reactive.test.js
+++ b/reactive/test/browser/reactive.test.js
@@ -356,7 +356,7 @@ describe('Reactive', () => {
 			expect(count).to.equal(2);
 		});
 
-		it('should skip updates if nothing changed', () => {
+		it('should skip updates if signal value did not change', () => {
 			let update;
 			let count = 0;
 			const App = component(() => {
@@ -374,6 +374,29 @@ describe('Reactive', () => {
 			expect(count).to.equal(1);
 
 			update(0);
+			rerender();
+			expect(count).to.equal(1);
+		});
+
+		it('should skip updates if computed result did not change', () => {
+			let update;
+			let count = 0;
+			const App = component(() => {
+				const [i, setI] = signal(0, 'i');
+				update = setI;
+				const tmp = computed(() => (i.value > 10 ? 'foo' : 'bar'), 'tmp');
+				const sum = computed(() => {
+					count++;
+					return tmp.value;
+				}, 'sum');
+
+				return <div>{sum.value}</div>;
+			});
+
+			render(<App />, scratch);
+			expect(count).to.equal(1);
+
+			update(1);
 			rerender();
 			expect(count).to.equal(1);
 		});

--- a/reactive/test/browser/reactive.test.js
+++ b/reactive/test/browser/reactive.test.js
@@ -306,6 +306,46 @@ describe('Reactive', () => {
 	});
 
 	describe('computed', () => {
+		it('should return atom', () => {
+			const App = component(() => {
+				const [name] = signal('foo');
+				const bar = computed(() => name.value);
+				return <div>{bar.value}</div>;
+			});
+
+			render(<App />, scratch);
+			expect(scratch.innerHTML).to.equal('<div>foo</div>');
+		});
+
+		it('should rerun on update', () => {
+			let update;
+			const App = component(() => {
+				const [name, updateName] = signal('foo');
+				update = updateName;
+				const bar = computed(() => name.value);
+				return <div>{bar.value}</div>;
+			});
+
+			render(<App />, scratch);
+			update('bar');
+			rerender();
+			expect(scratch.innerHTML).to.equal('<div>bar</div>');
+		});
+
+		it('should throw when a signal is updated inside computed', () => {
+			const App = component(() => {
+				const [name] = signal('foo');
+				const [_, setNope] = signal('foo');
+				const bar = computed(() => {
+					setNope(name.value);
+					return name.value;
+				});
+				return <div>{bar.value}</div>;
+			});
+
+			expect(() => render(<App />, scratch)).to.throw(/Must not/);
+		});
+
 		describe('displayName', () => {
 			it('should use default if not specified', () => {
 				let atom;

--- a/reactive/test/browser/reactive.test.js
+++ b/reactive/test/browser/reactive.test.js
@@ -1,36 +1,10 @@
 /* eslint-disable react/display-name */
 import { createElement, render } from 'preact';
-import { $, component } from 'preact/reactive';
+import { component, signal, computed } from 'preact/reactive';
 import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
 /** @jsx createElement */
-
-function atom(initalValue) {
-	const noopListener = v => null;
-	let listener = noopListener;
-	let value = initalValue;
-
-	const atom = {
-		_unsubSpy: undefined,
-		_value: value,
-		subscribe(newListener) {
-			listener = newListener;
-			listener(value);
-			atom._unsubSpy = sinon.spy(() => {
-				listener = noopListener;
-			});
-			return atom._unsubSpy;
-		},
-		update(newValue) {
-			value = newValue;
-			atom._value = value;
-			listener(value);
-		}
-	};
-
-	return atom;
-}
 
 describe('Reactive', () => {
 	/** @type {HTMLDivElement} */
@@ -48,138 +22,124 @@ describe('Reactive', () => {
 		teardown(scratch);
 	});
 
-	it('should subscribe to atoms', () => {
-		const name = atom('foo');
+	it('should pass props', () => {
+		let usedProps;
+		const App = component(props => {
+			usedProps = props;
+			return () => <div />;
+		});
 
-		function App() {
-			return <div>{$(name)}</div>;
-		}
+		render(<App foo="foo" />, scratch);
+		expect(usedProps).to.deep.equal({ foo: 'foo' });
 
-		render(<App />, scratch);
-		expect(scratch.innerHTML).to.equal('<div>foo</div>');
-
-		name.update('bar');
-		rerender();
-
-		expect(scratch.innerHTML).to.equal('<div>bar</div>');
+		render(<App bar="bar" />, scratch);
+		expect(usedProps).to.deep.equal({ bar: 'bar' });
 	});
 
-	it('should unsubscribe to atoms', () => {
-		const name = atom('foo');
+	describe('signals', () => {
+		it('should render signal value', () => {
+			const App = component(() => {
+				const [name] = signal('foo');
+				return () => <div>{name.value}</div>;
+			});
 
-		function App() {
-			return <div>{$(name)}</div>;
-		}
+			render(<App />, scratch);
+			expect(scratch.innerHTML).to.equal('<div>foo</div>');
+		});
 
-		render(<App />, scratch);
-		expect(scratch.innerHTML).to.equal('<div>foo</div>');
+		describe('updater', () => {
+			it('should update signal value', () => {
+				let update;
+				const App = component(() => {
+					const [name, setName] = signal('foo');
+					update = setName;
+					return () => <div>{name.value}</div>;
+				});
 
-		render(null, scratch);
-		rerender();
+				render(<App />, scratch);
+				update('bar');
+				rerender();
+				expect(scratch.innerHTML).to.equal('<div>bar</div>');
+			});
 
-		expect(name._unsubSpy).to.be.called;
+			it('should update signal via updater function', () => {
+				let update;
+				const App = component(() => {
+					const [name, setName] = signal('foo');
+					update = setName;
+					return () => <div>{name.value}</div>;
+				});
 
-		name.update('bar');
-		rerender();
+				render(<App />, scratch);
+				update(prev => prev + 'bar');
+				rerender();
+				expect(scratch.innerHTML).to.equal('<div>foobar</div>');
+			});
 
-		expect(scratch.innerHTML).to.equal('');
+			it('should abort signal update in updater function', () => {
+				let update;
+				const App = component(() => {
+					const [name, setName] = signal('foo');
+					update = setName;
+					return () => <div>{name.value}</div>;
+				});
+
+				render(<App />, scratch);
+				update(() => null);
+				rerender();
+				expect(scratch.innerHTML).to.equal('<div>foo</div>');
+			});
+		});
 	});
 
-	it('should not trigger an update if value is the same', () => {
-		const name = atom('foo');
+	describe('computed', () => {
+		// TODO
+	});
+
+	it('should not call unsubscribed computed atoms', () => {
+		let count = 0;
+		const App = component(() => {
+			computed(() => count++);
+			return () => <div />;
+		});
+
+		render(<App />, scratch);
+		expect(count).to.equal(0);
+
+		render(<App foo="foo" />, scratch);
+		expect(count).to.equal(0);
+	});
+
+	it('should unsubscribe from stale subscriptions', () => {
+		let update;
+		let updateFoo;
 
 		let count = 0;
-		function App() {
-			count++;
-			return <div>{$(name)}</div>;
-		}
+		const App = component(() => {
+			const [num, setNum] = signal(0, 'num');
+			const [foo, setFoo] = signal('foo', 'foo');
+			const [bar] = signal('bar', 'bar');
+
+			update = setNum;
+			updateFoo = setFoo;
+
+			return () => {
+				count++;
+				const v = num.value % 2 === 0 ? foo.value : bar.value;
+				return <div>{v}</div>;
+			};
+		});
 
 		render(<App />, scratch);
 		expect(scratch.innerHTML).to.equal('<div>foo</div>');
-		expect(count).to.equal(1);
 
-		name.update('foo');
+		update(1);
 		rerender();
-		expect(count).to.equal(1);
-	});
+		expect(count).to.equal(2);
 
-	describe('reactive components', () => {
-		it('should only instantiate once', () => {
-			let update;
-			let count = 0;
-			const App = component((_, get) => {
-				const name = atom('foo');
-				count++;
-				update = name.update;
-				return () => {
-					return <div>{get(name)}</div>;
-				};
-			});
-
-			render(<App />, scratch);
-			expect(count).to.equal(1);
-			expect(scratch.innerHTML).to.equal('<div>foo</div>');
-
-			update('bar');
-			rerender();
-			expect(count).to.equal(1);
-			expect(scratch.innerHTML).to.equal('<div>bar</div>');
-		});
-
-		it('should render', () => {
-			// Triger subscription via get() call
-			const App = component((_, get) => {
-				const name = atom('foo');
-				return () => <div>{get(name)}</div>;
-			});
-
-			render(<App />, scratch);
-			expect(scratch.innerHTML).to.equal('<div>foo</div>');
-		});
-
-		it('should pass initial props', () => {
-			const App = component((initProps, get) => {
-				const name = atom(initProps.value || 'foo');
-				return () => {
-					return <div>{get(name)}</div>;
-				};
-			});
-
-			render(<App value="bar" />, scratch);
-			expect(scratch.innerHTML).to.equal('<div>bar</div>');
-		});
-
-		it('should unsubscribe from stale subscriptions', () => {
-			let update;
-			let updateFoo;
-
-			let count = 0;
-			const App = component((_, get) => {
-				const num = atom(0);
-				const foo = atom('foo');
-				const bar = atom('bar');
-
-				update = num.update;
-				updateFoo = foo.update;
-
-				return () => {
-					count++;
-					const v = get(num) % 2 === 0 ? get(foo) : get(bar);
-					return <div>{v}</div>;
-				};
-			});
-
-			render(<App />, scratch);
-			expect(scratch.innerHTML).to.equal('<div>foo</div>');
-
-			update(1);
-			rerender();
-			expect(count).to.equal(2);
-
-			updateFoo('foo2');
-			rerender();
-			expect(count).to.equal(2);
-			expect(scratch.innerHTML).to.equal('<div>bar</div>');
-		});
+		updateFoo('foo2');
+		rerender();
+		expect(count).to.equal(2);
+		expect(scratch.innerHTML).to.equal('<div>bar</div>');
 	});
 });

--- a/reactive/test/browser/reactive.test.js
+++ b/reactive/test/browser/reactive.test.js
@@ -332,6 +332,30 @@ describe('Reactive', () => {
 			expect(scratch.innerHTML).to.equal('<div>bar</div>');
 		});
 
+		it('should only update once', () => {
+			let update;
+			let count = 0;
+			const App = component(() => {
+				const [name, updateName] = signal('foo');
+				update = updateName;
+				const a = computed(() => name.value + 'A');
+				const b = computed(() => name.value + 'B');
+				const c = computed(() => {
+					count++;
+					return a.value + ' ' + b.value;
+				});
+
+				return <div>{c.value}</div>;
+			});
+
+			render(<App />, scratch);
+			expect(count).to.equal(1);
+
+			update('bar');
+			rerender();
+			expect(count).to.equal(2);
+		});
+
 		it('should throw when a signal is updated inside computed', () => {
 			const App = component(() => {
 				const [name] = signal('foo');

--- a/reactive/test/browser/reactive.test.js
+++ b/reactive/test/browser/reactive.test.js
@@ -405,9 +405,7 @@ describe('Reactive', () => {
 			expect(scratch.innerHTML).to.equal('<div>bar</div>');
 		});
 
-		// TODO: Currently the component always updates, even if
-		// nobody subscribe to the context atom
-		it.skip('should only update if context value is used', () => {
+		it('should only update if context value is used', () => {
 			const Ctx = createContext('foo');
 
 			let count = 0;
@@ -416,13 +414,23 @@ describe('Reactive', () => {
 				return <div>{count++}</div>;
 			});
 
+			class Blocker extends Component {
+				shouldComponentUpdate() {
+					return false;
+				}
+
+				render() {
+					return <Inner />;
+				}
+			}
+
 			let update;
 			const App = component(() => {
 				const [ctx, setCtx] = signal('foo');
 				update = setCtx;
 				return (
 					<Ctx.Provider value={ctx.value}>
-						<Inner />
+						<Blocker />
 					</Ctx.Provider>
 				);
 			});

--- a/reactive/test/browser/reactive.test.js
+++ b/reactive/test/browser/reactive.test.js
@@ -356,6 +356,28 @@ describe('Reactive', () => {
 			expect(count).to.equal(2);
 		});
 
+		it('should skip updates if nothing changed', () => {
+			let update;
+			let count = 0;
+			const App = component(() => {
+				const [i, setI] = signal(0);
+				update = setI;
+				const sum = computed(() => {
+					count++;
+					return i.value;
+				});
+
+				return <div>{sum.value}</div>;
+			});
+
+			render(<App />, scratch);
+			expect(count).to.equal(1);
+
+			update(0);
+			rerender();
+			expect(count).to.equal(1);
+		});
+
 		it('should throw when a signal is updated inside computed', () => {
 			const App = component(() => {
 				const [name] = signal('foo');

--- a/reactive/test/browser/reactive.test.js
+++ b/reactive/test/browser/reactive.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/display-name */
-import { createElement, render } from 'preact';
+import { createElement, render, Component } from 'preact';
 import { component, signal, computed } from 'preact/reactive';
 import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
@@ -22,18 +22,103 @@ describe('Reactive', () => {
 		teardown(scratch);
 	});
 
-	it('should pass props', () => {
-		let usedProps;
-		const App = component(props => {
-			usedProps = props;
-			return () => <div />;
+	describe('component', () => {
+		it('should pass props', () => {
+			let usedProps;
+			const App = component(props => {
+				usedProps = props;
+				return () => <div />;
+			});
+
+			render(<App foo="foo" />, scratch);
+			expect(usedProps).to.deep.equal({ foo: 'foo' });
+
+			render(<App bar="bar" />, scratch);
+			expect(usedProps).to.deep.equal({ bar: 'bar' });
 		});
 
-		render(<App foo="foo" />, scratch);
-		expect(usedProps).to.deep.equal({ foo: 'foo' });
+		it('should not call unsubscribed computed atoms', () => {
+			let count = 0;
+			const App = component(() => {
+				computed(() => count++);
+				return () => <div />;
+			});
 
-		render(<App bar="bar" />, scratch);
-		expect(usedProps).to.deep.equal({ bar: 'bar' });
+			render(<App />, scratch);
+			expect(count).to.equal(0);
+
+			render(<App foo="foo" />, scratch);
+			expect(count).to.equal(0);
+		});
+
+		it('should unsubscribe from stale subscriptions', () => {
+			let update;
+			let updateFoo;
+
+			let count = 0;
+			const App = component(() => {
+				const [num, setNum] = signal(0, 'num');
+				const [foo, setFoo] = signal('foo', 'foo');
+				const [bar] = signal('bar', 'bar');
+
+				update = setNum;
+				updateFoo = setFoo;
+
+				return () => {
+					count++;
+					const v = num.value % 2 === 0 ? foo.value : bar.value;
+					return <div>{v}</div>;
+				};
+			});
+
+			render(<App />, scratch);
+			expect(scratch.innerHTML).to.equal('<div>foo</div>');
+
+			update(1);
+			rerender();
+			expect(count).to.equal(2);
+
+			updateFoo('foo2');
+			rerender();
+			expect(count).to.equal(2);
+			expect(scratch.innerHTML).to.equal('<div>bar</div>');
+		});
+
+		describe('displayName', () => {
+			it('should set default if none specified', () => {
+				const App = component(() => {
+					return () => <div>foo</div>;
+				});
+
+				render(<App />, scratch);
+				const atom =
+					scratch._children._children[0]._component.__reactive._list[0];
+				expect(atom.displayName).to.match(/^ReactiveComponent_\d+$/);
+			});
+
+			it('should use function name', () => {
+				const App = component(function Foo() {
+					return () => <div>foo</div>;
+				});
+
+				render(<App />, scratch);
+				const atom =
+					scratch._children._children[0]._component.__reactive._list[0];
+				expect(atom.displayName).to.match(/^Foo_\d+$/);
+			});
+
+			it('should use component displayName', () => {
+				const App = component(function Foo() {
+					return () => <div>foo</div>;
+				});
+				App.displayName = 'App';
+
+				render(<App />, scratch);
+				const atom =
+					scratch._children._children[0]._component.__reactive._list[0];
+				expect(atom.displayName).to.match(/^Foo_\d+$/);
+			});
+		});
 	});
 
 	describe('signals', () => {
@@ -45,6 +130,32 @@ describe('Reactive', () => {
 
 			render(<App />, scratch);
 			expect(scratch.innerHTML).to.equal('<div>foo</div>');
+		});
+
+		describe('displayName', () => {
+			it('should set default if none specified', () => {
+				let atom;
+				const App = component(() => {
+					const [name] = signal('foo');
+					atom = name;
+					return () => <div>{name.value}</div>;
+				});
+
+				render(<App />, scratch);
+				expect(atom.displayName).to.match(/^_\d+$/);
+			});
+
+			it('should use passed value', () => {
+				let atom;
+				const App = component(() => {
+					const [name] = signal('foo', 'foo');
+					atom = name;
+					return () => <div>{name.value}</div>;
+				});
+
+				render(<App />, scratch);
+				expect(atom.displayName).to.match(/^foo_\d+$/);
+			});
 		});
 
 		describe('updater', () => {
@@ -93,53 +204,32 @@ describe('Reactive', () => {
 	});
 
 	describe('computed', () => {
-		// TODO
-	});
+		describe('displayName', () => {
+			it('should use default if not specified', () => {
+				let atom;
+				const App = component(() => {
+					const [name] = signal('foo');
+					const bar = computed(() => name.value);
+					atom = bar;
+					return () => <div>{bar.value}</div>;
+				});
 
-	it('should not call unsubscribed computed atoms', () => {
-		let count = 0;
-		const App = component(() => {
-			computed(() => count++);
-			return () => <div />;
+				render(<App />, scratch);
+				expect(atom.displayName).to.match(/^_\d+$/);
+			});
+
+			it('should use passed name', () => {
+				let atom;
+				const App = component(() => {
+					const [name] = signal('foo');
+					const bar = computed(() => name.value, 'bar');
+					atom = bar;
+					return () => <div>{bar.value}</div>;
+				});
+
+				render(<App />, scratch);
+				expect(atom.displayName).to.match(/^bar_\d+$/);
+			});
 		});
-
-		render(<App />, scratch);
-		expect(count).to.equal(0);
-
-		render(<App foo="foo" />, scratch);
-		expect(count).to.equal(0);
-	});
-
-	it('should unsubscribe from stale subscriptions', () => {
-		let update;
-		let updateFoo;
-
-		let count = 0;
-		const App = component(() => {
-			const [num, setNum] = signal(0, 'num');
-			const [foo, setFoo] = signal('foo', 'foo');
-			const [bar] = signal('bar', 'bar');
-
-			update = setNum;
-			updateFoo = setFoo;
-
-			return () => {
-				count++;
-				const v = num.value % 2 === 0 ? foo.value : bar.value;
-				return <div>{v}</div>;
-			};
-		});
-
-		render(<App />, scratch);
-		expect(scratch.innerHTML).to.equal('<div>foo</div>');
-
-		update(1);
-		rerender();
-		expect(count).to.equal(2);
-
-		updateFoo('foo2');
-		rerender();
-		expect(count).to.equal(2);
-		expect(scratch.innerHTML).to.equal('<div>bar</div>');
 	});
 });

--- a/reactive/test/browser/reactive.test.js
+++ b/reactive/test/browser/reactive.test.js
@@ -84,6 +84,46 @@ describe('Reactive', () => {
 			expect(scratch.innerHTML).to.equal('<div>bar</div>');
 		});
 
+		it('should drop reactions on unmount', () => {
+			let updateName;
+			let count = 0;
+			const Inner = component(() => {
+				const [name, setName] = signal('foo');
+				updateName = setName;
+
+				return () => {
+					count++;
+					return <div>{name.value}</div>;
+				};
+			});
+
+			let updateOuter;
+			class Outer extends Component {
+				constructor(props) {
+					super(props);
+					updateOuter = v => this.setState({ v });
+					this.state = { v: 0 };
+				}
+
+				render() {
+					return this.state.v % 2 === 0 ? <Inner /> : <i>bar</i>;
+				}
+			}
+
+			render(<Outer />, scratch);
+			expect(scratch.textContent).to.equal('foo');
+			expect(count).to.equal(1);
+
+			updateOuter();
+			rerender();
+			expect(scratch.textContent).to.equal('bar');
+			expect(count).to.equal(1);
+
+			updateName('hehe');
+			rerender();
+			expect(count).to.equal(1);
+		});
+
 		describe('displayName', () => {
 			it('should set default if none specified', () => {
 				const App = component(() => {

--- a/reactive/test/browser/reactive.test.js
+++ b/reactive/test/browser/reactive.test.js
@@ -1,0 +1,185 @@
+/* eslint-disable react/display-name */
+import { createElement, render } from 'preact';
+import { $, component } from 'preact/reactive';
+import { setupRerender } from 'preact/test-utils';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+
+/** @jsx createElement */
+
+function atom(initalValue) {
+	const noopListener = v => null;
+	let listener = noopListener;
+	let value = initalValue;
+
+	const atom = {
+		_unsubSpy: undefined,
+		_value: value,
+		subscribe(newListener) {
+			listener = newListener;
+			listener(value);
+			atom._unsubSpy = sinon.spy(() => {
+				listener = noopListener;
+			});
+			return atom._unsubSpy;
+		},
+		update(newValue) {
+			value = newValue;
+			atom._value = value;
+			listener(value);
+		}
+	};
+
+	return atom;
+}
+
+describe('Reactive', () => {
+	/** @type {HTMLDivElement} */
+	let scratch;
+
+	/** @type {() => void} */
+	let rerender;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+		rerender = setupRerender();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('should subscribe to atoms', () => {
+		const name = atom('foo');
+
+		function App() {
+			return <div>{$(name)}</div>;
+		}
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>foo</div>');
+
+		name.update('bar');
+		rerender();
+
+		expect(scratch.innerHTML).to.equal('<div>bar</div>');
+	});
+
+	it('should unsubscribe to atoms', () => {
+		const name = atom('foo');
+
+		function App() {
+			return <div>{$(name)}</div>;
+		}
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>foo</div>');
+
+		render(null, scratch);
+		rerender();
+
+		expect(name._unsubSpy).to.be.called;
+
+		name.update('bar');
+		rerender();
+
+		expect(scratch.innerHTML).to.equal('');
+	});
+
+	it('should not trigger an update if value is the same', () => {
+		const name = atom('foo');
+
+		let count = 0;
+		function App() {
+			count++;
+			return <div>{$(name)}</div>;
+		}
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>foo</div>');
+		expect(count).to.equal(1);
+
+		name.update('foo');
+		rerender();
+		expect(count).to.equal(1);
+	});
+
+	describe('reactive components', () => {
+		it('should only instantiate once', () => {
+			let update;
+			let count = 0;
+			const App = component((_, get) => {
+				const name = atom('foo');
+				count++;
+				update = name.update;
+				return () => {
+					return <div>{get(name)}</div>;
+				};
+			});
+
+			render(<App />, scratch);
+			expect(count).to.equal(1);
+			expect(scratch.innerHTML).to.equal('<div>foo</div>');
+
+			update('bar');
+			rerender();
+			expect(count).to.equal(1);
+			expect(scratch.innerHTML).to.equal('<div>bar</div>');
+		});
+
+		it('should render', () => {
+			// Triger subscription via get() call
+			const App = component((_, get) => {
+				const name = atom('foo');
+				return () => <div>{get(name)}</div>;
+			});
+
+			render(<App />, scratch);
+			expect(scratch.innerHTML).to.equal('<div>foo</div>');
+		});
+
+		it('should pass initial props', () => {
+			const App = component((initProps, get) => {
+				const name = atom(initProps.value || 'foo');
+				return () => {
+					return <div>{get(name)}</div>;
+				};
+			});
+
+			render(<App value="bar" />, scratch);
+			expect(scratch.innerHTML).to.equal('<div>bar</div>');
+		});
+
+		it('should unsubscribe from stale subscriptions', () => {
+			let update;
+			let updateFoo;
+
+			let count = 0;
+			const App = component((_, get) => {
+				const num = atom(0);
+				const foo = atom('foo');
+				const bar = atom('bar');
+
+				update = num.update;
+				updateFoo = foo.update;
+
+				return () => {
+					count++;
+					const v = get(num) % 2 === 0 ? get(foo) : get(bar);
+					return <div>{v}</div>;
+				};
+			});
+
+			render(<App />, scratch);
+			expect(scratch.innerHTML).to.equal('<div>foo</div>');
+
+			update(1);
+			rerender();
+			expect(count).to.equal(2);
+
+			updateFoo('foo2');
+			rerender();
+			expect(count).to.equal(2);
+			expect(scratch.innerHTML).to.equal('<div>bar</div>');
+		});
+	});
+});

--- a/reactive/test/browser/reactive.test.js
+++ b/reactive/test/browser/reactive.test.js
@@ -6,7 +6,7 @@ import {
 	createContext,
 	options
 } from 'preact';
-import { component, signal, computed, inject, effect } from 'preact/reactive';
+import { signal, computed, inject, effect } from 'preact/reactive';
 import { act, setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
@@ -31,10 +31,10 @@ describe('Reactive', () => {
 	describe('component', () => {
 		it('should pass props', () => {
 			let usedProps;
-			const App = component(props => {
+			function App(props) {
 				usedProps = props;
 				return <div />;
-			});
+			}
 
 			render(<App foo="foo" />, scratch);
 			expect(usedProps).to.deep.equal({ foo: 'foo' });
@@ -45,10 +45,10 @@ describe('Reactive', () => {
 
 		it('should not call unsubscribed computed atoms', () => {
 			let count = 0;
-			const App = component(() => {
+			function App() {
 				computed(() => count++);
 				return <div />;
-			});
+			}
 
 			render(<App />, scratch);
 			expect(count).to.equal(0);
@@ -62,7 +62,7 @@ describe('Reactive', () => {
 			let updateFoo;
 
 			let count = 0;
-			const App = component(() => {
+			function App() {
 				const [num, setNum] = signal(0, 'num');
 				const [foo, setFoo] = signal('foo', 'foo');
 				const [bar] = signal('bar', 'bar');
@@ -73,7 +73,7 @@ describe('Reactive', () => {
 				count++;
 				const v = num.value % 2 === 0 ? foo.value : bar.value;
 				return <div>{v}</div>;
-			});
+			}
 
 			render(<App />, scratch);
 			expect(scratch.innerHTML).to.equal('<div>foo</div>');
@@ -91,13 +91,13 @@ describe('Reactive', () => {
 		it('should drop reactions on unmount', () => {
 			let updateName;
 			let count = 0;
-			const Inner = component(() => {
+			function Inner() {
 				const [name, setName] = signal('foo');
 				updateName = setName;
 
 				count++;
 				return <div>{name.value}</div>;
-			});
+			}
 
 			let updateOuter;
 			class Outer extends Component {
@@ -128,7 +128,7 @@ describe('Reactive', () => {
 
 		it('should throw errors as part of render context', () => {
 			let updateName;
-			const Inner = component(() => {
+			function Inner() {
 				const [name, setName] = signal('foo');
 				updateName = setName;
 
@@ -141,7 +141,7 @@ describe('Reactive', () => {
 				});
 
 				return <div>{foo.value}</div>;
-			});
+			}
 
 			class Outer extends Component {
 				constructor(props) {
@@ -169,47 +169,14 @@ describe('Reactive', () => {
 			rerender();
 			expect(scratch.innerHTML).to.equal('<div>errored</div>');
 		});
-
-		describe('displayName', () => {
-			it('should set default if none specified', () => {
-				const App = component(() => {
-					return <div>foo</div>;
-				});
-
-				render(<App />, scratch);
-				const atom = scratch._children._children[0]._component.__reactive._atom;
-				expect(atom.displayName).to.match(/^ReactiveComponent_\d+$/);
-			});
-
-			it('should use function name', () => {
-				const App = component(function Foo() {
-					return <div>foo</div>;
-				});
-
-				render(<App />, scratch);
-				const atom = scratch._children._children[0]._component.__reactive._atom;
-				expect(atom.displayName).to.match(/^Foo_\d+$/);
-			});
-
-			it('should use component displayName', () => {
-				const App = component(function Foo() {
-					return <div>foo</div>;
-				});
-				App.displayName = 'App';
-
-				render(<App />, scratch);
-				const atom = scratch._children._children[0]._component.__reactive._atom;
-				expect(atom.displayName).to.match(/^Foo_\d+$/);
-			});
-		});
 	});
 
 	describe('signals', () => {
 		it('should render signal value', () => {
-			const App = component(() => {
+			function App() {
 				const [name] = signal('foo');
 				return <div>{name.value}</div>;
-			});
+			}
 
 			render(<App />, scratch);
 			expect(scratch.innerHTML).to.equal('<div>foo</div>');
@@ -218,11 +185,11 @@ describe('Reactive', () => {
 		describe('displayName', () => {
 			it('should set default if none specified', () => {
 				let atom;
-				const App = component(() => {
+				function App() {
 					const [name] = signal('foo');
 					atom = name;
 					return <div>{name.value}</div>;
-				});
+				}
 
 				render(<App />, scratch);
 				expect(atom.displayName).to.match(/^_\d+$/);
@@ -230,11 +197,11 @@ describe('Reactive', () => {
 
 			it('should use passed value', () => {
 				let atom;
-				const App = component(() => {
+				function App() {
 					const [name] = signal('foo', 'foo');
 					atom = name;
 					return <div>{name.value}</div>;
-				});
+				}
 
 				render(<App />, scratch);
 				expect(atom.displayName).to.match(/^foo_\d+$/);
@@ -244,11 +211,11 @@ describe('Reactive', () => {
 		describe('updater', () => {
 			it('should update signal value', () => {
 				let update;
-				const App = component(() => {
+				function App() {
 					const [name, setName] = signal('foo');
 					update = setName;
 					return <div>{name.value}</div>;
-				});
+				}
 
 				render(<App />, scratch);
 				update('bar');
@@ -259,17 +226,17 @@ describe('Reactive', () => {
 			it('should NOT update when signal is not used', () => {
 				let update;
 
-				const Inner = component(props => {
+				function Inner(props) {
 					return <div>{props.name.value}</div>;
-				});
+				}
 
 				let count = 0;
-				const App = component(() => {
+				function App() {
 					const [name, setName] = signal('foo');
 					update = setName;
 					count++;
 					return <Inner name={name} />;
-				});
+				}
 
 				render(<App />, scratch);
 				expect(scratch.innerHTML).to.equal('<div>foo</div>');
@@ -283,11 +250,11 @@ describe('Reactive', () => {
 
 			it('should update signal via updater function', () => {
 				let update;
-				const App = component(() => {
+				function App() {
 					const [name, setName] = signal('foo');
 					update = setName;
 					return <div>{name.value}</div>;
-				});
+				}
 
 				render(<App />, scratch);
 				update(prev => prev + 'bar');
@@ -297,11 +264,11 @@ describe('Reactive', () => {
 
 			it('should abort signal update in updater function', () => {
 				let update;
-				const App = component(() => {
+				function App() {
 					const [name, setName] = signal('foo');
 					update = setName;
 					return <div>{name.value}</div>;
-				});
+				}
 
 				render(<App />, scratch);
 				update(() => null);
@@ -313,11 +280,11 @@ describe('Reactive', () => {
 
 	describe('computed', () => {
 		it('should return atom', () => {
-			const App = component(() => {
+			function App() {
 				const [name] = signal('foo');
 				const bar = computed(() => name.value);
 				return <div>{bar.value}</div>;
-			});
+			}
 
 			render(<App />, scratch);
 			expect(scratch.innerHTML).to.equal('<div>foo</div>');
@@ -325,12 +292,12 @@ describe('Reactive', () => {
 
 		it('should rerun on update', () => {
 			let update;
-			const App = component(() => {
+			function App() {
 				const [name, updateName] = signal('foo');
 				update = updateName;
 				const bar = computed(() => name.value);
 				return <div>{bar.value}</div>;
-			});
+			}
 
 			render(<App />, scratch);
 			update('bar');
@@ -341,7 +308,7 @@ describe('Reactive', () => {
 		it('should only update once', () => {
 			let update;
 			let count = 0;
-			const App = component(() => {
+			function App() {
 				const [name, updateName] = signal('foo');
 				update = updateName;
 				const a = computed(() => name.value + 'A');
@@ -352,7 +319,7 @@ describe('Reactive', () => {
 				});
 
 				return <div>{c.value}</div>;
-			});
+			}
 
 			render(<App />, scratch);
 			expect(count).to.equal(1);
@@ -365,7 +332,7 @@ describe('Reactive', () => {
 		it('should skip updates if signal value did not change', () => {
 			let update;
 			let count = 0;
-			const App = component(() => {
+			function App() {
 				const [i, setI] = signal(0);
 				update = setI;
 				const sum = computed(() => {
@@ -374,7 +341,7 @@ describe('Reactive', () => {
 				});
 
 				return <div>{sum.value}</div>;
-			});
+			}
 
 			render(<App />, scratch);
 			expect(count).to.equal(1);
@@ -387,7 +354,7 @@ describe('Reactive', () => {
 		it('should skip updates if computed result did not change', () => {
 			let update;
 			let count = 0;
-			const App = component(() => {
+			function App() {
 				const [i, setI] = signal(0, 'i');
 				update = setI;
 				const tmp = computed(() => (i.value > 10 ? 'foo' : 'bar'), 'tmp');
@@ -397,7 +364,7 @@ describe('Reactive', () => {
 				}, 'sum');
 
 				return <div>{sum.value}</div>;
-			});
+			}
 
 			render(<App />, scratch);
 			expect(count).to.equal(1);
@@ -408,7 +375,7 @@ describe('Reactive', () => {
 		});
 
 		it('should throw when a signal is updated inside computed', () => {
-			const App = component(() => {
+			function App() {
 				const [name] = signal('foo');
 				const [_, setNope] = signal('foo');
 				const bar = computed(() => {
@@ -416,7 +383,7 @@ describe('Reactive', () => {
 					return name.value;
 				});
 				return <div>{bar.value}</div>;
-			});
+			}
 
 			expect(() => render(<App />, scratch)).to.throw(/Must not/);
 		});
@@ -424,12 +391,12 @@ describe('Reactive', () => {
 		describe('displayName', () => {
 			it('should use default if not specified', () => {
 				let atom;
-				const App = component(() => {
+				function App() {
 					const [name] = signal('foo');
 					const bar = computed(() => name.value);
 					atom = bar;
 					return <div>{bar.value}</div>;
-				});
+				}
 
 				render(<App />, scratch);
 				expect(atom.displayName).to.match(/^_\d+$/);
@@ -437,12 +404,12 @@ describe('Reactive', () => {
 
 			it('should use passed name', () => {
 				let atom;
-				const App = component(() => {
+				function App() {
 					const [name] = signal('foo');
 					const bar = computed(() => name.value, 'bar');
 					atom = bar;
 					return <div>{bar.value}</div>;
-				});
+				}
 
 				render(<App />, scratch);
 				expect(atom.displayName).to.match(/^bar_\d+$/);
@@ -453,10 +420,10 @@ describe('Reactive', () => {
 	describe('effect', () => {
 		it('should call effect', () => {
 			let spy = sinon.spy();
-			const App = component(() => {
+			function App() {
 				effect(spy);
 				return null;
-			});
+			}
 
 			act(() => {
 				render(<App />, scratch);
@@ -467,21 +434,21 @@ describe('Reactive', () => {
 		it('should be called when dependency changes', () => {
 			let spy = sinon.spy();
 			let renderSpy = sinon.spy();
-			const Inner = component(props => {
+			function Inner(props) {
 				effect(() => {
 					spy(props.name.value);
 				});
 
 				renderSpy();
 				return null;
-			});
+			}
 
 			let update;
-			const App = component(() => {
+			function App() {
 				const [name, setName] = signal('foo');
 				update = setName;
 				return <Inner name={name} />;
-			});
+			}
 
 			act(() => {
 				render(<App />, scratch);
@@ -499,10 +466,10 @@ describe('Reactive', () => {
 
 		it.skip('should call unmount function', () => {
 			let spy = sinon.spy();
-			const App = component(() => {
+			function App() {
 				effect(() => spy);
 				return null;
-			});
+			}
 
 			act(() => {
 				render(<App />, scratch);
@@ -516,14 +483,14 @@ describe('Reactive', () => {
 		it('should not be called if options._skipEffect is set', () => {
 			const tmp = options._skipEffects;
 			options._skipEffects = true;
+			let spy = sinon.spy();
+
+			function App() {
+				effect(spy);
+				return null;
+			}
+
 			try {
-				let spy = sinon.spy();
-
-				const App = component(() => {
-					effect(spy);
-					return null;
-				});
-
 				act(() => {
 					render(<App />, scratch);
 				});
@@ -538,10 +505,10 @@ describe('Reactive', () => {
 		it('should read default value from context', () => {
 			const Ctx = createContext('foo');
 
-			const App = component(() => {
+			function App() {
 				const name = inject(Ctx);
 				return <div>{name.value}</div>;
-			});
+			}
 
 			render(<App />, scratch);
 			expect(scratch.innerHTML).to.equal('<div>foo</div>');
@@ -550,10 +517,10 @@ describe('Reactive', () => {
 		it('should read from context', () => {
 			const Ctx = createContext('foo');
 
-			const Inner = component(() => {
+			function Inner() {
 				const name = inject(Ctx);
 				return <div>{name.value}</div>;
-			});
+			}
 
 			function App() {
 				return (
@@ -570,10 +537,10 @@ describe('Reactive', () => {
 		it('should subscribe to updates from context', () => {
 			const Ctx = createContext('foo');
 
-			const Inner = component(() => {
+			function Inner() {
 				const name = inject(Ctx);
 				return <div>{name.value}</div>;
-			});
+			}
 
 			class Blocker extends Component {
 				shouldComponentUpdate() {
@@ -586,7 +553,7 @@ describe('Reactive', () => {
 			}
 
 			let update;
-			const App = component(() => {
+			function App() {
 				const [ctx, setCtx] = signal('foo');
 				update = setCtx;
 				return (
@@ -594,7 +561,7 @@ describe('Reactive', () => {
 						<Blocker />
 					</Ctx.Provider>
 				);
-			});
+			}
 
 			render(<App />, scratch);
 			expect(scratch.innerHTML).to.equal('<div>foo</div>');
@@ -608,10 +575,10 @@ describe('Reactive', () => {
 			const Ctx = createContext('foo');
 
 			let count = 0;
-			const Inner = component(() => {
+			function Inner() {
 				inject(Ctx); // unused
 				return <div>{count++}</div>;
-			});
+			}
 
 			class Blocker extends Component {
 				shouldComponentUpdate() {
@@ -624,7 +591,7 @@ describe('Reactive', () => {
 			}
 
 			let update;
-			const App = component(() => {
+			function App() {
 				const [ctx, setCtx] = signal('foo');
 				update = setCtx;
 				return (
@@ -632,7 +599,7 @@ describe('Reactive', () => {
 						<Blocker />
 					</Ctx.Provider>
 				);
-			});
+			}
 
 			render(<App />, scratch);
 			expect(scratch.innerHTML).to.equal('<div>0</div>');

--- a/reactive/test/browser/reactive.test.js
+++ b/reactive/test/browser/reactive.test.js
@@ -6,7 +6,7 @@ import {
 	createContext,
 	options
 } from 'preact';
-import { signal, computed, inject, effect } from 'preact/reactive';
+import { signal, computed, inject, effect, ref } from 'preact/reactive';
 import { act, setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
@@ -168,6 +168,20 @@ describe('Reactive', () => {
 			updateName('fail');
 			rerender();
 			expect(scratch.innerHTML).to.equal('<div>errored</div>');
+		});
+	});
+
+	describe('ref', () => {
+		it('should set element', () => {
+			let refValue;
+			function App() {
+				const myRef = ref(null);
+				refValue = myRef;
+				return <div ref={myRef} />;
+			}
+
+			render(<App />, scratch);
+			expect(refValue).to.deep.equal({ current: scratch.firstChild });
 		});
 	});
 

--- a/reactive/test/browser/reactive.test.js
+++ b/reactive/test/browser/reactive.test.js
@@ -6,7 +6,14 @@ import {
 	createContext,
 	options
 } from 'preact';
-import { signal, computed, inject, effect, ref } from 'preact/reactive';
+import {
+	signal,
+	computed,
+	inject,
+	effect,
+	readonly,
+	ref
+} from 'preact/reactive';
 import { act, setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
@@ -300,6 +307,45 @@ describe('Reactive', () => {
 				rerender();
 				expect(scratch.innerHTML).to.equal('<div>foo</div>');
 			});
+		});
+	});
+
+	describe('readonly', () => {
+		it('should turn into atom', () => {
+			let count = 0;
+			function App({ foo }) {
+				const $foo = readonly(foo);
+				count++;
+				return <div>{$foo.value}</div>;
+			}
+
+			render(<App foo={0} />, scratch);
+			expect(scratch.innerHTML).to.equal('<div>0</div>');
+			expect(count).to.equal(1);
+		});
+
+		it('should react to new values', () => {
+			let count = 0;
+			let computedCount = 0;
+			function App({ foo }) {
+				const $foo = readonly(foo);
+				const c = computed(() => {
+					computedCount++;
+					return $foo.value;
+				});
+				count++;
+				return <div>{c.value}</div>;
+			}
+
+			render(<App foo={0} />, scratch);
+			expect(scratch.innerHTML).to.equal('<div>0</div>');
+			expect(count).to.equal(1);
+			expect(computedCount).to.equal(1);
+
+			render(<App foo={1} />, scratch);
+			expect(scratch.innerHTML).to.equal('<div>1</div>');
+			expect(count).to.equal(2);
+			expect(computedCount).to.equal(2);
 		});
 	});
 


### PR DESCRIPTION
# Reactive addon

## Summary

This PR adds a new addon called `reactive`, which is an alternative to `hooks` for managing state. It's main purpose is to decouple the rendering phase from state updates to ensure optimal rendering performance by default, even for complex apps. It comes with some DX improvements, such as that dependencies are tracked automatically and don't have to be specified by hand for effects.

## Basic Example

```jsx
import { signal } from 'preact/reactive';

// Won't re-render despite state being updated. The effect will
// trigger only when `count.value` changes, not when the component
// re-renders.
function App() {
	const [count, setCount] = signal(0);

	// Look, no dependency args
	effect(() => {
		console.log(`count: ${count.value}`);
	});

	return <NeverReRendered count={count} />;
}

// Will only render once during mounting, will not re-render
// when state is updated in <App />
function NeverReRendered({ count }) {
	return <Inner count={count} />;
}

// Whenever the button is clicked, only the <Inner /> component will rerender
function Inner({ count }) {
	return (
		<button onClick={() => setCount(count.value + 1)}>
			increment {count.value}
		</button>
	);
}
```

## Motivation

Since the introduction of hooks we've seen more and more developers pick that as their main way to manage state. This works great for smaller applications but becomes complex and can easily lead to performance issues in bigger projects. Hooks tie state updates to rendering itself and thereby cause unnecessary re-renders of large portions of the component tree whenever state is updated. One can avoid most of these issues by manually placing memoized calls at the correct spots, but these are hard to track down.

This has been a frequent source of performance issues in projects I've consulted for over the past few years. In one example just rendering the page took 500ms on my Macbook M1 Air and 2s on a slower Android phone. This is the sole time the framework spent rendering. The layout resembled a product list which displays a few filters and a carousel at the top.

Virtual-DOM-based frameworks typically render top down from the component which holds the state. But often the state is only used in components quite a bit further down the tree which means we'll spent a lot of time comparing components which didn't change.

```jsx
const MyContext = createContext(null);

function Foo(props) {
	const [data, setData] = useState(null);

	// Provider and all its children will be re-rendered on state changes,
	// unless they manually opted out.
	return (
		<MyContext.Provider value={{ data }}>{props.children}</MyContext.Provider>
	);
}
```

As applications grow the state of components becomes more intertwined and state often ends up being only triggered to fire an effect.

```jsx
// Example of where an effect triggers a state update to trigger
// another effect
function Foo(props) {
	const [foo, setFoo] = useState(null);
	const [bar, setBar] = useState(null);

	useEffect(() => {
		// Update foo, to trigger the other effect
		setFoo('foobar');
	}, []);

	useEffect(() => {
		console.log(foo);
	}, [foo]);

	// ...
}
```

Whilst memoization can help in improving the performance, it tends to be used incorrectly or is easily defeated by passing a value which changes on each render.

So let's fix that. Let's find a system which avoids these problems by design. A system that only re-renders components that depend on the state that was updated.

A couple of years back when IE11 was still a thing, I've made very good experiences with various reactive libraries that track either or both read and write access to state. One example of that is the excellent [MobX](https://github.com/mobxjs/mobx) library.

Due to the separation of state updates and rendering the framework knows which exact components need to be updated. Instead of passing values down, you're passing descriptions on how to get that value down the tree. Depending on the framework this can be a function, a getter on an object or another kind of "box". That allows frameworks to skip huge portions of the component tree and would not trigger accidental renders caused by state updates to trigger effects.

## Detailed design

One key goal of `preact/reactive` is to have a very lean API, similar to hooks. Frameworks based around observable primitives tend to have a rather large API surface with a lot of new concepts to learn. Our system should be minimal and allow users to compose complex features out of smaller building blocks. It should have a lot of familiar aspects and enough new ones to make the transition to it as beginner friendly as possible.

### Signals

The core primitive of this new system are signals. Signals are very similar to `useState`.

```jsx
function App() {
	const [count, setCount] = signal(0);
	// ...
}
```

But instead of `count` being the number `0`, it is an object on which the original value can be accessed via the `count.value`. That object reference stays the same throughout all re-renderings. By ensuring a stable reference we can safely pass it down to components and track which components read its `.value` property. Whenever it's read inside a component, we add this component as a dependency to that signal. When the value changes we can directly update only these components and skip everything else.

### Computed Signals (aka derived values)

Computed signals are a way to derive a single value from other signals. It is automatically updated whenever the signals it depends upon are updated.

```jsx
function App() {
	const [name, setName] = signal('Jane Doe');
	const [age, setAge] = signal(32);

	// Automatically updated whenever `name` or `age` changes.
	const text = computed(() => {
		return `Name: ${name.value}, age: ${age.value}`;
	});

	// ...
}
```

This also works for conditional logic where new signals need to be subscribed to on the fly and old subscriptions need to be discarded.

```jsx
function App() {
  const [count, setCount] = signal(0);
  const [foo, setFoo] = signal('foo');
  const [bar, setBar] = signal('bar');

  // Automatically subscribes and unsubscribes from `foo` and `bar`
  const text = computed(() => {
    if (count.value > 10) {
      return foo.value;
    }

    return bar.value;
  });
});
```

### Effects

The way effects are triggered is basically a combination of `useEffect` and the tracking abilities of `computed()`. The effect will only run when the component is mounted or when the effect dependencies changes.

```jsx
function App() {
	const [count, setCount] = signal(0);

	effect(() => console.log(count.value));

	// ...
}
```

Similar to `useEffect` we can return a cleanup function that is called whenever the effect is updated or the component is unmounted.

```jsx
function App() {
	const [userId, setUserId] = signal(1);

	effect(() => {
		const id = userId.value;
		api.subscribeUser(id);

		return () => {
			api.unsubscribeUser(id);
		};
	});

	// ...
}
```

### Readonly: Reacting to prop changes

Because the `props` of a component are a plain object and not reactive by default, effects or derived signals would not be updated whenever props change. We can use the `readonly()` function to create a readonly signal that always updates when the passed value changes.

```jsx
function App(props) {
	// Signal is a stable reference. Value always updates
	// when `props.name` has changed.
	const name = readonly(props.name);
	const text = computed(() => `My name is: ${name.value}`);
	// ...
}
```

### Inject: Subscribing to context

The `inject()` function can be used to subscribe to context. It works similar to `useContext` with the sole difference that the return value is wrapped in a signal.

```jsx
const ThemeCtx = createContext('light');

function App(props) {
	const theme = inject(ThemeCtx);

	return <p>Theme: {theme.value}</p>;
}
```

### Debugging

Due to the nature of the system of being able to track signal reads, we can better show in devtools why a value was updated and how state relates to each component. This work has not yet started.

### Error handling

Errors can be caught via typicall Error boundaries. Since we track the component context a signal was created in, we rethrow the error on that component.

```js
function Foo() {
	const [foo, setFoo] = signal('foo');

	const text = computed(() => {
		if (foo.value !== 'foo') {
			// Errors thrown inside a computed signal can be caught
			// with error boundaries
			throw new Error('fail');
		}

		return foo.value;
	});

	// ...
}
```

## Drawbacks

With hooks developers had to learn about closures in depth. With a reactive system one needs to now about how variables are passed around in JavaScript (pass by value vs by reference).

Similar to hooks the callsite order must be consistent. This means that you cannot conditionally create signals on the fly.

## Alternatives

Libraries like [`MobX`](https://github.com/mobxjs/mobx) track read access of observables via getters.

```js
// Psuedo code:
// Turns object properties into observables
const obj = reactive({ foo: 1, bar: true });

// Read access is tracked via getters
const text = computed(() => obj.foo);
```

Whilst tracking reactivity via getters makes the code more brief, it poses a few considerable downsides. For them to work one must preserve the getters and destructuring prevents reads from being registered properly.

```js
// Pseudo code
// Turns object properties into observables
const { foo } = reactive({ foo: 1, bar: true });

// This breaks...
const text = computed(() => foo);
```

Consider the use case of reacting to changes to `props`. Making them reactive would only be possible by keeping `props` as an object.

```jsx
// This would work
function App(props) {
	const $props = reactive(props);
	// ...
}

// But how to track this? This is much better solved by readonly()
function App({ foo = 1, bar = true }) {
	// ...
}
```

Another use case to consider are other types than `Objects`. In a system based on tracking read access via getters we'd need to support `.entries()`, `.values()` and other iterable methods. And not just for objects, but also collection primitives like `Array`, `Map` and `Set` have to be intercepted.

Debugging is also made a bit trickier, because from the output of `console.log` can easily lead to infinite loop due to invoking all getters, if the collection object is not serialized manually beforehand.

I think this approach would introduce too many rabbit holes and complex issues, that I'd rather avoid entirely.

## Adoption Strategy

With the addition of the new addon developers can introduce reactive components on a component bases in their existing projects. Adoption can therefore happen incrementally and the system happily co-exists with all current solutions.

The current plan is to leverage this module in our devtools extension as the first real world project.

## Unresolved questions

This is mostly bikeshedding:

1. Should it be `foo.value` or `foo.$` ?

```jsx
<button onClick={() => setCount(count.value + 1)}>{count.value}</button>
```

vs

```jsx
<button onClick={() => setCount(count.$ + 1)}>{count.$}</button>
```

2. `inject` is not a good name for reading from context.
3. Do we have a better name for `readonly`?
4. How to work with refs?

_**EDIT:** Enhanced section about "alternative solutions"_
_**EDIT2:** Add section about error handling_