### PR TITLE
Improve karma test console logging

### DIFF
--- a/test/polyfills.js
+++ b/test/polyfills.js
@@ -204,6 +204,12 @@ function serialize(value, mode, indent, seen) {
 	seen.add(value);
 
 	const props = Object.keys(value).map(key => {
+		// Skip calling getters
+		const desc = Object.getOwnPropertyDescriptor(value, key);
+		if (typeof desc.get === 'function') {
+			return `get ${key}()`;
+		}
+
 		const v = serialize(value[key], mode, indent + 1, seen);
 		return `${key}: ${v}`;
 	});

--- a/test/polyfills.js
+++ b/test/polyfills.js
@@ -200,6 +200,9 @@ function serialize(value, mode, indent, seen) {
 	if (value instanceof Element) {
 		return value.outerHTML;
 	}
+	if (value instanceof Error) {
+		return value.stack;
+	}
 
 	seen.add(value);
 


### PR DESCRIPTION
- Fix `Error` objects not being serialized for kamra cli logs
- Don't access getters during serialization and just print the getter name instead (causes an infinite loop in #3474)