### PR TITLE
Track context on rerenderState

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -10,6 +10,7 @@ import { getParentContext, getParentDom } from './tree';
  * @type {import('./internal').RendererState}
  */
 export const rendererState = {
+	_parentDom: null,
 	_context: {},
 	_commitQueue: []
 };
@@ -109,7 +110,8 @@ function rerender(internal) {
 
 		rendererState._context = getParentContext(internal);
 		rendererState._commitQueue = [];
-		patch(internal, vnode, getParentDom(internal));
+		rendererState._parentDom = getParentDom(internal);
+		patch(internal, vnode);
 		commitRoot(internal);
 	}
 }

--- a/src/component.js
+++ b/src/component.js
@@ -3,7 +3,11 @@ import options from './options';
 import { createVNode, Fragment } from './create-element';
 import { patch } from './diff/patch';
 import { DIRTY_BIT, FORCE_UPDATE, MODE_UNMOUNTING } from './constants';
-import { getParentDom } from './tree';
+import { getParentContext, getParentDom } from './tree';
+
+export const rendererState = {
+	_context: {}
+};
 
 /**
  * Base Component class. Provides `setState()` and `forceUpdate()`, which
@@ -99,6 +103,7 @@ function rerender(internal) {
 		);
 
 		const commitQueue = [];
+		rendererState._context = getParentContext(internal);
 		patch(internal, vnode, commitQueue, getParentDom(internal));
 		commitRoot(internal, commitQueue);
 	}

--- a/src/component.js
+++ b/src/component.js
@@ -5,8 +5,13 @@ import { patch } from './diff/patch';
 import { DIRTY_BIT, FORCE_UPDATE, MODE_UNMOUNTING } from './constants';
 import { getParentContext, getParentDom } from './tree';
 
+/**
+ * The render queue
+ * @type {import('./internal').RendererState}
+ */
 export const rendererState = {
-	_context: {}
+	_context: {},
+	_commitQueue: []
 };
 
 /**
@@ -102,10 +107,10 @@ function rerender(internal) {
 			0
 		);
 
-		const commitQueue = [];
 		rendererState._context = getParentContext(internal);
-		patch(internal, vnode, commitQueue, getParentDom(internal));
-		commitRoot(internal, commitQueue);
+		rendererState._commitQueue = [];
+		patch(internal, vnode, getParentDom(internal));
+		commitRoot(internal);
 	}
 }
 

--- a/src/create-root.js
+++ b/src/create-root.js
@@ -10,6 +10,7 @@ import options from './options';
 import { mount } from './diff/mount';
 import { patch } from './diff/patch';
 import { createInternal } from './tree';
+import { rendererState } from './component';
 
 /**
  *
@@ -18,7 +19,6 @@ import { createInternal } from './tree';
  */
 export function createRoot(parentDom) {
 	let rootInternal,
-		commitQueue,
 		firstChild,
 		flags = 0;
 
@@ -31,10 +31,10 @@ export function createRoot(parentDom) {
 			/** @type {import('./internal').PreactElement} */ (parentDom.firstChild);
 
 		// List of effects that need to be called after diffing:
-		commitQueue = [];
+		rendererState._commitQueue = [];
 
 		if (rootInternal) {
-			patch(rootInternal, vnode, commitQueue, parentDom);
+			patch(rootInternal, vnode, parentDom);
 		} else {
 			rootInternal = createInternal(vnode);
 
@@ -53,11 +53,11 @@ export function createRoot(parentDom) {
 
 			rootInternal._context = {};
 
-			mount(rootInternal, vnode, commitQueue, parentDom, firstChild);
+			mount(rootInternal, vnode, parentDom, firstChild);
 		}
 
 		// Flush all queued effects
-		commitRoot(rootInternal, commitQueue);
+		commitRoot(rootInternal);
 	}
 
 	return {

--- a/src/create-root.js
+++ b/src/create-root.js
@@ -30,11 +30,13 @@ export function createRoot(parentDom) {
 		firstChild =
 			/** @type {import('./internal').PreactElement} */ (parentDom.firstChild);
 
+		rendererState._context = {};
 		// List of effects that need to be called after diffing:
 		rendererState._commitQueue = [];
+		rendererState._parentDom = parentDom;
 
 		if (rootInternal) {
-			patch(rootInternal, vnode, parentDom);
+			patch(rootInternal, vnode);
 		} else {
 			rootInternal = createInternal(vnode);
 
@@ -53,7 +55,7 @@ export function createRoot(parentDom) {
 
 			rootInternal._context = {};
 
-			mount(rootInternal, vnode, parentDom, firstChild);
+			mount(rootInternal, vnode, firstChild);
 		}
 
 		// Flush all queued effects

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -17,10 +17,9 @@ import { createInternal, getDomSibling } from '../tree';
  * Update an internal with new children.
  * @param {import('../internal').Internal} internal The internal whose children should be patched
  * @param {import('../internal').ComponentChild[]} children The new children, represented as VNodes
- * @param {import('../internal').CommitQueue} commitQueue
  * @param {import('../internal').PreactElement} parentDom
  */
-export function patchChildren(internal, children, commitQueue, parentDom) {
+export function patchChildren(internal, children, parentDom) {
 	let oldChildren =
 		(internal._children && internal._children.slice()) || EMPTY_ARR;
 
@@ -76,7 +75,6 @@ export function patchChildren(internal, children, commitQueue, parentDom) {
 			mount(
 				childInternal,
 				childVNode,
-				commitQueue,
 				parentDom,
 				getDomSibling(internal, skewedIndex)
 			);
@@ -91,13 +89,12 @@ export function patchChildren(internal, children, commitQueue, parentDom) {
 			mount(
 				childInternal,
 				childVNode,
-				commitQueue,
 				parentDom,
 				childInternal._dom
 			);
 		} else {
 			// Morph the old element into the new one, but don't append it to the dom yet
-			patch(childInternal, childVNode, commitQueue, parentDom);
+			patch(childInternal, childVNode, parentDom);
 		}
 
 		go: if (mountingChild) {

--- a/src/diff/commit.js
+++ b/src/diff/commit.js
@@ -1,11 +1,13 @@
+import { rendererState } from '../component';
 import options from '../options';
 
 /**
  * @param {import('../internal').Internal} rootInternal
- * @param {import('../internal').CommitQueue} commitQueue List of components
- * which have callbacks to invoke in commitRoot
  */
-export function commitRoot(rootInternal, commitQueue) {
+export function commitRoot(rootInternal) {
+	let commitQueue = [].concat(rendererState._commitQueue);
+	rendererState._commitQueue = [];
+
 	if (options._commit) options._commit(rootInternal, commitQueue);
 
 	commitQueue.some(internal => {

--- a/src/diff/component.js
+++ b/src/diff/component.js
@@ -1,5 +1,6 @@
 import options from '../options';
 import { DIRTY_BIT, FORCE_UPDATE, SKIP_CHILDREN } from '../constants';
+import { rendererState } from '../component';
 
 /**
  * Render a function component
@@ -10,7 +11,6 @@ import { DIRTY_BIT, FORCE_UPDATE, SKIP_CHILDREN } from '../constants';
 export function renderFunctionComponent(
 	internal,
 	newVNode,
-	context,
 	componentContext
 ) {
 	/** @type {import('../internal').Component} */
@@ -46,15 +46,18 @@ export function renderFunctionComponent(
 	while (counter++ < 25) {
 		internal.flags &= ~DIRTY_BIT;
 		if (renderHook) renderHook(internal);
-		renderResult = type.call(c, c.props, c.context);
+		renderResult = type.call(c, c.props, componentContext);
 		if (!(internal.flags & DIRTY_BIT)) {
 			break;
 		}
 	}
 	internal.flags &= ~DIRTY_BIT;
-
 	if (c.getChildContext != null) {
-		internal._context = Object.assign({}, context, c.getChildContext());
+		rendererState._context = internal._context = Object.assign(
+			{},
+			rendererState._context,
+			c.getChildContext()
+		);
 	}
 
 	return renderResult;
@@ -69,7 +72,6 @@ export function renderFunctionComponent(
 export function renderClassComponent(
 	internal,
 	newVNode,
-	context,
 	componentContext
 ) {
 	/** @type {import('../internal').Component} */
@@ -161,7 +163,11 @@ export function renderClassComponent(
 	c.state = c._nextState;
 
 	if (c.getChildContext != null) {
-		internal._context = Object.assign({}, context, c.getChildContext());
+		rendererState._context = internal._context = Object.assign(
+			{},
+			rendererState._context,
+			c.getChildContext()
+		);
 	}
 
 	if (!isNew) {

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -15,7 +15,7 @@ import {
 import { normalizeToVNode, Fragment } from '../create-element';
 import { setProperty } from './props';
 import { renderClassComponent, renderFunctionComponent } from './component';
-import { createInternal, getParentContext } from '../tree';
+import { createInternal } from '../tree';
 import options from '../options';
 import { rendererState } from '../component';
 /**

--- a/src/diff/patch.js
+++ b/src/diff/patch.js
@@ -27,10 +27,9 @@ import { rendererState } from '../component';
  * Diff two virtual nodes and apply proper changes to the DOM
  * @param {import('../internal').Internal} internal The Internal node to patch
  * @param {import('../internal').VNode | string} vnode The new virtual node
- * @param {import('../internal').CommitQueue} commitQueue
  * @param {import('../internal').PreactElement} parentDom The parent DOM element for insertion/deletions
  */
-export function patch(internal, vnode, commitQueue, parentDom) {
+export function patch(internal, vnode, parentDom) {
 	let flags = internal.flags;
 
 	if (flags & TYPE_TEXT) {
@@ -66,7 +65,7 @@ export function patch(internal, vnode, commitQueue, parentDom) {
 	if (flags & TYPE_ELEMENT) {
 		if (vnode._vnodeId !== internal._vnodeId) {
 			// @ts-ignore dom is a PreactElement here
-			patchElement(internal, vnode, commitQueue);
+			patchElement(internal, vnode);
 		}
 	} else {
 		try {
@@ -137,19 +136,18 @@ export function patch(internal, vnode, commitQueue, parentDom) {
 				mountChildren(
 					internal,
 					renderResult,
-					commitQueue,
 					parentDom,
 					siblingDom
 				);
 			} else {
-				patchChildren(internal, renderResult, commitQueue, parentDom);
+				patchChildren(internal, renderResult, parentDom);
 			}
 
 			if (
 				internal._commitCallbacks != null &&
 				internal._commitCallbacks.length
 			) {
-				commitQueue.push(internal);
+				rendererState._commitQueue.push(internal);
 			}
 
 			// In the event this subtree creates a new context for its children, restore
@@ -179,9 +177,8 @@ export function patch(internal, vnode, commitQueue, parentDom) {
  * Update an internal and its associated DOM element based on a new VNode
  * @param {import('../internal').Internal} internal
  * @param {import('../internal').VNode} vnode A VNode with props to compare and apply
- * @param {import('../internal').CommitQueue} commitQueue
  */
-function patchElement(internal, vnode, commitQueue) {
+function patchElement(internal, vnode) {
 	let dom = /** @type {import('../internal').PreactElement} */ (internal._dom),
 		oldProps = internal.props,
 		newProps = (internal.props = vnode.props),
@@ -231,7 +228,6 @@ function patchElement(internal, vnode, commitQueue) {
 		patchChildren(
 			internal,
 			newChildren && Array.isArray(newChildren) ? newChildren : [newChildren],
-			commitQueue,
 			dom
 		);
 	}

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -48,6 +48,7 @@ export interface Options extends preact.Options {
 export type RendererState = {
 	_context: Record<string, any>;
 	_commitQueue: CommitQueue;
+	_parentDom: Element | Document | ShadowRoot | DocumentFragment;
 };
 
 export type CommitQueue = Internal[];

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -45,6 +45,11 @@ export interface Options extends preact.Options {
 	_internal?(internal: Internal, vnode: VNode | string): void;
 }
 
+export type RendererState = {
+	_context: Record<string, any>;
+	_commitQueue: CommitQueue;
+};
+
 export type CommitQueue = Internal[];
 
 // Redefine ComponentFactory using our new internal FunctionalComponent interface above


### PR DESCRIPTION
This introduces a global called `rendererState` which we can use to track metadata for a root/ongoing render/.... We could expand this to track `_parentDom`, `commitQueue`, ...

Ideally we scope `_commitQueue` by render-root as well as context/... in case we ever decide to go on to async rendering