### PR TITLE
[ts] components can return ComponentChildren

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -87,7 +87,7 @@ export type ComponentProps<
 	: never;
 
 export interface FunctionComponent<P = {}> {
-	(props: RenderableProps<P>, context?: any): VNode<any> | null;
+	(props: RenderableProps<P>, context?: any): ComponentChildren;
 	displayName?: string;
 	defaultProps?: Partial<P>;
 }
@@ -180,7 +180,7 @@ export abstract class Component<P, S> {
 		props?: RenderableProps<P>,
 		state?: Readonly<S>,
 		context?: any
-	): ComponentChild;
+	): ComponentChildren;
 }
 
 //


### PR DESCRIPTION
Previously `FunctionComponent` was only typed as returning `VNode | null`, but Preact supports returning Arrays as well as any VDOM text primitive (boolean, etc). Class component render methods were typed as returning `ComponentChild`, which doesn't reflect the fact that this method can also return Arrays.