### PR TITLE
reset useImperativeHandle ref to null when the component get unmounted

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -197,8 +197,13 @@ export function useImperativeHandle(ref, createHandle, args) {
 	currentHook = 6;
 	useLayoutEffect(
 		() => {
-			if (typeof ref == 'function') ref(createHandle());
-			else if (ref) ref.current = createHandle();
+			if (typeof ref == 'function') {
+				ref(createHandle());
+				return () => ref(null);
+			} else if (ref) {
+				ref.current = createHandle();
+				return () => ref.current = null;
+			}
 		},
 		args == null ? args : args.concat(ref)
 	);

--- a/hooks/test/browser/useImperativeHandle.test.js
+++ b/hooks/test/browser/useImperativeHandle.test.js
@@ -179,4 +179,23 @@ describe('useImperativeHandle', () => {
 
 		expect(() => render(<Comp />, scratch)).to.not.throw();
 	});
+
+	it('should reset ref to null when the component get unmounted', () => {
+		let ref,
+			createHandleSpy = sinon.spy(() => ({ test: () => 'test' }));
+
+		function Comp() {
+			ref = useRef({});
+			useImperativeHandle(ref, createHandleSpy, [1]);
+			return <p>Test</p>;
+		}
+
+		render(<Comp />, scratch);
+		expect(createHandleSpy).to.have.been.calledOnce;
+		expect(ref.current).to.not.equal(null);
+
+		render(<div />, scratch);
+		expect(createHandleSpy).to.have.been.calledOnce;
+		expect(ref.current).to.equal(null);
+	});
 });


### PR DESCRIPTION
When the component get unmounted useImperativeHandle hook should reset ref to null state.

Example:
```js
const Component = forwardRef((props, ref) => {
  useImperativeHandle(ref, () => ({}));
  return <div>Test</div>;
});

export default function App() {
  const [mode, setMode] = useState(true);
  const ref = useRef();

  function onClick() {
    setMode(!mode);
  }

  return (
    <Fragment>
      <h1 onClick={onClick}>
        click me. value should change {+!!ref.current + 0}
      </h1>
      {mode ? <Component ref={ref} /> : <div>empty</div>}
    </Fragment>
  );
}
```

[Sandbox React](https://codesandbox.io/s/sleepy-dream-snkpyu)
[Sandbox Preact](https://codesandbox.io/s/frosty-cloud-z9crui)


[React reset ref.current to null on unmount event](https://github.com/facebook/react/blob/d5f1b067c8bbb826b823d0354a28ba31078b70c0/packages/react-reconciler/src/ReactFiberHooks.new.js#L1781) but Preact does not.