### PR TITLE
allow for passing in multiple refs through forwardRef

### DIFF
--- a/compat/src/forwardRef.js
+++ b/compat/src/forwardRef.js
@@ -33,7 +33,9 @@ export function forwardRef(fn) {
 		ref = props.ref || ref;
 		return fn(
 			clone,
-			!ref || (typeof ref === 'object' && !('current' in ref)) ? null : ref
+			!ref || (typeof ref === 'object' && Object.keys(ref).length === 0)
+				? null
+				: ref
 		);
 	}
 

--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -457,4 +457,18 @@ describe('forwardRef', () => {
 		render(App({}, null), scratch);
 		expect(actual).to.equal(null);
 	});
+
+	// Issue #3483
+	it('should allow for multiple refs', () => {
+		let actual;
+		const App = forwardRef((_, ref) => {
+			actual = ref;
+			return <div />;
+		});
+
+		const ref = { a: createRef(), b: createRef() };
+		// eslint-disable-next-line new-cap
+		render(<App ref={ref} />, scratch);
+		expect(actual).to.equal(ref);
+	});
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "preact",
 			"version": "10.6.6",
 			"license": "MIT",
 			"devDependencies": {


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/3483

We check for the absence of keys on the object as that is a better heuristic, when no ref is passed in we'll have an empty object (componentContext/state) which we checked for by doing `current in ref`