### PR TITLE
Simplify forwardRef

### DIFF
--- a/compat/src/forwardRef.js
+++ b/compat/src/forwardRef.js
@@ -24,9 +24,6 @@ export const REACT_FORWARD_SYMBOL =
  * @returns {import('./internal').FunctionComponent}
  */
 export function forwardRef(fn) {
-	// We always have ref in props.ref, except for
-	// mobx-react. It will call this function directly
-	// and always pass ref as the second argument.
 	function Forwarded(props) {
 		let clone = assign({}, props);
 		delete clone.ref;

--- a/compat/src/forwardRef.js
+++ b/compat/src/forwardRef.js
@@ -27,16 +27,10 @@ export function forwardRef(fn) {
 	// We always have ref in props.ref, except for
 	// mobx-react. It will call this function directly
 	// and always pass ref as the second argument.
-	function Forwarded(props, ref) {
+	function Forwarded(props) {
 		let clone = assign({}, props);
 		delete clone.ref;
-		ref = props.ref || ref;
-		return fn(
-			clone,
-			!ref || (typeof ref === 'object' && Object.keys(ref).length === 0)
-				? null
-				: ref
-		);
+		return fn(clone, props.ref);
 	}
 
 	// mobx-react checks for this being present

--- a/compat/src/forwardRef.js
+++ b/compat/src/forwardRef.js
@@ -30,7 +30,7 @@ export function forwardRef(fn) {
 	function Forwarded(props) {
 		let clone = assign({}, props);
 		delete clone.ref;
-		return fn(clone, props.ref);
+		return fn(clone, props.ref || null);
 	}
 
 	// mobx-react checks for this being present

--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -8,7 +8,8 @@ import React, {
 	useState,
 	useRef,
 	useImperativeHandle,
-	createPortal
+	createPortal,
+	Component
 } from 'preact/compat';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { setupRerender, act } from 'preact/test-utils';
@@ -470,5 +471,31 @@ describe('forwardRef', () => {
 		// eslint-disable-next-line new-cap
 		render(<App ref={ref} />, scratch);
 		expect(actual).to.equal(ref);
+	});
+
+	it('should not leak context into refs', () => {
+		class Provider extends Component {
+			getChildContext() {
+				return { foo: 2 };
+			}
+			render() {
+				return this.props.children;
+			}
+		}
+
+		let actual;
+		const Forwarded = forwardRef((_, ref) => {
+			actual = ref;
+			return <div />;
+		});
+
+		render(
+			<Provider>
+				<Forwarded />
+			</Provider>,
+			scratch
+		);
+
+		expect(actual).to.equal(null);
 	});
 });


### PR DESCRIPTION
The (re)use of the second argument here seems like it may have been to accommodate `forwardRef(forwardRef())`, but that is something that would be considered invalid usage of fowardRef - forwardRef creates a component that calls the given function (technically not function component) with `(props, ref)`, whereas a function component expects `(props, context)`.