### PR TITLE
add missing stuff for react 18

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -117,8 +117,29 @@ const flushSync = (callback, arg) => callback(arg);
  */
 const StrictMode = Fragment;
 
+const startTransition = callback => callback();
+const useTransition = () => {
+	const [isPending, setIsPending] = useState(false);
+
+	const start = cb => {
+		setIsPending(true);
+		cb();
+		setIsPending(false);
+	};
+	return [isPending, start];
+};
+
+const useDeferredValue = val => {
+	const value = useRef(val);
+	return value.current;
+};
+
 export * from 'preact/hooks';
 export {
+	useDeferredValue,
+	useTransition,
+	startTransition,
+	// Missing: useId, useSyncExternalStore and useInsertionEffect
 	version,
 	Children,
 	render,
@@ -149,6 +170,10 @@ export {
 
 // React copies the named exports to the default one.
 export default {
+	useDeferredValue,
+	useTransition,
+	startTransition,
+	// Missing: useId, useSyncExternalStore and useInsertionEffect
 	useState,
 	useReducer,
 	useEffect,

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -134,12 +134,41 @@ const useDeferredValue = val => {
 	return value.current;
 };
 
+const useSyncExternalStore = (subscribe, getSnapshot) => {
+	const value = getSnapshot();
+
+	const [state, setState] = useState(getSnapshot);
+
+	const newState = getSnapshot();
+	if (state !== newState) {
+		setState(newState);
+	}
+
+	useLayoutEffect(() => {
+		if (value !== state) {
+			setState(state);
+		}
+	}, [value, getSnapshot]);
+
+	useEffect(() => {
+		return subscribe(() => {
+			const newValue = getSnapshot();
+			if (newValue !== state) {
+				setState(newValue);
+			}
+		});
+	}, [subscribe, getSnapshot, state]);
+
+	return state;
+};
+
 export * from 'preact/hooks';
 export {
 	useDeferredValue,
+	useSyncExternalStore,
 	useTransition,
 	startTransition,
-	// Missing: useId, useSyncExternalStore and useInsertionEffect
+	// Missing: useId and useInsertionEffect
 	version,
 	Children,
 	render,
@@ -171,9 +200,10 @@ export {
 // React copies the named exports to the default one.
 export default {
 	useDeferredValue,
+	useSyncExternalStore,
 	useTransition,
 	startTransition,
-	// Missing: useId, useSyncExternalStore and useInsertionEffect
+	// Missing: useId and useInsertionEffect
 	useState,
 	useReducer,
 	useEffect,


### PR DESCRIPTION
These are some preliminary implementations for the v18 methods.

We are still missing useId which has a pending PR to main, useSyncExternalStore can essentially be a state and effect combination and useInsertionEffect can be a useLayoutEffect