### PR TITLE
add missing compat hooks for React 18

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -139,8 +139,8 @@ declare namespace React {
 	): void;
 	export const unstable_now: () => number;
 
-	export function useDefferedValue<T = any>(val: T): T;
-	export function useInsertionEffect(cb: () => void, deps: any[]): void;
+	export function useDeferredValue<T = any>(val: T): T;
+	export function useInsertionEffect(cb: () => void, deps?: any[]): void;
 	export function useTransition(): [boolean, (cb: () => void) => void];
 	export function useSyncExternalStore<T = any>(
 		subscribe: () => () => void,

--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -138,4 +138,12 @@ declare namespace React {
 		callback: () => void
 	): void;
 	export const unstable_now: () => number;
+
+	export function useDefferedValue<T = any>(val: T): T;
+	export function useInsertionEffect(cb: () => void, deps: any[]): void;
+	export function useTransition(): [boolean, (cb: () => void) => void];
+	export function useSyncExternalStore<T = any>(
+		subscribe: () => () => void,
+		getSnapshot: () => T
+	): T;
 }

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -19,6 +19,12 @@ import {
 	useContext,
 	useDebugValue
 } from 'preact/hooks';
+import {
+	useDeferredValue,
+	useInsertionEffect,
+	useSyncExternalStore,
+	useTransition
+} from './react-18-hooks';
 import { PureComponent } from './PureComponent';
 import { memo } from './memo';
 import { forwardRef } from './forwardRef';
@@ -119,6 +125,10 @@ const StrictMode = Fragment;
 
 export * from 'preact/hooks';
 export {
+	useDeferredValue,
+	useInsertionEffect,
+	useSyncExternalStore,
+	useTransition,
 	version,
 	Children,
 	render,
@@ -149,6 +159,10 @@ export {
 
 // React copies the named exports to the default one.
 export default {
+	useDeferredValue,
+	useInsertionEffect,
+	useSyncExternalStore,
+	useTransition,
 	useState,
 	useReducer,
 	useEffect,

--- a/compat/src/react-18-hooks.js
+++ b/compat/src/react-18-hooks.js
@@ -34,24 +34,18 @@ export const useInsertionEffect = useEffect;
 export function useSyncExternalStore(subscribe, getSnapshot) {
 	const [state, setState] = useState(getSnapshot);
 	const value = getSnapshot();
-	if (state !== value) {
-		setState(value);
-	}
 
 	useLayoutEffect(() => {
 		if (value !== state) {
-			setState(state);
+			setState(value);
 		}
 	}, [value]);
 
 	useEffect(() => {
 		return subscribe(() => {
-			const newValue = getSnapshot();
-			if (newValue !== state) {
-				setState(newValue);
-			}
+			setState(getSnapshot());
 		});
-	}, [subscribe, getSnapshot, state]);
+	}, [subscribe, getSnapshot]);
 
 	return state;
 }

--- a/compat/src/react-18-hooks.js
+++ b/compat/src/react-18-hooks.js
@@ -1,32 +1,11 @@
-import { useState, useLayoutEffect, useEffect } from 'preact/hooks';
-
-/**
- * Asynchronously schedule a callback
- * @type {(cb: () => void) => void}
- */
-/* istanbul ignore next */
-// Note the following line isn't tree-shaken by rollup cuz of rollup/rollup#2566
-const defer =
-	typeof Promise == 'function'
-		? Promise.prototype.then.bind(Promise.resolve())
-		: setTimeout;
+import { useState, useLayoutEffect, useEffect, useCallback } from 'preact/hooks';
 
 export function useDeferredValue(val) {
 	return val;
 }
 
 export function useTransition() {
-	const [isPending, setIsPending] = useState(false);
-
-	const start = cb => {
-		setIsPending(true);
-		cb();
-		defer(() => {
-			setIsPending(false);
-		});
-	};
-
-	return [isPending, start];
+  return [false, useCallback(cb => { cb(); }, [])];
 }
 
 export const useInsertionEffect = useEffect;

--- a/compat/src/react-18-hooks.js
+++ b/compat/src/react-18-hooks.js
@@ -1,0 +1,60 @@
+import { useState, useLayoutEffect, useEffect } from 'preact/hooks';
+
+/**
+ * Asynchronously schedule a callback
+ * @type {(cb: () => void) => void}
+ */
+/* istanbul ignore next */
+// Note the following line isn't tree-shaken by rollup cuz of rollup/rollup#2566
+const defer =
+	typeof Promise == 'function'
+		? Promise.prototype.then.bind(Promise.resolve())
+		: setTimeout;
+
+export function useDeferredValue(val) {
+	return val;
+}
+
+export function useTransition() {
+	const [isPending, setIsPending] = useState(false);
+
+	const start = cb => {
+		setIsPending(true);
+		cb();
+		defer(() => {
+			setIsPending(false);
+		});
+	};
+
+	return [isPending, start];
+}
+
+export const useInsertionEffect = useEffect;
+
+export function useSyncExternalStore(subscribe, getSnapshot) {
+	const [state, setState] = useState(getSnapshot);
+	const value = getSnapshot();
+	if (state !== value) {
+		setState(value);
+	}
+
+	useLayoutEffect(() => {
+		if (value !== state) {
+			setState(state);
+		}
+	}, [value]);
+
+	useEffect(() => {
+		return subscribe(() => {
+			const newValue = getSnapshot();
+			if (newValue !== state) {
+				setState(newValue);
+			}
+		});
+	}, [subscribe, getSnapshot, state]);
+
+	return state;
+}
+
+// TODO: useId... This could be a bit more challenging as RTS does not have
+// all the capabilities our common renderer has.

--- a/compat/test/browser/reactHooks.test.js
+++ b/compat/test/browser/reactHooks.test.js
@@ -56,7 +56,7 @@ describe('React-18-hooks', () => {
 	});
 
 	describe('useTransition', () => {
-		it('runs transitions', async () => {
+		it('runs transitions', () => {
 			const spy = sinon.spy();
 
 			let go;
@@ -72,10 +72,6 @@ describe('React-18-hooks', () => {
 			go(spy);
 			rerender();
 			expect(spy).to.be.calledOnce;
-			expect(scratch.innerHTML).to.equal('<p>Pending: yes</p>');
-
-			await new Promise(res => setTimeout(res, 10));
-			rerender();
 			expect(scratch.innerHTML).to.equal('<p>Pending: no</p>');
 		});
 	});

--- a/compat/test/browser/reactHooks.test.js
+++ b/compat/test/browser/reactHooks.test.js
@@ -97,5 +97,60 @@ describe('React-18-hooks', () => {
 			expect(subscribe).to.be.calledOnce;
 			expect(getSnapshot).to.be.calledTwice;
 		});
+
+		it('subscribes and rerenders when called', () => {
+			let flush;
+			const subscribe = sinon.spy(cb => {
+				flush = cb;
+			});
+			let called = false;
+			const getSnapshot = sinon.spy(() => {
+				if (called) {
+					return 'hello new world';
+				}
+
+				return 'hello world';
+			});
+
+			const App = () => {
+				const value = useSyncExternalStore(subscribe, getSnapshot);
+				return <p>{value}</p>;
+			};
+
+			act(() => {
+				render(<App />, scratch);
+			});
+			expect(scratch.innerHTML).to.equal('<p>hello world</p>');
+			expect(subscribe).to.be.calledOnce;
+			expect(getSnapshot).to.be.calledTwice;
+
+			called = true;
+			flush();
+			rerender();
+
+			expect(scratch.innerHTML).to.equal('<p>hello new world</p>');
+		});
+
+		it('uses new value if the first one is changed', () => {
+			const subscribe = sinon.spy();
+			let calls = 0;
+			const getSnapshot = sinon.spy(() => {
+				if (calls === 0) {
+					calls++;
+					return 'hello earth';
+				}
+				return 'hello world';
+			});
+
+			const App = () => {
+				const value = useSyncExternalStore(subscribe, getSnapshot);
+				return <p>{value}</p>;
+			};
+
+			act(() => {
+				render(<App />, scratch);
+			});
+			expect(scratch.innerHTML).to.equal('<p>hello world</p>');
+		});
 	});
 });

--- a/compat/test/browser/reactHooks.test.js
+++ b/compat/test/browser/reactHooks.test.js
@@ -1,0 +1,101 @@
+import React, {
+	createElement,
+	useDeferredValue,
+	useInsertionEffect,
+	useSyncExternalStore,
+	useTransition,
+	render
+} from 'preact/compat';
+import { setupRerender, act } from 'preact/test-utils';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+
+describe('React-18-hooks', () => {
+	/** @type {HTMLDivElement} */
+	let scratch;
+
+	/** @type {() => void} */
+	let rerender;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+		rerender = setupRerender();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	describe('useDeferredValue', () => {
+		it('returns the value', () => {
+			const App = props => {
+				const val = useDeferredValue(props.text);
+				return <p>{val}</p>;
+			};
+
+			render(<App text="hello world" />, scratch);
+
+			expect(scratch.innerHTML).to.equal('<p>hello world</p>');
+		});
+	});
+
+	describe('useInsertionEffect', () => {
+		it('runs the effect', () => {
+			const spy = sinon.spy();
+			const App = () => {
+				useInsertionEffect(spy, []);
+				return <p>hello world</p>;
+			};
+
+			act(() => {
+				render(<App />, scratch);
+			});
+
+			expect(scratch.innerHTML).to.equal('<p>hello world</p>');
+			expect(spy).to.be.calledOnce;
+		});
+	});
+
+	describe('useTransition', () => {
+		it('runs transitions', async () => {
+			const spy = sinon.spy();
+
+			let go;
+			const App = () => {
+				const [isPending, start] = useTransition();
+				go = start;
+				return <p>Pending: {isPending ? 'yes' : 'no'}</p>;
+			};
+
+			render(<App />, scratch);
+			expect(scratch.innerHTML).to.equal('<p>Pending: no</p>');
+
+			go(spy);
+			rerender();
+			expect(spy).to.be.calledOnce;
+			expect(scratch.innerHTML).to.equal('<p>Pending: yes</p>');
+
+			await new Promise(res => setTimeout(res, 10));
+			rerender();
+			expect(scratch.innerHTML).to.equal('<p>Pending: no</p>');
+		});
+	});
+
+	describe('useSyncExternalStore', () => {
+		it('subscribes and follows effects', () => {
+			const subscribe = sinon.spy();
+			const getSnapshot = sinon.spy(() => 'hello world');
+
+			const App = () => {
+				const value = useSyncExternalStore(subscribe, getSnapshot);
+				return <p>{value}</p>;
+			};
+
+			act(() => {
+				render(<App />, scratch);
+			});
+			expect(scratch.innerHTML).to.equal('<p>hello world</p>');
+			expect(subscribe).to.be.calledOnce;
+			expect(getSnapshot).to.be.calledTwice;
+		});
+	});
+});


### PR DESCRIPTION
This has a bit more considerations compared to #3498 and tries to account for

- a transition essentially happening after a microtick, we could use other heuristics if someone knows better ones 😅  but yes React hooks into the task queue
- useDeferredValue as rightfully pointed out by @gaearon we do not have to do anything special here (thanks for the feedback again)
- useInsertionEffect from the React implementation looks like a `useEffect` correct me if I am wrong please
- useSyncExternalStore is actually close to the React implementation but skipped some hoops they use for ensuring value consistency during a render (with regards to interrupts, ..)

Currently we are missing useId #3402  does a first attempt at that in our new structure but I noticed we miss `_depth` and `_parent` references in `render-to-string` which could complicate this a bit.

A bit of a personal opinion here, I do think we should add `useId` to `preact/hooks` as it seems like a really useful one to me

> note that this bundle size will most likely be tree-shaken out for _most_ people