### PR TITLE
Fix cleanup of `debounceRendering` hook after exceptions

### DIFF
--- a/test-utils/src/index.js
+++ b/test-utils/src/index.js
@@ -61,11 +61,12 @@ export function act(cb) {
 				toFlush();
 				rerender();
 			}
-			teardown();
 		} catch (e) {
 			if (!err) {
 				err = e;
 			}
+		} finally {
+			teardown();
 		}
 
 		options.requestAnimationFrame = previousRequestAnimationFrame;

--- a/test-utils/test/shared/act.test.js
+++ b/test-utils/test/shared/act.test.js
@@ -466,6 +466,22 @@ describe('act', () => {
 				expect(scratch.textContent).to.equal('1');
 			});
 
+			it('should restore custom `debounceRendering` hook', () => {
+				const prevDebounce = options.debounceRendering;
+				const tempDebounce = () => {};
+				options.debounceRendering = tempDebounce;
+
+				try {
+					renderBrokenEffect();
+				} catch (e) {}
+
+				try {
+					expect(options.debounceRendering).to.equal(tempDebounce);
+				} finally {
+					options.debounceRendering = prevDebounce;
+				}
+			});
+
 			it('should not affect effects in future renders', () => {
 				try {
 					renderBrokenEffect();


### PR DESCRIPTION
Fix cleanup of the `options.debounceRendering` hook when an effect run
during an `act` callback throws. Failing to reset this hook could cause
subsequent state updates happening outside of `act` for not to be applied.