### PR TITLE
add `server.browser.js`

### DIFF
--- a/compat/server.browser.js
+++ b/compat/server.browser.js
@@ -1,0 +1,4 @@
+export {
+	renderToString,
+	renderToString as renderToStaticMarkup
+} from 'preact-render-to-string';

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
 			"require": "./compat/client.js"
 		},
 		"./compat/server": {
+			"browser": "./compat/server.browser.js",
 			"import": "./compat/server.mjs",
 			"require": "./compat/server.js"
 		},
@@ -202,6 +203,7 @@
 		"compat/src",
 		"compat/client.js",
 		"compat/client.mjs",
+		"compat/server.browser.js",
 		"compat/server.js",
 		"compat/server.mjs",
 		"compat/scheduler.js",


### PR DESCRIPTION
comply with react's new server file, all though they export CJS and we do ESM https://www.runpkg.com/?react-dom@18.1.0/server.browser.js

Fixes https://github.com/preactjs/preact/issues/3543