### PR TITLE
implement state settling in X

### DIFF
--- a/hooks/test/browser/useEffect.test.js
+++ b/hooks/test/browser/useEffect.test.js
@@ -503,4 +503,30 @@ describe('useEffect', () => {
 			'Parent - Effect'
 		]);
 	});
+
+	it('should cancel effects from a disposed render', () => {
+		const calls = [];
+		const App = () => {
+			const [greeting, setGreeting] = useState('bye');
+
+			useEffect(() => {
+				calls.push('doing effect' + greeting);
+				return () => {
+					calls.push('cleaning up' + greeting);
+				};
+			}, [greeting]);
+
+			if (greeting === 'bye') {
+				setGreeting('hi');
+			}
+
+			return <p>{greeting}</p>;
+		};
+
+		act(() => {
+			render(<App />, scratch);
+		});
+		expect(calls.length).to.equal(1);
+		expect(calls).to.deep.equal(['doing effecthi']);
+	});
 });

--- a/hooks/test/browser/useLayoutEffect.test.js
+++ b/hooks/test/browser/useLayoutEffect.test.js
@@ -386,4 +386,30 @@ describe('useLayoutEffect', () => {
 			'Parent - Effect'
 		]);
 	});
+
+	it('should cancel effects from a disposed render', () => {
+		const calls = [];
+		const App = () => {
+			const [greeting, setGreeting] = useState('bye');
+
+			useLayoutEffect(() => {
+				calls.push('doing effect' + greeting);
+				return () => {
+					calls.push('cleaning up' + greeting);
+				};
+			}, [greeting]);
+
+			if (greeting === 'bye') {
+				setGreeting('hi');
+			}
+
+			return <p>{greeting}</p>;
+		};
+
+		act(() => {
+			render(<App />, scratch);
+		});
+		expect(calls.length).to.equal(1);
+		expect(calls).to.deep.equal(['doing effecthi']);
+	});
 });

--- a/hooks/test/browser/useState.test.js
+++ b/hooks/test/browser/useState.test.js
@@ -226,7 +226,9 @@ describe('useState', () => {
 			return <p>{greeting}</p>;
 		};
 
-		render(<App />, scratch);
+		act(() => {
+			render(<App />, scratch);
+		});
 		expect(calls.length).to.equal(2);
 		expect(calls).to.deep.equal(['bye', 'hi']);
 		expect(scratch.textContent).to.equal('hi');

--- a/hooks/test/browser/useState.test.js
+++ b/hooks/test/browser/useState.test.js
@@ -1,4 +1,4 @@
-import { setupRerender } from 'preact/test-utils';
+import { setupRerender, act } from 'preact/test-utils';
 import { createElement, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useState } from 'preact/hooks';

--- a/hooks/test/browser/useState.test.js
+++ b/hooks/test/browser/useState.test.js
@@ -211,4 +211,24 @@ describe('useState', () => {
 		rerender();
 		expect(scratch.innerHTML).to.equal('');
 	});
+
+	it('should render a second time when the render function updates state', () => {
+		const calls = [];
+		const App = () => {
+			const [greeting, setGreeting] = useState('bye');
+
+			if (greeting === 'bye') {
+				setGreeting('hi');
+			}
+
+			calls.push(greeting);
+
+			return <p>{greeting}</p>;
+		};
+
+		render(<App />, scratch);
+		expect(calls.length).to.equal(2);
+		expect(calls).to.deep.equal(['bye', 'hi']);
+		expect(scratch.textContent).to.equal('hi');
+	});
 });


### PR DESCRIPTION
Supersedes https://github.com/preactjs/preact/pull/3522
Mirrors https://github.com/preactjs/preact/pull/3440 from Preact 11

This introduces state settling like React in Preact, this is something some libraries rely on to have states settle after a given amount of renders.

Codesandbox as illustration https://codesandbox.io/s/young-cdn-jof35q?file=/src/index.js