### PR TITLE
make createRoot / hydrateRoot compatible with React spec

### DIFF
--- a/compat/client.js
+++ b/compat/client.js
@@ -1,13 +1,19 @@
-const { render, hydrate } = require('preact/compat');
+const { render, hydrate, unmountComponentAtNode } = require('preact/compat');
 
-exports.createRoot = function(container) {
+function createRoot(container) {
 	return {
 		render(children) {
-			return render(children, container);
+			render(children, container);
+		},
+		unmount() {
+			unmountComponentAtNode(container);
 		}
 	};
-};
+}
+
+exports.createRoot = createRoot;
 
 exports.hydrateRoot = function(container, children) {
-	return hydrate(children, container);
+	hydrate(children, container);
+	return createRoot(container);
 };

--- a/compat/client.mjs
+++ b/compat/client.mjs
@@ -1,13 +1,17 @@
-import { render, hydrate } from 'preact/compat'
+import { render, hydrate, unmountComponentAtNode } from 'preact/compat'
 
 export function createRoot(container) {
 	return {
 		render(children) {
-			return render(children, container)
+			render(children, container)
+		},
+		unmount() {
+			unmountComponentAtNode(container)
 		}
 	}
 }
 
 export function hydrateRoot(container, children) {
-	return hydrate(children, container);
+	hydrate(children, container)
+	return createRoot(container)
 }


### PR DESCRIPTION
* hydrateRoot returns Root instance
    * https://github.com/facebook/react/blob/v18.0.0/packages/react-dom/src/client/ReactDOMRoot.js#L255-L259
* Root instance has `unmount()` method
* `Root.prototype.render()` and `Root.prototype.unmount()` returns void
    * ref. https://github.com/facebook/react/blob/v17.0.2/packages/react-dom/src/client/ReactDOMRoot.js#L15-L20