### PR TITLE
Clear pending state from repeated renders

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -41,19 +41,17 @@ options._render = vnode => {
 			hooks._pendingEffects = [];
 			currentComponent._renderCallbacks = [];
 			hooks._list.forEach(hookItem => {
-				if (hookItem._pendingArgs) hookItem._pendingArgs = undefined;
-				if (hookItem._pendingValue) hookItem._pendingValue = undefined;
+				hookItem._pendingValue = hookItem._pendingArgs = undefined;
 			});
 		} else {
 			hooks._list.forEach(hookItem => {
 				if (hookItem._pendingArgs) {
 					hookItem._args = hookItem._pendingArgs;
-					hookItem._pendingArgs = undefined;
 				}
 				if (hookItem._pendingValue) {
 					hookItem._value = hookItem._pendingValue;
-					hookItem._pendingValue = undefined;
 				}
+				hookItem._pendingValue = hookItem._pendingArgs = undefined;
 			});
 			hooks._pendingEffects.forEach(invokeCleanup);
 			hooks._pendingEffects.forEach(invokeEffect);
@@ -81,12 +79,11 @@ options._commit = (vnode, commitQueue) => {
 				component.__hooks._list.forEach(hookItem => {
 					if (hookItem._pendingArgs) {
 						hookItem._args = hookItem._pendingArgs;
-						hookItem._pendingArgs = undefined;
 					}
 					if (hookItem._pendingValue) {
 						hookItem._value = hookItem._pendingValue;
-						hookItem._pendingValue = undefined;
 					}
+					hookItem._pendingValue = hookItem._pendingArgs = undefined;
 				});
 			}
 

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -195,7 +195,7 @@ export function useEffect(callback, args) {
 	/** @type {import('./internal').EffectHookState} */
 	const state = getHookState(currentIndex++, 3);
 	if (!options._skipEffects && argsChanged(state._args, args)) {
-		state._pendingValue = callback;
+		state._value = callback;
 		state._pendingArgs = args;
 
 		currentComponent.__hooks._pendingEffects.push(state);
@@ -210,7 +210,7 @@ export function useLayoutEffect(callback, args) {
 	/** @type {import('./internal').EffectHookState} */
 	const state = getHookState(currentIndex++, 4);
 	if (!options._skipEffects && argsChanged(state._args, args)) {
-		state._pendingValue = callback;
+		state._value = callback;
 		state._pendingArgs = args;
 
 		currentComponent._renderCallbacks.push(state);

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -48,7 +48,6 @@ export type Cleanup = () => void;
 
 export interface EffectHookState {
 	_value?: Effect;
-	_pendingValue?: any;
 	_args?: any[];
 	_pendingArgs?: any[];
 	_cleanup?: Cleanup | void;

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -48,13 +48,17 @@ export type Cleanup = () => void;
 
 export interface EffectHookState {
 	_value?: Effect;
+	_pendingValue?: any;
 	_args?: any[];
+	_pendingArgs?: any[];
 	_cleanup?: Cleanup | void;
 }
 
 export interface MemoHookState {
 	_value?: any;
+	_pendingValue?: any;
 	_args?: any[];
+	_pendingArgs?: any[];
 	_factory?: () => any;
 }
 

--- a/hooks/test/browser/useEffect.test.js
+++ b/hooks/test/browser/useEffect.test.js
@@ -529,4 +529,68 @@ describe('useEffect', () => {
 		expect(calls.length).to.equal(1);
 		expect(calls).to.deep.equal(['doing effecthi']);
 	});
+
+	it('should not rerun committed effects', () => {
+		const calls = [];
+		const App = ({ i }) => {
+			const [greeting, setGreeting] = useState('hi');
+
+			useEffect(() => {
+				calls.push('doing effect' + greeting);
+				return () => {
+					calls.push('cleaning up' + greeting);
+				};
+			}, []);
+
+			if (i === 2) {
+				setGreeting('bye');
+			}
+
+			return <p>{greeting}</p>;
+		};
+
+		act(() => {
+			render(<App />, scratch);
+		});
+		expect(calls.length).to.equal(1);
+		expect(calls).to.deep.equal(['doing effecthi']);
+
+		act(() => {
+			render(<App i={2} />, scratch);
+		});
+	});
+
+	it('should not schedule effects that have no change', () => {
+		const calls = [];
+		let set;
+		const App = ({ i }) => {
+			const [greeting, setGreeting] = useState('hi');
+			set = setGreeting;
+
+			useEffect(() => {
+				calls.push('doing effect' + greeting);
+				return () => {
+					calls.push('cleaning up' + greeting);
+				};
+			}, [greeting]);
+
+			if (greeting === 'bye') {
+				setGreeting('hi');
+			}
+
+			return <p>{greeting}</p>;
+		};
+
+		act(() => {
+			render(<App />, scratch);
+		});
+		expect(calls.length).to.equal(1);
+		expect(calls).to.deep.equal(['doing effecthi']);
+
+		act(() => {
+			set('bye');
+		});
+		expect(calls.length).to.equal(1);
+		expect(calls).to.deep.equal(['doing effecthi']);
+	});
 });


### PR DESCRIPTION
When we repeat a render as implemented in #3553, we need to clear new args/values to ensure that we don't repeat effects that don't result in a new state, this is needed for consistent rendering