### PR TITLE
Add `_pendingValue` to `mangle.json`

### DIFF
--- a/mangle.json
+++ b/mangle.json
@@ -31,6 +31,7 @@
       "$_list": "__",
       "$_pendingEffects": "__h",
       "$_value": "__",
+      "$_pendingValue": "__V",
       "$_original": "__v",
       "$_args": "__H",
       "$_factory": "__h",


### PR DESCRIPTION
PR #3567 added a new property to hooks for pending state. Devtools needs to be able to access these to be able to show them in the sidebar. With this PR we ensure that devtools can rely on a consistent name to access it.