### PR TITLE
Remove setState on unmounted component warning

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -377,13 +377,6 @@ Component.prototype.setState = function(update, callback) {
 					`"this.state = {}" directly.\n\n${getOwnerStack(getCurrentVNode())}`
 			);
 		}
-	} else if (this._parentDom == null) {
-		console.warn(
-			`Can't call "this.setState" on an unmounted component. This is a no-op, ` +
-				`but it indicates a memory leak in your application. To fix, cancel all ` +
-				`subscriptions and asynchronous tasks in the componentWillUnmount method.` +
-				`\n\n${getOwnerStack(this._vnode)}`
-		);
 	}
 
 	return setState.call(this, update, callback);

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -190,29 +190,6 @@ describe('debug', () => {
 		expect(console.warn).to.not.be.called;
 	});
 
-	it('should warn when calling setState on an unmounted Component', () => {
-		let setState;
-
-		class Foo extends Component {
-			constructor(props) {
-				super(props);
-				setState = () => this.setState({ foo: true });
-			}
-			render() {
-				return <div>foo</div>;
-			}
-		}
-
-		render(<Foo />, scratch);
-		expect(console.warn).to.not.be.called;
-
-		render(null, scratch);
-
-		setState();
-		expect(console.warn).to.be.calledOnce;
-		expect(console.warn.args[0]).to.match(/no-op/);
-	});
-
 	it('should warn when calling forceUpdate inside the constructor', () => {
 		class Foo extends Component {
 			constructor(props) {


### PR DESCRIPTION
As discussed in https://github.com/preactjs/preact/issues/3470 this warning can cause unwarranted concern in users.

Following the path of React, where this warning was removed https://github.com/facebook/react/pull/22114#issuecomment-929191048 it can likely be similarly removed from Preact.

Basically, Preact already checks if the component is unmounted, hence its ability to provide the warning, and most users that run into this implement anti-patterns to suppress the warning instead of addressing the actual issue being warned about.

The actual issue is less likely to be an indication of a real memory leak, and more likely to be just a single late update.

With all this in mind, it makes sense to also remove the warning here.

What this does:
- Removes the warning for setting state after a component has unmounted
- Removes test that checked for warning

Resolves #3470