### PR TITLE
Add support for svg property shape-rendering

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -10,7 +10,7 @@ export const REACT_ELEMENT_TYPE =
 	(typeof Symbol != 'undefined' && Symbol.for && Symbol.for('react.element')) ||
 	0xeac7;
 
-const CAMEL_PROPS = /^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|dominant|fill|flood|font|glyph(?!R)|horiz|marker(?!H|W|U)|overline|paint|stop|strikethrough|stroke|text(?!L)|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/;
+const CAMEL_PROPS = /^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|dominant|fill|flood|font|glyph(?!R)|horiz|marker(?!H|W|U)|overline|paint|shape|stop|strikethrough|stroke|text(?!L)|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/;
 
 const IS_DOM = typeof document !== 'undefined';
 

--- a/compat/test/browser/svg.test.js
+++ b/compat/test/browser/svg.test.js
@@ -74,6 +74,7 @@ describe('svg', () => {
 				clipRule="value"
 				clipPathUnits="value"
 				glyphOrientationHorizontal="value"
+				shapeRendering="crispEdges"
 				glyphRef="value"
 				markerStart="value"
 				markerHeight="value"
@@ -87,7 +88,7 @@ describe('svg', () => {
 
 		expect(serializeHtml(scratch)).to.eql(
 			sortAttributes(
-				'<svg clip-path="value" clip-rule="value" clipPathUnits="value" glyph-orientationhorizontal="value" glyphRef="value" marker-start="value" markerHeight="value" markerUnits="value" markerWidth="value" x1="value" xChannelSelector="value"></svg>'
+				'<svg clip-path="value" clip-rule="value" clipPathUnits="value" glyph-orientationhorizontal="value" shape-rendering="crispEdges" glyphRef="value" marker-start="value" markerHeight="value" markerUnits="value" markerWidth="value" x1="value" xChannelSelector="value"></svg>'
 			)
 		);
 	});


### PR DESCRIPTION
Adding support for the conversion from `shapeRendering` to `shape-rendering` as a SVG property as it seems to be missing.

[Reproducible demo](https://codesandbox.io/s/infallible-pond-o53o79?file=/src/index.js)
[SVG docs - shape-rendering](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/shape-rendering)