### PR TITLE
fix: commit hooks in options.diffed

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -65,28 +65,24 @@ options.diffed = vnode => {
 	if (oldAfterDiff) oldAfterDiff(vnode);
 
 	const c = vnode._component;
-	if (c && c.__hooks && c.__hooks._pendingEffects.length) {
-		afterPaint(afterPaintEffects.push(c));
+	if (c && c.__hooks) {
+		if (c.__hooks._pendingEffects.length) afterPaint(afterPaintEffects.push(c));
+		c.__hooks._list.forEach(hookItem => {
+			if (hookItem._pendingArgs) {
+				hookItem._args = hookItem._pendingArgs;
+			}
+			if (hookItem._pendingValue) {
+				hookItem._value = hookItem._pendingValue;
+			}
+			hookItem._pendingValue = hookItem._pendingArgs = undefined;
+		});
 	}
-	currentComponent = null;
-	previousComponent = null;
+	previousComponent = currentComponent = null;
 };
 
 options._commit = (vnode, commitQueue) => {
 	commitQueue.some(component => {
 		try {
-			if (component.__hooks) {
-				component.__hooks._list.forEach(hookItem => {
-					if (hookItem._pendingArgs) {
-						hookItem._args = hookItem._pendingArgs;
-					}
-					if (hookItem._pendingValue) {
-						hookItem._value = hookItem._pendingValue;
-					}
-					hookItem._pendingValue = hookItem._pendingArgs = undefined;
-				});
-			}
-
 			component._renderCallbacks.forEach(invokeCleanup);
 			component._renderCallbacks = component._renderCallbacks.filter(cb =>
 				cb._value ? invokeEffect(cb) : true

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -44,15 +44,6 @@ options._render = vnode => {
 				hookItem._pendingValue = hookItem._pendingArgs = undefined;
 			});
 		} else {
-			hooks._list.forEach(hookItem => {
-				if (hookItem._pendingArgs) {
-					hookItem._args = hookItem._pendingArgs;
-				}
-				if (hookItem._pendingValue) {
-					hookItem._value = hookItem._pendingValue;
-				}
-				hookItem._pendingValue = hookItem._pendingArgs = undefined;
-			});
 			hooks._pendingEffects.forEach(invokeCleanup);
 			hooks._pendingEffects.forEach(invokeEffect);
 			hooks._pendingEffects = [];


### PR DESCRIPTION
Commit hooks in diffed to bypass the issue of us dealing with a component that isn't in the commitQueue, components that are missing effects aren't admitted to the commitQueue and are essentially missing the commit of their pending arguments and values. This wasn't an issue in user-land as it would correct itself on the next invocation of `_render` because we would hit that `else` branch indicating that we are dealing with a new component.

This PR also means we can remove the updating of pending values in the else branch