### PR TITLE
10.8.2

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -2,7 +2,7 @@ import { options, Fragment, Component } from 'preact';
 
 export function initDevTools() {
 	if (typeof window != 'undefined' && window.__PREACT_DEVTOOLS__) {
-		window.__PREACT_DEVTOOLS__.attachPreact('10.8.1', options, {
+		window.__PREACT_DEVTOOLS__.attachPreact('10.8.2', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "preact",
-	"version": "10.8.1",
+	"version": "10.8.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "preact",
-			"version": "10.8.1",
+			"version": "10.8.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@actions/github": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "preact",
 	"amdName": "preact",
-	"version": "10.8.1",
+	"version": "10.8.2",
 	"private": false,
 	"description": "Fast 3kb React-compatible Virtual DOM library.",
 	"main": "dist/preact.js",


### PR DESCRIPTION
- Fix allow return `undefined` in `useMemo` after skipped render (#3580)
- Add support for svg property shape-rendering (#3577)
- Fix incorrect `useMemo` return value after skipped render (#3579)
- fix: commit hooks in options.diffed (#3578)
- Remove setState on unmounted component warning (#3576)
- Add `_pendingValue` to `mangle.json` (#3575)
- Improve unit tests to cover fix on #3573 (#3574)
- restrict "oninputCapture" conversion to just "oninput" vs "oninput*" (#3573)