### PR TITLE
Preact X useId

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -24,6 +24,7 @@ declare namespace React {
 	export import useDebugValue = _hooks.useDebugValue;
 	export import useEffect = _hooks.useEffect;
 	export import useImperativeHandle = _hooks.useImperativeHandle;
+	export import useId = _hooks.useId;
 	export import useLayoutEffect = _hooks.useLayoutEffect;
 	export import useMemo = _hooks.useMemo;
 	export import useReducer = _hooks.useReducer;

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -9,6 +9,7 @@ import {
 } from 'preact';
 import {
 	useState,
+	useId,
 	useReducer,
 	useEffect,
 	useLayoutEffect,
@@ -201,6 +202,7 @@ export {
 // React copies the named exports to the default one.
 export default {
 	useState,
+	useId,
 	useReducer,
 	useEffect,
 	useLayoutEffect,

--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -138,4 +138,4 @@ export function useErrorBoundary(
 	callback?: (error: any, errorInfo: ErrorInfo) => Promise<void> | void
 ): [any, () => void];
 
-export function useId<T>(): string;
+export function useId(): string;

--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -137,3 +137,5 @@ export function useDebugValue<T>(value: T, formatter?: (value: T) => any): void;
 export function useErrorBoundary(
 	callback?: (error: any, errorInfo: ErrorInfo) => Promise<void> | void
 ): [any, () => void];
+
+export function useId<T>(): string;

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -40,7 +40,7 @@ options._diff = vnode => {
 				? vnode._parent._children.indexOf(vnode)
 				: 0;
 		vnode._mask = parentMask + position;
-	} else {
+	} else if (!vnode._mask) {
 		vnode._mask = vnode._parent._mask;
 	}
 	currentComponent = null;

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -27,19 +27,16 @@ const RAF_TIMEOUT = 100;
 let prevRaf;
 
 options._diff = vnode => {
-	if (vnode.type === Fragment) {
-		// Skip so we don't have to ensure wrapping fragments in RTS and prepass
-		vnode._mask = '';
-	} else if (typeof vnode.type === 'function' && !vnode._mask) {
+	if (typeof vnode.type === "function" && !vnode._mask && vnode.type !== Fragment) {
 		const parentMask =
-			vnode._parent && vnode._parent._mask ? vnode._parent._mask : '';
+		vnode[PARENT] && vnode[PARENT]._mask ? vnode[PARENT]._mask : "";
 		const position =
-			vnode._parent && vnode._parent._children
-				? vnode._parent._children.indexOf(vnode)
-				: 0;
+		vnode[PARENT] && vnode[PARENT][CHILDREN]
+			? vnode[PARENT][CHILDREN].indexOf(vnode)
+			: 0;
 		vnode._mask = parentMask + position;
 	} else if (!vnode._mask) {
-		vnode._mask = vnode._parent._mask;
+		vnode._mask = vnode[PARENT] ? vnode[PARENT]._mask : "";
 	}
 	currentComponent = null;
 	if (oldBeforeDiff) oldBeforeDiff(vnode);

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -27,16 +27,20 @@ const RAF_TIMEOUT = 100;
 let prevRaf;
 
 options._diff = vnode => {
-	if (typeof vnode.type === "function" && !vnode._mask && vnode.type !== Fragment) {
+	if (
+		typeof vnode.type === 'function' &&
+		!vnode._mask &&
+		vnode.type !== Fragment
+	) {
 		const parentMask =
-		vnode[PARENT] && vnode[PARENT]._mask ? vnode[PARENT]._mask : "";
+			vnode._parent && vnode._parent._mask ? vnode._parent._mask : '';
 		const position =
-		vnode[PARENT] && vnode[PARENT][CHILDREN]
-			? vnode[PARENT][CHILDREN].indexOf(vnode)
-			: 0;
+			vnode._parent && vnode._parent._children
+				? vnode._parent._children.indexOf(vnode)
+				: 0;
 		vnode._mask = parentMask + position;
 	} else if (!vnode._mask) {
-		vnode._mask = vnode[PARENT] ? vnode[PARENT]._mask : "";
+		vnode._mask = vnode._parent ? vnode._parent._mask : '';
 	}
 	currentComponent = null;
 	if (oldBeforeDiff) oldBeforeDiff(vnode);

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -96,7 +96,6 @@ options._render = vnode => {
 };
 
 options._commit = (vnode, commitQueue) => {
-	mask = 0;
 	commitQueue.some(component => {
 		try {
 			component._renderCallbacks.forEach(invokeCleanup);

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -47,26 +47,6 @@ options._diff = vnode => {
 	if (oldBeforeDiff) oldBeforeDiff(vnode);
 };
 
-options.diffed = vnode => {
-	if (oldAfterDiff) oldAfterDiff(vnode);
-
-	const c = vnode._component;
-	if (c && c.__hooks) {
-		if (c.__hooks._pendingEffects.length) afterPaint(afterPaintEffects.push(c));
-		c.__hooks._list.forEach(hookItem => {
-			if (hookItem._pendingArgs) {
-				hookItem._args = hookItem._pendingArgs;
-			}
-			if (hookItem._pendingValue !== EMPTY) {
-				hookItem._value = hookItem._pendingValue;
-			}
-			hookItem._pendingArgs = undefined;
-			hookItem._pendingValue = EMPTY;
-		});
-	}
-	previousComponent = currentComponent = null;
-};
-
 options._render = vnode => {
 	if (oldBeforeRender) oldBeforeRender(vnode);
 
@@ -93,6 +73,26 @@ options._render = vnode => {
 		}
 	}
 	previousComponent = currentComponent;
+};
+
+options.diffed = vnode => {
+	if (oldAfterDiff) oldAfterDiff(vnode);
+
+	const c = vnode._component;
+	if (c && c.__hooks) {
+		if (c.__hooks._pendingEffects.length) afterPaint(afterPaintEffects.push(c));
+		c.__hooks._list.forEach(hookItem => {
+			if (hookItem._pendingArgs) {
+				hookItem._args = hookItem._pendingArgs;
+			}
+			if (hookItem._pendingValue !== EMPTY) {
+				hookItem._value = hookItem._pendingValue;
+			}
+			hookItem._pendingArgs = undefined;
+			hookItem._pendingValue = EMPTY;
+		});
+	}
+	previousComponent = currentComponent = null;
 };
 
 options._commit = (vnode, commitQueue) => {

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -383,13 +383,11 @@ export function useErrorBoundary(cb) {
 	];
 }
 
-function hash(s) {
-	let h = 0,
-		i = s.length;
-	while (i > 0) {
-		h = ((h << 5) - h + s.charCodeAt(--i)) | 0;
-	}
-	return h;
+function hash(str) {
+	let i = 0,
+		out = 11;
+	while (i < str.length) out = (101 * out + str.charCodeAt(i++)) >>> 0;
+	return out;
 }
 
 export function useId() {

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -1,4 +1,4 @@
-import { options } from 'preact';
+import { Fragment, options } from 'preact';
 
 /** @type {number} */
 let currentIndex;
@@ -26,15 +26,19 @@ let oldBeforeUnmount = options.unmount;
 const RAF_TIMEOUT = 100;
 let prevRaf;
 
-let mask = 0;
 let localIdCounter = 0;
 
 options._diff = vnode => {
 	if (typeof vnode.type === 'function' && !vnode._mask) {
-		vnode._mask =
-			vnode._parent && vnode._parent._mask
-				? vnode._parent && vnode._parent._mask + 1
-				: mask++;
+		const parentMask =
+			vnode._parent && vnode._parent._mask ? vnode._parent._mask : '';
+		const position =
+			vnode._parent && vnode._parent._children
+				? vnode._parent._children.indexOf(vnode)
+				: 0;
+		vnode._mask = parentMask + position;
+	} else {
+		vnode._mask = vnode._parent._mask;
 	}
 	currentComponent = null;
 	if (oldBeforeDiff) oldBeforeDiff(vnode);
@@ -380,7 +384,8 @@ export function useErrorBoundary(cb) {
 export function useId() {
 	const state = getHookState(currentIndex++, 11);
 	if (!state._value) {
-		state._value = '_P' + currentComponent._vnode._mask + localIdCounter++;
+		state._value =
+			'_P' + currentComponent._vnode._mask.toString(32) + localIdCounter++;
 	}
 
 	return state._value;

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -27,17 +27,19 @@ const RAF_TIMEOUT = 100;
 let prevRaf;
 
 options._diff = vnode => {
-	if (vnode.type === Fragment) {
-		// Skip so we don't have to ensure wrapping fragments in RTS and prepass
-		vnode._mask = '';
-	} else if (typeof vnode.type === 'function' && !vnode._mask) {
+	if (
+		typeof vnode.type === 'function' &&
+		!vnode._mask &&
+		vnode.type !== Fragment
+	) {
 		vnode._mask =
 			(vnode._parent && vnode._parent._mask ? vnode._parent._mask : '') +
 			(vnode._parent && vnode._parent._children
 				? vnode._parent._children.indexOf(vnode)
 				: 0);
-	} else {
-		vnode._mask = vnode._parent._mask;
+	} else if (!vnode._mask) {
+		vnode._mask =
+			vnode._parent && vnode._parent._mask ? vnode._parent._mask : '';
 	}
 
 	currentComponent = null;

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -41,13 +41,13 @@ options._diff = vnode => {
 			// this is the first component rendered and hasn't been seen, it's a root:
 			vnode._mask = mask = '';
 		} else {
-			// replace mask[depth] with the next character: (basically *mask[depth-1]++)
+			// replace mask[depth] with the next: (basically *mask[depth-1]++)
 			const offset = Number(mask[depth - 1]) + 1;
 			vnode._mask = mask = mask.slice(0, depth - 1) + offset;
 		}
-		// we're about to render the children of this component, push a new level onto the mask:
+
 		depth++;
-		mask += '0'; // next level starts off at the base character (code 65) again
+		mask += '0';
 	}
 	currentComponent = null;
 
@@ -85,7 +85,6 @@ options.diffed = vnode => {
 	if (oldAfterDiff) oldAfterDiff(vnode);
 
 	if (typeof vnode.type === 'function' && vnode.type !== Fragment) {
-		// jump back up the stack, remove the last char from the mask:
 		depth--;
 		mask = mask.slice(0, -1);
 	}

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -383,11 +383,19 @@ export function useErrorBoundary(cb) {
 	];
 }
 
+function hash(s) {
+	let h = 0,
+		i = s.length;
+	while (i > 0) {
+		h = ((h << 5) - h + s.charCodeAt(--i)) | 0;
+	}
+	return h;
+}
+
 export function useId() {
 	const state = getHookState(currentIndex++, 11);
 	if (!state._value) {
-		state._value =
-			'P' + currentComponent._vnode._mask.toString(32) + localIdCounter++;
+		state._value = 'P' + hash(currentComponent._vnode._mask) + localIdCounter++;
 	}
 
 	return state._value;

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -397,6 +397,7 @@ export function useErrorBoundary(cb) {
 export function useId() {
 	const state = getHookState(currentIndex++, 11);
 	if (!state._value) {
+		// TODO: consider Number(currentComponent._vnode._mask + currentIndex).toString(36)
 		state._value = 'P' + currentComponent._vnode._mask + '-' + currentIndex;
 	}
 

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -37,18 +37,22 @@ options._diff = vnode => {
 		if (vnode._mask) {
 			// already visited, pick up where we left off: (fixes subtree updates)
 			mask = vnode._mask;
+			depth = vnode._maskDepth;
 		} else if (depth === 0) {
 			// this is the first component rendered and hasn't been seen, it's a root:
 			vnode._mask = mask = '';
+			vnode._maskDepth = depth;
 		} else {
 			// replace mask[depth] with the next: (basically *mask[depth-1]++)
 			const offset = Number(mask[depth - 1]) + 1;
 			vnode._mask = mask = mask.slice(0, depth - 1) + offset;
+			vnode._maskDepth = depth;
 		}
 
 		depth++;
 		mask += '0';
 	}
+
 	currentComponent = null;
 
 	if (oldBeforeDiff) oldBeforeDiff(vnode);

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -26,8 +26,6 @@ let oldBeforeUnmount = options.unmount;
 const RAF_TIMEOUT = 100;
 let prevRaf;
 
-let localIdCounter = 0;
-
 options._diff = vnode => {
 	if (vnode.type === Fragment) {
 		// Skip so we don't have to ensure wrapping fragments in RTS and prepass
@@ -51,7 +49,6 @@ options._render = vnode => {
 	if (oldBeforeRender) oldBeforeRender(vnode);
 
 	currentComponent = vnode._component;
-	localIdCounter = 0;
 	currentIndex = 0;
 
 	const hooks = currentComponent.__hooks;
@@ -393,7 +390,7 @@ function hash(str) {
 export function useId() {
 	const state = getHookState(currentIndex++, 11);
 	if (!state._value) {
-		state._value = 'P' + hash(currentComponent._vnode._mask) + localIdCounter++;
+		state._value = 'P' + hash(currentComponent._vnode._mask + currentIndex);
 	}
 
 	return state._value;

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -26,15 +26,45 @@ let oldBeforeUnmount = options.unmount;
 const RAF_TIMEOUT = 100;
 let prevRaf;
 
+let mask = 0;
+let localIdCounter = 0;
+
 options._diff = vnode => {
+	if (typeof vnode.type === 'function' && !vnode._mask) {
+		vnode._mask =
+			vnode._parent && vnode._parent._mask
+				? vnode._parent && vnode._parent._mask + 1
+				: mask++;
+	}
 	currentComponent = null;
 	if (oldBeforeDiff) oldBeforeDiff(vnode);
+};
+
+options.diffed = vnode => {
+	if (oldAfterDiff) oldAfterDiff(vnode);
+
+	const c = vnode._component;
+	if (c && c.__hooks) {
+		if (c.__hooks._pendingEffects.length) afterPaint(afterPaintEffects.push(c));
+		c.__hooks._list.forEach(hookItem => {
+			if (hookItem._pendingArgs) {
+				hookItem._args = hookItem._pendingArgs;
+			}
+			if (hookItem._pendingValue !== EMPTY) {
+				hookItem._value = hookItem._pendingValue;
+			}
+			hookItem._pendingArgs = undefined;
+			hookItem._pendingValue = EMPTY;
+		});
+	}
+	previousComponent = currentComponent = null;
 };
 
 options._render = vnode => {
 	if (oldBeforeRender) oldBeforeRender(vnode);
 
 	currentComponent = vnode._component;
+	localIdCounter = 0;
 	currentIndex = 0;
 
 	const hooks = currentComponent.__hooks;
@@ -58,27 +88,8 @@ options._render = vnode => {
 	previousComponent = currentComponent;
 };
 
-options.diffed = vnode => {
-	if (oldAfterDiff) oldAfterDiff(vnode);
-
-	const c = vnode._component;
-	if (c && c.__hooks) {
-		if (c.__hooks._pendingEffects.length) afterPaint(afterPaintEffects.push(c));
-		c.__hooks._list.forEach(hookItem => {
-			if (hookItem._pendingArgs) {
-				hookItem._args = hookItem._pendingArgs;
-			}
-			if (hookItem._pendingValue !== EMPTY) {
-				hookItem._value = hookItem._pendingValue;
-			}
-			hookItem._pendingArgs = undefined;
-			hookItem._pendingValue = EMPTY;
-		});
-	}
-	previousComponent = currentComponent = null;
-};
-
 options._commit = (vnode, commitQueue) => {
+	mask = 0;
 	commitQueue.some(component => {
 		try {
 			component._renderCallbacks.forEach(invokeCleanup);
@@ -364,6 +375,15 @@ export function useErrorBoundary(cb) {
 			errState[1](undefined);
 		}
 	];
+}
+
+export function useId() {
+	const state = getHookState(currentIndex++, 11);
+	if (!state._value) {
+		state._value = '_P' + currentComponent._vnode._mask + localIdCounter++;
+	}
+
+	return state._value;
 }
 
 /**

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -29,7 +29,10 @@ let prevRaf;
 let localIdCounter = 0;
 
 options._diff = vnode => {
-	if (typeof vnode.type === 'function' && !vnode._mask) {
+	if (vnode.type === Fragment) {
+		// Skip so we don't have to ensure wrapping fragments in RTS and prepass
+		vnode._mask = '';
+	} else if (typeof vnode.type === 'function' && !vnode._mask) {
 		const parentMask =
 			vnode._parent && vnode._parent._mask ? vnode._parent._mask : '';
 		const position =
@@ -385,7 +388,7 @@ export function useId() {
 	const state = getHookState(currentIndex++, 11);
 	if (!state._value) {
 		state._value =
-			'_P' + currentComponent._vnode._mask.toString(32) + localIdCounter++;
+			'P' + currentComponent._vnode._mask.toString(32) + localIdCounter++;
 	}
 
 	return state._value;

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -1,7 +1,8 @@
 import {
 	Component as PreactComponent,
 	PreactContext,
-	ErrorInfo
+	ErrorInfo,
+	VNode as PreactVNode
 } from '../../src/internal';
 import { Reducer } from '.';
 
@@ -35,6 +36,10 @@ export interface ComponentHooks {
 
 export interface Component extends PreactComponent<any, any> {
 	__hooks?: ComponentHooks;
+}
+
+export interface VNode extends PreactVNode {
+	_mask?: string;
 }
 
 export type HookState =

--- a/hooks/test/browser/useId.test.js
+++ b/hooks/test/browser/useId.test.js
@@ -52,12 +52,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P00"><div id="P000"><span id="P001">h</span></div></div>'
+			'<div id="P480"><div id="P15360"><span id="P15361">h</span></div></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P00"><div id="P000"><span id="P001">h</span></div></div>'
+			'<div id="P480"><div id="P15360"><span id="P15361">h</span></div></div>'
 		);
 	});
 
@@ -80,12 +80,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P00"><span id="P000">h</span><span id="P010">h</span><span id="P020">h</span></div>'
+			'<div id="P480"><span id="P15360">h</span><span id="P15670">h</span><span id="P15980">h</span></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P00"><span id="P000">h</span><span id="P010">h</span><span id="P020">h</span></div>'
+			'<div id="P480"><span id="P15360">h</span><span id="P15670">h</span><span id="P15980">h</span></div>'
 		);
 	});
 });

--- a/hooks/test/browser/useId.test.js
+++ b/hooks/test/browser/useId.test.js
@@ -52,12 +52,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P480"><div id="P15360"><span id="P15361">h</span></div></div>'
+			'<div id="P11590"><div id="P1171070"><span id="P1171071">h</span></div></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P480"><div id="P15360"><span id="P15361">h</span></div></div>'
+			'<div id="P11590"><div id="P1171070"><span id="P1171071">h</span></div></div>'
 		);
 	});
 
@@ -80,12 +80,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P480"><span id="P15360">h</span><span id="P15670">h</span><span id="P15980">h</span></div>'
+			'<div id="P11590"><span id="P1171070">h</span><span id="P1171080">h</span><span id="P1171090">h</span></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P480"><span id="P15360">h</span><span id="P15670">h</span><span id="P15980">h</span></div>'
+			'<div id="P11590"><span id="P1171070">h</span><span id="P1171080">h</span><span id="P1171090">h</span></div>'
 		);
 	});
 });

--- a/hooks/test/browser/useId.test.js
+++ b/hooks/test/browser/useId.test.js
@@ -52,12 +52,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="_P10"><div id="_P20"><span id="_P21">h</span></div></div>'
+			'<div id="_P000"><div id="_P0000"><span id="_P0001">h</span></div></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="_P10"><div id="_P20"><span id="_P21">h</span></div></div>'
+			'<div id="_P000"><div id="_P0000"><span id="_P0001">h</span></div></div>'
 		);
 	});
 
@@ -80,12 +80,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="_P10"><span id="_P20">h</span><span id="_P30">h</span><span id="_P40">h</span></div>'
+			'<div id="_P000"><span id="_P0000">h</span><span id="_P0010">h</span><span id="_P0020">h</span></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="_P10"><span id="_P20">h</span><span id="_P30">h</span><span id="_P40">h</span></div>'
+			'<div id="_P000"><span id="_P0000">h</span><span id="_P0010">h</span><span id="_P0020">h</span></div>'
 		);
 	});
 });

--- a/hooks/test/browser/useId.test.js
+++ b/hooks/test/browser/useId.test.js
@@ -52,12 +52,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="_P000"><div id="_P0000"><span id="_P0001">h</span></div></div>'
+			'<div id="P00"><div id="P000"><span id="P001">h</span></div></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="_P000"><div id="_P0000"><span id="_P0001">h</span></div></div>'
+			'<div id="P00"><div id="P000"><span id="P001">h</span></div></div>'
 		);
 	});
 
@@ -80,12 +80,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="_P000"><span id="_P0000">h</span><span id="_P0010">h</span><span id="_P0020">h</span></div>'
+			'<div id="P00"><span id="P000">h</span><span id="P010">h</span><span id="P020">h</span></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="_P000"><span id="_P0000">h</span><span id="_P0010">h</span><span id="_P0020">h</span></div>'
+			'<div id="P00"><span id="P000">h</span><span id="P010">h</span><span id="P020">h</span></div>'
 		);
 	});
 });

--- a/hooks/test/browser/useId.test.js
+++ b/hooks/test/browser/useId.test.js
@@ -52,12 +52,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P11590"><div id="P1171070"><span id="P1171071">h</span></div></div>'
+			'<div id="P117108"><div id="P11827856"><span id="P11827857">h</span></div></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P11590"><div id="P1171070"><span id="P1171071">h</span></div></div>'
+			'<div id="P117108"><div id="P11827856"><span id="P11827857">h</span></div></div>'
 		);
 	});
 
@@ -80,12 +80,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P11590"><span id="P1171070">h</span><span id="P1171080">h</span><span id="P1171090">h</span></div>'
+			'<div id="P117108"><span id="P11827856">h</span><span id="P11827957">h</span><span id="P11828058">h</span></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P11590"><span id="P1171070">h</span><span id="P1171080">h</span><span id="P1171090">h</span></div>'
+			'<div id="P117108"><span id="P11827856">h</span><span id="P11827957">h</span><span id="P11828058">h</span></div>'
 		);
 	});
 });

--- a/hooks/test/browser/useId.test.js
+++ b/hooks/test/browser/useId.test.js
@@ -1,0 +1,91 @@
+import { createElement, render } from 'preact';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { useId } from 'preact/hooks';
+
+/** @jsx createElement */
+
+describe('useId', () => {
+	/** @type {HTMLDivElement} */
+	let scratch;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('keeps the id consistent after an update', () => {
+		function Comp() {
+			const id = useId();
+			return <div id={id} />;
+		}
+
+		render(<Comp />, scratch);
+		const id = scratch.firstChild.getAttribute('id');
+		expect(scratch.firstChild.getAttribute('id')).to.equal(id);
+
+		render(<Comp />, scratch);
+		expect(scratch.firstChild.getAttribute('id')).to.equal(id);
+	});
+
+	it('ids are unique according to dom-depth', () => {
+		function Child() {
+			const id = useId();
+			const spanId = useId();
+			return (
+				<div id={id}>
+					<span id={spanId}>h</span>
+				</div>
+			);
+		}
+
+		function Comp() {
+			const id = useId();
+			return (
+				<div id={id}>
+					<Child />
+				</div>
+			);
+		}
+
+		render(<Comp />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<div id="_P10"><div id="_P20"><span id="_P21">h</span></div></div>'
+		);
+
+		render(<Comp />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<div id="_P10"><div id="_P20"><span id="_P21">h</span></div></div>'
+		);
+	});
+
+	it('ids are unique across siblings', () => {
+		function Child() {
+			const id = useId();
+			return <span id={id}>h</span>;
+		}
+
+		function Comp() {
+			const id = useId();
+			return (
+				<div id={id}>
+					<Child />
+					<Child />
+					<Child />
+				</div>
+			);
+		}
+
+		render(<Comp />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<div id="_P10"><span id="_P20">h</span><span id="_P30">h</span><span id="_P40">h</span></div>'
+		);
+
+		render(<Comp />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<div id="_P10"><span id="_P20">h</span><span id="_P30">h</span><span id="_P40">h</span></div>'
+		);
+	});
+});

--- a/hooks/test/browser/useId.test.js
+++ b/hooks/test/browser/useId.test.js
@@ -54,12 +54,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P-1"><div id="P1-1"><span id="P1-2">h</span></div></div>'
+			'<div id="P481"><div id="P15361"><span id="P15362">h</span></div></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P-1"><div id="P1-1"><span id="P1-2">h</span></div></div>'
+			'<div id="P481"><div id="P15361"><span id="P15362">h</span></div></div>'
 		);
 	});
 
@@ -82,12 +82,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P-1"><span id="P1-1">h</span><span id="P2-1">h</span><span id="P3-1">h</span></div>'
+			'<div id="P481"><span id="P15361">h</span><span id="P15671">h</span><span id="P15981">h</span></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P-1"><span id="P1-1">h</span><span id="P2-1">h</span><span id="P3-1">h</span></div>'
+			'<div id="P481"><span id="P15361">h</span><span id="P15671">h</span><span id="P15981">h</span></div>'
 		);
 	});
 
@@ -120,13 +120,13 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P-1"><div><span id="P11-1">h</span></div></div>'
+			'<div id="P481"><div><span id="P476641">h</span></div></div>'
 		);
 
 		set(true);
 		rerender();
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P-1"><div><span id="P11-1">h</span><span id="P12-1">h</span></div></div>'
+			'<div id="P481"><div><span id="P476641">h</span><span id="P15671">h</span></div></div>'
 		);
 	});
 });

--- a/hooks/test/browser/useId.test.js
+++ b/hooks/test/browser/useId.test.js
@@ -126,7 +126,7 @@ describe('useId', () => {
 		set(true);
 		rerender();
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P-1"><div><span id="P11-1">h</span><span id="P2-1">h</span></div></div>'
+			'<div id="P-1"><div><span id="P11-1">h</span><span id="P12-1">h</span></div></div>'
 		);
 	});
 });

--- a/hooks/test/browser/useId.test.js
+++ b/hooks/test/browser/useId.test.js
@@ -126,7 +126,7 @@ describe('useId', () => {
 		set(true);
 		rerender();
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P481"><div><span id="P476641">h</span><span id="P15671">h</span></div></div>'
+			'<div id="P481"><div><span id="P476641">h</span><span id="P486251">h</span></div></div>'
 		);
 	});
 });

--- a/hooks/test/browser/useId.test.js
+++ b/hooks/test/browser/useId.test.js
@@ -52,12 +52,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P117108"><div id="P11827856"><span id="P11827857">h</span></div></div>'
+			'<div id="P-1"><div id="P1-1"><span id="P1-2">h</span></div></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P117108"><div id="P11827856"><span id="P11827857">h</span></div></div>'
+			'<div id="P-1"><div id="P1-1"><span id="P1-2">h</span></div></div>'
 		);
 	});
 
@@ -80,12 +80,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P117108"><span id="P11827856">h</span><span id="P11827957">h</span><span id="P11828058">h</span></div>'
+			'<div id="P-1"><span id="P1-1">h</span><span id="P2-1">h</span><span id="P3-1">h</span></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P117108"><span id="P11827856">h</span><span id="P11827957">h</span><span id="P11828058">h</span></div>'
+			'<div id="P-1"><span id="P1-1">h</span><span id="P2-1">h</span><span id="P3-1">h</span></div>'
 		);
 	});
 });


### PR DESCRIPTION
Currently to the thought of a [prefix tree](https://en.wikipedia.org/wiki/Trie) this would be an alternative to `useId`. This tries to follow our component tree and has a `mask` variable.

Resolves https://github.com/preactjs/preact/issues/3373

## Mount

Every time we encounter a component a long the way we will set `vnode._mask`  to the global counter we are following, this means that every node that _can_ generate an id will have a unique mask. When we invoke `useId` we will look at the `localIdCounter` (reset for every component we see) this with the combination of our prefix will ensure that we generate a consistent `id` even if we are invoking multiple `useId` calls.

## Mounting a new subtree

When we see a new subtree we will look at the parentMask and count from there, this however means that we could cause conflicts, ideally we would need to keep incrementing `mask`. If we can find a way to reset the `mask` counter for SSR environments we would bypass this.

## Notes

- We can optimize subsequent client-side renders by using a counter that increments after hydration but atm I don't think we have a good way to track this

DEMO:  https://codesandbox.io/s/crazy-platform-omyl5l?file=/src/hooks.js