### PR TITLE
Preact X controlled components

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -364,6 +364,21 @@ function diffElementNodes(
 			);
 		}
 
+		if (
+			(nodeType === 'input' ||
+				nodeType === 'textarea' ||
+				nodeType === 'select') &&
+			(newProps.onInput || newProps.onChange)
+		) {
+			if (newProps.value != null) {
+				dom._isControlled = true;
+				dom._prevValue = newProps.value;
+			} else if (newProps.checked != null) {
+				dom._isControlled = true;
+				dom._prevValue = newProps.checked;
+			}
+		}
+
 		// we created a new parent, so none of the previously attached children can be reused:
 		excessDomChildren = null;
 		// we are creating a new node, so we can assume this is a new subtree (in case we are hydrating), this deopts the hydrate
@@ -436,6 +451,12 @@ function diffElementNodes(
 					if (excessDomChildren[i] != null) removeNode(excessDomChildren[i]);
 				}
 			}
+		}
+
+		if (newProps.value != null && dom._isControlled) {
+			dom._prevValue = newProps.value;
+		} else if (newProps.checked != null && dom._isControlled) {
+			dom._prevValue = newProps.checked;
 		}
 
 		// (as above, don't diff props during hydration)

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -157,7 +157,7 @@ function eventProxy(e) {
 			const start = this.selectionStart;
 			const end = this.selectionEnd;
 			this.value = this._prevValue;
-			this.setSelectionRange(start, end, direction);
+			if (start != null) this.setSelectionRange(start, end, direction);
 		}
 		if (this.checked != null && e.type === 'change') {
 			this.checked = this._prevValue;

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -151,6 +151,14 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
  */
 function eventProxy(e) {
 	this._listeners[e.type + false](options.event ? options.event(e) : e);
+	if (this._isControlled) {
+		if (this.value != null && (e.type === 'input' || e.type === 'change')) {
+			this.value = this._prevValue;
+		}
+		if (this.checked != null && e.type === 'change') {
+			this.checked = this._prevValue;
+		}
+	}
 }
 
 function eventProxyCapture(e) {

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -153,7 +153,11 @@ function eventProxy(e) {
 	this._listeners[e.type + false](options.event ? options.event(e) : e);
 	if (this._isControlled) {
 		if (this.value != null && (e.type === 'input' || e.type === 'change')) {
+			const direction = this.selectionDirection;
+			const start = this.selectionStart;
+			const end = this.selectionEnd;
 			this.value = this._prevValue;
+			this.setSelectionRange(start, end, direction);
 		}
 		if (this.checked != null && e.type === 'change') {
 			this.checked = this._prevValue;


### PR DESCRIPTION
In this PR we introduce controlled components, however it runs into the selection issue shown [here](https://jovidecroock.com/blog/controlled-inputs) basically given the following code

```js
const Issue = () => {
  const [value, setValue] = useState('')

  const onInput = (e) => {
    if (e.currentTarget.value.length <= 3) {
      setValue(e.currentTarget.value)
    }
  }

  return <input value={value} onInput={onInput} />
}
```

When we type "aaaa" the fourth "a" won't appear, however if we go to the front of the input (start of selection) and type another a the selection will move our cursor to the end of the input.

You can try for yourself [here](https://codesandbox.io/s/inspiring-mayer-vmev4o?file=/src/index.js)

This can be fixed however with the following code: https://github.com/preactjs/preact/pull/3584/commits/b66ab9d19196b4a05236cb8dfbc5c0fcbc51c95d