### PR TITLE
Tree shake class components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "preact",
 			"version": "10.5.13",
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,13 @@
 		"Samsung>=8.2",
 		"not dead"
 	],
+  "sideEffects": [
+    "./compat/**/*",
+    "./debug/**/*",
+    "./devtools/**/*",
+    "./hooks/**/*",
+    "./test-utils/**/*"
+  ],
 	"exports": {
 		".": {
       "types": "./src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "preact",
 	"amdName": "preact",
-	"version": "10.5.13",
+	"version": "11.0.0-beta",
 	"private": false,
 	"description": "Fast 3kb React-compatible Virtual DOM library.",
 	"main": "dist/preact.js",

--- a/src/component.js
+++ b/src/component.js
@@ -5,6 +5,8 @@ import { patch } from './diff/patch';
 import { DIRTY_BIT, FORCE_UPDATE, MODE_UNMOUNTING } from './constants';
 import { getParentContext, getParentDom } from './tree';
 
+export let ENABLE_CLASSES = false;
+
 /**
  * The render queue
  * @type {import('./internal').RendererState}
@@ -23,6 +25,7 @@ export const rendererState = {
  * getChildContext
  */
 export function Component(props, context) {
+	ENABLE_CLASSES = true;
 	this.props = props;
 	this.context = context;
 }

--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -4,6 +4,7 @@ import {
 	MODE_PENDING_ERROR,
 	TYPE_COMPONENT
 } from '../constants';
+import { ENABLE_CLASSES } from '../component';
 
 /**
  * Find the closest error boundary to a thrown error and call it
@@ -19,13 +20,13 @@ export function _catchError(error, internal) {
 			~internal.flags & MODE_RERENDERING_ERROR
 		) {
 			try {
-				if (internal.type.getDerivedStateFromError) {
+				if (ENABLE_CLASSES && internal.type.getDerivedStateFromError) {
 					internal._component.setState(
 						internal.type.getDerivedStateFromError(error)
 					);
 				}
 
-				if (internal._component.componentDidCatch) {
+				if (ENABLE_CLASSES && internal._component.componentDidCatch) {
 					internal._component.componentDidCatch(error);
 				}
 

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -322,7 +322,7 @@ function mountComponent(internal, startDom) {
 
 	if (provider) provider._subs.add(internal);
 
-	if (ENABLE_CLASSES && internal.flags & TYPE_CLASS) {
+	if (internal.flags & TYPE_CLASS) {
 		// @ts-ignore `type` is a class component constructor
 		c = new type(newProps, componentContext);
 	} else {

--- a/src/diff/patch.js
+++ b/src/diff/patch.js
@@ -21,7 +21,7 @@ import {
 import { getDomSibling } from '../tree';
 import { mountChildren } from './mount';
 import { Fragment } from '../create-element';
-import { rendererState } from '../component';
+import { ENABLE_CLASSES, rendererState } from '../component';
 
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
@@ -225,41 +225,44 @@ function patchComponent(internal, newVNode) {
 		c._nextState = c.state;
 	}
 
-	if (type.getDerivedStateFromProps != null) {
-		if (c._nextState == c.state) {
-			c._nextState = Object.assign({}, c._nextState);
-		}
-
-		Object.assign(
-			c._nextState,
-			type.getDerivedStateFromProps(newProps, c._nextState)
-		);
-	}
-
 	let oldProps = c.props;
 	let oldState = c.state;
 
-	if (
-		type.getDerivedStateFromProps == null &&
-		newProps !== oldProps &&
-		c.componentWillReceiveProps != null
-	) {
-		c.componentWillReceiveProps(newProps, componentContext);
-	}
+	if (ENABLE_CLASSES) {
+		if (type.getDerivedStateFromProps != null) {
+			if (c._nextState == c.state) {
+				c._nextState = Object.assign({}, c._nextState);
+			}
 
-	if (
-		!(internal.flags & FORCE_UPDATE) &&
-		c.shouldComponentUpdate != null &&
-		c.shouldComponentUpdate(newProps, c._nextState, componentContext) === false
-	) {
-		c.props = newProps;
-		c.state = c._nextState;
-		internal.flags |= SKIP_CHILDREN;
-		return;
-	}
+			Object.assign(
+				c._nextState,
+				type.getDerivedStateFromProps(newProps, c._nextState)
+			);
+		}
 
-	if (c.componentWillUpdate != null) {
-		c.componentWillUpdate(newProps, c._nextState, componentContext);
+		if (
+			type.getDerivedStateFromProps == null &&
+			newProps !== oldProps &&
+			c.componentWillReceiveProps != null
+		) {
+			c.componentWillReceiveProps(newProps, componentContext);
+		}
+
+		if (
+			!(internal.flags & FORCE_UPDATE) &&
+			c.shouldComponentUpdate != null &&
+			c.shouldComponentUpdate(newProps, c._nextState, componentContext) ===
+				false
+		) {
+			c.props = newProps;
+			c.state = c._nextState;
+			internal.flags |= SKIP_CHILDREN;
+			return;
+		}
+
+		if (c.componentWillUpdate != null) {
+			c.componentWillUpdate(newProps, c._nextState, componentContext);
+		}
 	}
 
 	c.context = componentContext;
@@ -274,7 +277,7 @@ function patchComponent(internal, newVNode) {
 	while (counter++ < 25) {
 		internal.flags &= ~DIRTY_BIT;
 		if (renderHook) renderHook(internal);
-		if (internal.flags & TYPE_CLASS) {
+		if (ENABLE_CLASSES && internal.flags & TYPE_CLASS) {
 			renderResult = c.render(c.props, c.state, c.context);
 			// note: disable repeat render invocation for class components
 			break;
@@ -297,15 +300,17 @@ function patchComponent(internal, newVNode) {
 		);
 	}
 
-	if (c.getSnapshotBeforeUpdate != null) {
-		snapshot = c.getSnapshotBeforeUpdate(oldProps, oldState);
-	}
+	if (ENABLE_CLASSES) {
+		if (c.getSnapshotBeforeUpdate != null) {
+			snapshot = c.getSnapshotBeforeUpdate(oldProps, oldState);
+		}
 
-	// Only schedule componentDidUpdate if the component successfully rendered
-	if (c.componentDidUpdate != null) {
-		internal._commitCallbacks.push(() => {
-			c.componentDidUpdate(oldProps, oldState, snapshot);
-		});
+		// Only schedule componentDidUpdate if the component successfully rendered
+		if (c.componentDidUpdate != null) {
+			internal._commitCallbacks.push(() => {
+				c.componentDidUpdate(oldProps, oldState, snapshot);
+			});
+		}
 	}
 
 	if (renderResult == null) {

--- a/src/diff/unmount.js
+++ b/src/diff/unmount.js
@@ -2,6 +2,7 @@ import { MODE_UNMOUNTING, TYPE_DOM, TYPE_ROOT } from '../constants';
 import { unsubscribeFromContext } from '../create-context';
 import options from '../options';
 import { applyRef } from './refs';
+import { ENABLE_CLASSES } from '../component';
 
 /**
  * Unmount a virtual node from the tree and apply DOM changes
@@ -24,7 +25,7 @@ export function unmount(internal, parentInternal, skipRemove) {
 	if ((r = internal._component)) {
 		unsubscribeFromContext(internal);
 
-		if (r.componentWillUnmount) {
+		if (ENABLE_CLASSES && r.componentWillUnmount) {
 			try {
 				r.componentWillUnmount();
 			} catch (e) {


### PR DESCRIPTION
This PR introduces tree-shaking for class components, we have a test repo where we have tested this with vite and the results are 500bytes less!!!

```
## With class-components
$ vite build
vite v2.9.13 building for production...
✓ 5 modules transformed.
dist/index.html                 0.38 KiB
dist/assets/index.6f0ba079.js   11.62 KiB / gzip: 4.73 KiB
✨  Done in 0.81s.

## Without class-components
❯ yarn build
yarn run v1.22.17
$ vite build
vite v2.9.13 building for production...
✓ 5 modules transformed.
dist/index.html                 0.38 KiB
dist/assets/index.917e7781.js   10.04 KiB / gzip: 4.23 KiB
✨  Done in 0.70s.
```