### PR TITLE
Improve tree shaking in compat

### DIFF
--- a/compat/src/forwardRef.js
+++ b/compat/src/forwardRef.js
@@ -1,14 +1,18 @@
 import { options } from 'preact';
 
-let oldDiffHook = options._diff;
-options._diff = (internal, vnode) => {
-	if (internal.type && internal.type._forwarded && vnode.ref) {
-		vnode.props.ref = vnode.ref;
-		vnode.ref = null;
-		internal.ref = null;
-	}
-	if (oldDiffHook) oldDiffHook(internal, vnode);
-};
+export function setupRefForwarding() {
+	options._fowardingRefs = true;
+	let oldDiffHook = options._diff;
+	options._diff = (internal, vnode) => {
+		if (internal.type && internal.type._forwarded && vnode.ref) {
+			vnode.props.ref = vnode.ref;
+			vnode.ref = null;
+			internal.ref = null;
+		}
+		if (oldDiffHook) oldDiffHook(internal, vnode);
+	};
+}
+
 
 export const REACT_FORWARD_SYMBOL = Symbol.for('react.forward_ref');
 
@@ -20,6 +24,8 @@ export const REACT_FORWARD_SYMBOL = Symbol.for('react.forward_ref');
  * @returns {import('./internal').FunctionComponent}
  */
 export function forwardRef(fn) {
+	if (!options._forwardingRefs) setupRefForwarding()
+
 	function Forwarded(props) {
 		let clone = Object.assign({}, props);
 		delete clone.ref;

--- a/compat/src/memo.js
+++ b/compat/src/memo.js
@@ -1,4 +1,5 @@
-import { createElement, Component } from 'preact';
+import { createElement, Component, options } from 'preact';
+import { setupRefForwarding } from './forwardRef';
 import { shallowDiffers } from './util';
 
 /**
@@ -9,6 +10,8 @@ import { shallowDiffers } from './util';
  * @returns {import('./internal').FunctionComponent}
  */
 export function memo(c, comparer) {
+	if (!options._forwardingRefs) setupRefForwarding()
+
 	function Memoed() {}
 
 	Memoed.prototype = new Component();

--- a/compat/test/browser/events.test.js
+++ b/compat/test/browser/events.test.js
@@ -1,4 +1,4 @@
-import { render } from 'preact';
+import { render } from '../../src';
 import {
 	setupScratch,
 	teardown,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
 		"not dead"
 	],
   "sideEffects": [
-    "./compat/**/*",
     "./debug/**/*",
     "./devtools/**/*",
     "./hooks/**/*",

--- a/src/diff/patch.js
+++ b/src/diff/patch.js
@@ -241,22 +241,23 @@ function patchComponent(internal, newVNode) {
 		) {
 			c.componentWillReceiveProps(newProps, componentContext);
 		}
+	}
 
-		if (
-			!(internal.flags & FORCE_UPDATE) &&
-			c.shouldComponentUpdate != null &&
-			c.shouldComponentUpdate(newProps, c._nextState, componentContext) ===
-				false
-		) {
-			c.props = newProps;
-			c.state = c._nextState;
-			internal.flags |= SKIP_CHILDREN;
-			return;
-		}
+	if (
+		!(internal.flags & FORCE_UPDATE) &&
+		c.shouldComponentUpdate != null &&
+		c.shouldComponentUpdate(newProps, c._nextState, componentContext) ===
+			false
+	) {
+		c.props = newProps;
+		c.state = c._nextState;
+		internal.flags |= SKIP_CHILDREN;
+		internal.flags &= ~DIRTY_BIT;
+		return;
+	}
 
-		if (c.componentWillUpdate != null) {
-			c.componentWillUpdate(newProps, c._nextState, componentContext);
-		}
+	if (ENABLE_CLASSES && c.componentWillUpdate != null) {
+		c.componentWillUpdate(newProps, c._nextState, componentContext);
 	}
 
 	c.context = componentContext;


### PR DESCRIPTION
This would improve the tree-shakeability of compat, most of these can be done on-demand apart from the `options.vnode` one, that one should be part of our `jsx` hooks and `createElement`