### PR TITLE
Switch to setTimeout

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -149,7 +149,7 @@ export function enqueueRender(internal) {
 		prevDebounce !== options.debounceRendering
 	) {
 		prevDebounce = options.debounceRendering;
-		(prevDebounce || queueMicrotask)(process);
+		(prevDebounce || setTimeout)(process);
 	}
 }
 


### PR DESCRIPTION
This improves the general correctness of DOM-events in Preact, micro-ticks are fired in-between events bubbling up and events firing. This means that when two similar events fire and both are setting state that one will fire set state rerender and then the other one will. Similarly if we fire an event that sets some dom and the ancestor of this eventTarget also has a similar listener _after_ dom manipulation we will bubble up and refire the event....