### PR TITLE
Svg attributes improvements

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -10,7 +10,7 @@ export const REACT_ELEMENT_TYPE =
 	(typeof Symbol != 'undefined' && Symbol.for && Symbol.for('react.element')) ||
 	0xeac7;
 
-const CAMEL_PROPS = /^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|dominant|fill|flood|font|glyph(?!R)|horiz|marker(?!H|W|U)|overline|paint|shape|stop|strikethrough|stroke|text(?!L)|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/;
+const CAMEL_PROPS = /^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|dominant|fill|flood|font|glyph(?!R)|horiz|image|letter|lighting|marker(?!H|W|U)|overline|paint|pointer|shape|stop|strikethrough|stroke|text(?!L)|transform|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/;
 
 const IS_DOM = typeof document !== 'undefined';
 
@@ -156,7 +156,7 @@ options.vnode = vnode => {
 			} else if (/^on(Ani|Tra|Tou|BeforeInp|Compo)/.test(i)) {
 				i = i.toLowerCase();
 			} else if (nonCustomElement && CAMEL_PROPS.test(i)) {
-				i = i.replace(/[A-Z0-9]/, '-$&').toLowerCase();
+				i = i.replace(/[A-Z0-9]/g, '-$&').toLowerCase();
 			} else if (value === null) {
 				value = undefined;
 			}

--- a/compat/test/browser/svg.test.js
+++ b/compat/test/browser/svg.test.js
@@ -73,13 +73,22 @@ describe('svg', () => {
 				clipPath="value"
 				clipRule="value"
 				clipPathUnits="value"
+				colorInterpolationFilters="auto"
+				fontSizeAdjust="value"
 				glyphOrientationHorizontal="value"
+				glyphOrientationVertical="value"
 				shapeRendering="crispEdges"
 				glyphRef="value"
+				horizAdvX="value"
+				horizOriginX="value"
 				markerStart="value"
 				markerHeight="value"
 				markerUnits="value"
 				markerWidth="value"
+				unitsPerEm="value"
+				vertAdvY="value"
+				vertOriginX="value"
+				vertOriginY="value"
 				x1="value"
 				xChannelSelector="value"
 			/>,
@@ -88,7 +97,7 @@ describe('svg', () => {
 
 		expect(serializeHtml(scratch)).to.eql(
 			sortAttributes(
-				'<svg clip-path="value" clip-rule="value" clipPathUnits="value" glyph-orientationhorizontal="value" shape-rendering="crispEdges" glyphRef="value" marker-start="value" markerHeight="value" markerUnits="value" markerWidth="value" x1="value" xChannelSelector="value"></svg>'
+				'<svg clip-path="value" clip-rule="value" clipPathUnits="value" color-interpolation-filters="auto" font-size-adjust="value" glyph-orientation-horizontal="value" glyph-orientation-vertical="value" shape-rendering="crispEdges" glyphRef="value" horiz-adv-x="value" horiz-origin-x="value" marker-start="value" markerHeight="value" markerUnits="value" markerWidth="value" units-per-em="value" vert-adv-y="value" vert-origin-x="value" vert-origin-y="value" x1="value" xChannelSelector="value"></svg>'
 			)
 		);
 	});


### PR DESCRIPTION
Hi, guys! 

Added support for properties:

-   `image-rendering`
-   `letter-spacing`
-   `lighting-color`
-   `pointer-events`
-   `transform-origin`

Property conversion fixed:

-   `color-interpolation-filters`
-   `font-size-adjust`
-   `glyph-orientation-horizontal`
-   `glyph-orientation-vertical`
-   `horiz-adv-x`
-   `horiz-origin-x`
-   `units-per-em`
-   `vert-adv-y`
-   `vert-origin-x`
-   `vert-origin-y`

Old behavior:
- `colorInterpolationFilters` -> `color-interpolationfilters`
- `fontSizeAdjust` -> `font-sizeadjust`
- `glyphOrientationHorizontal` -> `glyph-orientationhorizontal`
- `glyphOrientationVertical` -> `glyph-orientationvertical`
- `horizAdvX` -> `horiz-advx`
- `horizOriginX` -> `horiz-originx`
- `unitsPerEm` -> `units-perem`
- `vertAdvY` -> `vert-advy`
- `vertOriginX` -> `vert-originx`
- `vertOriginY` -> `vert-originy`

New (correct) behavior:
- `colorInterpolationFilters` -> `color-interpolation-filters`
- `fontSizeAdjust` -> `font-size-adjust`
- `glyphOrientationHorizontal` -> `glyph-orientation-horizontal`
- `glyphOrientationVertical` -> `glyph-orientation-vertical`
- `horizAdvX` -> `horiz-adv-x`
- `horizOriginX` -> `horiz-origin-x`
- `unitsPerEm` -> `units-per-em`
- `vertAdvY` -> `vert-adv-y`
- `vertOriginX` -> `vert-origin-x`
- `vertOriginY` -> `vert-origin-y`

Added behavior validation tests
