### PR TITLE
defer bailing out of updates to the render phase

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -167,11 +167,15 @@ export function useReducer(reducer, initialState, init) {
 				const currentValue = hookState._nextValue
 					? hookState._nextValue[0]
 					: hookState._value[0];
-				hookState._nextValue = [
-					hookState._reducer(currentValue, action),
-					hookState._value[1]
-				];
-				hookState._component.setState({});
+				const nextValue = hookState._reducer(currentValue, action);
+
+				if (currentValue !== nextValue) {
+					hookState._nextValue = [
+						hookState._reducer(currentValue, action),
+						hookState._value[1]
+					];
+					hookState._component.setState({});
+				}
 			}
 		];
 

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -43,8 +43,11 @@ options._render = vnode => {
 			hooks._pendingEffects = [];
 			currentComponent._renderCallbacks = [];
 			hooks._list.forEach(hookItem => {
+				if (hookItem._nextValue) {
+					hookItem._value = hookItem._nextValue;
+				}
 				hookItem._pendingValue = EMPTY;
-				hookItem._pendingArgs = undefined;
+				hookItem._nextValue = hookItem._pendingArgs = undefined;
 			});
 		} else {
 			hooks._pendingEffects.forEach(invokeCleanup);

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -62,6 +62,7 @@ export interface MemoHookState {
 }
 
 export interface ReducerHookState {
+	_nextValue?: any;
 	_value?: any;
 	_component?: Component;
 	_reducer?: Reducer<any, any>;

--- a/mangle.json
+++ b/mangle.json
@@ -31,6 +31,7 @@
       "$_pendingEffects": "__h",
       "$_value": "__",
       "$_pendingValue": "__V",
+      "$_nextValue": "__N",
       "$_original": "__v",
       "$_args": "__H",
       "$_factory": "__h",


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/2715

This introduces a `_nextState` for our reducer/state hooks, what this effectively does is it will trigger a render for all WIP states and check in our `shouldComponentUpdate` whether we can bail or not. This increases our feature parity for bailing out of updates, React does this a bit later even post render-phase.