### PR TITLE
insert comments for adjacent text-nodes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 indent_style = tab
 end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = true
+trim_trailing_whitespace = false
 insert_final_newline = true
 
 [{*.json,.*rc,*.yml}]

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
 				"benchmark": "^2.1.4",
 				"chai": "^4.3.6",
 				"check-export-map": "^1.2.0",
+				"copyfiles": "^2.4.1",
 				"coveralls": "^3.1.1",
 				"cross-env": "^7.0.3",
 				"csstype": "^3.0.5",
@@ -4620,6 +4621,184 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/copyfiles": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+			"integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
+			"dev": true,
+			"dependencies": {
+				"glob": "^7.0.5",
+				"minimatch": "^3.0.3",
+				"mkdirp": "^1.0.4",
+				"noms": "0.0.0",
+				"through2": "^2.0.1",
+				"untildify": "^4.0.0",
+				"yargs": "^16.1.0"
+			},
+			"bin": {
+				"copyfiles": "copyfiles",
+				"copyup": "copyfiles"
+			}
+		},
+		"node_modules/copyfiles/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/copyfiles/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/copyfiles/node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/copyfiles/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/copyfiles/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/copyfiles/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/copyfiles/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/copyfiles/node_modules/mkdirp": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+			"dev": true,
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/copyfiles/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/copyfiles/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/copyfiles/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/copyfiles/node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/copyfiles/node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/copyfiles/node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/core-js-compat": {
@@ -11248,6 +11427,40 @@
 			"integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
 			"dev": true
 		},
+		"node_modules/noms": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+			"integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"readable-stream": "~1.0.31"
+			}
+		},
+		"node_modules/noms/node_modules/isarray": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+			"dev": true
+		},
+		"node_modules/noms/node_modules/readable-stream": {
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+			"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+			"dev": true,
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.1",
+				"isarray": "0.0.1",
+				"string_decoder": "~0.10.x"
+			}
+		},
+		"node_modules/noms/node_modules/string_decoder": {
+			"version": "0.10.31",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+			"integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+			"dev": true
+		},
 		"node_modules/normalize-package-data": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -16793,6 +17006,16 @@
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
+		"node_modules/through2": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+			"dev": true,
+			"dependencies": {
+				"readable-stream": "~2.3.6",
+				"xtend": "~4.0.1"
+			}
+		},
 		"node_modules/timed-out": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
@@ -17225,6 +17448,15 @@
 			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
 			"integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
 			"dev": true
+		},
+		"node_modules/untildify": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+			"integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/upper-case": {
 			"version": "2.0.2",
@@ -21786,6 +22018,140 @@
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
 			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
 			"dev": true
+		},
+		"copyfiles": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+			"integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.0.5",
+				"minimatch": "^3.0.3",
+				"mkdirp": "^1.0.4",
+				"noms": "0.0.0",
+				"through2": "^2.0.1",
+				"untildify": "^4.0.0",
+				"yargs": "^16.1.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"cliui": {
+					"version": "7.0.4",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+					"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^7.0.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				},
+				"wrap-ansi": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+					"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"y18n": {
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "16.2.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+					"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^7.0.2",
+						"escalade": "^3.1.1",
+						"get-caller-file": "^2.0.5",
+						"require-directory": "^2.1.1",
+						"string-width": "^4.2.0",
+						"y18n": "^5.0.5",
+						"yargs-parser": "^20.2.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "20.2.9",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+					"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+					"dev": true
+				}
+			}
 		},
 		"core-js-compat": {
 			"version": "3.11.0",
@@ -27017,6 +27383,42 @@
 			"integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
 			"dev": true
 		},
+		"noms": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+			"integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"readable-stream": "~1.0.31"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+					"dev": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+					"dev": true
+				}
+			}
+		},
 		"normalize-package-data": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -31336,6 +31738,16 @@
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
+		"through2": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+			"dev": true,
+			"requires": {
+				"readable-stream": "~2.3.6",
+				"xtend": "~4.0.1"
+			}
+		},
 		"timed-out": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
@@ -31653,6 +32065,12 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
 			"integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
+			"dev": true
+		},
+		"untildify": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+			"integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
 			"dev": true
 		},
 		"upper-case": {

--- a/package.json
+++ b/package.json
@@ -21,23 +21,23 @@
 		"Samsung>=8.2",
 		"not dead"
 	],
-  "sideEffects": [
-    "./compat/**/*",
-    "./debug/**/*",
-    "./devtools/**/*",
-    "./hooks/**/*",
-    "./test-utils/**/*"
-  ],
+	"sideEffects": [
+		"./compat/**/*",
+		"./debug/**/*",
+		"./devtools/**/*",
+		"./hooks/**/*",
+		"./test-utils/**/*"
+	],
 	"exports": {
 		".": {
-      "types": "./src/index.d.ts",
+			"types": "./src/index.d.ts",
 			"module": "./dist/preact.mjs",
 			"import": "./dist/preact.mjs",
 			"require": "./dist/preact.js",
 			"umd": "./dist/preact.umd.js"
 		},
 		"./compat": {
-      "types": "./compat/src/index.d.ts",
+			"types": "./compat/src/index.d.ts",
 			"module": "./compat/dist/compat.mjs",
 			"import": "./compat/dist/compat.mjs",
 			"require": "./compat/dist/compat.js",
@@ -50,35 +50,35 @@
 			"umd": "./debug/dist/debug.umd.js"
 		},
 		"./devtools": {
-      "types": "./devtools/src/index.d.ts",
+			"types": "./devtools/src/index.d.ts",
 			"module": "./devtools/dist/devtools.mjs",
 			"import": "./devtools/dist/devtools.mjs",
 			"require": "./devtools/dist/devtools.js",
 			"umd": "./devtools/dist/devtools.umd.js"
 		},
 		"./hooks": {
-      "types": "./hooks/src/index.d.ts",
+			"types": "./hooks/src/index.d.ts",
 			"module": "./hooks/dist/hooks.mjs",
 			"import": "./hooks/dist/hooks.mjs",
 			"require": "./hooks/dist/hooks.js",
 			"umd": "./hooks/dist/hooks.umd.js"
 		},
 		"./test-utils": {
-      "types": "./test-utils/src/index.d.ts",
+			"types": "./test-utils/src/index.d.ts",
 			"module": "./test-utils/dist/testUtils.mjs",
 			"import": "./test-utils/dist/testUtils.mjs",
 			"require": "./test-utils/dist/testUtils.js",
 			"umd": "./test-utils/dist/testUtils.umd.js"
 		},
 		"./jsx-runtime": {
-      "types": "./jsx-runtime/src/index.d.ts",
+			"types": "./jsx-runtime/src/index.d.ts",
 			"module": "./jsx-runtime/dist/jsxRuntime.mjs",
 			"import": "./jsx-runtime/dist/jsxRuntime.mjs",
 			"require": "./jsx-runtime/dist/jsxRuntime.js",
 			"umd": "./jsx-runtime/dist/jsxRuntime.umd.js"
 		},
 		"./jsx-dev-runtime": {
-      "types": "./jsx-runtime/src/index.d.ts",
+			"types": "./jsx-runtime/src/index.d.ts",
 			"module": "./jsx-runtime/dist/jsxRuntime.mjs",
 			"import": "./jsx-runtime/dist/jsxRuntime.mjs",
 			"require": "./jsx-runtime/dist/jsxRuntime.js",
@@ -90,12 +90,12 @@
 			"require": "./server/dist/server.js",
 			"umd": "./server/dist/server.umd.js"
 		},
-    "./compat/client": {
+		"./compat/client": {
 			"import": "./compat/client.mjs",
 			"require": "./compat/client.js"
 		},
 		"./compat/server": {
-      "browser": "./compat/server.browser.js",
+			"browser": "./compat/server.browser.js",
 			"module": "./compat/server.mjs",
 			"import": "./compat/server.mjs",
 			"require": "./compat/server.js"
@@ -126,7 +126,7 @@
 		"build:test-utils": "npm run -s _bundle -- --cwd test-utils",
 		"build:compat": "npm run -s _bundle -- --cwd compat --globals 'preact/hooks=preactHooks'",
 		"build:jsx": "npm run -s _bundle -- --cwd jsx-runtime",
-		"build:server": "npm run -s _bundle -- --cwd server",
+		"build:server": "cd server && npm run build",
 		"postbuild": "node ./config/compat-entries.js",
 		"dev": "microbundle watch --raw --format cjs --no-generateTypes",
 		"dev:hooks": "microbundle watch --raw --format cjs --cwd hooks --no-generateTypes",
@@ -138,7 +138,7 @@
 		"test:ts:compat": "tsc -p compat/test/ts/",
 		"test:mocha": "mocha --recursive --require \"@babel/register\" test/shared test/node",
 		"test:mocha:watch": "npm run test:mocha -- --watch",
-		"test:mocha:server": "SERVER=true BABEL_ENV=test mocha -r @babel/register -r server/test/setup.js server/test/**/*.test.js --watch-ignore='benches/**'",
+		"test:mocha:server": "cross-env SERVER=true BABEL_ENV=test mocha -r @babel/register -r server/test/setup.js server/test/**/*.test.js --watch-ignore='benches/**'",
 		"test:karma": "cross-env COVERAGE=true BABEL_NO_MODULES=true karma start karma.conf.js --single-run",
 		"test:karma:minify": "cross-env COVERAGE=true MINIFY=true BABEL_NO_MODULES=true karma start karma.conf.js --single-run",
 		"test:karma:watch": "cross-env BABEL_NO_MODULES=true karma start karma.conf.js --no-single-run",
@@ -218,7 +218,7 @@
 		"compat/server.js",
 		"compat/server.browser.js",
 		"compat/server.mjs",
-    "compat/client.js",
+		"compat/client.js",
 		"compat/client.mjs",
 		"compat/test-utils.js",
 		"compat/jsx-runtime.js",
@@ -282,6 +282,7 @@
 		"benchmark": "^2.1.4",
 		"chai": "^4.3.6",
 		"check-export-map": "^1.2.0",
+		"copyfiles": "^2.4.1",
 		"coveralls": "^3.1.1",
 		"cross-env": "^7.0.3",
 		"csstype": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
 		"test:ts:compat": "tsc -p compat/test/ts/",
 		"test:mocha": "mocha --recursive --require \"@babel/register\" test/shared test/node",
 		"test:mocha:watch": "npm run test:mocha -- --watch",
-		"test:mocha:server": "cross-env SERVER=true BABEL_ENV=test mocha -r @babel/register -r server/test/setup.js server/test/**/*.test.js --watch-ignore='benches/**'",
+		"test:mocha:server": "SERVER=true BABEL_ENV=test mocha -r @babel/register -r server/test/setup.js server/test/**/*.test.js --watch-ignore='benches/**'",
 		"test:karma": "cross-env COVERAGE=true BABEL_NO_MODULES=true karma start karma.conf.js --single-run",
 		"test:karma:minify": "cross-env COVERAGE=true MINIFY=true BABEL_NO_MODULES=true karma start karma.conf.js --single-run",
 		"test:karma:watch": "cross-env BABEL_NO_MODULES=true karma start karma.conf.js --no-single-run",

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -94,6 +94,14 @@ function _renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 				isSvgMode,
 				selectValue
 			);
+			if (
+				vnode[i + 1] != null &&
+				vnode[i] != null &&
+				typeof vnode[i] !== 'object' &&
+				typeof vnode[i + 1] !== 'object'
+			) {
+				rendered += '<!-- -->';
+			}
 		}
 		return rendered;
 	}
@@ -370,6 +378,15 @@ function _renderToString(vnode, context, opts, inner, isSvgMode, selectValue) {
 						lastWasText = isText;
 					} else {
 						pieces.push(ret);
+					}
+
+					if (
+						children[i + 1] != null &&
+						children[i] != null &&
+						typeof children[i] !== 'object' &&
+						typeof children[i + 1] !== 'object'
+					) {
+						pieces.push('<!-- -->');
 					}
 				}
 			}

--- a/server/test/context.test.js
+++ b/server/test/context.test.js
@@ -25,7 +25,7 @@ describe('context', () => {
 		);
 
 		expect(rendered).to.equal(dedent`
-			<section>value is: correct</section>
+			<section>value is: <!-- -->correct</section>
 		`);
 	});
 
@@ -38,7 +38,7 @@ describe('context', () => {
 		);
 
 		expect(rendered).to.equal(dedent`
-			<section>value is: correct</section>
+			<section>value is: <!-- -->correct</section>
 		`);
 	});
 
@@ -53,7 +53,7 @@ describe('context', () => {
 		);
 
 		expect(rendered).to.equal(dedent`
-			<section>value is: correct</section>
+			<section>value is: <!-- -->correct</section>
 		`);
 	});
 
@@ -77,7 +77,7 @@ describe('context', () => {
 		);
 
 		expect(rendered).to.equal(dedent`
-			<section>value is: correct</section>
+			<section>value is: <!-- -->correct</section>
 		`);
 	});
 });

--- a/server/test/pretty.test.js
+++ b/server/test/pretty.test.js
@@ -123,7 +123,9 @@ describe('pretty', () => {
 			<div>hello{' '} <b /></div>
 		)).to.equal(dedent`
 			<div>
-				hello  
+				hello
+				<!-- --> 
+				<!-- --> 
 				<b></b>
 			</div>
 		`);
@@ -133,9 +135,12 @@ describe('pretty', () => {
 			<div>hello{' '} <b />{'a'}{'b'}</div>
 		)).to.equal(dedent`
 			<div>
-				hello  
+				hello
+				<!-- --> 
+				<!-- --> 
 				<b></b>
-				ab
+				a
+				<!-- -->b
 			</div>
 		`);
 	});
@@ -146,7 +151,9 @@ describe('pretty', () => {
 			<div><Fragment>foo</Fragment>bar{' '} <b /></div>
 		)).to.equal(dedent`
 			<div>
-				foobar  
+				foobar
+				<!-- --> 
+				<!-- --> 
 				<b></b>
 			</div>
 		`);
@@ -189,6 +196,7 @@ describe('pretty', () => {
 		).to.equal(dedent`
 			<p>
 				a
+				<!-- -->
 				<a>b</a>
 			</p>
 		`);
@@ -219,7 +227,8 @@ describe('pretty', () => {
 		).to.equal(dedent`
 			<p>
 				<b></b>
-				\ a\ 
+				 a
+				<!-- --> 
 			</p>
 		`);
 	});

--- a/server/test/render.test.js
+++ b/server/test/render.test.js
@@ -21,6 +21,13 @@ describe('render', () => {
 			expect(rendered).to.equal(expected);
 		});
 
+		describe('text-nodes', () => {
+			it('separates adjacent text-nodes', () => {
+				let rendered = render(<div>bar {'xd'}</div>);
+				expect(rendered).to.equal(`<div>bar <!-- -->xd</div>`);
+			});
+		});
+
 		describe('whitespace', () => {
 			it('should omit whitespace between elements', () => {
 				let children = [];
@@ -197,7 +204,7 @@ describe('render', () => {
 						{null}|{undefined}|{false}
 					</div>
 				),
-				expected = `<div>||</div>`;
+				expected = `<div>|<!-- -->|</div>`;
 
 			expect(rendered).to.equal(expected);
 		});


### PR DESCRIPTION
This PR will insert comments for adjacent text-nodes, when the babel transform runs for `<p>x{' '}y</p>` it will generate 3 text-nodes, when we enter hydration we see 1 dom-node but 3 virtual nodes so we want to correctly hydrate these as 3 dom-nodes hence we insert comments so the DOM is forced to see these as 3 dom-nodes as well