### PR TITLE
Fix `useSyncExternalStore` not working with function values

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -141,7 +141,7 @@ export function useSyncExternalStore(subscribe, getSnapshot) {
 
 	useEffect(() => {
 		return subscribe(() => {
-			setState(getSnapshot());
+			setState(() => getSnapshot());
 		});
 	}, [subscribe, getSnapshot]);
 

--- a/compat/test/browser/hooks.test.js
+++ b/compat/test/browser/hooks.test.js
@@ -127,5 +127,35 @@ describe('React-18-hooks', () => {
 
 			expect(scratch.innerHTML).to.equal('<p>hello new world</p>');
 		});
+
+		it('should not call function values on subscription', () => {
+			let flush;
+			const subscribe = sinon.spy(cb => {
+				flush = cb;
+				return () => {};
+			});
+
+			let i = 0;
+			const getSnapshot = sinon.spy(() => {
+				return () => 'value: ' + i++;
+			});
+
+			const App = () => {
+				const value = useSyncExternalStore(subscribe, getSnapshot);
+				return <p>{value()}</p>;
+			};
+
+			act(() => {
+				render(<App />, scratch);
+			});
+			expect(scratch.innerHTML).to.equal('<p>value: 0</p>');
+			expect(subscribe).to.be.calledOnce;
+			expect(getSnapshot).to.be.calledOnce;
+
+			flush();
+			rerender();
+
+			expect(scratch.innerHTML).to.equal('<p>value: 1</p>');
+		});
 	});
 });


### PR DESCRIPTION
When the value returned by the `getSnapshot` argument is a function we were calling that immediately instead of passing the function as a value around. This was caused by `useState` having the updater functionality, where a function is interpreted as being an updater function which allows you to optionally cancel a state update. But we don't want that here, we want the function itself to be preserved as a value.

Fixes #3632