### PR TITLE
Multiple state hooks in a component

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -189,10 +189,15 @@ export function useReducer(reducer, initialState, init) {
 					x => x._component
 				);
 				const allHooksEmpty = stateHooks.every(x => !x._nextValue);
+				// When we have no updated hooks in the component we invoke the previous SCU or
+				// traverse the VDOM tree further.
 				if (allHooksEmpty) {
 					return prevScu ? prevScu(p, s, c) : true;
 				}
 
+				// We check whether we have components with a nextValue set that
+				// have values that aren't equal to one another this pushes
+				// us to update further down the tree
 				const shouldSkipUpdating = stateHooks.every(hookItem => {
 					if (!hookItem._nextValue) return true;
 					const currentValue = hookItem._value[0];
@@ -205,6 +210,11 @@ export function useReducer(reducer, initialState, init) {
 					return prevScu ? prevScu(p, s, c) : true;
 				}
 
+				// When all set nextValues are equal to their original value
+				// we bail out of updating.
+				// Thinking: would this be dangerous with a batch of updates where
+				// Comp1 updates --> Comp2 updated in same batch twice but has same eventual state --> this leads to us
+				// not diving into Comp3
 				return false;
 			};
 		}

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -68,7 +68,7 @@ options.diffed = vnode => {
 			if (hookItem._pendingArgs) {
 				hookItem._args = hookItem._pendingArgs;
 			}
-			if (hookItem._pendingValue !== EMPTY && !hookItem._component) {
+			if (hookItem._pendingValue !== EMPTY) {
 				hookItem._value = hookItem._pendingValue;
 			}
 			hookItem._pendingArgs = undefined;


### PR DESCRIPTION
Currently the last sCU wins which basically means we are losing a bit of granularity, as well as filtering out React.memo when wrapped. The new flow looks like the following:

- hold a flag whether we have added SCU
- when we traverse if no state-hooks have a pending next state --> update because this means no state setters have been invoked for this component (call former SCU)
- when there are invocations look at whether all of the ones with a nextState have equal states
  - if they all have equal states between next and original bail out
  - if not continue updating (call former SCU)