### PR TITLE
avoid crashing due to __hooks being null

### DIFF
--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -2088,4 +2088,29 @@ describe('suspense', () => {
 			expect(scratch.innerHTML).to.eql(`<div>123</div>`);
 		});
 	});
+
+	it('should not crash due to suspending a ', () => {
+		const [Suspender, suspend] = createSuspender(() => {
+			const [state] = useState('hello world');
+			return <p>{state}</p>;
+		});
+
+		const suspense = (
+			<Suspense fallback={<div>Suspended...</div>}>
+				<Suspender />
+			</Suspense>
+		);
+
+		render(suspense, scratch);
+		expect(scratch.innerHTML).to.equal('<p>hello world</p>');
+
+		const [resolve] = suspend();
+		rerender();
+		expect(scratch.innerHTML).to.equal(`<div>Suspended...</div>`);
+
+		return resolve(() => <p>hello new world</p>).then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.eql(`<p>hello new world</p>`);
+		});
+	});
 });

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -2089,7 +2089,7 @@ describe('suspense', () => {
 		});
 	});
 
-	it('should not crash due to suspending a ', () => {
+	it('should not crash due to suspending a component with useState', () => {
 		const [Suspender, suspend] = createSuspender(() => {
 			const [state] = useState('hello world');
 			return <p>{state}</p>;

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -185,6 +185,7 @@ export function useReducer(reducer, initialState, init) {
 			hookState._component.__hooks._hasScuFromHooks = true;
 			const prevScu = hookState._component.shouldComponentUpdate;
 			hookState._component.shouldComponentUpdate = (p, s, c) => {
+				if (!hookState._component.__hooks) return true;
 				const stateHooks = hookState._component.__hooks._list.filter(
 					x => x._component
 				);


### PR DESCRIPTION
fixes #3647

When suspending we reset `__hooks` to null, when this happens we should update rather than crashing 😅 