### PR TITLE
fix `useSyncExternalStore` relying on changed render values

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -140,7 +140,7 @@ export function useSyncExternalStore(subscribe, getSnapshot) {
 
 	useLayoutEffect(() => {
 		if (value !== state) {
-			setState(value);
+			setState(() => value);
 		}
 	}, [subscribe, value, getSnapshot]);
 

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -136,8 +136,13 @@ export const useInsertionEffect = useLayoutEffect;
 export function useSyncExternalStore(subscribe, getSnapshot) {
 	const [state, setState] = useState(getSnapshot);
 
-	// TODO: in suspense for data we could have a discrepancy here because Preact won't re-init the "useState"
-	// when this unsuspends which could lead to stale state as the subscription is torn down.
+	const value = getSnapshot();
+
+	useLayoutEffect(() => {
+		if (value !== state) {
+			setState(value);
+		}
+	}, [subscribe, value, getSnapshot]);
 
 	useEffect(() => {
 		return subscribe(() => {

--- a/compat/test/browser/hooks.test.js
+++ b/compat/test/browser/hooks.test.js
@@ -4,7 +4,9 @@ import React, {
 	useInsertionEffect,
 	useSyncExternalStore,
 	useTransition,
-	render
+	render,
+	useState,
+	useCallback
 } from 'preact/compat';
 import { setupRerender, act } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
@@ -156,6 +158,33 @@ describe('React-18-hooks', () => {
 			rerender();
 
 			expect(scratch.innerHTML).to.equal('<p>value: 1</p>');
+		});
+
+		it.only('works with useCallback', () => {
+			let toggle;
+			const App = () => {
+				const [state, setState] = useState(true);
+				toggle = setState.bind(this, () => false);
+
+				const value = useSyncExternalStore(
+					useCallback(() => {
+						return () => {};
+					}, [state]),
+					() => (state ? 'yep' : 'nope')
+				);
+
+				return <p>{value}</p>;
+			};
+
+			act(() => {
+				render(<App />, scratch);
+			});
+			expect(scratch.innerHTML).to.equal('<p>yep</p>');
+
+			toggle();
+			rerender();
+
+			expect(scratch.innerHTML).to.equal('<p>nope</p>');
 		});
 	});
 });

--- a/compat/test/browser/hooks.test.js
+++ b/compat/test/browser/hooks.test.js
@@ -160,7 +160,7 @@ describe('React-18-hooks', () => {
 			expect(scratch.innerHTML).to.equal('<p>value: 1</p>');
 		});
 
-		it.only('works with useCallback', () => {
+		it('works with useCallback', () => {
 			let toggle;
 			const App = () => {
 				const [state, setState] = useState(true);

--- a/compat/test/browser/hooks.test.js
+++ b/compat/test/browser/hooks.test.js
@@ -93,7 +93,7 @@ describe('React-18-hooks', () => {
 			});
 			expect(scratch.innerHTML).to.equal('<p>hello world</p>');
 			expect(subscribe).to.be.calledOnce;
-			expect(getSnapshot).to.be.calledOnce;
+			expect(getSnapshot).to.be.calledTwice;
 		});
 
 		it('subscribes and rerenders when called', () => {
@@ -121,7 +121,7 @@ describe('React-18-hooks', () => {
 			});
 			expect(scratch.innerHTML).to.equal('<p>hello world</p>');
 			expect(subscribe).to.be.calledOnce;
-			expect(getSnapshot).to.be.calledOnce;
+			expect(getSnapshot).to.be.calledTwice;
 
 			called = true;
 			flush();
@@ -137,9 +137,11 @@ describe('React-18-hooks', () => {
 				return () => {};
 			});
 
+			const func = () => 'value: ' + i++;
+
 			let i = 0;
 			const getSnapshot = sinon.spy(() => {
-				return () => 'value: ' + i++;
+				return func;
 			});
 
 			const App = () => {
@@ -152,12 +154,12 @@ describe('React-18-hooks', () => {
 			});
 			expect(scratch.innerHTML).to.equal('<p>value: 0</p>');
 			expect(subscribe).to.be.calledOnce;
-			expect(getSnapshot).to.be.calledOnce;
+			expect(getSnapshot).to.be.calledTwice;
 
 			flush();
 			rerender();
 
-			expect(scratch.innerHTML).to.equal('<p>value: 1</p>');
+			expect(scratch.innerHTML).to.equal('<p>value: 0</p>');
 		});
 
 		it('works with useCallback', () => {


### PR DESCRIPTION
fixes #3654

It looks like Apollo and other libs can have their snapshot changed during render time, i.e. not part of the subscribe, this means that we need to check in a layout effect whether we are due to re-render, luckily this is similar how React does it as well 😅 