### PR TITLE
fix sync-external-store with zustand

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -140,27 +140,27 @@ export const useInsertionEffect = useLayoutEffect;
 export function useSyncExternalStore(subscribe, getSnapshot) {
 	const value = getSnapshot();
 
-	const [{ inst }, forceUpdate] = useState({ inst: { value, getSnapshot } });
+	const [{ _instance }, forceUpdate] = useState({
+		_instance: { _value: value, _getSnapshot: getSnapshot }
+	});
 
 	useLayoutEffect(() => {
-		inst.value = value;
-		inst.getSnapshot = getSnapshot;
+		_instance._value = value;
+		_instance._getSnapshot = getSnapshot;
 
-		if (inst.value !== getSnapshot()) {
-			forceUpdate({ inst });
+		if (_instance._value !== getSnapshot()) {
+			forceUpdate({ _instance });
 		}
 	}, [subscribe, value, getSnapshot]);
 
 	useEffect(() => {
-		const newValue = inst.getSnapshot();
-		if (inst.value !== newValue) {
-			forceUpdate({ inst });
+		if (_instance._value !== _instance._getSnapshot()) {
+			forceUpdate({ _instance });
 		}
 
 		return subscribe(() => {
-			const newValue = inst.getSnapshot();
-			if (inst.value !== newValue) {
-				forceUpdate({ inst });
+			if (_instance._value !== _instance._getSnapshot()) {
+				forceUpdate({ _instance });
 			}
 		});
 	}, [subscribe]);

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -133,28 +133,32 @@ export function useTransition() {
 // styles/... before it attaches
 export const useInsertionEffect = useLayoutEffect;
 
+/**
+ * This is taken from https://github.com/facebook/react/blob/main/packages/use-sync-external-store/src/useSyncExternalStoreShimClient.js#L84
+ * on a high level this cuts out the warnings, ... and attempts a smaller implementation
+ */
 export function useSyncExternalStore(subscribe, getSnapshot) {
 	const value = getSnapshot();
+
 	const [{ inst }, forceUpdate] = useState({ inst: { value, getSnapshot } });
 
 	useLayoutEffect(() => {
 		inst.value = value;
 		inst.getSnapshot = getSnapshot;
 
-		const newValue = getSnapshot();
-		if (inst.value !== newValue) {
+		if (inst.value !== getSnapshot()) {
 			forceUpdate({ inst });
 		}
 	}, [subscribe, value, getSnapshot]);
 
 	useEffect(() => {
-		const newValue = getSnapshot();
+		const newValue = inst.getSnapshot();
 		if (inst.value !== newValue) {
 			forceUpdate({ inst });
 		}
 
 		return subscribe(() => {
-			const newValue = getSnapshot();
+			const newValue = inst.getSnapshot();
 			if (inst.value !== newValue) {
 				forceUpdate({ inst });
 			}

--- a/compat/test/browser/hooks.test.js
+++ b/compat/test/browser/hooks.test.js
@@ -162,6 +162,34 @@ describe('React-18-hooks', () => {
 			expect(scratch.innerHTML).to.equal('<p>value: 0</p>');
 		});
 
+		it('should work with changing getSnapshot', () => {
+			let flush;
+			const subscribe = sinon.spy(cb => {
+				flush = cb;
+				return () => {};
+			});
+
+			let i = 0;
+			const App = () => {
+				const value = useSyncExternalStore(subscribe, () => {
+					return i;
+				});
+				return <p>value: {value}</p>;
+			};
+
+			act(() => {
+				render(<App />, scratch);
+			});
+			expect(scratch.innerHTML).to.equal('<p>value: 0</p>');
+			expect(subscribe).to.be.calledOnce;
+
+			i++;
+			flush();
+			rerender();
+
+			expect(scratch.innerHTML).to.equal('<p>value: 1</p>');
+		});
+
 		it('works with useCallback', () => {
 			let toggle;
 			const App = () => {

--- a/compat/test/browser/hooks.test.js
+++ b/compat/test/browser/hooks.test.js
@@ -93,7 +93,7 @@ describe('React-18-hooks', () => {
 			});
 			expect(scratch.innerHTML).to.equal('<p>hello world</p>');
 			expect(subscribe).to.be.calledOnce;
-			expect(getSnapshot).to.be.calledTwice;
+			expect(getSnapshot).to.be.calledThrice;
 		});
 
 		it('subscribes and rerenders when called', () => {
@@ -121,7 +121,7 @@ describe('React-18-hooks', () => {
 			});
 			expect(scratch.innerHTML).to.equal('<p>hello world</p>');
 			expect(subscribe).to.be.calledOnce;
-			expect(getSnapshot).to.be.calledTwice;
+			expect(getSnapshot).to.be.calledThrice;
 
 			called = true;
 			flush();
@@ -154,7 +154,7 @@ describe('React-18-hooks', () => {
 			});
 			expect(scratch.innerHTML).to.equal('<p>value: 0</p>');
 			expect(subscribe).to.be.calledOnce;
-			expect(getSnapshot).to.be.calledTwice;
+			expect(getSnapshot).to.be.calledThrice;
 
 			flush();
 			rerender();


### PR DESCRIPTION
fixes https://github.com/preactjs/preact/issues/3662

When zustand is used they use the [withSelector](https://github.com/facebook/react/blob/main/packages/use-sync-external-store/src/useSyncExternalStoreWithSelector.js#L39) variant of sync-external-store. This relies on `getSnapshot` not being incorporated in the `useEffect` dependency array.

Creating a test for it atm