### PR TITLE
fix case where we set SCU multiple times

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -43,8 +43,11 @@ options._render = vnode => {
 			hooks._pendingEffects = [];
 			currentComponent._renderCallbacks = [];
 			hooks._list.forEach(hookItem => {
+				if (hookItem._nextValue) {
+					hookItem._value = hookItem._nextValue;
+				}
 				hookItem._pendingValue = EMPTY;
-				hookItem._pendingArgs = undefined;
+				hookItem._nextValue = hookItem._pendingArgs = undefined;
 			});
 		} else {
 			hooks._pendingEffects.forEach(invokeCleanup);

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -43,11 +43,8 @@ options._render = vnode => {
 			hooks._pendingEffects = [];
 			currentComponent._renderCallbacks = [];
 			hooks._list.forEach(hookItem => {
-				if (hookItem._nextValue) {
-					hookItem._value = hookItem._nextValue;
-				}
 				hookItem._pendingValue = EMPTY;
-				hookItem._nextValue = hookItem._pendingArgs = undefined;
+				hookItem._pendingArgs = undefined;
 			});
 		} else {
 			hooks._pendingEffects.forEach(invokeCleanup);
@@ -181,10 +178,10 @@ export function useReducer(reducer, initialState, init) {
 
 		hookState._component = currentComponent;
 
-		if (!hookState._component._hasScuFromHooks) {
-			hookState._component.__hooks._hasScuFromHooks = true;
-			const prevScu = hookState._component.shouldComponentUpdate;
-			hookState._component.shouldComponentUpdate = (p, s, c) => {
+		if (!currentComponent._hasScuFromHooks) {
+			currentComponent._hasScuFromHooks = true;
+			const prevScu = currentComponent.shouldComponentUpdate;
+			currentComponent.shouldComponentUpdate = (p, s, c) => {
 				if (!hookState._component.__hooks) return true;
 				const stateHooks = hookState._component.__hooks._list.filter(
 					x => x._component

--- a/hooks/test/browser/useState.test.js
+++ b/hooks/test/browser/useState.test.js
@@ -234,6 +234,7 @@ describe('useState', () => {
 		expect(scratch.textContent).to.equal('hi');
 	});
 
+	// https://github.com/preactjs/preact/issues/3669
 	it('correctly updates with multiple state updates', () => {
 		let simulateClick;
 		function TestWidget() {

--- a/hooks/test/browser/useState.test.js
+++ b/hooks/test/browser/useState.test.js
@@ -234,6 +234,31 @@ describe('useState', () => {
 		expect(scratch.textContent).to.equal('hi');
 	});
 
+	it('correctly updates with multiple state updates', () => {
+		let simulateClick;
+		function TestWidget() {
+			const [saved, setSaved] = useState(false);
+			const [, setSaving] = useState(false);
+
+			simulateClick = () => {
+				setSaving(true);
+				setSaved(true);
+				setSaving(false);
+			};
+
+			return <div>{saved ? 'Saved!' : 'Unsaved!'}</div>;
+		}
+
+		render(<TestWidget />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>Unsaved!</div>');
+
+		act(() => {
+			simulateClick();
+		});
+
+		expect(scratch.innerHTML).to.equal('<div>Saved!</div>');
+	});
+
 	it('does not loop when states are equal after batches', () => {
 		const renderSpy = sinon.spy();
 		const Context = createContext(null);


### PR DESCRIPTION
Fixes #3669

We were setting `hookState._component.__hooks._hasScuFromHooks = true;` rather than `hookState._component._hasScuFromHooks` which becomes problematic as we start setting as many SCU's as there are stateful hooks in a component.

On the bright side found a golfing opportunity