### PR TITLE
Fix hooks calling shouldComponentUpdate without context

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -184,7 +184,7 @@ export function useReducer(reducer, initialState, init) {
 		if (!currentComponent._hasScuFromHooks) {
 			currentComponent._hasScuFromHooks = true;
 			const prevScu = currentComponent.shouldComponentUpdate;
-			currentComponent.shouldComponentUpdate = (p, s, c) => {
+			currentComponent.shouldComponentUpdate = function (p, s, c) {
 				if (!hookState._component.__hooks) return true;
 				const stateHooks = hookState._component.__hooks._list.filter(
 					x => x._component

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -193,7 +193,7 @@ export function useReducer(reducer, initialState, init) {
 				// When we have no updated hooks in the component we invoke the previous SCU or
 				// traverse the VDOM tree further.
 				if (allHooksEmpty) {
-					return prevScu ? prevScu(p, s, c) : true;
+					return prevScu ? prevScu.call(this, p, s, c) : true;
 				}
 
 				// We check whether we have components with a nextValue set that
@@ -208,7 +208,7 @@ export function useReducer(reducer, initialState, init) {
 				});
 
 				if (!shouldSkipUpdating) {
-					return prevScu ? prevScu(p, s, c) : true;
+					return prevScu ? prevScu.call(this, p, s, c) : true;
 				}
 
 				// When all set nextValues are equal to their original value


### PR DESCRIPTION
This was breaking code that relies on `this` within shouldComponentUpdate.