### PR TITLE
ensure we iterate over all hooks

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -184,7 +184,7 @@ export function useReducer(reducer, initialState, init) {
 		if (!currentComponent._hasScuFromHooks) {
 			currentComponent._hasScuFromHooks = true;
 			const prevScu = currentComponent.shouldComponentUpdate;
-			currentComponent.shouldComponentUpdate = function (p, s, c) {
+			currentComponent.shouldComponentUpdate = function(p, s, c) {
 				if (!hookState._component.__hooks) return true;
 				const stateHooks = hookState._component.__hooks._list.filter(
 					x => x._component
@@ -199,15 +199,16 @@ export function useReducer(reducer, initialState, init) {
 				// We check whether we have components with a nextValue set that
 				// have values that aren't equal to one another this pushes
 				// us to update further down the tree
-				const shouldSkipUpdating = stateHooks.every(hookItem => {
-					if (!hookItem._nextValue) return true;
+				let shouldUpdate = false;
+				stateHooks.forEach(hookItem => {
+					if (!hookItem._nextValue) return;
 					const currentValue = hookItem._value[0];
 					hookItem._value = hookItem._nextValue;
 					hookItem._nextValue = undefined;
-					return currentValue === hookItem._value[0];
+					if (currentValue !== hookItem._value[0]) shouldUpdate = true;
 				});
 
-				if (!shouldSkipUpdating) {
+				if (shouldUpdate) {
 					return prevScu ? prevScu.call(this, p, s, c) : true;
 				}
 

--- a/hooks/test/browser/useState.test.js
+++ b/hooks/test/browser/useState.test.js
@@ -260,6 +260,41 @@ describe('useState', () => {
 		expect(scratch.innerHTML).to.equal('<div>Saved!</div>');
 	});
 
+	// https://github.com/preactjs/preact/issues/3674
+	it('ensure we iterate over all hooks', () => {
+		let open, close;
+
+		function TestWidget() {
+			const [, setCounter] = useState(0);
+			const [isOpen, setOpen] = useState(false);
+
+			open = () => {
+				setCounter(42);
+				setOpen(true);
+			};
+
+			close = () => {
+				setOpen(false);
+			};
+
+			return <div>{isOpen ? 'open' : 'closed'}</div>;
+		}
+
+		render(<TestWidget />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>closed</div>');
+
+		act(() => {
+			open();
+		});
+
+		expect(scratch.innerHTML).to.equal('<div>open</div>');
+
+		act(() => {
+			close();
+		});
+		expect(scratch.innerHTML).to.equal('<div>closed</div>');
+	});
+
 	it('does not loop when states are equal after batches', () => {
 		const renderSpy = sinon.spy();
 		const Context = createContext(null);


### PR DESCRIPTION
Fixes #3674 

Due to `.every` we bailed out of the loop on the first time we find a `false` which in this case means we update from 0 --> 42 for the unused hook and never set the `_nextValue` to `_value` for the second update

CC @robertknight 