### PR TITLE
undo jsx-element removal

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -87,7 +87,7 @@ export type ComponentProps<
 	: never;
 
 export interface FunctionComponent<P = {}> {
-	(props: RenderableProps<P>, context?: any): ComponentChild;
+	(props: RenderableProps<P>, context?: any): VNode<any>;
 	displayName?: string;
 	defaultProps?: Partial<P>;
 }

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -36,6 +36,7 @@ export namespace JSXInternal {
 					: never;
 		  }[keyof IntrinsicElements]
 		| ComponentType<P>;
+	export interface Element extends VNode<any> {}
 	export type ElementClass = Component<any, any> | FunctionComponent<any>;
 
 	export interface ElementAttributesProperty {

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -102,21 +102,22 @@ const UseOfComponentWithChildren = () => {
 	);
 };
 
-const DummyChildren: FunctionalComponent = ({ children }) => {
-	return children;
-};
+// TODO: make this work
+// const DummyChildren: FunctionalComponent = ({ children }) => {
+// 	return children;
+// };
 
-function ReturnChildren(props: { children: preact.ComponentChildren }) {
-	return props.children;
-}
+// function ReturnChildren(props: { children: preact.ComponentChildren }) {
+// 	return props.children;
+// }
 
-function TestUndefinedChildren() {
-	return (
-		<ReturnChildren>
-			<ReturnChildren>Hello</ReturnChildren>
-		</ReturnChildren>
-	);
-}
+// function TestUndefinedChildren() {
+// 	return (
+// 		<ReturnChildren>
+// 			<ReturnChildren>Hello</ReturnChildren>
+// 		</ReturnChildren>
+// 	);
+// }
 
 // using ref and or jsx
 class ComponentUsingRef extends Component<any, any> {


### PR DESCRIPTION
Resolves #3679 
Re-opens #3611

While working on this I did not realise that we have an override in our tests to make `JSX.Element` work https://github.com/preactjs/preact/blob/master/test/ts/jsx-namespacce-test.tsx#L7 which lead me to believe that TS constructs its own given the `ElementType` you export. This was wrong, this re-introduces the bug of `children` which is a more subtile issue with how we typed `FunctionComponent` and `ClassComponent`