### PR TITLE
Pass `errorInfo` to `useErrorBoundary` calbback

### DIFF
--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -1,4 +1,4 @@
-import { PreactContext, Ref as PreactRef } from '../..';
+import { ErrorInfo, PreactContext, Ref as PreactRef } from '../..';
 
 type Inputs = ReadonlyArray<unknown>;
 
@@ -135,5 +135,5 @@ export function useContext<T>(context: PreactContext<T>): T;
 export function useDebugValue<T>(value: T, formatter?: (value: T) => any): void;
 
 export function useErrorBoundary(
-	callback?: (error: any) => Promise<void> | void
+	callback?: (error: any, errorInfo: ErrorInfo) => Promise<void> | void
 ): [any, () => void];

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -345,7 +345,7 @@ export function useDebugValue(value, formatter) {
 }
 
 /**
- * @param {(error: any) => void} cb
+ * @param {(error: any, errorInfo: import('preact').ErrorInfo) => void} cb
  */
 export function useErrorBoundary(cb) {
 	/** @type {import('./internal').ErrorBoundaryHookState} */
@@ -353,8 +353,8 @@ export function useErrorBoundary(cb) {
 	const errState = useState();
 	state._value = cb;
 	if (!currentComponent.componentDidCatch) {
-		currentComponent.componentDidCatch = err => {
-			if (state._value) state._value(err);
+		currentComponent.componentDidCatch = (err, errorInfo) => {
+			if (state._value) state._value(err, errorInfo);
 			errState[1](err);
 		};
 	}

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -1,6 +1,7 @@
 import {
 	Component as PreactComponent,
-	PreactContext
+	PreactContext,
+	ErrorInfo
 } from '../../src/internal';
 import { Reducer } from '.';
 
@@ -75,5 +76,5 @@ export interface ContextHookState {
 }
 
 export interface ErrorBoundaryHookState {
-	_value?: (error: any) => void;
+	_value?: (error: any, errorInfo: ErrorInfo) => void;
 }

--- a/hooks/test/browser/errorBoundary.test.js
+++ b/hooks/test/browser/errorBoundary.test.js
@@ -57,7 +57,25 @@ describe('errorBoundary', () => {
 		rerender();
 		expect(scratch.innerHTML).to.equal('<p>Error</p>');
 		expect(spy).to.be.calledOnce;
-		expect(spy).to.be.calledWith(error);
+		expect(spy).to.be.calledWith(error, {});
+	});
+
+	it('returns error', () => {
+		const error = new Error('test');
+		const Throws = () => {
+			throw error;
+		};
+
+		let returned;
+		const App = () => {
+			const [err] = useErrorBoundary();
+			returned = err;
+			return err ? <p>Error</p> : <Throws />;
+		};
+
+		render(<App />, scratch);
+		rerender();
+		expect(returned).to.equal(error);
 	});
 
 	it('does not leave a stale closure', () => {


### PR DESCRIPTION
Fixes #3687 .