### PR TITLE
improve types for bare createElement and h calls

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -219,7 +219,7 @@ export function createElement<T extends HTMLElement>(
 ): VNode<any>;
 export function createElement<P>(
 	type: ComponentType<P>,
-	props: (ClassAttributes & P) | null,
+	props: (Attributes & P) | null,
 	...children: ComponentChildren[]
 ): VNode<any>;
 export namespace createElement {
@@ -258,7 +258,7 @@ export function h<T extends HTMLElement>(
 ): VNode<any>;
 export function h<P>(
 	type: ComponentType<P>,
-	props: (ClassAttributes & P) | null,
+	props: (Attributes & P) | null,
 	...children: ComponentChildren[]
 ): VNode<any>;
 export namespace h {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -187,36 +187,68 @@ export abstract class Component<P, S> {
 // Preact createElement
 // -----------------------------------
 
-export function createElement(
+export function createElement<
+	P extends JSXInternal.HTMLAttributes<T>,
+	T extends HTMLElement
+>(
+	type: keyof JSXInternal.IntrinsicElements,
+	props: (ClassAttributes<T> & P) | null,
+	...children: ComponentChildren[]
+): VNode<any>;
+export function createElement<
+	P extends JSXInternal.HTMLAttributes<T>,
+	T extends HTMLElement
+>(
+	type: keyof JSXInternal.IntrinsicElements,
+	props: (ClassAttributes<T> & P) | null,
+	...children: ComponentChildren[]
+): VNode<any>;
+export function createElement<T extends HTMLElement>(
 	type: string,
 	props:
-		| (JSXInternal.HTMLAttributes &
-				JSXInternal.SVGAttributes &
-				Record<string, any>)
+		| (ClassAttributes<T> &
+				JSXInternal.HTMLAttributes &
+				JSXInternal.SVGAttributes)
 		| null,
 	...children: ComponentChildren[]
 ): VNode<any>;
 export function createElement<P>(
 	type: ComponentType<P>,
-	props: (Attributes & P) | null,
+	props: (ClassAttributes & P) | null,
 	...children: ComponentChildren[]
 ): VNode<any>;
 export namespace createElement {
 	export import JSX = JSXInternal;
 }
 
-export function h(
+export function h<
+	P extends JSXInternal.HTMLAttributes<T>,
+	T extends HTMLElement
+>(
+	type: keyof JSXInternal.IntrinsicElements,
+	props: (ClassAttributes<T> & P) | null,
+	...children: ComponentChildren[]
+): VNode<any>;
+export function h<
+	P extends JSXInternal.HTMLAttributes<T>,
+	T extends HTMLElement
+>(
+	type: keyof JSXInternal.IntrinsicElements,
+	props: (ClassAttributes<T> & P) | null,
+	...children: ComponentChildren[]
+): VNode<any>;
+export function h<T extends HTMLElement>(
 	type: string,
 	props:
-		| (JSXInternal.HTMLAttributes &
-				JSXInternal.SVGAttributes &
-				Record<string, any>)
+		| (ClassAttributes<T> &
+				JSXInternal.HTMLAttributes &
+				JSXInternal.SVGAttributes)
 		| null,
 	...children: ComponentChildren[]
 ): VNode<any>;
 export function h<P>(
 	type: ComponentType<P>,
-	props: (Attributes & P) | null,
+	props: (ClassAttributes & P) | null,
 	...children: ComponentChildren[]
 ): VNode<any>;
 export namespace h {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -189,7 +189,10 @@ export abstract class Component<P, S> {
 
 export function createElement(
 	type: 'input',
-	props: (DOMAttributes<'input'> & ClassAttributes<T>) | null,
+	props:
+		| (JSXInternal.DOMAttributes<HTMLInputElement> &
+				ClassAttributes<HTMLInputElement>)
+		| null,
 	...children: ComponentChildren[]
 ): VNode<any>;
 export function createElement<
@@ -201,7 +204,7 @@ export function createElement<
 	...children: ComponentChildren[]
 ): VNode<any>;
 export function createElement<
-	P extends JSXInternal.HTMLAttributes<T>,
+	P extends JSXInternal.SVGAttributes<T>,
 	T extends HTMLElement
 >(
 	type: keyof JSXInternal.IntrinsicElements,
@@ -228,7 +231,10 @@ export namespace createElement {
 
 export function h(
 	type: 'input',
-	props: (DOMAttributes<'input'> & ClassAttributes<T>) | null,
+	props:
+		| (JSXInternal.DOMAttributes<HTMLInputElement> &
+				ClassAttributes<HTMLInputElement>)
+		| null,
 	...children: ComponentChildren[]
 ): VNode<any>;
 export function h<
@@ -240,7 +246,7 @@ export function h<
 	...children: ComponentChildren[]
 ): VNode<any>;
 export function h<
-	P extends JSXInternal.HTMLAttributes<T>,
+	P extends JSXInternal.SVGAttributes<T>,
 	T extends HTMLElement
 >(
 	type: keyof JSXInternal.IntrinsicElements,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -187,6 +187,11 @@ export abstract class Component<P, S> {
 // Preact createElement
 // -----------------------------------
 
+export function createElement(
+	type: 'input',
+	props: (DOMAttributes<'input'> & ClassAttributes<T>) | null,
+	...children: ComponentChildren[]
+): VNode<any>;
 export function createElement<
 	P extends JSXInternal.HTMLAttributes<T>,
 	T extends HTMLElement
@@ -221,6 +226,11 @@ export namespace createElement {
 	export import JSX = JSXInternal;
 }
 
+export function h(
+	type: 'input',
+	props: (DOMAttributes<'input'> & ClassAttributes<T>) | null,
+	...children: ComponentChildren[]
+): VNode<any>;
 export function h<
 	P extends JSXInternal.HTMLAttributes<T>,
 	T extends HTMLElement

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -5,7 +5,8 @@ import {
 	ComponentProps,
 	FunctionalComponent,
 	AnyComponent,
-	h
+	h,
+	createRef
 } from '../../';
 
 interface DummyProps {
@@ -314,3 +315,7 @@ const acceptsNumberAsLength = <div style={{ marginTop: 20 }} />;
 const acceptsStringAsLength = <div style={{ marginTop: '20px' }} />;
 
 const ReturnNull: FunctionalComponent = () => null;
+
+const ref = createRef<HTMLDivElement>();
+createElement('div', { ref: ref }, 'hi');
+h('div', { ref: ref }, 'hi');

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -316,11 +316,19 @@ const acceptsStringAsLength = <div style={{ marginTop: '20px' }} />;
 
 const ReturnNull: FunctionalComponent = () => null;
 
+// Refs should work on elements
 const ref = createRef<HTMLDivElement>();
 createElement('div', { ref: ref }, 'hi');
 h('div', { ref: ref }, 'hi');
 
+// Refs should work on functions
 const functionRef = createRef();
 const RefComponentTest = () => <p>hi</p>;
 createElement(RefComponentTest, { ref: functionRef }, 'hi');
 h(RefComponentTest, { ref: functionRef }, 'hi');
+
+// Should accept onInput
+const onInput = (e: h.JSX.TargetedEvent<HTMLInputElement>) => {};
+<input onInput={onInput} />;
+createElement('input', { onInput: onInput });
+h('input', { onInput: onInput });

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -319,3 +319,8 @@ const ReturnNull: FunctionalComponent = () => null;
 const ref = createRef<HTMLDivElement>();
 createElement('div', { ref: ref }, 'hi');
 h('div', { ref: ref }, 'hi');
+
+const functionRef = createRef();
+const RefComponentTest = () => <p>hi</p>;
+createElement(RefComponentTest, { ref: functionRef }, 'hi');
+h(RefComponentTest, { ref: functionRef }, 'hi');


### PR DESCRIPTION
Resolves #3618 
Resolves https://github.com/preactjs/preact/issues/2612

This fine-tunes the element creation calls to derive more state from the context in which they are called. This also makes a special case for input so we can correctly leverage onInput