### PR TITLE
fix case where we would omit the ref from reused vnodes

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -83,7 +83,7 @@ export function diffChildren(
 				childVNode.type,
 				childVNode.props,
 				childVNode.key,
-				childVNode.ref,
+				childVNode.ref ? childVNode.ref : null,
 				childVNode._original
 			);
 		} else {

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -83,7 +83,7 @@ export function diffChildren(
 				childVNode.type,
 				childVNode.props,
 				childVNode.key,
-				null,
+				childVNode.ref,
 				childVNode._original
 			);
 		} else {
@@ -244,14 +244,7 @@ function reorderChildren(childVNode, oldDom, parentDom) {
 			if (typeof vnode.type == 'function') {
 				oldDom = reorderChildren(vnode, oldDom, parentDom);
 			} else {
-				oldDom = placeChild(
-					parentDom,
-					vnode,
-					vnode,
-					c,
-					vnode._dom,
-					oldDom
-				);
+				oldDom = placeChild(parentDom, vnode, vnode, c, vnode._dom, oldDom);
 			}
 		}
 	}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -497,7 +497,9 @@ export function unmount(vnode, parentVNode, skipRemove) {
 	if (options.unmount) options.unmount(vnode);
 
 	if ((r = vnode.ref)) {
-		if (!r.current || r.current === vnode._dom) applyRef(r, null, parentVNode);
+		if (!r.current || r.current === vnode._dom) {
+			applyRef(r, null, parentVNode);
+		}
 	}
 
 	if ((r = vnode._component) != null) {

--- a/test/browser/refs.test.js
+++ b/test/browser/refs.test.js
@@ -517,13 +517,16 @@ describe('refs', () => {
 		}
 
 		render(<App count={0} />, scratch);
-		expect(calls[0]).to.equal(scratch.firstChild.firstChild);
 		render(<App count={1} />, scratch);
-		expect(calls[1]).to.equal(null);
-		expect(calls[2]).to.equal(scratch.firstChild.firstChild);
 		render(<App count={2} />, scratch);
-		expect(calls[3]).to.equal(null);
-		expect(calls[4]).to.equal(scratch.firstChild.firstChild);
+		expect(calls.length).to.equal(5);
+		expect(calls).to.deep.equal([
+			scratch.firstChild.firstChild,
+			null,
+			scratch.firstChild.firstChild,
+			null,
+			scratch.firstChild.firstChild
+		]);
 	});
 
 	it('should properly call null for memoized components unkeyed', () => {
@@ -534,12 +537,9 @@ describe('refs', () => {
 		}
 
 		render(<App count={0} />, scratch);
-		expect(calls[0]).to.equal(scratch.firstChild.firstChild);
 		render(<App count={1} />, scratch);
-		expect(calls[1]).to.equal(null);
-		expect(calls[2]).to.equal(scratch.firstChild.firstChild);
 		render(<App count={2} />, scratch);
-		expect(calls[3]).to.equal(null);
-		expect(calls[4]).to.equal(scratch.firstChild.firstChild);
+		expect(calls.length).to.equal(1);
+		expect(calls[0]).to.equal(scratch.firstChild.firstChild);
 	});
 });

--- a/test/browser/refs.test.js
+++ b/test/browser/refs.test.js
@@ -478,4 +478,34 @@ describe('refs', () => {
 		render(<App />, scratch);
 		expect(el).to.not.be.equal(null);
 	});
+
+	it('should not remove refs for memoized components keyed', () => {
+		const ref = createRef();
+		const element = <div ref={ref}>hey</div>;
+		function App(props) {
+			return <div key={props.count}>{element}</div>;
+		}
+
+		render(<App count={0} />, scratch);
+		expect(ref.current).to.equal(scratch.firstChild.firstChild);
+		render(<App count={1} />, scratch);
+		expect(ref.current).to.equal(scratch.firstChild.firstChild);
+		render(<App count={2} />, scratch);
+		expect(ref.current).to.equal(scratch.firstChild.firstChild);
+	});
+
+	it('should not remove refs for memoized components unkeyed', () => {
+		const ref = createRef();
+		const element = <div ref={ref}>hey</div>;
+		function App(props) {
+			return <div>{element}</div>;
+		}
+
+		render(<App count={0} />, scratch);
+		expect(ref.current).to.equal(scratch.firstChild.firstChild);
+		render(<App count={1} />, scratch);
+		expect(ref.current).to.equal(scratch.firstChild.firstChild);
+		render(<App count={2} />, scratch);
+		expect(ref.current).to.equal(scratch.firstChild.firstChild);
+	});
 });

--- a/test/browser/refs.test.js
+++ b/test/browser/refs.test.js
@@ -509,7 +509,8 @@ describe('refs', () => {
 		expect(ref.current).to.equal(scratch.firstChild.firstChild);
 	});
 
-	it('should properly call null for memoized components keyed', () => {
+	// TODO
+	it.skip('should properly call null for memoized components keyed', () => {
 		const calls = [];
 		const element = <div ref={x => calls.push(x)}>hey</div>;
 		function App(props) {

--- a/test/browser/refs.test.js
+++ b/test/browser/refs.test.js
@@ -508,4 +508,38 @@ describe('refs', () => {
 		render(<App count={2} />, scratch);
 		expect(ref.current).to.equal(scratch.firstChild.firstChild);
 	});
+
+	it('should properly call null for memoized components keyed', () => {
+		const calls = [];
+		const element = <div ref={x => calls.push(x)}>hey</div>;
+		function App(props) {
+			return <div key={props.count}>{element}</div>;
+		}
+
+		render(<App count={0} />, scratch);
+		expect(calls[0]).to.equal(scratch.firstChild.firstChild);
+		render(<App count={1} />, scratch);
+		expect(calls[1]).to.equal(null);
+		expect(calls[2]).to.equal(scratch.firstChild.firstChild);
+		render(<App count={2} />, scratch);
+		expect(calls[3]).to.equal(null);
+		expect(calls[4]).to.equal(scratch.firstChild.firstChild);
+	});
+
+	it('should properly call null for memoized components unkeyed', () => {
+		const calls = [];
+		const element = <div ref={x => calls.push(x)}>hey</div>;
+		function App(props) {
+			return <div>{element}</div>;
+		}
+
+		render(<App count={0} />, scratch);
+		expect(calls[0]).to.equal(scratch.firstChild.firstChild);
+		render(<App count={1} />, scratch);
+		expect(calls[1]).to.equal(null);
+		expect(calls[2]).to.equal(scratch.firstChild.firstChild);
+		render(<App count={2} />, scratch);
+		expect(calls[3]).to.equal(null);
+		expect(calls[4]).to.equal(scratch.firstChild.firstChild);
+	});
 });


### PR DESCRIPTION
fixes https://github.com/preactjs/preact/issues/3695

I think this should be a safe change as the ref from a reused element i.e. `const x = <div ref={ref}>` will always point at the same ref