### PR TITLE
fix: render()'s TS type still included `replaceNode` in v11

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -225,7 +225,6 @@ export namespace h {
 export function render(
 	vnode: ComponentChild,
 	parent: Element | Document | ShadowRoot | DocumentFragment,
-	replaceNode?: Element | Text
 ): void;
 export function hydrate(
 	vnode: ComponentChild,


### PR DESCRIPTION
Missed (or perhaps more likely skipped) in #3099