### PR TITLE
Cleanup _parent, _dom and __hooks after unmount

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -143,7 +143,7 @@ Suspense.prototype._childDidSuspend = function(promise, suspendingVNode) {
 		if (!--c._pendingSuspensionCount) {
 			// If the suspension was during hydration we don't need to restore the
 			// suspended children into the _children array
-			if (c.state._suspended) {
+			if (c.state._suspended && c._vnode._children) {
 				const suspendedVNode = c.state._suspended;
 				c._vnode._children[0] = removeOriginal(
 					suspendedVNode,

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -143,7 +143,7 @@ Suspense.prototype._childDidSuspend = function(promise, suspendingVNode) {
 		if (!--c._pendingSuspensionCount) {
 			// If the suspension was during hydration we don't need to restore the
 			// suspended children into the _children array
-			if (c.state._suspended && c._vnode._children) {
+			if (c.state._suspended) {
 				const suspendedVNode = c.state._suspended;
 				c._vnode._children[0] = removeOriginal(
 					suspendedVNode,

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -110,6 +110,7 @@ options.unmount = vnode => {
 				hasErrored = e;
 			}
 		});
+		c.__hooks = undefined;
 		if (hasErrored) options._catchError(hasErrored, c._vnode);
 	}
 };

--- a/mangle.json
+++ b/mangle.json
@@ -25,6 +25,7 @@
   "props": {
     "cname": 6,
     "props": {
+      "$_listeners": "l",
       "$_cleanup": "__c",
       "$__hooks": "__H",
       "$_list": "__",

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -528,7 +528,8 @@ export function unmount(vnode, parentVNode, skipRemove) {
 
 	// Must be set to `undefined` to properly clean up `_nextDom`
 	// for which `null` is a valid value. See comment in `create-element.js`
-	vnode._dom = vnode._parent = vnode._dom = vnode._nextDom = undefined;
+	if (vnode._dom) vnode._dom._listeners = undefined
+	vnode._children = vnode._dom = vnode._parent = vnode._dom = vnode._nextDom = undefined;
 }
 
 /** The `.render()` method for a PFC backing instance. */

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -528,7 +528,6 @@ export function unmount(vnode, parentVNode, skipRemove) {
 
 	// Must be set to `undefined` to properly clean up `_nextDom`
 	// for which `null` is a valid value. See comment in `create-element.js`
-	if (vnode._dom) vnode._dom._listeners = undefined
 	vnode._children = vnode._dom = vnode._parent = vnode._dom = vnode._nextDom = undefined;
 }
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -522,11 +522,14 @@ export function unmount(vnode, parentVNode, skipRemove) {
 		}
 	}
 
-	if (!skipRemove && vnode._dom != null) removeNode(vnode._dom);
+	if (!skipRemove && vnode._dom != null) {
+		removeNode(vnode._dom);
+		vnode._dom = undefined;
+	}
 
 	// Must be set to `undefined` to properly clean up `_nextDom`
 	// for which `null` is a valid value. See comment in `create-element.js`
-	vnode._dom = vnode._nextDom = undefined;
+	vnode._parent = vnode._dom = vnode._nextDom = undefined;
 }
 
 /** The `.render()` method for a PFC backing instance. */

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -512,6 +512,7 @@ export function unmount(vnode, parentVNode, skipRemove) {
 		}
 
 		r.base = r._parentDom = null;
+		vnode._component = undefined;
 	}
 
 	if ((r = vnode._children)) {
@@ -528,7 +529,7 @@ export function unmount(vnode, parentVNode, skipRemove) {
 
 	// Must be set to `undefined` to properly clean up `_nextDom`
 	// for which `null` is a valid value. See comment in `create-element.js`
-	vnode._children = vnode._dom = vnode._parent = vnode._dom = vnode._nextDom = undefined;
+	vnode._children = vnode._parent = vnode._dom = vnode._nextDom = undefined;
 }
 
 /** The `.render()` method for a PFC backing instance. */

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -524,12 +524,11 @@ export function unmount(vnode, parentVNode, skipRemove) {
 
 	if (!skipRemove && vnode._dom != null) {
 		removeNode(vnode._dom);
-		vnode._dom = undefined;
 	}
 
 	// Must be set to `undefined` to properly clean up `_nextDom`
 	// for which `null` is a valid value. See comment in `create-element.js`
-	vnode._parent = vnode._dom = vnode._nextDom = undefined;
+	vnode._dom = vnode._parent = vnode._dom = vnode._nextDom = undefined;
 }
 
 /** The `.render()` method for a PFC backing instance. */

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -529,7 +529,7 @@ export function unmount(vnode, parentVNode, skipRemove) {
 
 	// Must be set to `undefined` to properly clean up `_nextDom`
 	// for which `null` is a valid value. See comment in `create-element.js`
-	vnode._children = vnode._parent = vnode._dom = vnode._nextDom = undefined;
+	vnode._parent = vnode._dom = vnode._nextDom = undefined;
 }
 
 /** The `.render()` method for a PFC backing instance. */


### PR DESCRIPTION
Possible fix for https://github.com/preactjs/preact/issues/3668

The only thing we can’t cleanup during unmount are the `_children` due to this https://github.com/preactjs/preact/blob/master/compat/src/suspense.js#L148 and the `_dom._listeners` due to

```
FAILED TESTS:
    ✖ should allow component to re-suspend using normal suspension mechanics after initial suspended hydration resumes
      Chrome Headless 105.0.5195.52 (Mac OS 10.15.7)

    Error: Uncaught TypeError: Cannot read properties of undefined (reading 'clickfalse') (compat/test/browser/suspense-hydration.test.js:426)
        at  (compat/test/browser/suspense-hydration.test.js:654:23)
```