### PR TITLE
fix typescript definition for class | className

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -656,8 +656,8 @@ export namespace JSXInternal {
 		challenge?: string;
 		checked?: boolean;
 		cite?: string;
-		class?: string;
-		className?: string;
+		class?: string | undefined;
+		className?: string | undefined;
 		cols?: number;
 		colSpan?: number;
 		content?: string;


### PR DESCRIPTION
When using typescript's `exactOptionalPropertyTypes` and accessing `css-modules` with a index definition the class and or className must be typed to `string | undefined` to appease the compiler.

this fix just modifies those properties to also include undefined, which won't break anything.