### PR TITLE
support falsy data attributes

### DIFF
--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -475,6 +475,16 @@ describe('compat render', () => {
 		expect(updateSpy).to.not.be.calledOnce;
 	});
 
+	it('should support false aria-* attributes', () => {
+		render(<div aria-checked={false} />, scratch);
+		expect(scratch.firstChild.getAttribute('aria-checked')).to.equal('false');
+	});
+
+	it('should support false data-* attributes', () => {
+		render(<div data-checked={false} />, scratch);
+		expect(scratch.firstChild.getAttribute('data-checked')).to.equal('false');
+	});
+
 	it("should support react-relay's usage of __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED", () => {
 		const Ctx = createContext('foo');
 

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -133,10 +133,7 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 
 		if (typeof value === 'function') {
 			// never serialize functions as attribute values
-		} else if (
-			value != null &&
-			(value !== false || (name[0] === 'a' && name[1] === 'r'))
-		) {
+		} else if (value != null && (value !== false || name.indexOf('-') != -1)) {
 			dom.setAttribute(name, value);
 		} else {
 			dom.removeAttribute(name);

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -462,9 +462,19 @@ describe('render()', () => {
 		expect(scratch.childNodes[0]).to.have.property('className', 'bar');
 	});
 
-	it('should support false aria-* attributes', () => {
+	it('should support false string aria-* attributes', () => {
 		render(<div aria-checked="false" />, scratch);
 		expect(scratch.firstChild.getAttribute('aria-checked')).to.equal('false');
+	});
+
+	it('should support false aria-* attributes', () => {
+		render(<div aria-checked={false} />, scratch);
+		expect(scratch.firstChild.getAttribute('aria-checked')).to.equal('false');
+	});
+
+	it('should support false data-* attributes', () => {
+		render(<div data-checked={false} />, scratch);
+		expect(scratch.firstChild.getAttribute('data-checked')).to.equal('false');
 	});
 
 	it('should set checked attribute on custom elements without checked property', () => {


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/3717

This moves us from `aria-` special casing to checking for a dash so we cover both `data-` and `aria-`