### PR TITLE
fix TargetedEvent target definition

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -327,8 +327,8 @@ export namespace JSXInternal {
 	export type TargetedEvent<
 		Target extends EventTarget = EventTarget,
 		TypedEvent extends Event = Event
-	> = Omit<TypedEvent, 'currentTarget'> & {
-		readonly currentTarget: Target;
+	> = Omit<TypedEvent, 'target'> & {
+		readonly target: Target;
 	};
 
 	export type TargetedAnimationEvent<

--- a/test/ts/custom-elements.tsx
+++ b/test/ts/custom-elements.tsx
@@ -58,8 +58,8 @@ class SimpleComponent extends Component {
 							// arrow function
 							console.log(this.componentProp);
 
-							// Validate `currentTarget` is HTMLElement
-							console.log('clicked ', e.currentTarget.style.display);
+							// Validate `target` is HTMLElement
+							console.log('clicked ', e.target.style.display);
 						}}
 					></clickable-ce>
 					<color-picker space="rgb" dir="rtl"></color-picker>


### PR DESCRIPTION
## Why this change?

The Typescript definitions for events are still painful to use, as there are many conflicts with existing UI libraries. For example, `@mui/material` is built around the .target property. The typescript definitions of preact will cause the developer a headache as the typescript definition for the ChangeEvent does not work with `.target` or `.currentTarget` without a few lines of Typscript pain around it.

## Issues with this change

I needed to change the test case, as it uses `currentTarget`. Currently there is no "easy fix" to make  both currentTarget and target work in the same manner, as there will be conflicts due to two possible types when reading the value, which typescript cannot handle.

Simply try to solve the type issues here: https://github.com/preactjs/preact/pull/3723/files#diff-4b06a366f0a931f1bcf0692b56074ecf2b561160741f28d958c9985007d28125R62