### PR TITLE
Add missing "types" field for preact/debug

### DIFF
--- a/debug/src/index.d.ts
+++ b/debug/src/index.d.ts
@@ -1,0 +1,4 @@
+/**
+ * Reset the history of which prop type warnings have been logged.
+ */
+export function resetPropWarnings(): void;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 			"require": "./compat/dist/compat.js"
 		},
 		"./debug": {
+			"types": "./debug/src/index.d.ts",
 			"browser": "./debug/dist/debug.module.js",
 			"umd": "./debug/dist/debug.umd.js",
 			"import": "./debug/dist/debug.mjs",


### PR DESCRIPTION
Discovered in: https://github.com/withastro/astro/pull/4763#discussion_r973298929

We were missing the  `types` field for `preact/debug`.