### PR TITLE
remove _nextDom resetting as it collides with nested fragment switching

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -205,17 +205,6 @@ export function diffChildren(
 	// Remove remaining oldChildren if there are any.
 	for (i = oldChildrenLength; i--; ) {
 		if (oldChildren[i] != null) {
-			if (
-				typeof newParentVNode.type == 'function' &&
-				oldChildren[i]._dom != null &&
-				oldChildren[i]._dom == newParentVNode._nextDom
-			) {
-				// If the newParentVNode.__nextDom points to a dom node that is about to
-				// be unmounted, then get the next sibling of that vnode and set
-				// _nextDom to it
-				newParentVNode._nextDom = getDomSibling(oldParentVNode, i + 1);
-			}
-
 			unmount(oldChildren[i], oldChildren[i]);
 		}
 	}


### PR DESCRIPTION
fixes #3737 

I have tracked this down for a bit and it looks like when the _nextDom is set to `<div />` from the second render we switch it to become `<p>first paragraph` which means instead of appending the `<p>second paragraph` we will be adding it as the first element. If instead of `i + 1` in `getDomSibling` we say `i` it also works due to us removing the `null` element first