### PR TITLE
fix equality for non root children

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -233,7 +233,7 @@ export function useReducer(reducer, initialState, init) {
 					}
 				});
 
-				return shouldUpdate
+				return shouldUpdate || hookState._component.props !== p
 					? prevScu
 						? prevScu.call(this, p, s, c)
 						: true

--- a/hooks/test/browser/errorBoundary.test.js
+++ b/hooks/test/browser/errorBoundary.test.js
@@ -102,9 +102,9 @@ describe('errorBoundary', () => {
 		resetErr();
 		render(<App onError={spy2} />, scratch);
 		rerender();
-		expect(scratch.innerHTML).to.equal('<p>Error</p>');
 		expect(spy).to.be.calledOnce;
 		expect(spy2).to.be.calledOnce;
 		expect(spy2).to.be.calledWith(error);
+		expect(scratch.innerHTML).to.equal('<p>Error</p>');
 	});
 });

--- a/hooks/test/browser/useState.test.js
+++ b/hooks/test/browser/useState.test.js
@@ -346,4 +346,29 @@ describe('useState', () => {
 
 		expect(renderSpy).to.be.calledTwice;
 	});
+
+	// see preactjs/preact#3731
+	it('respects updates initiated from the parent', () => {
+		let setChild, setParent;
+		const Child = props => {
+			const [, setState] = useState(false);
+			setChild = setState;
+			return <p>{props.text}</p>;
+		};
+
+		const Parent = () => {
+			const [state, setState] = useState('hello world');
+			setParent = setState;
+			return <Child text={state} />;
+		};
+
+		render(<Parent />, scratch);
+		expect(scratch.innerHTML).to.equal('<p>hello world</p>');
+
+		setParent('hello world!!!');
+		setChild(true);
+		setChild(false);
+		rerender();
+		expect(scratch.innerHTML).to.equal('<p>hello world!!!</p>');
+	});
 });


### PR DESCRIPTION
 fixes #3731

We only want to run the state optimization when the invoker is the root of the update, this means that when a parent trickles through to its children it could have altered props which means we can't bail out of eventually consistent states.

We started checking whether we are the root of an update this is easily checked because we [shallowly copy the vnode](https://github.com/preactjs/preact/blob/master/src/component.js#L127) which means our props will be referentially equal at the root of an update