### PR TITLE
Avoid synchronously adding setState callbacks

### DIFF
--- a/mangle.json
+++ b/mangle.json
@@ -44,6 +44,7 @@
       "$_force": "__e",
       "$_nextState": "__s",
       "$_renderCallbacks": "__h",
+      "$_stateCallbacks": "_sb",
       "$_vnode": "__v",
       "$_children": "__k",
       "$_pendingSuspensionCount": "__u",

--- a/src/component.js
+++ b/src/component.js
@@ -47,7 +47,9 @@ Component.prototype.setState = function(update, callback) {
 	if (update == null) return;
 
 	if (this._vnode) {
-		if (callback) this._renderCallbacks.push(callback);
+		if (callback) {
+			this._stateCallbacks.push(callback);
+		}
 		enqueueRender(this);
 	}
 };

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -89,6 +89,7 @@ export function diff(
 				c._globalContext = globalContext;
 				isNew = c._dirty = true;
 				c._renderCallbacks = [];
+				c._stateCallbacks = [];
 			}
 
 			// Invoke getDerivedStateFromProps
@@ -108,6 +109,11 @@ export function diff(
 
 			oldProps = c.props;
 			oldState = c.state;
+
+			if (c._stateCallbacks.length) {
+				c._renderCallbacks.push(...c._stateCallbacks);
+				c._stateCallbacks = [];
+			}
 
 			// Invoke pre-render lifecycle methods
 			if (isNew) {

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -110,8 +110,8 @@ export function diff(
 			oldProps = c.props;
 			oldState = c.state;
 
-			if (c._stateCallbacks.length) {
-				c._renderCallbacks.push(...c._stateCallbacks);
+			for (tmp = 0; tmp < c._stateCallbacks.length; tmp++) {
+				c._renderCallbacks.push(c._stateCallbacks[tmp]);
 				c._stateCallbacks = [];
 			}
 

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -133,6 +133,7 @@ export interface Component<P = {}, S = {}> extends preact.Component<P, S> {
 	_dirty: boolean;
 	_force?: boolean;
 	_renderCallbacks: Array<() => void>; // Only class components
+	_stateCallbacks: Array<() => void>; // Only class components
 	_globalContext?: any;
 	_vnode?: VNode<P> | null;
 	_nextState?: S | null; // Only class components

--- a/test/browser/lifecycles/componentDidUpdate.test.js
+++ b/test/browser/lifecycles/componentDidUpdate.test.js
@@ -404,6 +404,7 @@ describe('Lifecycle methods', () => {
 				}
 
 				componentDidMount() {
+					// eslint-disable-next-line
 					this.setState({ show: true });
 				}
 

--- a/test/browser/lifecycles/componentDidUpdate.test.js
+++ b/test/browser/lifecycles/componentDidUpdate.test.js
@@ -381,5 +381,54 @@ describe('Lifecycle methods', () => {
 			expect(Inner.prototype.componentDidUpdate).to.have.been.called;
 			expect(outerChildText).to.equal(`Outer: ${newValue.toString()}`);
 		});
+
+		it('should not interfere with setState callbacks', () => {
+			let invocation;
+
+			class Child extends Component {
+				componentDidMount() {
+					this.props.setValue(10);
+				}
+				render() {
+					return <p>Hello world</p>;
+				}
+			}
+
+			class App extends Component {
+				constructor(props) {
+					super(props);
+					this.state = {
+						show: false,
+						count: null
+					};
+				}
+
+				componentDidMount() {
+					this.setState({ show: true });
+				}
+
+				componentDidUpdate() {}
+
+				render() {
+					if (this.state.show) {
+						return (
+							<Child
+								setValue={i =>
+									this.setState({ count: i }, () => {
+										invocation = this.state;
+									})
+								}
+							/>
+						);
+					}
+					return null;
+				}
+			}
+
+			render(<App />, scratch);
+
+			rerender();
+			expect(invocation.count).to.equal(10);
+		});
 	});
 });


### PR DESCRIPTION
Fixes #3742

The issue in question is caused by our mutable _renderCallbacks and the timing of which we push our new state-setting callback into it.

In the test-scenario we have a component that mounts without children due to a `loading` state variable being true, imagine a spinner or something instead here.
After our component mounts we set this variable to `false` effectively mounting our child-component which has a `componentDidMount` of itself which calls a setState on the parent, due to this `setState` we will synchronously push our `setState` callback onto the `_renderCallbacks` which is the one from the render we are still processing.

Now why do we call it with `componentDidUpdate` and not without? Well we push a `_renderCallback` when we are updating from loading true to false which puts this parent component into the renderQueue which we consume in the inverse order of the tree (child --> parent) this leads us to calling the setState callback when the intermediary render completes (read not the one where we update the parent state).


To solve this we ensure that we only push this callback when we are consuming the render coupled to this dirty state by means of adding a `_stateCallbacks` mechanism that is consumed when the component is handled. 