### PR TITLE
chore(compat): add package.json to exports

### DIFF
--- a/compat/package.json
+++ b/compat/package.json
@@ -44,6 +44,10 @@
 		"./scheduler": {
 			"import": "./scheduler.mjs",
 			"require": "./scheduler.js"
+		},
+		"./package.json": {
+			"import": "./package.json",
+			"require": "./package.json"
 		}
 	}
 }

--- a/compat/package.json
+++ b/compat/package.json
@@ -45,9 +45,6 @@
 			"import": "./scheduler.mjs",
 			"require": "./scheduler.js"
 		},
-		"./package.json": {
-			"import": "./package.json",
-			"require": "./package.json"
-		}
+		"./package.json": "./package.json"
 	}
 }


### PR DESCRIPTION
# Summary

When I switched from webpack aliasing react to preact, to doing it on package level in an Next.JS codebase I ran into a problem - storybook was throwing error - webpack was trying to access `package.json`, but it wasn't defined in the `exports`. 

Adding this inside of `package.json` helped my case, but if this not is not how we should approach it, please guide me towards a better solution.