### PR TITLE
Adding better support for hooks related to `time-slicing`(concurrent) ⏲️ 

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -32,7 +32,7 @@ declare namespace React {
 	export import useState = _hooks.useState;
 	// React 18 hooks
 	export import useInsertionEffect = _hooks.useLayoutEffect;
-	export function useTransition(): [false, typeof startTransition];
+	export function useTransition(): [boolean, typeof startTransition];
 	export function useDeferredValue<T = any>(val: T): T;
 	export function useSyncExternalStore<T>(
 		subscribe: (flush: () => void) => () => void,

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -39,15 +39,9 @@ const requestIdleCallbackPreact =
 		self.requestIdleCallback &&
 		self.requestIdleCallback.bind(window)) ||
 	function (cb) {
-		let start = Date.now()
-		return setTimeout(function () {
-			cb({
-				didTimeout: false,
-				timeRemaining: function () {
-					return Math.max(0, 50 - (Date.now() - start))
-				},
-			})
-		}, 3)
+		return queueMicrotask(() => {
+			cb();
+		});
 	}
 
 

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -34,6 +34,23 @@ import {
 	__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
 } from './render';
 
+const requestIdleCallbackPreact =
+	(typeof self !== 'undefined' &&
+		self.requestIdleCallback &&
+		self.requestIdleCallback.bind(window)) ||
+	function (cb) {
+		let start = Date.now()
+		return setTimeout(function () {
+			cb({
+				didTimeout: false,
+				timeRemaining: function () {
+					return Math.max(0, 50 - (Date.now() - start))
+				},
+			})
+		}, 3)
+	}
+
+
 const version = '17.0.2'; // trick libraries to think we are react
 
 /**
@@ -119,7 +136,9 @@ const flushSync = (callback, arg) => callback(arg);
 const StrictMode = Fragment;
 
 export function startTransition(cb) {
-	cb();
+	requestIdleCallbackPreact(() => {
+		cb();
+	});
 }
 
 export function useDeferredValue(val) {

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -34,16 +34,30 @@ import {
 	__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
 } from './render';
 
+
 const requestIdleCallbackPreact =
-	(typeof self !== "undefined" &&
+	(typeof self !== 'undefined' &&
 		self.requestIdleCallback &&
 		self.requestIdleCallback.bind(window)) ||
 	function (cb) {
-		return queueMicrotask(() => {
-			cb();
-		});
-	};
+		let start = Date.now()
+		return setTimeout(function () {
+			cb({
+				didTimeout: false,
+				timeRemaining: function () {
+					return Math.max(0, 50 - (Date.now() - start))
+				},
+			})
+		}, 3)
+	}
 
+const cancelIdleCallbackPreact =
+	(typeof self !== 'undefined' &&
+		self.cancelIdleCallback &&
+		self.cancelIdleCallback.bind(window)) ||
+	function (id) {
+		return clearTimeout(id)
+	}
 
 const version = '17.0.2'; // trick libraries to think we are react
 
@@ -130,9 +144,16 @@ const flushSync = (callback, arg) => callback(arg);
 const StrictMode = Fragment;
 
 export function startTransition(cb) {
-	requestIdleCallbackPreact(() => {
+
+	const preactIdleTask = requestIdleCallbackPreact(() => {
 		cb();
 	});
+
+	useEffect(() => {
+		return () => {
+			cancelIdleCallbackPreact(preactIdleTask);
+		}
+	}, [preactIdleTask]);
 }
 
 export function useDeferredValue(val) {

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -35,14 +35,14 @@ import {
 } from './render';
 
 const requestIdleCallbackPreact =
-	(typeof self !== 'undefined' &&
+	(typeof self !== "undefined" &&
 		self.requestIdleCallback &&
 		self.requestIdleCallback.bind(window)) ||
 	function (cb) {
 		return queueMicrotask(() => {
 			cb();
 		});
-	}
+	};
 
 
 const version = '17.0.2'; // trick libraries to think we are react
@@ -140,7 +140,17 @@ export function useDeferredValue(val) {
 }
 
 export function useTransition() {
-	return [false, startTransition];
+	const [isTransitionPending, setIsTransitionPending] = useState(false);
+
+	const startTransitionFunction = (cb) => {
+		setIsTransitionPending(true);
+		requestIdleCallbackPreact(() => {
+			cb();
+			setIsTransitionPending(false);
+		});
+	};
+
+	return [isTransitionPending, startTransitionFunction];
 }
 
 // TODO: in theory this should be done after a VNode is diffed as we want to insert


### PR DESCRIPTION
### Adding better support for concurrency⏲️ 

Running the concurrent task in idle period using [`window.requestIdleCallback`](https://developer.chrome.com/blog/using-requestidlecallback/).

> - Adding support for running the concurrental tasks by running it in idle period without blocking other urgent functions. (including `scroll`, `touch`, `click`...)
> - Mocking `useTransition` behaviour using `useState` hook.


_Extremely sorry if I made any mistakes :(_

