### PR TITLE
[Typescript] Fix props not spreadable to input elements

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -977,7 +977,7 @@ export namespace JSXInternal {
 		i: HTMLAttributes<HTMLElement>;
 		iframe: HTMLAttributes<HTMLIFrameElement>;
 		img: HTMLAttributes<HTMLImageElement>;
-		input: HTMLAttributes<HTMLInputElement> & { defaultValue?: string | SignalLike<string> };
+		input: HTMLAttributes<HTMLInputElement>;
 		ins: HTMLAttributes<HTMLModElement>;
 		kbd: HTMLAttributes<HTMLElement>;
 		keygen: HTMLAttributes<HTMLUnknownElement>;

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -977,7 +977,7 @@ export namespace JSXInternal {
 		i: HTMLAttributes<HTMLElement>;
 		iframe: HTMLAttributes<HTMLIFrameElement>;
 		img: HTMLAttributes<HTMLImageElement>;
-		input: HTMLAttributes<HTMLInputElement> & { defaultValue?: string };
+		input: HTMLAttributes<HTMLInputElement> & { defaultValue?: string | SignalLike<string> };
 		ins: HTMLAttributes<HTMLModElement>;
 		kbd: HTMLAttributes<HTMLElement>;
 		keygen: HTMLAttributes<HTMLUnknownElement>;


### PR DESCRIPTION
This is meant to be an extremely minor fix for the following problem I've run into in the most recent version of Preact:

```tsx
// Props are spreadable to all types except for input elements
const a = <div {...({} as h.JSX.HTMLAttributes<HTMLDivElement>)} />;            // Works fine
const b = <input {...({} as h.JSX.HTMLAttributes<HTMLInputElement>)} />;        // TS Error
```

The only change was updating [its definition](https://github.com/preactjs/preact/blob/e968a5a4000dfa9bec7e8d7b26543b23def6d29d/src/jsx.d.ts#L980) from
```tsx
input: HTMLAttributes<HTMLInputElement> & { defaultValue?: string };
```

to
```tsx
input: HTMLAttributes<HTMLInputElement> & { defaultValue?: string | SignalLike<string> };
```

I will admit I'm not sure if there's a deeper issue that was causing the problem or if this has unintended consequences elsewhere, but just adjusting this one single type seemed to solve everything that I had noticed personally.