### PR TITLE
Skip HTML comments during hydration

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -325,13 +325,12 @@ function placeChild(
 	if (nextDom !== undefined) {
 		oldDom = nextDom;
 	} else {
-		oldDom = newDom.nextSibling;
-	}
-
-	// Skip over comment nodes. Will be removed right after calling diffChildren
-	// in diff so that the vnode tree matches the DOM tree again.
-	while (oldDom !== null && oldDom.nodeType === 8) {
-		oldDom = oldDom.nextSibling;
+		oldDom = newDom;
+		// Skip over comment nodes. Will be removed right after calling diffChildren
+		// in diff so that the vnode tree matches the DOM tree again.
+		do {
+			oldDom = oldDom.nextSibling;
+		} while (oldDom !== null && oldDom.nodeType === 8);
 	}
 
 	return oldDom;

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -328,6 +328,12 @@ function placeChild(
 		oldDom = newDom.nextSibling;
 	}
 
+	// Skip over comment nodes. Will be removed right after calling diffChildren
+	// in diff so that the vnode tree matches the DOM tree again.
+	while (oldDom !== null && oldDom.nodeType === 8) {
+		oldDom = oldDom.nextSibling;
+	}
+
 	return oldDom;
 }
 

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -50,11 +50,11 @@ describe('hydrate()', () => {
 	beforeEach(() => {
 		scratch = setupScratch();
 		attributesSpy = spyOnElementAttributes();
+		clearLog();
 	});
 
 	afterEach(() => {
 		teardown(scratch);
-		clearLog();
 	});
 
 	it('should reuse existing DOM', () => {

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -92,6 +92,7 @@ describe('hydrate()', () => {
 			scratch
 		);
 		expect(scratch.innerHTML).to.equal('<p><i>0</i><b>1</b></p>');
+		expect(getLog()).to.deep.equal(['Comment.remove()']);
 	});
 
 	it('should reuse existing DOM when given components', () => {
@@ -462,5 +463,13 @@ describe('hydrate()', () => {
 		scratch.innerHTML = '<p>hello <!-- c -->foo</p>';
 		hydrate(<p>hello {'foo'}</p>, scratch);
 		expect(scratch.innerHTML).to.equal('<p>hello foo</p>');
+		expect(getLog()).to.deep.equal(['Comment.remove()']);
+	});
+
+	it('should skip over multiple comment nodes', () => {
+		scratch.innerHTML = '<p>hello <!-- a --><!-- b -->foo</p>';
+		hydrate(<p>hello {'foo'}</p>, scratch);
+		expect(scratch.innerHTML).to.equal('<p>hello foo</p>');
+		expect(getLog()).to.deep.equal(['Comment.remove()', 'Comment.remove()']);
 	});
 });


### PR DESCRIPTION
We'd unnecessarily move nodes when the HTML we're going to hydrate contains comments. This is expected because it's sort of a mismatch between the SSR'd tree vs the virtual tree. But it turns out that this feature is needed for streaming SSR as comment nodes are used to indicate hydration boundaries.

Fixes #3767 .