### PR TITLE
Fix useId uniqueness with shared parents + DOM nodes in between

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -1,4 +1,4 @@
-import { Fragment, options } from 'preact';
+import { options } from 'preact';
 
 /** @type {number} */
 let currentIndex;
@@ -374,26 +374,15 @@ export function useId() {
 		// the root node.
 		/** @type {import('./internal.d').VNode} */
 		let root = currentComponent._vnode;
-		let parent = root._parent;
-		let i = 0;
-		while (parent !== null) {
-			if (parent.type !== Fragment && typeof parent.type === 'function') {
-				i++;
-			}
-
-			root = parent;
-			parent = parent._parent;
+		while (root !== null && root._parent !== null) {
+			root = root._parent;
 		}
 
 		// Attach the id usage array to the root node and resize it to fit
-		let ids = root._mask || (root._mask = [0]);
-		while (ids.length < i) {
-			ids.push(0);
-		}
+		let mask = root._mask || (root._mask = [0, 0]);
 
 		// Increase the current component depth pointer
-		ids[i - 1]++;
-		state._value = 'P' + ids.join('') + currentIndex;
+		state._value = 'P' + mask[0] + mask[1]++ + currentIndex;
 	}
 
 	return state._value;

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -372,6 +372,7 @@ export function useId() {
 	if (!state._value) {
 		// Traverse the tree upwards and count the components until we reach
 		// the root node.
+		/** @type {import('./internal.d').VNode} */
 		let root = currentComponent._vnode;
 		let parent = root._parent;
 		let i = 0;
@@ -385,7 +386,7 @@ export function useId() {
 		}
 
 		// Attach the id usage array to the root node and resize it to fit
-		let ids = root._ids || (root._ids = [0]);
+		let ids = root._mask || (root._mask = [0]);
 		while (ids.length < i) {
 			ids.push(0);
 		}

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -370,18 +370,14 @@ export function useErrorBoundary(cb) {
 export function useId() {
 	const state = getHookState(currentIndex++, 11);
 	if (!state._value) {
-		// Traverse the tree upwards and count the components until we reach
-		// the root node.
+		// Grab either the root node or the nearest async boundary node.
 		/** @type {import('./internal.d').VNode} */
 		let root = currentComponent._vnode;
-		while (root !== null && root._parent !== null) {
+		while (root !== null && !root._mask && root._parent !== null) {
 			root = root._parent;
 		}
 
-		// Attach the id usage array to the root node and resize it to fit
 		let mask = root._mask || (root._mask = [0, 0]);
-
-		// Increase the current component depth pointer
 		state._value = 'P' + mask[0] + mask[1]++ + currentIndex;
 	}
 

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -367,15 +367,6 @@ export function useErrorBoundary(cb) {
 	];
 }
 
-function hash(s) {
-	let h = 0,
-		i = s.length;
-	while (i > 0) {
-		h = ((h << 5) - h + s.charCodeAt(--i)) | 0;
-	}
-	return h;
-}
-
 export function useId() {
 	const state = getHookState(currentIndex++, 11);
 	if (!state._value) {
@@ -401,7 +392,7 @@ export function useId() {
 
 		// Increase the current component depth pointer
 		ids[i - 1]++;
-		state._value = 'P' + hash(ids.join('')) + currentIndex;
+		state._value = 'P' + ids.join('') + currentIndex;
 	}
 
 	return state._value;

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -378,7 +378,7 @@ export function useId() {
 		}
 
 		let mask = root._mask || (root._mask = [0, 0]);
-		state._value = 'P' + mask[0] + mask[1]++ + currentIndex;
+		state._value = 'P' + mask[0] + '-' + mask[1]++;
 	}
 
 	return state._value;

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -38,6 +38,10 @@ export interface Component extends PreactComponent<any, any> {
 	__hooks?: ComponentHooks;
 }
 
+export interface VNode extends PreactVNode {
+	_mask?: number[];
+}
+
 export type HookState =
 	| EffectHookState
 	| MemoHookState

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -38,10 +38,6 @@ export interface Component extends PreactComponent<any, any> {
 	__hooks?: ComponentHooks;
 }
 
-export interface VNode extends PreactVNode {
-	_mask?: string;
-}
-
 export type HookState =
 	| EffectHookState
 	| MemoHookState

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -39,7 +39,7 @@ export interface Component extends PreactComponent<any, any> {
 }
 
 export interface VNode extends PreactVNode {
-	_mask?: number[];
+	_mask?: [number, number];
 }
 
 export type HookState =

--- a/hooks/test/browser/useId.test.js
+++ b/hooks/test/browser/useId.test.js
@@ -55,12 +55,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P481"><div id="P15361"><span id="P15362">h</span></div></div>'
+			'<div id="P481"><div id="P491"><span id="P502">h</span></div></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P481"><div id="P15361"><span id="P15362">h</span></div></div>'
+			'<div id="P481"><div id="P491"><span id="P502">h</span></div></div>'
 		);
 	});
 
@@ -83,12 +83,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P481"><span id="P15361">h</span><span id="P15671">h</span><span id="P15981">h</span></div>'
+			'<div id="P481"><span id="P491">h</span><span id="P501">h</span><span id="P511">h</span></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P481"><span id="P15361">h</span><span id="P15671">h</span><span id="P15981">h</span></div>'
+			'<div id="P481"><span id="P491">h</span><span id="P501">h</span><span id="P511">h</span></div>'
 		);
 	});
 
@@ -121,13 +121,13 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P481"><div><span id="P476641">h</span></div></div>'
+			'<div id="P481"><div><span id="P15671">h</span></div></div>'
 		);
 
 		set(true);
 		rerender();
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P481"><div><span id="P476641">h</span><span id="P486251">h</span></div></div>'
+			'<div id="P481"><div><span id="P15671">h</span><span id="P15981">h</span></div></div>'
 		);
 	});
 
@@ -350,6 +350,32 @@ describe('useId', () => {
 		}
 
 		render(<App />, scratch);
-		expect(scratch.innerHTML).to.equal('<div><p>P481</p><p>P476951</p></div>');
+		expect(scratch.innerHTML).to.equal('<div><p>P481</p><p>P15671</p></div>');
+	});
+
+	it('should skip over HTML', () => {
+		const ids = [];
+
+		function Foo() {
+			const id = useId();
+			ids.push(id);
+			return <p>{id}</p>;
+		}
+
+		function App() {
+			return (
+				<div>
+					<span>
+						<Foo />
+					</span>
+					<span>
+						<Foo />
+					</span>
+				</div>
+			);
+		}
+
+		render(<App />, scratch);
+		expect(ids).to.deep.equal(['P491', 'P501']);
 	});
 });

--- a/hooks/test/browser/useId.test.js
+++ b/hooks/test/browser/useId.test.js
@@ -55,12 +55,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P481"><div id="P491"><span id="P502">h</span></div></div>'
+			'<div id="P01"><div id="P11"><span id="P22">h</span></div></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P481"><div id="P491"><span id="P502">h</span></div></div>'
+			'<div id="P01"><div id="P11"><span id="P22">h</span></div></div>'
 		);
 	});
 
@@ -83,12 +83,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P481"><span id="P491">h</span><span id="P501">h</span><span id="P511">h</span></div>'
+			'<div id="P01"><span id="P11">h</span><span id="P21">h</span><span id="P31">h</span></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P481"><span id="P491">h</span><span id="P501">h</span><span id="P511">h</span></div>'
+			'<div id="P01"><span id="P11">h</span><span id="P21">h</span><span id="P31">h</span></div>'
 		);
 	});
 
@@ -121,13 +121,13 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P481"><div><span id="P15671">h</span></div></div>'
+			'<div id="P01"><div><span id="P011">h</span></div></div>'
 		);
 
 		set(true);
 		rerender();
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P481"><div><span id="P15671">h</span><span id="P15981">h</span></div></div>'
+			'<div id="P01"><div><span id="P011">h</span><span id="P021">h</span></div></div>'
 		);
 	});
 
@@ -350,7 +350,7 @@ describe('useId', () => {
 		}
 
 		render(<App />, scratch);
-		expect(scratch.innerHTML).to.equal('<div><p>P481</p><p>P15671</p></div>');
+		expect(scratch.innerHTML).to.equal('<div><p>P01</p><p>P011</p></div>');
 	});
 
 	it('should skip over HTML', () => {
@@ -376,7 +376,7 @@ describe('useId', () => {
 		}
 
 		render(<App />, scratch);
-		expect(ids).to.deep.equal(['P491', 'P501']);
+		expect(ids).to.deep.equal(['P11', 'P21']);
 	});
 
 	it('should reset for each renderToString roots', () => {

--- a/hooks/test/browser/useId.test.js
+++ b/hooks/test/browser/useId.test.js
@@ -55,12 +55,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P01"><div id="P11"><span id="P22">h</span></div></div>'
+			'<div id="P001"><div id="P011"><span id="P022">h</span></div></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P01"><div id="P11"><span id="P22">h</span></div></div>'
+			'<div id="P001"><div id="P011"><span id="P022">h</span></div></div>'
 		);
 	});
 
@@ -83,12 +83,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P01"><span id="P11">h</span><span id="P21">h</span><span id="P31">h</span></div>'
+			'<div id="P001"><span id="P011">h</span><span id="P021">h</span><span id="P031">h</span></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P01"><span id="P11">h</span><span id="P21">h</span><span id="P31">h</span></div>'
+			'<div id="P001"><span id="P011">h</span><span id="P021">h</span><span id="P031">h</span></div>'
 		);
 	});
 
@@ -121,13 +121,13 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P01"><div><span id="P011">h</span></div></div>'
+			'<div id="P001"><div><span id="P011">h</span></div></div>'
 		);
 
 		set(true);
 		rerender();
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P01"><div><span id="P011">h</span><span id="P021">h</span></div></div>'
+			'<div id="P001"><div><span id="P011">h</span><span id="P021">h</span></div></div>'
 		);
 	});
 
@@ -332,13 +332,16 @@ describe('useId', () => {
 			return <Fragment>{children}</Fragment>;
 		};
 
+		const ids = [];
 		function Foo() {
 			const id = useId();
+			ids.push(id);
 			return <p>{id}</p>;
 		}
 
 		function App() {
 			const id = useId();
+			ids.push(id);
 			return (
 				<div>
 					<p>{id}</p>
@@ -350,7 +353,7 @@ describe('useId', () => {
 		}
 
 		render(<App />, scratch);
-		expect(scratch.innerHTML).to.equal('<div><p>P01</p><p>P011</p></div>');
+		expect(ids[0]).not.to.equal(ids[1]);
 	});
 
 	it('should skip over HTML', () => {
@@ -376,7 +379,7 @@ describe('useId', () => {
 		}
 
 		render(<App />, scratch);
-		expect(ids).to.deep.equal(['P11', 'P21']);
+		expect(ids[0]).not.to.equal(ids[1]);
 	});
 
 	it('should reset for each renderToString roots', () => {

--- a/hooks/test/browser/useId.test.js
+++ b/hooks/test/browser/useId.test.js
@@ -55,12 +55,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P001"><div id="P011"><span id="P022">h</span></div></div>'
+			'<div id="P0-0"><div id="P0-1"><span id="P0-2">h</span></div></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P001"><div id="P011"><span id="P022">h</span></div></div>'
+			'<div id="P0-0"><div id="P0-1"><span id="P0-2">h</span></div></div>'
 		);
 	});
 
@@ -83,12 +83,12 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P001"><span id="P011">h</span><span id="P021">h</span><span id="P031">h</span></div>'
+			'<div id="P0-0"><span id="P0-1">h</span><span id="P0-2">h</span><span id="P0-3">h</span></div>'
 		);
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P001"><span id="P011">h</span><span id="P021">h</span><span id="P031">h</span></div>'
+			'<div id="P0-0"><span id="P0-1">h</span><span id="P0-2">h</span><span id="P0-3">h</span></div>'
 		);
 	});
 
@@ -121,13 +121,13 @@ describe('useId', () => {
 
 		render(<Comp />, scratch);
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P001"><div><span id="P011">h</span></div></div>'
+			'<div id="P0-0"><div><span id="P0-1">h</span></div></div>'
 		);
 
 		set(true);
 		rerender();
 		expect(scratch.innerHTML).to.equal(
-			'<div id="P001"><div><span id="P011">h</span><span id="P021">h</span></div></div>'
+			'<div id="P0-0"><div><span id="P0-1">h</span><span id="P0-2">h</span></div></div>'
 		);
 	});
 

--- a/hooks/test/browser/useId.test.js
+++ b/hooks/test/browser/useId.test.js
@@ -405,4 +405,29 @@ describe('useId', () => {
 		const res2 = rts(<App />);
 		expect(res1).to.equal(res2);
 	});
+
+	it('should work with conditional components', () => {
+		function Foo() {
+			const id = useId();
+			return <p>{id}</p>;
+		}
+		function Bar() {
+			const id = useId();
+			return <p>{id}</p>;
+		}
+
+		let update;
+		function App() {
+			const [v, setV] = useState(false);
+			update = setV;
+			return <div>{!v ? <Foo /> : <Bar />}</div>;
+		}
+
+		render(<App />, scratch);
+		const first = scratch.innerHTML;
+
+		update(v => !v);
+		rerender();
+		expect(first).not.to.equal(scratch.innerHTML);
+	});
 });

--- a/hooks/test/browser/useId.test.js
+++ b/hooks/test/browser/useId.test.js
@@ -378,4 +378,31 @@ describe('useId', () => {
 		render(<App />, scratch);
 		expect(ids).to.deep.equal(['P491', 'P501']);
 	});
+
+	it('should reset for each renderToString roots', () => {
+		const ids = [];
+
+		function Foo() {
+			const id = useId();
+			ids.push(id);
+			return <p>{id}</p>;
+		}
+
+		function App() {
+			return (
+				<div>
+					<span>
+						<Foo />
+					</span>
+					<span>
+						<Foo />
+					</span>
+				</div>
+			);
+		}
+
+		const res1 = rts(<App />);
+		const res2 = rts(<App />);
+		expect(res1).to.equal(res2);
+	});
 });

--- a/mangle.json
+++ b/mangle.json
@@ -39,7 +39,6 @@
       "$_depth": "__b",
       "$_nextDom": "__d",
       "$_dirty": "__d",
-      "$_mask": "__m",
       "$_detachOnNextRender": "__b",
       "$_force": "__e",
       "$_nextState": "__s",

--- a/mangle.json
+++ b/mangle.json
@@ -39,6 +39,7 @@
       "$_depth": "__b",
       "$_nextDom": "__d",
       "$_dirty": "__d",
+      "$_mask": "__m",
       "$_detachOnNextRender": "__b",
       "$_force": "__e",
       "$_nextState": "__s",


### PR DESCRIPTION
This PR changes the id generation for `useId` and fixes an issue where the id wasn't unique anymore when two components were in different HTML nodes, but shared the same component parent.

Instead of storing a `_mask` property on every component `vnode`, regardless of whether `useId` is used or not, we'll only calculate the id when `useId` is called. When that happens we'll walk up the tree and count the component `vnodes` up until we reach the root. Then we create a component depth array and increase the component depth index of the current component. Joining all indexes will yield the final ID.

Whilst this PR drops the need for `vnode._mask` it stores the component depth array on the root `vnode` as `vnode._ids`. This behavior is similar to before where ids have the constraint that they are unique per root, not globally unique.

Fixes #3772 .