### PR TITLE
fix case where keyed children would get removed

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -293,7 +293,7 @@ function placeChild(
 			for (
 				let sibDom = oldDom, j = 0;
 				(sibDom = sibDom.nextSibling) && j < oldChildren.length;
-				j += 2
+				j += 1
 			) {
 				if (sibDom == newDom) {
 					break outer;

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -689,8 +689,8 @@ describe('Fragment', () => {
 		expect(scratch.innerHTML).to.equal(htmlForFalse);
 		expectDomLogToBe(
 			[
-				'<div>fooHellobeep.insertBefore(<div>beep, <div>foo)',
-				'<div>beepbarHello.appendChild(<div>bar)'
+				'<div>fooHellobeep.appendChild(<div>Hello)',
+				'<div>barbeepHello.appendChild(<div>bar)'
 			],
 			'rendering true to false'
 		);
@@ -702,8 +702,8 @@ describe('Fragment', () => {
 		expect(scratch.innerHTML).to.equal(htmlForTrue);
 		expectDomLogToBe(
 			[
-				'<div>beepHellofoo.insertBefore(<div>foo, <div>beep)',
-				'<div>fooboopHello.appendChild(<div>boop)'
+				'<div>beepHellofoo.appendChild(<div>Hello)',
+				'<div>boopfooHello.appendChild(<div>boop)'
 			],
 			'rendering false to true'
 		);
@@ -744,7 +744,6 @@ describe('Fragment', () => {
 			'<div>1Hello2.insertBefore(<span>1, <span>1)',
 			'<div>.appendChild(#text)',
 			'<div>11Hello2.insertBefore(<div>Hello, <span>1)',
-			'<div>1Hello1Hello2.insertBefore(<span>2, <span>1)',
 			'<span>1.remove()',
 			'<div>Hello.remove()'
 		]);
@@ -759,7 +758,6 @@ describe('Fragment', () => {
 			'<div>1Hello2.insertBefore(<span>1, <span>1)',
 			'<div>.appendChild(#text)',
 			'<div>11Hello2.insertBefore(<div>Hello, <span>1)',
-			'<div>1Hello1Hello2.insertBefore(<span>2, <span>1)',
 			'<span>1.remove()',
 			'<div>Hello.remove()'
 		]);
@@ -1499,8 +1497,8 @@ describe('Fragment', () => {
 		);
 		expectDomLogToBe(
 			[
-				'<div>beepHellofoo.insertBefore(<div>foo, <div>beep)',
-				'<div>fooboopHello.appendChild(<div>boop)',
+				'<div>beepHellofoo.appendChild(<div>Hello)',
+				'<div>boopfooHello.appendChild(<div>boop)',
 				'<div>.appendChild(#text)',
 				'<div>fooHelloboop.appendChild(<div>boop)'
 			],
@@ -2761,6 +2759,57 @@ describe('Fragment', () => {
 			'<div>3.remove()',
 			'<div>14AB.appendChild(<div>A)',
 			'<div>14BA.appendChild(<div>B)'
+		]);
+	});
+
+	it('should not remove keyed elements', () => {
+		let deleteItem = () => {};
+		const Element = ({ item, deleteItem }) => (
+			<Fragment>
+				<div>Item: {item}</div>
+				{''} {/* If you delete this, it works fine. */}
+			</Fragment>
+		);
+
+		class App extends Component {
+			constructor(props) {
+				super(props);
+				this.state = {
+					items: Array(10)
+						.fill()
+						.map((_, i) => i)
+				};
+			}
+
+			render(_props, state) {
+				deleteItem = () => {
+					this.setState({
+						items: this.state.items.filter(i => i !== this.state.items[2])
+					});
+				};
+
+				return state.items.map(item => (
+					<Element item={item} deleteItem={deleteItem} key={item} />
+				));
+			}
+		}
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<div>Item: 0</div> <div>Item: 1</div> <div>Item: 2</div> <div>Item: 3</div> <div>Item: 4</div> <div>Item: 5</div> <div>Item: 6</div> <div>Item: 7</div> <div>Item: 8</div> <div>Item: 9</div> '
+		);
+
+		clearLog();
+		deleteItem();
+		rerender();
+
+		expect(scratch.innerHTML).to.equal(
+			'<div>Item: 0</div> <div>Item: 1</div> <div>Item: 3</div> <div>Item: 4</div> <div>Item: 5</div> <div>Item: 6</div> <div>Item: 7</div> <div>Item: 8</div> <div>Item: 9</div> '
+		);
+		expectDomLogToBe([
+			'<div>Item: 2.remove()',
+			'#text.remove()',
+			'#text.remove()'
 		]);
 	});
 

--- a/test/browser/keys.test.js
+++ b/test/browser/keys.test.js
@@ -319,7 +319,11 @@ describe('keys', () => {
 		render(<List values={values} />, scratch);
 		expect(scratch.textContent).to.equal('abcd', 'move to beginning');
 		expect(getLog()).to.deep.equal(
-			['<ol>bcda.insertBefore(<li>a, <li>b)'],
+			[
+				'<ol>bcda.appendChild(<li>b)',
+				'<ol>cdab.appendChild(<li>c)',
+				'<ol>dabc.appendChild(<li>d)'
+			],
 			'move to beginning'
 		);
 	});
@@ -337,15 +341,15 @@ describe('keys', () => {
 		render(<List values={values} />, scratch);
 		expect(scratch.textContent).to.equal(values.join(''));
 		expect(getLog()).to.deep.equal([
-			'<ol>abcdefghij.insertBefore(<li>j, <li>a)',
-			'<ol>jabcdefghi.insertBefore(<li>i, <li>a)',
-			'<ol>jiabcdefgh.insertBefore(<li>h, <li>a)',
-			'<ol>jihabcdefg.insertBefore(<li>g, <li>a)',
-			'<ol>jihgabcdef.appendChild(<li>e)',
-			'<ol>jihgabcdfe.appendChild(<li>d)',
-			'<ol>jihgabcfed.appendChild(<li>c)',
-			'<ol>jihgabfedc.appendChild(<li>b)',
-			'<ol>jihgafedcb.appendChild(<li>a)'
+			'<ol>abcdefghij.appendChild(<li>i)',
+			'<ol>abcdefghji.appendChild(<li>h)',
+			'<ol>abcdefgjih.appendChild(<li>g)',
+			'<ol>abcdefjihg.appendChild(<li>f)',
+			'<ol>abcdejihgf.appendChild(<li>e)',
+			'<ol>abcdjihgfe.appendChild(<li>d)',
+			'<ol>abcjihgfed.appendChild(<li>c)',
+			'<ol>abjihgfedc.appendChild(<li>b)',
+			'<ol>ajihgfedcb.appendChild(<li>a)'
 		]);
 	});
 


### PR DESCRIPTION
Fixes #3766

When we have a fragment the DOM needs to dig deeper to find the matching elements, what happens is that we  remove 1 element which means when we always skip by 2 we can't find any elements anymore, I know we have went back and forth on removing/not-removing this quite a bit now but this is a really valid case imo.

We can still opt not to do this for unkeyed elements if we find the byte-offset worth which might be a bit expensive as we would have to carry the fact that there's a parent to the Fragment that has a key