### PR TITLE
Backport x v2

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -134,9 +134,22 @@ declare namespace React {
 	): C;
 
 	export interface ForwardFn<P = {}, T = any> {
-		(props: P, ref: Ref<T>): preact.ComponentChild;
+		(props: P, ref: ForwardedRef<T>): preact.ComponentChild;
 		displayName?: string;
 	}
+
+	interface MutableRefObject<T> {
+		current: T;
+	}
+
+	export type ForwardedRef<T> =
+		| ((instance: T | null) => void)
+		| MutableRefObject<T | null>
+		| null;
+
+	export type PropsWithChildren<P = unknown> = P & {
+		children?: preact.ComponentChild | undefined;
+	};
 
 	export function forwardRef<R, P = {}>(
 		fn: ForwardFn<P, R>

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -138,6 +138,16 @@ export function useTransition() {
 export const useInsertionEffect = useLayoutEffect;
 
 /**
+ * Check if two values are the same value
+ * @param {*} x
+ * @param {*} y
+ * @returns {boolean}
+ */
+function is(x, y) {
+	return (x === y && (x !== 0 || 1 / x === 1 / y)) || (x !== x && y !== y);
+}
+
+/**
  * This is taken from https://github.com/facebook/react/blob/main/packages/use-sync-external-store/src/useSyncExternalStoreShimClient.js#L84
  * on a high level this cuts out the warnings, ... and attempts a smaller implementation
  */
@@ -152,18 +162,18 @@ export function useSyncExternalStore(subscribe, getSnapshot) {
 		_instance._value = value;
 		_instance._getSnapshot = getSnapshot;
 
-		if (_instance._value !== getSnapshot()) {
+		if (!is(_instance._value, getSnapshot())) {
 			forceUpdate({ _instance });
 		}
 	}, [subscribe, value, getSnapshot]);
 
 	useEffect(() => {
-		if (_instance._value !== _instance._getSnapshot()) {
+		if (!is(_instance._value, _instance._getSnapshot())) {
 			forceUpdate({ _instance });
 		}
 
 		return subscribe(() => {
-			if (_instance._value !== _instance._getSnapshot()) {
+			if (!is(_instance._value, _instance._getSnapshot())) {
 				forceUpdate({ _instance });
 			}
 		});

--- a/debug/src/index.d.ts
+++ b/debug/src/index.d.ts
@@ -1,0 +1,4 @@
+/**
+ * Reset the history of which prop type warnings have been logged.
+ */
+export function resetPropWarnings(): void;

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -216,7 +216,7 @@ export function useReducer(reducer, initialState, init) {
 					}
 				});
 
-				return shouldUpdate
+				return shouldUpdate || hookState._internal.props !== p
 					? prevScu
 						? prevScu.call(this, p, s, c)
 						: true

--- a/hooks/test/browser/useState.test.js
+++ b/hooks/test/browser/useState.test.js
@@ -346,4 +346,29 @@ describe('useState', () => {
 
 		expect(renderSpy).to.be.calledTwice;
 	});
+
+	// see preactjs/preact#3731
+	it('respects updates initiated from the parent', () => {
+		let setChild, setParent;
+		const Child = props => {
+			const [, setState] = useState(false);
+			setChild = setState;
+			return <p>{props.text}</p>;
+		};
+
+		const Parent = () => {
+			const [state, setState] = useState('hello world');
+			setParent = setState;
+			return <Child text={state} />;
+		};
+
+		render(<Parent />, scratch);
+		expect(scratch.innerHTML).to.equal('<p>hello world</p>');
+
+		setParent('hello world!!!');
+		setChild(true);
+		setChild(false);
+		rerender();
+		expect(scratch.innerHTML).to.equal('<p>hello world!!!</p>');
+	});
 });

--- a/mangle.json
+++ b/mangle.json
@@ -52,6 +52,7 @@
       "$_children": "__k",
       "$_pendingSuspensionCount": "__u",
       "$_childDidSuspend": "__c",
+      "$_stateCallbacks": "_sb",
       "$_onResolve": "__R",
       "$_suspended": "__e",
       "$_dom": "__e",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 			"umd": "./compat/dist/compat.umd.js"
 		},
 		"./debug": {
+      "types": "./debug/src/index.d.ts",
 			"module": "./debug/dist/debug.mjs",
 			"import": "./debug/dist/debug.mjs",
 			"require": "./debug/dist/debug.js",

--- a/src/component.js
+++ b/src/component.js
@@ -53,7 +53,7 @@ Component.prototype.setState = function(update, callback) {
 
 	const internal = this._internal;
 	if (update != null && internal) {
-		if (callback) internal._commitCallbacks.push(callback.bind(this));
+		if (callback) internal._stateCallbacks.push(callback.bind(this));
 		internal.rerender(internal);
 	}
 };

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -367,6 +367,10 @@ function mountComponent(internal, startDom) {
 		if (renderHook) renderHook(internal);
 		if (ENABLE_CLASSES && internal.flags & TYPE_CLASS) {
 			renderResult = c.render(c.props, c.state, c.context);
+			for (let i = 0; i < internal._stateCallbacks.length; i++) {
+				internal._commitCallbacks.push(internal._stateCallbacks[i]);
+			}
+			internal._stateCallbacks = [];
 			// note: disable repeat render invocation for class components
 			break;
 		} else {

--- a/src/diff/patch.js
+++ b/src/diff/patch.js
@@ -244,6 +244,10 @@ function patchComponent(internal, newVNode) {
 		c.props = newProps;
 		c.state = c._nextState;
 		internal.flags |= SKIP_CHILDREN;
+		for (let i = 0; i < internal._stateCallbacks.length; i++) {
+			internal._commitCallbacks.push(internal._stateCallbacks[i]);
+		}
+		internal._stateCallbacks = [];
 		return;
 	}
 
@@ -265,6 +269,10 @@ function patchComponent(internal, newVNode) {
 		if (renderHook) renderHook(internal);
 		if (ENABLE_CLASSES && internal.flags & TYPE_CLASS) {
 			renderResult = c.render(c.props, c.state, c.context);
+			for (let i = 0; i < internal._stateCallbacks.length; i++) {
+				internal._commitCallbacks.push(internal._stateCallbacks[i]);
+			}
+			internal._stateCallbacks = [];
 			// note: disable repeat render invocation for class components
 			break;
 		} else {

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -94,10 +94,7 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 
 		if (typeof value === 'function') {
 			// never serialize functions as attribute values
-		} else if (
-			value != null &&
-			(value !== false || (name[0] === 'a' && name[1] === 'r'))
-		) {
+		} else if (value != null && (value !== false || name.indexOf('-') != -1)) {
 			dom.setAttribute(name, value);
 		} else {
 			dom.removeAttribute(name);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -39,7 +39,7 @@ export type Key = string | number | any;
 
 export type RefObject<T> = { current: T | null };
 export type RefCallback<T> = (instance: T | null) => void;
-export type Ref<T> = RefObject<T> | RefCallback<T>;
+export type Ref<T> = RefObject<T> | RefCallback<T> | null;
 
 export type ComponentChild =
 	| VNode<any>

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -164,6 +164,7 @@ export interface Internal<P = {}> {
 	_depth: number | null;
 	/** Callbacks to invoke when this internal commits */
 	_commitCallbacks: Array<() => void>;
+	_stateCallbacks: Array<() => void>; // Only class components
 }
 
 export interface Component<P = {}, S = {}> extends preact.Component<P, S> {

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -647,8 +647,8 @@ export namespace JSXInternal {
 		challenge?: string;
 		checked?: boolean;
 		cite?: string;
-		class?: string;
-		className?: string;
+		class?: string | undefined;
+		className?: string | undefined;
 		cols?: number;
 		colSpan?: number;
 		content?: string;

--- a/src/tree.js
+++ b/src/tree.js
@@ -89,6 +89,7 @@ export function createInternal(vnode, parentInternal) {
 		_prevRef: null,
 		data: flags & TYPE_COMPONENT ? {} : null,
 		_commitCallbacks: flags & TYPE_COMPONENT ? [] : null,
+		_stateCallbacks: flags & TYPE_COMPONENT ? [] : null,
 		rerender: enqueueRender,
 		flags,
 		_children: null,

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -84,6 +84,57 @@ describe('Fragment', () => {
 		]);
 	});
 
+	it('should not remove keyed elements', () => {
+		let deleteItem = () => {};
+		const Element = ({ item, deleteItem }) => (
+			<Fragment>
+				<div>Item: {item}</div>
+				{''} {/* If you delete this, it works fine. */}
+			</Fragment>
+		);
+
+		class App extends Component {
+			constructor(props) {
+				super(props);
+				this.state = {
+					items: Array(10)
+						.fill()
+						.map((_, i) => i)
+				};
+			}
+
+			render(_props, state) {
+				deleteItem = () => {
+					this.setState({
+						items: this.state.items.filter(i => i !== this.state.items[2])
+					});
+				};
+
+				return state.items.map(item => (
+					<Element item={item} deleteItem={deleteItem} key={item} />
+				));
+			}
+		}
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<div>Item: 0</div> <div>Item: 1</div> <div>Item: 2</div> <div>Item: 3</div> <div>Item: 4</div> <div>Item: 5</div> <div>Item: 6</div> <div>Item: 7</div> <div>Item: 8</div> <div>Item: 9</div> '
+		);
+
+		clearLog();
+		deleteItem();
+		rerender();
+
+		expect(scratch.innerHTML).to.equal(
+			'<div>Item: 0</div> <div>Item: 1</div> <div>Item: 3</div> <div>Item: 4</div> <div>Item: 5</div> <div>Item: 6</div> <div>Item: 7</div> <div>Item: 8</div> <div>Item: 9</div> '
+		);
+		expectDomLogToBe([
+			'<div>Item: 2.remove()',
+			'#text.remove()',
+			'#text.remove()'
+		]);
+	});
+
 	it('should render multiple children via noop renderer', () => {
 		render(
 			<Fragment>

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -1502,6 +1502,63 @@ describe('Fragment', () => {
 		);
 	});
 
+	it('should swap nested fragments correctly', () => {
+		let swap;
+		class App extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { first: true };
+			}
+
+			render() {
+				if (this.state.first) {
+					return (
+						<Fragment>
+							{
+								<Fragment>
+									<p>1. Original item first paragraph</p>
+								</Fragment>
+							}
+							<p>2. Original item second paragraph</p>
+							<button onClick={(swap = () => this.setState({ first: false }))}>
+								Click me
+							</button>
+						</Fragment>
+					);
+				}
+				return (
+					<Fragment>
+						<p>1. Second item first paragraph</p>
+						<Fragment>
+							<p>2. Second item second paragraph</p>
+							<div />
+						</Fragment>
+						<button onClick={(swap = () => this.setState({ first: true }))}>
+							Click me
+						</button>
+					</Fragment>
+				);
+			}
+		}
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<p>1. Original item first paragraph</p><p>2. Original item second paragraph</p><button>Click me</button>'
+		);
+
+		swap();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<p>1. Second item first paragraph</p><p>2. Second item second paragraph</p><div></div><button>Click me</button>'
+		);
+
+		swap();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<p>1. Original item first paragraph</p><p>2. Original item second paragraph</p><button>Click me</button>'
+		);
+	});
+
 	it('should preserve state with reordering in multiple levels with lots of Fragment siblings', () => {
 		// Also fails if the # of divs outside the Fragment equals or exceeds
 		// the # inside the Fragment for both conditions

--- a/test/browser/lifecycles/componentDidMount.test.js
+++ b/test/browser/lifecycles/componentDidMount.test.js
@@ -1,4 +1,5 @@
 import { createElement, render, Component } from 'preact';
+import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../_util/helpers';
 
 /** @jsx createElement */
@@ -6,9 +7,11 @@ import { setupScratch, teardown } from '../../_util/helpers';
 describe('Lifecycle methods', () => {
 	/** @type {HTMLDivElement} */
 	let scratch;
+	let rerender;
 
 	beforeEach(() => {
 		scratch = setupScratch();
+		rerender = setupRerender();
 	});
 
 	afterEach(() => {
@@ -31,6 +34,33 @@ describe('Lifecycle methods', () => {
 
 			render(<App />, scratch);
 			expect(spy).to.have.been.calledOnceWith(scratch.firstChild);
+		});
+
+		it('supports multiple setState callbacks', () => {
+			const spy = sinon.spy();
+
+			class App extends Component {
+				constructor(props) {
+					super(props);
+					this.state = { count: 0 };
+				}
+
+				componentDidMount() {
+					// eslint-disable-next-line
+					this.setState({ count: 1 }, spy);
+					// eslint-disable-next-line
+					this.setState({ count: 2 }, spy);
+				}
+
+				render() {
+					return <div />;
+				}
+			}
+
+			render(<App />, scratch);
+
+			rerender();
+			expect(spy).to.have.been.calledTwice;
 		});
 	});
 });

--- a/test/browser/lifecycles/componentDidUpdate.test.js
+++ b/test/browser/lifecycles/componentDidUpdate.test.js
@@ -381,5 +381,55 @@ describe('Lifecycle methods', () => {
 			expect(Inner.prototype.componentDidUpdate).to.have.been.called;
 			expect(outerChildText).to.equal(`Outer: ${newValue.toString()}`);
 		});
+
+		it('should not interfere with setState callbacks', () => {
+			let invocation;
+
+			class Child extends Component {
+				componentDidMount() {
+					this.props.setValue(10);
+				}
+				render() {
+					return <p>Hello world</p>;
+				}
+			}
+
+			class App extends Component {
+				constructor(props) {
+					super(props);
+					this.state = {
+						show: false,
+						count: null
+					};
+				}
+
+				componentDidMount() {
+					// eslint-disable-next-line
+					this.setState({ show: true });
+				}
+
+				componentDidUpdate() {}
+
+				render() {
+					if (this.state.show) {
+						return (
+							<Child
+								setValue={i =>
+									this.setState({ count: i }, () => {
+										invocation = this.state;
+									})
+								}
+							/>
+						);
+					}
+					return null;
+				}
+			}
+
+			render(<App />, scratch);
+
+			rerender();
+			expect(invocation.count).to.equal(10);
+		});
 	});
 });

--- a/test/browser/refs.test.js
+++ b/test/browser/refs.test.js
@@ -536,4 +536,69 @@ describe('refs', () => {
 		expect(el.innerHTML).to.be.equal('Bar');
 		expect(ref.current.innerHTML).to.be.equal('Foo');
 	});
+
+	it.skip('should not remove refs for memoized components keyed', () => {
+		const ref = createRef();
+		const element = <div ref={ref}>hey</div>;
+		function App(props) {
+			return <div key={props.count}>{element}</div>;
+		}
+
+		render(<App count={0} />, scratch);
+		expect(ref.current).to.equal(scratch.firstChild.firstChild);
+		render(<App count={1} />, scratch);
+		expect(ref.current).to.equal(scratch.firstChild.firstChild);
+		render(<App count={2} />, scratch);
+		expect(ref.current).to.equal(scratch.firstChild.firstChild);
+	});
+
+	it('should not remove refs for memoized components unkeyed', () => {
+		const ref = createRef();
+		const element = <div ref={ref}>hey</div>;
+		function App(props) {
+			return <div>{element}</div>;
+		}
+
+		render(<App count={0} />, scratch);
+		expect(ref.current).to.equal(scratch.firstChild.firstChild);
+		render(<App count={1} />, scratch);
+		expect(ref.current).to.equal(scratch.firstChild.firstChild);
+		render(<App count={2} />, scratch);
+		expect(ref.current).to.equal(scratch.firstChild.firstChild);
+	});
+
+	// TODO
+	it.skip('should properly call null for memoized components keyed', () => {
+		const calls = [];
+		const element = <div ref={x => calls.push(x)}>hey</div>;
+		function App(props) {
+			return <div key={props.count}>{element}</div>;
+		}
+
+		render(<App count={0} />, scratch);
+		render(<App count={1} />, scratch);
+		render(<App count={2} />, scratch);
+		expect(calls.length).to.equal(5);
+		expect(calls).to.deep.equal([
+			scratch.firstChild.firstChild,
+			null,
+			scratch.firstChild.firstChild,
+			null,
+			scratch.firstChild.firstChild
+		]);
+	});
+
+	it('should properly call null for memoized components unkeyed', () => {
+		const calls = [];
+		const element = <div ref={x => calls.push(x)}>hey</div>;
+		function App(props) {
+			return <div>{element}</div>;
+		}
+
+		render(<App count={0} />, scratch);
+		render(<App count={1} />, scratch);
+		render(<App count={2} />, scratch);
+		expect(calls.length).to.equal(1);
+		expect(calls[0]).to.equal(scratch.firstChild.firstChild);
+	});
 });

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -462,9 +462,19 @@ describe('render()', () => {
 		expect(scratch.childNodes[0]).to.have.property('className', 'bar');
 	});
 
-	it('should support false aria-* attributes', () => {
+	it('should support false string aria-* attributes', () => {
 		render(<div aria-checked="false" />, scratch);
 		expect(scratch.firstChild.getAttribute('aria-checked')).to.equal('false');
+	});
+
+	it('should support false aria-* attributes', () => {
+		render(<div aria-checked={false} />, scratch);
+		expect(scratch.firstChild.getAttribute('aria-checked')).to.equal('false');
+	});
+
+	it('should support false data-* attributes', () => {
+		render(<div data-checked={false} />, scratch);
+		expect(scratch.firstChild.getAttribute('data-checked')).to.equal('false');
 	});
 
 	it('should set checked attribute on custom elements without checked property', () => {


### PR DESCRIPTION
This backports all v10 changes to v11 apart from 2

- signal types (as signals does not support v11 yet)
- `useId` as we have some open changes to that at the moment