### PR TITLE
Consolidate benchmark workflow steps into a single reusable workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,28 +15,28 @@ on:
       - 'src/**.js'
 
 jobs:
+  build_test:
+    name: Build & Test
+    uses: ./.github/workflows/ci.yml
+
   prepare:
-    name: Prepare benchmarks
+    name: Prepare environment
     runs-on: ubuntu-latest
+    needs: build_test
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Download locally built preact package
+        uses: actions/download-artifact@v3
         with:
-          node-version-file: 'package.json'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-      - run: npm ci
-      - name: Package
-        # Use --ignore-scripts here to avoid re-building again before pack
-        run: |
-          npm pack --ignore-scripts
-          mv preact-*.tgz preact-local.tgz
-      - name: Upload build output
+          name: npm-package
+      - run: mv preact.tgz preact-local.tgz
+      - name: Upload locally built preact package
         uses: actions/upload-artifact@v3
         with:
-          name: build-output
+          name: bench-environment
           path: preact-local.tgz
-      - uses: andrewiggins/download-base-artifact@v2
+      - name: Download base package
+        uses: andrewiggins/download-base-artifact@v2
         with:
           artifact: npm-package
           workflow: ci.yml
@@ -45,245 +45,65 @@ jobs:
       - name: Upload base preact package
         uses: actions/upload-artifact@v3
         with:
-          name: build-output
+          name: bench-environment
           path: preact-master.tgz
 
   bench_todo:
     name: Bench todo
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/run-bench.yml
     needs: prepare
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: 'package.json'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-      - uses: actions/download-artifact@v3
-        with:
-          name: build-output
-      - name: install & build
-        run: |
-          cd benches
-          npm ci
-      - name: bench
-        run: |
-          export CHROMEDRIVER_FILEPATH=$(which chromedriver)
-          cd benches
-          npm run bench todo.html
-      - name: Upload results
-        uses: actions/upload-artifact@v3
-        with:
-          name: results
-          path: benches/results/todo.json
+    with:
+      benchmark: todo
+      timeout: 10
 
   bench_text_update:
     name: Bench text_update
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/run-bench.yml
     needs: prepare
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: 'package.json'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-      - uses: actions/download-artifact@v3
-        with:
-          name: build-output
-      - name: install & build
-        run: |
-          cd benches
-          npm ci
-      - name: bench
-        run: |
-          export CHROMEDRIVER_FILEPATH=$(which chromedriver)
-          cd benches
-          npm run bench text_update.html
-      - name: Upload results
-        uses: actions/upload-artifact@v3
-        with:
-          name: results
-          path: benches/results/text_update.json
+    with:
+      benchmark: text_update
+      timeout: 10
 
   bench_many_updates:
     name: Bench many_updates
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/run-bench.yml
     needs: prepare
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: 'package.json'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-      - uses: actions/download-artifact@v3
-        with:
-          name: build-output
-      - name: install & build
-        run: |
-          cd benches
-          npm ci
-      - name: bench
-        run: |
-          export CHROMEDRIVER_FILEPATH=$(which chromedriver)
-          cd benches
-          npm run bench many_updates.html
-      - name: Upload results
-        uses: actions/upload-artifact@v3
-        with:
-          name: results
-          path: benches/results/many_updates.json
+    with:
+      benchmark: many_updates
+      timeout: 10
 
   bench_02_replace1k:
     name: Bench 02_replace1k
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/run-bench.yml
     needs: prepare
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: 'package.json'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-      - uses: actions/download-artifact@v3
-        with:
-          name: build-output
-      - name: install & build
-        run: |
-          cd benches
-          npm ci
-      - name: bench
-        run: |
-          export CHROMEDRIVER_FILEPATH=$(which chromedriver)
-          cd benches
-          npm run bench 02_replace1k.html
-      - name: Upload results
-        uses: actions/upload-artifact@v3
-        with:
-          name: results
-          path: benches/results/02_replace1k.json
+    with:
+      benchmark: 02_replace1k
 
   bench_03_update10th1k_x16:
     name: Bench 03_update10th1k_x16
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/run-bench.yml
     needs: prepare
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: 'package.json'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-      - uses: actions/download-artifact@v3
-        with:
-          name: build-output
-      - name: install & build
-        run: |
-          cd benches
-          npm ci
-      - name: bench
-        run: |
-          export CHROMEDRIVER_FILEPATH=$(which chromedriver)
-          cd benches
-          npm run bench 03_update10th1k_x16.html
-      - name: Upload results
-        uses: actions/upload-artifact@v3
-        with:
-          name: results
-          path: benches/results/03_update10th1k_x16.json
+    with:
+      benchmark: 03_update10th1k_x16
 
   bench_07_create10k:
     name: Bench 07_create10k
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/run-bench.yml
     needs: prepare
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: 'package.json'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-      - uses: actions/download-artifact@v3
-        with:
-          name: build-output
-      - name: install & build
-        run: |
-          cd benches
-          npm ci
-      - name: bench
-        run: |
-          export CHROMEDRIVER_FILEPATH=$(which chromedriver)
-          cd benches
-          npm run bench 07_create10k.html
-      - name: Upload results
-        uses: actions/upload-artifact@v3
-        with:
-          name: results
-          path: benches/results/07_create10k.json
+    with:
+      benchmark: 07_create10k
 
   bench_hydrate1k:
     name: Bench hydrate1k
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/run-bench.yml
     needs: prepare
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: 'package.json'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-      - uses: actions/download-artifact@v3
-        with:
-          name: build-output
-      - name: install & build
-        run: |
-          cd benches
-          npm ci
-      - name: bench
-        run: |
-          export CHROMEDRIVER_FILEPATH=$(which chromedriver)
-          cd benches
-          npm run bench hydrate1k.html
-      - name: Upload results
-        uses: actions/upload-artifact@v3
-        with:
-          name: results
-          path: benches/results/hydrate1k.json
+    with:
+      benchmark: hydrate1k
 
   bench_filter_list:
     name: Bench filter_list
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/run-bench.yml
     needs: prepare
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: 'package.json'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-      - uses: actions/download-artifact@v3
-        with:
-          name: build-output
-      - name: install & build
-        run: |
-          cd benches
-          npm ci
-      - name: bench
-        run: |
-          export CHROMEDRIVER_FILEPATH=$(which chromedriver)
-          cd benches
-          npm run bench filter_list.html
-      - name: Upload results
-        uses: actions/upload-artifact@v3
-        with:
-          name: results
-          path: benches/results/filter_list.json
+    with:
+      benchmark: filter_list
+      timeout: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   workflow_dispatch:
+  workflow_call:
   pull_request:
     branches:
       - '**'
@@ -9,7 +10,6 @@ on:
     branches:
       - master
       - restructure
-  workflow_call:
 
 jobs:
   build_test:

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -1,0 +1,64 @@
+name: Run Benchmark
+
+# Expectations:
+#
+# This workflow expects calling workflows to have uploaded an artifact named
+# "bench-environment" that contains any built artifacts required to run the
+# benchmark. This typically is the dist/ folder that running `npm run build`
+# produces and/or a tarball of a previous build to bench the local build against
+
+on:
+  workflow_call:
+    inputs:
+      benchmark:
+        description: 'The name of the benchmark to run. Should be name of an HTML file without the .html extension'
+        type: string
+        required: true
+      trace:
+        description: 'Whether to capture browser traces for this benchmark run'
+        type: boolean
+        required: false
+        default: false
+      timeout:
+        description: 'How many minutes to give the benchmark to run before timing out and failing'
+        type: number
+        required: false
+        default: 20
+
+jobs:
+  run_bench:
+    name: Bench ${{ inputs.benchmark }}
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+      - uses: actions/download-artifact@v3
+        with:
+          name: bench-environment
+      - name: Install deps
+        working-directory: benches
+        run: npm ci
+      - name: Run benchmark
+        working-directory: benches
+        run: |
+          export CHROMEDRIVER_FILEPATH=$(which chromedriver)
+          npm run bench ${{ inputs.benchmark }}.html -- --trace=${{ inputs.trace }}
+      - name: Upload results
+        uses: actions/upload-artifact@v3
+        with:
+          name: results
+          path: benches/results/${{ inputs.benchmark }}.json
+      - name: Tar logs if present
+        working-directory: benches
+        run: '[ -d logs ] && tar -zcvf ${{ inputs.benchmark}}_logs.tgz logs || echo "No logs found"'
+      - name: Upload logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.benchmark}}_logs
+          path: benches/${{ inputs.benchmark}}_logs.tgz
+          if-no-files-found: ignore


### PR DESCRIPTION
- Simplify the definition of benchmarks by creating a new workflow, `run-bench.yml`, that can be reused for all benchmarks
- Reuse the `ci.yml` workflow to build the repo 
- Add `trace` option to `run-bench` workflow