### PR TITLE
Add an explicit export default for compatibility with esbuild

### DIFF
--- a/compat/client.mjs
+++ b/compat/client.mjs
@@ -15,3 +15,8 @@ export function hydrateRoot(container, children) {
 	hydrate(children, container)
 	return createRoot(container)
 }
+
+export default {
+	createRoot,
+	hydrateRoot
+}

--- a/compat/test/browser/exports.test.js
+++ b/compat/test/browser/exports.test.js
@@ -1,8 +1,23 @@
 import Compat from 'preact/compat';
+import CompatClient from 'preact/compat/client';
 // eslint-disable-next-line no-duplicate-imports
 import * as Named from 'preact/compat';
+// eslint-disable-next-line no-duplicate-imports
+import * as NamedClient from 'preact/compat/client';
 
 describe('compat exports', () => {
+	describe('client', () => {
+		it('should have a default export', () => {
+			expect(CompatClient.createRoot).to.be.a('function');
+			expect(CompatClient.hydrateRoot).to.be.a('function');
+		});
+
+		it('should have named exports', () => {
+			expect(NamedClient.createRoot).to.be.a('function');
+			expect(NamedClient.hydrateRoot).to.be.a('function');
+		});
+	});
+
 	it('should have a default export', () => {
 		expect(Compat.createElement).to.be.a('function');
 		expect(Compat.Component).to.be.a('function');


### PR DESCRIPTION
Hi, as I tried to switch from react to preact in my project which uses esbuild I encountered an error caused by a lack of explicit default exports.

> ✘ [ERROR] No matching export in "node_modules/react-dom/client.mjs" for import "default"
>
>    frontend/build/index.js:6:7:
>      6 │ import ReactDOM from 'react-dom/client'
>        ╵        ~~~~~~~~
>
>1 error

This was the only thing I had to change to make my app work.
Hope this will make someone's transition more seamless.