### PR TITLE
Release 10.11.3

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -2,7 +2,7 @@ import { options, Fragment, Component } from 'preact';
 
 export function initDevTools() {
 	if (typeof window != 'undefined' && window.__PREACT_DEVTOOLS__) {
-		window.__PREACT_DEVTOOLS__.attachPreact('10.11.2', options, {
+		window.__PREACT_DEVTOOLS__.attachPreact('10.11.3', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "preact",
-	"version": "10.11.2",
+	"version": "10.11.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "preact",
-			"version": "10.11.2",
+			"version": "10.11.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@actions/github": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "preact",
 	"amdName": "preact",
-	"version": "10.11.2",
+	"version": "10.11.3",
 	"private": false,
 	"description": "Fast 3kb React-compatible Virtual DOM library.",
 	"main": "dist/preact.js",


### PR DESCRIPTION
## Bug Fixes
- Add an explicit `default` export for compatibility with esbuild (#3783, thanks @Verseth)
- Fix `useId` uniqueness with shared parents + DOM nodes in between (#3773, thanks @marvinhagemeister)
- Fix case where keyed children would get removed (#3779, thanks @JoviDeCroock)
- Use `Object.is` in useSyncExternalStore (#3776, thanks @zalishchuk)

## Maintenance
- Consolidate benchmark workflow steps into a single reusable workflow (#3782, thanks @andrewiggins)
- Upgrade bench dependencies (#3778, thanks @andrewiggins)
- Upgrade workflow actions (#3777, thanks @andrewiggins)