### PR TITLE
Debug: limit "object as children" error to elements

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -318,7 +318,7 @@ export function initDebug() {
 		// Putting this check in `options.diffed` ensures that
 		// `vnode._children` is set and that we only validate the children
 		// that were actually rendered.
-		if (typeof vnode.type === 'string' && vnode._children) {
+		if (vnode._children) {
 			vnode._children.forEach(child => {
 				if (typeof child === 'object' && child && child.type === undefined) {
 					const keys = Object.keys(child).join(',');

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -318,12 +318,9 @@ export function initDebug() {
 		// Putting this check in `options.diffed` ensures that
 		// `vnode._children` is set and that we only validate the children
 		// that were actually rendered.
-		if (vnode._children) {
+		if (typeof vnode.type === 'string' && vnode._children) {
 			vnode._children.forEach(child => {
-				if (child && child.type === undefined) {
-					// Remove internal vnode keys that will always be patched
-					delete child._parent;
-					delete child._depth;
+				if (typeof child === 'object' && child && child.type === undefined) {
 					const keys = Object.keys(child).join(',');
 					throw new Error(
 						`Objects are not valid as a child. Encountered an object with the keys {${keys}}.` +


### PR DESCRIPTION
This should fix preactjs/preact-render-to-string#254 without incurring the performance overhead of converting primitives in JSX text positions to VNodes.

If this works, we can remove [these lines](https://github.com/preactjs/preact-render-to-string/blob/fac154450e5455446c1cf844f2e7cbb9e0bd4127/src/index.js#L140-L147) from render-to-string.