### PR TITLE
V11: Fix incorrect version passed to devtools package

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -2,7 +2,7 @@ import { options, Fragment, Component } from 'preact';
 
 export function initDevTools() {
 	if (typeof window != 'undefined' && window.__PREACT_DEVTOOLS__) {
-		window.__PREACT_DEVTOOLS__.attachPreact('10.5.13', options, {
+		window.__PREACT_DEVTOOLS__.attachPreact('11.0.0-beta', options, {
 			Fragment,
 			Component
 		});


### PR DESCRIPTION
This matches the version in `preact/devtools` with the one in `package.json`.