### PR TITLE
Preserve event handler return values (#3812)

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -108,9 +108,9 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
  * @private
  */
 function eventProxy(e) {
-	this._listeners[e.type + false](options.event ? options.event(e) : e);
+	return this._listeners[e.type + false](options.event ? options.event(e) : e);
 }
 
 function eventProxyCapture(e) {
-	this._listeners[e.type + true](options.event ? options.event(e) : e);
+	return this._listeners[e.type + true](options.event ? options.event(e) : e);
 }


### PR DESCRIPTION
I'm not aware of any bugs caused by this, but currently we drop the return value of event handlers rather than returning it to the DOM. This corrects that.

Co-authored-by: Jason Miller <developit@users.noreply.github.com>