### PR TITLE
Remove prevRef from internal

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -157,7 +157,8 @@ export function patchChildren(internal, children, parentDom) {
 	for (i = 0; i < newChildren.length; i++) {
 		childInternal = newChildren[i];
 		if (childInternal) {
-			let oldRef = childInternal._prevRef;
+			let oldRef = childInternal.ref;
+			childInternal.ref = normalizeToVNode(children[i]).ref;
 			if (childInternal.ref != oldRef) {
 				if (oldRef) applyRef(oldRef, null, childInternal);
 				if (childInternal.ref)

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -179,8 +179,7 @@ export function patchChildren(internal, children, parentDom) {
 	if (refs) {
 		for (i = 0; i < refs.length; i += 2) {
 			const internal = refs[i];
-			const previous = refs[i + 1];
-			if (previous) applyRef(previous, null, internal);
+			if (refs[i + 1]) applyRef(refs[i + 1], null, internal);
 			if (internal && internal.ref)
 				applyRef(internal.ref, internal._component || internal.data, internal);
 		}

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -29,7 +29,7 @@ export function patchChildren(internal, children, parentDom) {
 	let skew = 0;
 	let i;
 
-	const refs = [];
+	let refs;
 	/** @type {import('../internal').Internal} */
 	let childInternal;
 
@@ -73,6 +73,7 @@ export function patchChildren(internal, children, parentDom) {
 			childInternal = createInternal(childVNode, internal);
 
 			if (childVNode.ref) {
+				if (!refs) refs = [];
 				refs.push({ internal: childInternal });
 				childInternal.ref = childVNode.ref;
 			}
@@ -92,6 +93,7 @@ export function patchChildren(internal, children, parentDom) {
 			(MODE_HYDRATE | MODE_SUSPENDED)
 		) {
 			if (childVNode.ref) {
+				if (!refs) refs = [];
 				refs.push({ internal: childInternal });
 				childInternal.ref = childVNode.ref;
 			}
@@ -100,6 +102,7 @@ export function patchChildren(internal, children, parentDom) {
 			mount(childInternal, childVNode, parentDom, childInternal.data);
 		} else {
 			if (childInternal.ref != childVNode.ref) {
+				if (!refs) refs = [];
 				refs.push({ internal: childInternal, previous: childInternal.ref });
 				childInternal.ref = childVNode.ref;
 			}
@@ -170,15 +173,17 @@ export function patchChildren(internal, children, parentDom) {
 	}
 
 	// Set refs only after unmount
-	for (i = 0; i < refs.length; i++) {
-		const refObj = refs[i];
-		if (refObj.previous) applyRef(refObj.previous, null, refObj.internal);
-		if (refObj.internal && refObj.internal.ref)
-			applyRef(
-				refObj.internal.ref,
-				refObj.internal._component || refObj.internal.data,
-				refObj.internal
-			);
+	if (refs) {
+		for (i = 0; i < refs.length; i++) {
+			const refObj = refs[i];
+			if (refObj.previous) applyRef(refObj.previous, null, refObj.internal);
+			if (refObj.internal && refObj.internal.ref)
+				applyRef(
+					refObj.internal.ref,
+					refObj.internal._component || refObj.internal.data,
+					refObj.internal
+				);
+		}
 	}
 }
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -75,7 +75,7 @@ export function patchChildren(internal, children, parentDom) {
 			if (!refs) refs = [];
 
 			if (childVNode.ref) {
-				refs.push({ internal: childInternal });
+				refs.push(childInternal, undefined);
 				childInternal.ref = childVNode.ref;
 			}
 
@@ -97,7 +97,7 @@ export function patchChildren(internal, children, parentDom) {
 			if (!refs) refs = [];
 
 			if (childVNode.ref) {
-				refs.push({ internal: childInternal });
+				refs.push(childInternal, undefined);
 				childInternal.ref = childVNode.ref;
 			}
 
@@ -106,7 +106,7 @@ export function patchChildren(internal, children, parentDom) {
 		} else {
 			if (childInternal.ref != childVNode.ref) {
 				if (!refs) refs = [];
-				refs.push({ internal: childInternal, previous: childInternal.ref });
+				refs.push(childInternal, childInternal.ref);
 				childInternal.ref = childVNode.ref;
 			}
 
@@ -177,15 +177,12 @@ export function patchChildren(internal, children, parentDom) {
 
 	// Set refs only after unmount
 	if (refs) {
-		for (i = 0; i < refs.length; i++) {
-			const refObj = refs[i];
-			if (refObj.previous) applyRef(refObj.previous, null, refObj.internal);
-			if (refObj.internal && refObj.internal.ref)
-				applyRef(
-					refObj.internal.ref,
-					refObj.internal._component || refObj.internal.data,
-					refObj.internal
-				);
+		for (i = 0; i < refs.length; i += 2) {
+			const internal = refs[i];
+			const previous = refs[i + 1];
+			if (previous) applyRef(previous, null, internal);
+			if (internal && internal.ref)
+				applyRef(internal.ref, internal._component || internal.data, internal);
 		}
 	}
 }

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -72,8 +72,9 @@ export function patchChildren(internal, children, parentDom) {
 		if (mountingChild) {
 			childInternal = createInternal(childVNode, internal);
 
+			if (!refs) refs = [];
+
 			if (childVNode.ref) {
-				if (!refs) refs = [];
 				refs.push({ internal: childInternal });
 				childInternal.ref = childVNode.ref;
 			}
@@ -83,7 +84,8 @@ export function patchChildren(internal, children, parentDom) {
 				childInternal,
 				childVNode,
 				parentDom,
-				getDomSibling(internal, skewedIndex)
+				getDomSibling(internal, skewedIndex),
+				refs
 			);
 		}
 		// If this node suspended during hydration, and no other flags are set:
@@ -92,8 +94,9 @@ export function patchChildren(internal, children, parentDom) {
 			(childInternal.flags & (MODE_HYDRATE | MODE_SUSPENDED)) ===
 			(MODE_HYDRATE | MODE_SUSPENDED)
 		) {
+			if (!refs) refs = [];
+
 			if (childVNode.ref) {
-				if (!refs) refs = [];
 				refs.push({ internal: childInternal });
 				childInternal.ref = childVNode.ref;
 			}

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -265,7 +265,7 @@ export function mountChildren(internal, children, parentDom, startDom, refs) {
 
 		if (childInternal.ref) {
 			if (refs) {
-				refs.push({ internal: childInternal });
+				refs.push(childInternal, undefined);
 				childInternal.ref = childVNode.ref;
 			} else {
 				applyRef(

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -27,7 +27,7 @@ import { commitQueue } from './commit';
  * @param {import('../internal').PreactNode} startDom
  * @returns {import('../internal').PreactNode | null} pointer to the next DOM node to be hydrated (or null)
  */
-export function mount(internal, newVNode, parentDom, startDom) {
+export function mount(internal, newVNode, parentDom, startDom, refs) {
 	if (options._diff) options._diff(internal, newVNode);
 
 	/** @type {import('../internal').PreactNode} */
@@ -55,7 +55,8 @@ export function mount(internal, newVNode, parentDom, startDom) {
 					internal,
 					renderResult,
 					parentDom,
-					startDom
+					startDom,
+					refs
 				);
 			}
 
@@ -72,7 +73,7 @@ export function mount(internal, newVNode, parentDom, startDom) {
 					? startDom
 					: null;
 
-			nextDomSibling = mountElement(internal, hydrateDom);
+			nextDomSibling = mountElement(internal, hydrateDom, refs);
 		}
 
 		if (options.diffed) options.diffed(internal);
@@ -100,7 +101,7 @@ export function mount(internal, newVNode, parentDom, startDom) {
  * @param {import('../internal').PreactNode} dom A DOM node to attempt to re-use during hydration
  * @returns {import('../internal').PreactNode}
  */
-function mountElement(internal, dom) {
+function mountElement(internal, dom, refs) {
 	let newProps = internal.props;
 	let nodeType = internal.type;
 	let flags = internal.flags;
@@ -202,7 +203,8 @@ function mountElement(internal, dom) {
 				internal,
 				Array.isArray(newChildren) ? newChildren : [newChildren],
 				dom,
-				isNew ? null : dom.firstChild
+				isNew ? null : dom.firstChild,
+				refs
 			);
 		}
 
@@ -223,7 +225,7 @@ function mountElement(internal, dom) {
  * @param {import('../internal').PreactElement} parentDom The element into which this subtree is rendered
  * @param {import('../internal').PreactNode} startDom
  */
-export function mountChildren(internal, children, parentDom, startDom) {
+export function mountChildren(internal, children, parentDom, startDom, refs) {
 	let internalChildren = (internal._children = []),
 		i,
 		childVNode,
@@ -262,11 +264,16 @@ export function mountChildren(internal, children, parentDom, startDom) {
 		}
 
 		if (childInternal.ref) {
-			applyRef(
-				childInternal.ref,
-				childInternal._component || newDom,
-				childInternal
-			);
+			if (refs) {
+				refs.push({ internal: childInternal });
+				childInternal.ref = childVNode.ref;
+			} else {
+				applyRef(
+					childInternal.ref,
+					childInternal._component || newDom,
+					childInternal
+				);
+			}
 		}
 	}
 

--- a/src/diff/patch.js
+++ b/src/diff/patch.js
@@ -122,9 +122,6 @@ export function patch(internal, vnode, parentDom) {
 
 	// Once we have successfully rendered the new VNode, copy it's ID over
 	internal._vnodeId = vnode._vnodeId;
-
-	internal._prevRef = internal.ref;
-	internal.ref = vnode.ref;
 }
 
 /**

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -136,7 +136,6 @@ export interface Internal<P = {}> {
 	props: (P & { children: ComponentChildren }) | string | number;
 	key: any;
 	ref: Ref<any> | null;
-	_prevRef: Ref<any> | null;
 
 	/** Bitfield containing information about the Internal or its component. */
 	flags: number;

--- a/src/tree.js
+++ b/src/tree.js
@@ -86,7 +86,6 @@ export function createInternal(vnode, parentInternal) {
 		props,
 		key,
 		ref,
-		_prevRef: null,
 		data: flags & TYPE_COMPONENT ? {} : null,
 		_commitCallbacks: flags & TYPE_COMPONENT ? [] : null,
 		_stateCallbacks: flags & TYPE_COMPONENT ? [] : null,

--- a/test/browser/refs.test.js
+++ b/test/browser/refs.test.js
@@ -566,8 +566,7 @@ describe('refs', () => {
 		expect(ref.current).to.equal(scratch.firstChild.firstChild);
 	});
 
-	// TODO
-	it.skip('should properly call null for memoized components keyed', () => {
+	it('should properly call null for memoized components keyed', () => {
 		const calls = [];
 		const element = <div ref={x => calls.push(x)}>hey</div>;
 		function App(props) {
@@ -575,13 +574,15 @@ describe('refs', () => {
 		}
 
 		render(<App count={0} />, scratch);
+		const firstChildAfterFirstRender = scratch.firstChild.firstChild;
 		render(<App count={1} />, scratch);
+		const firstChildAfterSecondRender = scratch.firstChild.firstChild;
 		render(<App count={2} />, scratch);
 		expect(calls.length).to.equal(5);
 		expect(calls).to.deep.equal([
-			scratch.firstChild.firstChild,
+			firstChildAfterFirstRender,
 			null,
-			scratch.firstChild.firstChild,
+			firstChildAfterSecondRender,
 			null,
 			scratch.firstChild.firstChild
 		]);

--- a/test/browser/refs.test.js
+++ b/test/browser/refs.test.js
@@ -536,7 +536,7 @@ describe('refs', () => {
 		expect(ref.current.innerHTML).to.be.equal('Foo');
 	});
 
-	it.skip('should not remove refs for memoized components keyed', () => {
+	it('should not remove refs for memoized components keyed', () => {
 		const ref = createRef();
 		const element = <div ref={ref}>hey</div>;
 		function App(props) {

--- a/test/browser/refs.test.js
+++ b/test/browser/refs.test.js
@@ -456,7 +456,7 @@ describe('refs', () => {
 		ref.resetHistory();
 
 		render(<App open />, scratch);
-		expect(ref).to.have.been.calledOnce.and.calledWith(
+		expect(ref).to.have.been.calledTwice.and.calledWith(
 			scratch.firstElementChild.firstElementChild
 		);
 	});

--- a/test/browser/refs.test.js
+++ b/test/browser/refs.test.js
@@ -415,8 +415,7 @@ describe('refs', () => {
 		expect(input.value).to.equal('foo');
 	});
 
-	// @TODO: re-enable these tests when we add a ref queue
-	it.skip('should correctly set nested child refs', () => {
+	it('should correctly set nested child refs', () => {
 		const ref = createRef();
 		const App = ({ open }) =>
 			open ? (
@@ -436,7 +435,7 @@ describe('refs', () => {
 		expect(ref.current).to.not.be.null;
 	});
 
-	it.skip('should correctly set nested child function refs', () => {
+	it('should correctly set nested child function refs', () => {
 		const ref = sinon.spy();
 		const App = ({ open }) =>
 			open ? (


### PR DESCRIPTION
We can probably golf bytes by working around the keys on the ref object in the refs array.

Removing the lazy initialization saves another 13b