### PR TITLE
give the internal a stable id based on both depth and initial vnodeId

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -142,7 +142,7 @@ export function enqueueRender(internal) {
 /** Flush the render queue by rerendering all queued components */
 function processRenderQueue() {
 	while ((len = processRenderQueue._rerenderCount = renderQueue.length)) {
-		renderQueue.sort((a, b) => a._depth - b._depth);
+		renderQueue.sort((a, b) => (a.id % 1000) - (b.id % 1000));
 		while (len--) {
 			renderQueuedInternal(renderQueue.shift());
 		}

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -131,6 +131,7 @@ export interface VNode<P = {}> extends preact.VNode<P> {
  * Think of an Internal like a long-lived VNode with stored data and tree linkages.
  */
 export interface Internal<P = {}> {
+	id: number;
 	type: string | ComponentType<P>;
 	/** The props object for Elements/Components, and the string contents for Text */
 	props: (P & { children: ComponentChildren }) | string | number;
@@ -157,8 +158,6 @@ export interface Internal<P = {}> {
 	 */
 	/** The component instance for which this is a backing Internal node */
 	_component: Component | null;
-	/** This Internal's distance from the tree root */
-	_depth: number | null;
 	/** Callbacks to invoke when this internal commits */
 	_commitCallbacks: Array<() => void>;
 	_stateCallbacks: Array<() => void>; // Only class components

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -152,15 +152,8 @@ export interface Internal<P = {}> {
 	_parent: Internal;
 	/** most recent vnode ID */
 	_vnodeId: number;
-	/**
-	 * Associated DOM element for the Internal, or its nearest realized descendant.
-	 * For Fragments, this is the first DOM child.
-	 */
 	/** The component instance for which this is a backing Internal node */
 	_component: Component | null;
-	/** Callbacks to invoke when this internal commits */
-	_commitCallbacks: Array<() => void>;
-	_stateCallbacks: Array<() => void>; // Only class components
 }
 
 export interface Component<P = {}, S = {}> extends preact.Component<P, S> {

--- a/src/tree.js
+++ b/src/tree.js
@@ -82,6 +82,8 @@ export function createInternal(vnode, parentInternal) {
 
 	/** @type {import('./internal').Internal} */
 	const internal = {
+		id:
+			(vnodeId * 1000) + (parentInternal ? (parentInternal.id % 1000) + 1 : 0),
 		type,
 		props,
 		key,
@@ -96,8 +98,7 @@ export function createInternal(vnode, parentInternal) {
 		_children: null,
 		_parent: parentInternal,
 		_vnodeId: vnodeId,
-		_component: null,
-		_depth: parentInternal ? parentInternal._depth + 1 : 0
+		_component: null
 	};
 
 	if (options._internal) options._internal(internal, vnode);


### PR DESCRIPTION
We currently can't remove `_vnodeId` as we rely on [rotating those](https://github.com/preactjs/preact/blob/v11/src/diff/patch.js#L129) to check for strict equality.

This PR adds a stable identifier when we first create an internal, we base this off of the `_vnodeId` and the depth of the internal.

I think this could function as a good replacement to `useId`

TODO: we should later on verify with https://github.com/preactjs/preact/pull/2396 whether this still works correctly with depth ordering