### PR TITLE
ES6-in-browser compatibility

### DIFF
--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -1,5 +1,5 @@
-import { assign, slice } from './util';
-import { createVNode } from './create-element';
+import { assign, slice } from './util.js';
+import { createVNode } from './create-element.js';
 
 /**
  * Clones the given VNode, optionally adding attributes/props and replacing its children.

--- a/src/component.js
+++ b/src/component.js
@@ -1,7 +1,7 @@
-import { assign } from './util';
-import { diff, commitRoot } from './diff/index';
-import options from './options';
-import { Fragment } from './create-element';
+import { assign } from './util.js';
+import { diff, commitRoot } from './diff/index.js';
+import options from './options.js';
+import { Fragment } from './create-element.js';
 
 /**
  * Base Component class. Provides `setState()` and `forceUpdate()`, which

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -1,4 +1,4 @@
-import { enqueueRender } from './component';
+import { enqueueRender } from './component.js';
 
 export let i = 0;
 

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -1,5 +1,5 @@
-import { slice } from './util';
-import options from './options';
+import { slice } from './util.js';
+import options from './options.js';
 
 let vnodeId = 0;
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -1,7 +1,7 @@
-import { diff, unmount, applyRef } from './index';
-import { createVNode, Fragment } from '../create-element';
-import { EMPTY_OBJ, EMPTY_ARR } from '../constants';
-import { getDomSibling } from '../component';
+import { diff, unmount, applyRef } from './index.js';
+import { createVNode, Fragment } from '../create-element.js';
+import { EMPTY_OBJ, EMPTY_ARR } from '../constants.js';
+import { getDomSibling } from '../component.js';
 
 /**
  * Diff the children of a virtual node

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -1,10 +1,10 @@
-import { EMPTY_OBJ } from '../constants';
-import { Component, getDomSibling } from '../component';
-import { Fragment } from '../create-element';
-import { diffChildren } from './children';
-import { diffProps, setProperty } from './props';
-import { assign, removeNode, slice } from '../util';
-import options from '../options';
+import { EMPTY_OBJ } from '../constants.js';
+import { Component, getDomSibling } from '../component.js';
+import { Fragment } from '../create-element.js';
+import { diffChildren } from './children.js';
+import { diffProps, setProperty } from './props.js';
+import { assign, removeNode, slice } from '../util.js';
+import options from '../options.js';
 
 /**
  * Diff two virtual nodes and apply proper changes to the DOM

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -1,5 +1,5 @@
-import { IS_NON_DIMENSIONAL } from '../constants';
-import options from '../options';
+import { IS_NON_DIMENSIONAL } from '../constants.js';
+import options from '../options.js';
 
 /**
  * Diff the old and new properties of a VNode and apply changes to the DOM node

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
-export { render, hydrate } from './render';
+export { render, hydrate } from './render.js';
 export {
 	createElement,
 	createElement as h,
 	Fragment,
 	createRef,
 	isValidElement
-} from './create-element';
-export { Component } from './component';
-export { cloneElement } from './clone-element';
-export { createContext } from './create-context';
-export { toChildArray } from './diff/children';
-export { default as options } from './options';
+} from './create-element.js';
+export { Component } from './component.js';
+export { cloneElement } from './clone-element.js';
+export { createContext } from './create-context.js';
+export { toChildArray } from './diff/children.js';
+export { default as options } from './options.js';

--- a/src/options.js
+++ b/src/options.js
@@ -1,4 +1,4 @@
-import { _catchError } from './diff/catch-error';
+import { _catchError } from './diff/catch-error.js';
 
 /**
  * The `option` object can potentially contain callback functions

--- a/src/render.js
+++ b/src/render.js
@@ -1,8 +1,8 @@
-import { EMPTY_OBJ } from './constants';
-import { commitRoot, diff } from './diff/index';
-import { createElement, Fragment } from './create-element';
-import options from './options';
-import { slice } from './util';
+import { EMPTY_OBJ } from './constants.js';
+import { commitRoot, diff } from './diff/index.js';
+import { createElement, Fragment } from './create-element.js';
+import options from './options.js';
+import { slice } from './util.js';
 
 /**
  * Render a Preact virtual node into a DOM element

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,4 @@
-import { EMPTY_ARR } from "./constants";
+import { EMPTY_ARR } from "./constants.js";
 
 /**
  * Assign properties from `props` to `obj`


### PR DESCRIPTION
This allows developers to use the code without installing even one package.

We all know the npm meme: https://www.youtube.com/watch?v=mQif8VDt7nE

It doesn't need to be like that.

**test.html**:

```html
<html>
    <head>
        <script type="importmap">
            {
                "imports": {
                    "preact": "/preact/src/index.js"
                }
            }
        </script>
    </head>
    <body>        
        <script type="module">
            import { h, Component, render } from 'preact';
            import htm from 'https://unpkg.com/htm?module';
            // Initialize htm with Preact
            const html = htm.bind(h);
            function App(props) {
                return html`<h1>Hello ${props.name}!</h1>`;
            }
            render(html`<${App} name="World" />`, document.body);
        </script>
    </body>
</html>
```
