### PR TITLE
docs: Fix a few typos

### DIFF
--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -108,7 +108,7 @@ const unstable_batchedUpdates = (callback, arg) => callback(arg);
  * @template Arg
  * @template Result
  * @param {(arg: Arg) => Result} callback function that runs before the flush
- * @param {Arg} [arg] Optional arugment that can be passed to the callback
+ * @param {Arg} [arg] Optional argument that can be passed to the callback
  * @returns
  */
 const flushSync = (callback, arg) => callback(arg);

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -72,7 +72,7 @@ export function initDebug() {
 			errorInfo.componentStack = getOwnerStack(vnode);
 			oldCatchError(error, vnode, oldVNode, errorInfo);
 
-			// when an error was handled by an ErrorBoundary we will nontheless emit an error
+			// when an error was handled by an ErrorBoundary we will nonetheless emit an error
 			// event on the window object. This is to make up for react compatibility in dev mode
 			// and thus make the Next.js dev overlay work.
 			if (typeof error.then != 'function') {

--- a/test/polyfills.js
+++ b/test/polyfills.js
@@ -71,7 +71,7 @@ chai.use((chai, util) => {
 
 //
 // The following code overwrites karma's internal logging feature to
-// support a much prettier and humand readable represantation of
+// support a much prettier and humand readable representation of
 // console logs in our terminal. This includes indentation, coloring
 // and support for Map and Set objects.
 //


### PR DESCRIPTION
There are small typos in:
- compat/src/index.js
- debug/src/debug.js
- test/polyfills.js

Fixes:
- Should read `representation` rather than `represantation`.
- Should read `nonetheless` rather than `nontheless`.
- Should read `argument` rather than `arugment`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md