### PR TITLE
ensure we respect max and min safe integers

### DIFF
--- a/jsx-runtime/src/index.js
+++ b/jsx-runtime/src/index.js
@@ -43,7 +43,7 @@ function createVNode(type, props, key, __source, __self) {
 		key,
 		ref,
 		constructor: undefined,
-		_vnodeId: --vnodeId,
+		_vnodeId: (vnodeId = (vnodeId - 1) | 0),
 		__source,
 		__self
 	};

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -42,7 +42,7 @@ export function createElement(type, props, children) {
 		key,
 		ref,
 		constructor: undefined,
-		_vnodeId: ++vnodeId
+		_vnodeId: (vnodeId = (vnodeId + 1) | 0)
 	};
 
 	if (options.vnode != null) options.vnode(vnode);


### PR DESCRIPTION
Currently when `jsx` and `createElement` are used for a long time on the server or client we risk going over the max/min safe integer which in essence is a small risk but I think we should account for it as it's a crash risk