### PR TITLE
Adapt to React api: add context argument to compat/Children map api

### DIFF
--- a/compat/src/Children.js
+++ b/compat/src/Children.js
@@ -1,8 +1,8 @@
 import { toChildArray } from 'preact';
 
-const mapFn = (children, fn) => {
+const mapFn = (children, fn, context) => {
 	if (children == null) return null;
-	return toChildArray(toChildArray(children).map(fn));
+	return toChildArray(toChildArray(children).map(fn.bind(context)));
 };
 
 // This API is completely unnecessary for Preact, so it's basically passthrough.

--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -407,11 +407,13 @@ declare namespace React {
 	export const Children: {
 		map<T extends preact1.ComponentChild, R>(
 			children: T | T[],
-			fn: (child: T, i: number) => R
+			fn: (child: T, i: number) => R,
+			context: any
 		): R[];
 		forEach<T extends preact1.ComponentChild>(
 			children: T | T[],
-			fn: (child: T, i: number) => void
+			fn: (child: T, i: number) => void,
+			context: any
 		): void;
 		count: (children: preact1.ComponentChildren) => number;
 		only: (children: preact1.ComponentChildren) => preact1.ComponentChild;

--- a/compat/test/browser/Children.test.js
+++ b/compat/test/browser/Children.test.js
@@ -115,7 +115,7 @@ describe('Children', () => {
 			};
 			render(<Foo>foo</Foo>, scratch);
 
-			expect(spy.mock.calls[0]).to.equal(context);
+			expect(spy.mock.contexts[0]).to.equal(context);
 		});
 
 		it('should flatten result', () => {

--- a/compat/test/browser/Children.test.js
+++ b/compat/test/browser/Children.test.js
@@ -5,6 +5,7 @@ import {
 } from '../../../test/_util/helpers';
 import { div, span } from '../../../test/_util/dom';
 import React, { createElement, Children, render } from 'preact/compat';
+import sinon from 'sinon';
 
 describe('Children', () => {
 	/** @type {HTMLDivElement} */
@@ -104,6 +105,17 @@ describe('Children', () => {
 
 			render(<Foo>{testNumber}</Foo>, scratch);
 			expect(serializeHtml(scratch)).to.equal('<div><span>0</span></div>');
+		});
+
+		it('should propagate "this" context', () => {
+			const context = {};
+			const spy = sinon.spy(child => child); // noop
+			const Foo = ({ children }) => {
+				return React.Children.map(children, spy, context);
+			};
+			render(<Foo>foo</Foo>, scratch);
+
+			expect(spy.thisValues[0]).to.equal(context);
 		});
 
 		it('should flatten result', () => {

--- a/compat/test/browser/Children.test.js
+++ b/compat/test/browser/Children.test.js
@@ -5,7 +5,7 @@ import {
 } from '../../../test/_util/helpers';
 import { div, span } from '../../../test/_util/dom';
 import React, { createElement, Children, render } from 'preact/compat';
-import sinon from 'sinon';
+import { vi } from 'vitest';
 
 describe('Children', () => {
 	/** @type {HTMLDivElement} */
@@ -109,13 +109,13 @@ describe('Children', () => {
 
 		it('should propagate "this" context', () => {
 			const context = {};
-			const spy = sinon.spy(child => child); // noop
+			const spy = vi.fn(child => child); // noop
 			const Foo = ({ children }) => {
 				return React.Children.map(children, spy, context);
 			};
 			render(<Foo>foo</Foo>, scratch);
 
-			expect(spy.thisValues[0]).to.equal(context);
+			expect(spy.mock.calls[0]).to.equal(context);
 		});
 
 		it('should flatten result', () => {


### PR DESCRIPTION
React's children api map function supports a "context" argument that we don't.
Fixes https://github.com/preactjs/preact/issues/2644.

Based mostly on #2645.

There was a problem though: When I ran `npm run test:karma`, it didn't test `Children.test.js`. Even the [pipeline on the forked project](https://github.com/ParSal123/preact/actions/runs/3868538874/jobs/6594048965#step:5:151) didn't run `Children.test.js`. I couldn't figure it out. Don't know if this is an issue or just misconfiguration.