### PR TITLE
Improve suspense test spies

### DIFF
--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -338,11 +338,7 @@ describe('suspense', () => {
 		});
 	});
 
-	it('should not call lifecycle methods of an initially suspending component', () => {
-		let componentWillMount = sinon.spy();
-		let componentDidMount = sinon.spy();
-		let componentWillUnmount = sinon.spy();
-
+	it('should properly call lifecycle methods of an initially suspending component', () => {
 		/** @type {() => Promise<void>} */
 		let resolve;
 		let resolved = false;
@@ -361,16 +357,17 @@ describe('suspense', () => {
 				}
 				return <div>Lifecycle</div>;
 			}
-			componentWillMount() {
-				componentWillMount();
-			}
-			componentDidMount() {
-				componentDidMount();
-			}
-			componentWillUnmount() {
-				componentWillUnmount();
-			}
+			componentWillMount() {}
+			componentDidMount() {}
+			componentDidUpdate() {}
+			componentWillUnmount() {}
 		}
+
+		const lifecycles = LifecycleSuspender.prototype;
+		sinon.spy(lifecycles, 'componentWillMount');
+		sinon.spy(lifecycles, 'componentDidMount');
+		sinon.spy(lifecycles, 'componentDidUpdate');
+		sinon.spy(lifecycles, 'componentWillUnmount');
 
 		render(
 			<Suspense fallback={<div>Suspended...</div>}>
@@ -380,33 +377,32 @@ describe('suspense', () => {
 		);
 
 		expect(scratch.innerHTML).to.eql(``);
-		expect(componentWillMount).to.have.been.calledOnce;
-		expect(componentDidMount).to.not.have.been.called;
-		expect(componentWillUnmount).to.not.have.been.called;
+		expect(lifecycles.componentWillMount).to.have.been.calledOnce;
+		expect(lifecycles.componentDidMount).to.not.have.been.called;
+		expect(lifecycles.componentDidUpdate).to.not.have.been.called;
+		expect(lifecycles.componentWillUnmount).to.not.have.been.called;
 
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(`<div>Suspended...</div>`);
-		expect(componentWillMount).to.have.been.calledOnce;
-		expect(componentDidMount).to.not.have.been.called;
-		expect(componentWillUnmount).to.not.have.been.called;
+		expect(lifecycles.componentWillMount).to.have.been.calledOnce;
+		expect(lifecycles.componentDidMount).to.not.have.been.called;
+		expect(lifecycles.componentDidUpdate).to.not.have.been.called;
+		expect(lifecycles.componentWillUnmount).to.not.have.been.called;
 
 		return resolve().then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(`<div>Lifecycle</div>`);
 
-			expect(componentWillMount).to.have.been.calledOnce;
-			expect(componentDidMount).to.have.been.calledOnce;
-			expect(componentWillUnmount).to.not.have.been.called;
+			expect(lifecycles.componentWillMount).to.have.been.calledOnce;
+			expect(lifecycles.componentDidMount).to.have.been.calledOnce;
+			// TODO: This is unexpected. See TODO in next test regarding this and preactjs/preact#2098
+			expect(lifecycles.componentDidUpdate).to.have.been.calledOnce;
+			expect(lifecycles.componentWillUnmount).to.not.have.been.called;
 		});
 	});
 
 	it('should properly call lifecycle methods and maintain state of a delayed suspending component', () => {
-		let componentWillMount = sinon.spy();
-		let componentDidMount = sinon.spy();
-		let componentDidUpdate = sinon.spy();
-		let componentWillUnmount = sinon.spy();
-
 		/** @type {() => void} */
 		let increment;
 
@@ -439,19 +435,17 @@ describe('suspense', () => {
 					</Fragment>
 				);
 			}
-			componentWillMount() {
-				componentWillMount();
-			}
-			componentDidMount() {
-				componentDidMount();
-			}
-			componentWillUnmount() {
-				componentWillUnmount();
-			}
-			componentDidUpdate() {
-				componentDidUpdate();
-			}
+			componentWillMount() {}
+			componentDidMount() {}
+			componentWillUnmount() {}
+			componentDidUpdate() {}
 		}
+
+		const lifecycles = LifecycleSuspender.prototype;
+		sinon.spy(lifecycles, 'componentWillMount');
+		sinon.spy(lifecycles, 'componentDidMount');
+		sinon.spy(lifecycles, 'componentDidUpdate');
+		sinon.spy(lifecycles, 'componentWillUnmount');
 
 		render(
 			<Suspense fallback={<div>Suspended...</div>}>
@@ -461,62 +455,60 @@ describe('suspense', () => {
 		);
 
 		expect(scratch.innerHTML).to.eql(`<p>Count: 0</p>`);
-		expect(componentWillMount).to.have.been.calledOnce;
-		expect(componentDidMount).to.have.been.calledOnce;
-		expect(componentDidUpdate).to.not.have.been.called;
-		expect(componentWillUnmount).to.not.have.been.called;
+		expect(lifecycles.componentWillMount).to.have.been.calledOnce;
+		expect(lifecycles.componentDidMount).to.have.been.calledOnce;
+		expect(lifecycles.componentDidUpdate).to.not.have.been.called;
+		expect(lifecycles.componentWillUnmount).to.not.have.been.called;
 
 		increment();
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(`<p>Count: 1</p>`);
-		expect(componentWillMount).to.have.been.calledOnce;
-		expect(componentDidMount).to.have.been.calledOnce;
-		expect(componentDidUpdate).to.have.been.calledOnce;
-		expect(componentWillUnmount).to.not.have.been.called;
+		expect(lifecycles.componentWillMount).to.have.been.calledOnce;
+		expect(lifecycles.componentDidMount).to.have.been.calledOnce;
+		expect(lifecycles.componentDidUpdate).to.have.been.calledOnce;
+		expect(lifecycles.componentWillUnmount).to.not.have.been.called;
 
 		increment();
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(`<div>Suspended...</div>`);
-		expect(componentWillMount).to.have.been.calledOnce;
-		expect(componentDidMount).to.have.been.calledOnce;
-		expect(componentDidUpdate).to.have.been.calledOnce;
-		expect(componentWillUnmount).to.not.have.been.called;
+		expect(lifecycles.componentWillMount).to.have.been.calledOnce;
+		expect(lifecycles.componentDidMount).to.have.been.calledOnce;
+		expect(lifecycles.componentDidUpdate).to.have.been.calledOnce;
+		expect(lifecycles.componentWillUnmount).to.not.have.been.called;
 
 		return resolve().then(() => {
 			rerender();
 
 			expect(scratch.innerHTML).to.eql(`<p>Count: 2</p>`);
-			expect(componentWillMount).to.have.been.calledOnce;
-			expect(componentDidMount).to.have.been.calledOnce;
+			expect(lifecycles.componentWillMount).to.have.been.calledOnce;
+			expect(lifecycles.componentDidMount).to.have.been.calledOnce;
 			// TODO: This is called thrice since the cDU queued up after the second
 			// increment is never cleared once the component suspends. So when it
 			// resumes and the component is rerendered, we queue up another cDU so
 			// cDU is called an extra time.
-			expect(componentDidUpdate).to.have.been.calledThrice;
-			expect(componentWillUnmount).to.not.have.been.called;
+			expect(lifecycles.componentDidUpdate).to.have.been.calledThrice;
+			expect(lifecycles.componentWillUnmount).to.not.have.been.called;
 		});
 	});
 
 	it('should not call lifecycle methods when a sibling suspends', () => {
-		let componentWillMount = sinon.spy();
-		let componentDidMount = sinon.spy();
-		let componentWillUnmount = sinon.spy();
 		class LifecycleLogger extends Component {
 			render() {
 				return <div>Lifecycle</div>;
 			}
-			componentWillMount() {
-				componentWillMount();
-			}
-			componentDidMount() {
-				componentDidMount();
-			}
-			componentWillUnmount() {
-				componentWillUnmount();
-			}
+			componentWillMount() {}
+			componentDidMount() {}
+			componentDidUpdate() {}
+			componentWillUnmount() {}
 		}
+
+		const lifecycles = LifecycleLogger.prototype;
+		sinon.spy(lifecycles, 'componentWillMount');
+		sinon.spy(lifecycles, 'componentDidMount');
+		sinon.spy(lifecycles, 'componentDidUpdate');
+		sinon.spy(lifecycles, 'componentWillUnmount');
 
 		const [Suspender, suspend] = createSuspender(() => <div>Suspense</div>);
 
@@ -529,18 +521,20 @@ describe('suspense', () => {
 		);
 
 		expect(scratch.innerHTML).to.eql(`<div>Suspense</div><div>Lifecycle</div>`);
-		expect(componentWillMount).to.have.been.calledOnce;
-		expect(componentDidMount).to.have.been.calledOnce;
-		expect(componentWillUnmount).to.not.have.been.called;
+		expect(lifecycles.componentWillMount).to.have.been.calledOnce;
+		expect(lifecycles.componentDidMount).to.have.been.calledOnce;
+		expect(lifecycles.componentDidUpdate).to.not.have.been.called;
+		expect(lifecycles.componentWillUnmount).to.not.have.been.called;
 
 		const [resolve] = suspend();
 
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(`<div>Suspended...</div>`);
-		expect(componentWillMount).to.have.been.calledOnce;
-		expect(componentDidMount).to.have.been.calledOnce;
-		expect(componentWillUnmount).to.not.have.been.called;
+		expect(lifecycles.componentWillMount).to.have.been.calledOnce;
+		expect(lifecycles.componentDidMount).to.have.been.calledOnce;
+		expect(lifecycles.componentDidUpdate).to.not.have.been.called;
+		expect(lifecycles.componentWillUnmount).to.not.have.been.called;
 
 		return resolve(() => <div>Suspense 2</div>).then(() => {
 			rerender();
@@ -548,9 +542,10 @@ describe('suspense', () => {
 				`<div>Suspense 2</div><div>Lifecycle</div>`
 			);
 
-			expect(componentWillMount).to.have.been.calledOnce;
-			expect(componentDidMount).to.have.been.calledOnce;
-			expect(componentWillUnmount).to.not.have.been.called;
+			expect(lifecycles.componentWillMount).to.have.been.calledOnce;
+			expect(lifecycles.componentDidMount).to.have.been.calledOnce;
+			expect(lifecycles.componentDidUpdate).to.have.been.calledOnce;
+			expect(lifecycles.componentWillUnmount).to.not.have.been.called;
 		});
 	});
 
@@ -564,18 +559,10 @@ describe('suspense', () => {
 			componentWillUnmount() {}
 		}
 
-		const componentWillMount = sinon.spy(
-			LifecycleLogger.prototype,
-			'componentWillMount'
-		);
-		const componentDidMount = sinon.spy(
-			LifecycleLogger.prototype,
-			'componentDidMount'
-		);
-		const componentWillUnmount = sinon.spy(
-			LifecycleLogger.prototype,
-			'componentWillUnmount'
-		);
+		const lifecycles = LifecycleLogger.prototype;
+		sinon.spy(lifecycles, 'componentWillMount');
+		sinon.spy(lifecycles, 'componentDidMount');
+		sinon.spy(lifecycles, 'componentWillUnmount');
 
 		const [Suspender, suspend] = createSuspender(() => <div>Suspense</div>);
 
@@ -587,26 +574,26 @@ describe('suspense', () => {
 		);
 
 		expect(scratch.innerHTML).to.eql(`<div>Suspense</div>`);
-		expect(componentWillMount).to.not.have.been.called;
-		expect(componentDidMount).to.not.have.been.called;
-		expect(componentWillUnmount).to.not.have.been.called;
+		expect(lifecycles.componentWillMount).to.not.have.been.called;
+		expect(lifecycles.componentDidMount).to.not.have.been.called;
+		expect(lifecycles.componentWillUnmount).to.not.have.been.called;
 
 		const [resolve] = suspend();
 
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(`<div>Lifecycle</div>`);
-		expect(componentWillMount).to.have.been.calledOnce;
-		expect(componentDidMount).to.have.been.calledOnce;
-		expect(componentWillUnmount).to.not.have.been.called;
+		expect(lifecycles.componentWillMount).to.have.been.calledOnce;
+		expect(lifecycles.componentDidMount).to.have.been.calledOnce;
+		expect(lifecycles.componentWillUnmount).to.not.have.been.called;
 
 		return resolve(() => <div>Suspense 2</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(`<div>Suspense 2</div>`);
 
-			expect(componentWillMount).to.have.been.calledOnce;
-			expect(componentDidMount).to.have.been.calledOnce;
-			expect(componentWillUnmount).to.have.been.calledOnce;
+			expect(lifecycles.componentWillMount).to.have.been.calledOnce;
+			expect(lifecycles.componentDidMount).to.have.been.calledOnce;
+			expect(lifecycles.componentWillUnmount).to.have.been.calledOnce;
 		});
 	});
 


### PR DESCRIPTION
I'm working a bug & fix that impacts these tests and it's hard to debug them cuz as written, the error message doesn't log what method the spy assertion failed for. In the screenshots below can find it stack trace but in another branch, I don't see that 🤷‍♂️. It also lacks call information. So this PR rewrites how we spy on lifecycles so the method name is included in errors and the error message includes information about the calls to the method!

Before:
<img width="724" alt="image" src="https://user-images.githubusercontent.com/459878/211423059-39f4a395-fdd7-40e8-9158-9ebb0944dd8e.png">

After:
<img width="822" alt="image" src="https://user-images.githubusercontent.com/459878/211423256-43b9e876-9cb3-4b2a-94df-f096138e0adf.png">
