### PR TITLE
Narrows type of `parent` in render functions.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -275,11 +275,19 @@ export namespace h {
 // Preact render
 // -----------------------------------
 
-type Parent = Omit<Pick<Element | Document | ShadowRoot | DocumentFragment, 'nodeType' | 'parentNode' | 'firstChild' | 'insertBefore' | 'appendChild' | 'removeChild'>, 'childNodes'> & { childNodes: ArrayLike<Node> }
+interface ContainerNode {
+	nodeType: Node['nodeType'];
+	parentNode: Node['nodeType'];
+	firstChild: Node['firstChild'];
+	insertBefore: Node['insertBefore'];
+	appendChild: Node['appendChild'];
+	removeChild: Node['removeChild'];
+	childNodes: ArrayLike<Node>
+}
 
 export function render(
 	vnode: ComponentChild,
-	parent: Parent
+	parent: ContainerNode
 ): void;
 /**
  * @deprecated Will be removed in v11.
@@ -288,12 +296,12 @@ export function render(
  */
 export function render(
 	vnode: ComponentChild,
-	parent: Parent,
+	parent: ContainerNode,
 	replaceNode?: Element | Text
 ): void;
 export function hydrate(
 	vnode: ComponentChild,
-	parent: Parent
+	parent: ContainerNode
 ): void;
 export function cloneElement(
 	vnode: VNode<any>,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -277,7 +277,7 @@ export namespace h {
 
 interface ContainerNode {
 	nodeType: Node['nodeType'];
-	parentNode: Node['nodeType'];
+	parentNode: Node['parentNode'];
 	firstChild: Node['firstChild'];
 	insertBefore: Node['insertBefore'];
 	appendChild: Node['appendChild'];

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -275,9 +275,11 @@ export namespace h {
 // Preact render
 // -----------------------------------
 
+type Parent = Omit<Pick<Element | Document | ShadowRoot | DocumentFragment, 'nodeType' | 'parentNode' | 'firstChild' | 'insertBefore' | 'appendChild' | 'removeChild'>, 'childNodes'> & { childNodes: ArrayLike<Node> }
+
 export function render(
 	vnode: ComponentChild,
-	parent: Element | Document | ShadowRoot | DocumentFragment
+	parent: Parent
 ): void;
 /**
  * @deprecated Will be removed in v11.
@@ -286,12 +288,12 @@ export function render(
  */
 export function render(
 	vnode: ComponentChild,
-	parent: Element | Document | ShadowRoot | DocumentFragment,
+	parent: Parent,
 	replaceNode?: Element | Text
 ): void;
 export function hydrate(
 	vnode: ComponentChild,
-	parent: Element | Document | ShadowRoot | DocumentFragment
+	parent: Parent
 ): void;
 export function cloneElement(
 	vnode: VNode<any>,

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -79,6 +79,12 @@ render(
 	document
 );
 
+// Mounting into different types of Nodes
+render(h('div', {}), document.createElement('div'));
+render(h('div', {}), document);
+render(h('div', {}), document.createElement('div').shadowRoot!);
+render(h('div', {}), document.createDocumentFragment());
+
 // Accessing children
 const ComponentWithChildren: FunctionalComponent<DummerComponentProps> = ({
 	input,


### PR DESCRIPTION
https://gist.github.com/developit/f4c67a2ede71dc2fab7f357f39cff28c is the recommended way to partial root rendering in Preact 10+, but it isn't API compliant code given the current API definition as expressed by the TS types. This PR changes the type of `parent` to align with what is *actually* required by the preact render functions according to @developit.

Assuming the linked code actually works, then it means preact doesn't actually need a NodeList, but rather just needs an `ArrayLike<Node>`. Along with limiting the property set of `Parent`, I have also narrowed `Parent['childNodes']` to be an `ArrayLike<Node>` so someone can assign a `Node[]` to it.

I suspect my stylistic choice of a single long line is not acceptable for this repository, but I'm not clear what the proper way to break this into multiple lines is for this repository.  If someone can provide me with feedback on how to correctly split the lines, please let me know!

Note: I recognize that this is a pretty substantial type change, but without it the official recommendation (and only option in Preact 11) for doing partial root rendering is incorrect. Either the recommendation for how to do partial root rendering should be corrected to not lead people to an incorrect solution, or this PR (or one like it) should be merged to correctly express the type that preact expects for its `render` functions.