### PR TITLE
Changes `EventHandler<...>` to have a `this` of type `void`.

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -418,11 +418,7 @@ export namespace JSXInternal {
 	>;
 
 	export interface EventHandler<E extends TargetedEvent> {
-		/**
-		 * The `this` keyword always points to the DOM element the event handler
-		 * was invoked on. See: https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Event_handlers#Event_handlers_parameters_this_binding_and_the_return_value
-		 */
-		(this: never, event: E): void;
+		(this: void, event: E): void;
 	}
 
 	export type AnimationEventHandler<Target extends EventTarget> = EventHandler<

--- a/test/ts/Component-test.tsx
+++ b/test/ts/Component-test.tsx
@@ -2,12 +2,6 @@ import 'mocha';
 import { expect } from 'chai';
 import { createElement, Component, RenderableProps, Fragment } from '../../';
 
-// Test `this` binding on event handlers
-function onHandler(this: HTMLInputElement, event: any) {
-	return this.value;
-}
-const foo = <input onChange={onHandler} />;
-
 export class ContextComponent extends Component<{ foo: string }> {
 	getChildContext() {
 		return { something: 2 };


### PR DESCRIPTION
Originally, `this` was set to `E['currentTarget']` which, based on the MDN doc linked in #2166, certainly sounds like the correct thing to do.  A couple years later it was changed to `never` in #3147 with no commentary on the PR or commit indicating why.  My guess is that this was changed so arrow functions would work, which I believe are permanently bound and cannot be rebound by the caller.

I believe that `never` is wrong because this code doesn't compile:
```ts
declare const event: JSX.TargetedEvent<HTMLElement, Event>

declare const apple: JSX.EventHandler<JSX.TargetedEvent<HTMLElement, Event>>
apple(event) // error TS2684: The 'this' context of type 'void' is not assignable to method's 'this' of type 'never'.

function Apple(model: Pick<JSX.HTMLAttributes<HTMLElement>, 'onInput'>) {
	model.onInput && model.onInput(event) // error TS2684: The 'this' context of type 'Pick<HTMLAttributes<HTMLElement>, "onInput">' is not assignable to method's 'this' of type 'never'.
}
```
Changing to `void` resolves this error and I believe will work everywhere that never worked.

I removed the comment since it no longer applies with this being `never` or `void`.  It appears that it was just forgotten when the switch from `E['currentTarget']` to `never` was made.