### PR TITLE
Re-sort rerender queue if modified while we are processing rerenders

### DIFF
--- a/compat/test/browser/context.test.js
+++ b/compat/test/browser/context.test.js
@@ -54,13 +54,13 @@ describe('components', () => {
 				toggleLocation = () => {
 					const oldLocation = this.state.location;
 					const newLocation = oldLocation === route1 ? route2 : route1;
-					console.log('Toggling  location', oldLocation, '->', newLocation);
+					// console.log('Toggling  location', oldLocation, '->', newLocation);
 					this.setState({ location: newLocation });
 				};
 			}
 
 			render() {
-				console.log('Rendering Router', { location: this.state.location });
+				// console.log('Rendering Router', { location: this.state.location });
 				return (
 					<RouterContext.Provider value={{ location: this.state.location }}>
 						{this.props.children}
@@ -77,9 +77,9 @@ describe('components', () => {
 				return (
 					<RouterContext.Consumer>
 						{contextValue => {
-							console.log('Rendering Route', {
-								location: contextValue.location
-							});
+							// console.log('Rendering Route', {
+							// 	location: contextValue.location
+							// });
 							// Pretend to do something with the context value
 							const newContextValue = { ...contextValue };
 							return (
@@ -98,11 +98,11 @@ describe('components', () => {
 			const { location } = useContext(RouterContext);
 
 			pageRenders.push({ location, localState });
-			console.log('Rendering Page', { location, localState });
+			// console.log('Rendering Page', { location, localState });
 
 			toggleLocalState = () => {
 				let newValue = !localState;
-				console.log('Toggling  localState', localState, '->', newValue);
+				// console.log('Toggling  localState', localState, '->', newValue);
 				setLocalState(newValue);
 			};
 

--- a/compat/test/browser/context.test.js
+++ b/compat/test/browser/context.test.js
@@ -1,0 +1,144 @@
+import { setupRerender } from 'preact/test-utils';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+import React, {
+	render,
+	createElement,
+	createContext,
+	Component,
+	useState,
+	useContext
+} from 'preact/compat';
+
+describe('components', () => {
+	/** @type {HTMLDivElement} */
+	let scratch;
+
+	/** @type {() => void} */
+	let rerender;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+		rerender = setupRerender();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('nested context updates propagate throughout the tree synchronously', () => {
+		const RouterContext = createContext({ location: '__default_value__' });
+
+		const route1 = '/page/1';
+		const route2 = '/page/2';
+
+		/** @type {() => void} */
+		let toggleLocalState;
+		/** @type {() => void} */
+		let toggleLocation;
+
+		/** @type {Array<{location: string, localState: boolean}>} */
+		let pageRenders = [];
+
+		function runUpdate() {
+			toggleLocalState();
+			toggleLocation();
+		}
+
+		/**
+		 * @extends {React.Component<{children: any}, {location: string}>}
+		 */
+		class Router extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { location: route1 };
+				toggleLocation = () => {
+					const oldLocation = this.state.location;
+					const newLocation = oldLocation === route1 ? route2 : route1;
+					console.log('Toggling  location', oldLocation, '->', newLocation);
+					this.setState({ location: newLocation });
+				};
+			}
+
+			render() {
+				console.log('Rendering Router', { location: this.state.location });
+				return (
+					<RouterContext.Provider value={{ location: this.state.location }}>
+						{this.props.children}
+					</RouterContext.Provider>
+				);
+			}
+		}
+
+		/**
+		 * @extends {React.Component<{children: any}>}
+		 */
+		class Route extends Component {
+			render() {
+				return (
+					<RouterContext.Consumer>
+						{contextValue => {
+							console.log('Rendering Route', {
+								location: contextValue.location
+							});
+							// Pretend to do something with the context value
+							const newContextValue = { ...contextValue };
+							return (
+								<RouterContext.Provider value={newContextValue}>
+									{this.props.children}
+								</RouterContext.Provider>
+							);
+						}}
+					</RouterContext.Consumer>
+				);
+			}
+		}
+
+		function Page() {
+			const [localState, setLocalState] = useState(true);
+			const { location } = useContext(RouterContext);
+
+			pageRenders.push({ location, localState });
+			console.log('Rendering Page', { location, localState });
+
+			toggleLocalState = () => {
+				let newValue = !localState;
+				console.log('Toggling  localState', localState, '->', newValue);
+				setLocalState(newValue);
+			};
+
+			return (
+				<>
+					<div>localState: {localState.toString()}</div>
+					<div>location: {location}</div>
+					<div>
+						<button type="button" onClick={runUpdate}>
+							Trigger update
+						</button>
+					</div>
+				</>
+			);
+		}
+
+		function App() {
+			return (
+				<Router>
+					<Route>
+						<Page />
+					</Route>
+				</Router>
+			);
+		}
+
+		render(<App />, scratch);
+		expect(pageRenders).to.deep.equal([{ location: route1, localState: true }]);
+
+		pageRenders = [];
+		runUpdate(); // Simulate button click
+		rerender();
+
+		// Page should rerender once with both propagated context and local state updates
+		expect(pageRenders).to.deep.equal([
+			{ location: route2, localState: false }
+		]);
+	});
+});

--- a/src/component.js
+++ b/src/component.js
@@ -119,7 +119,7 @@ export function getDomSibling(vnode, childIndex) {
  * Trigger in-place re-rendering of a component.
  * @param {import('./internal').Component} component The component to rerender
  */
-export function renderComponent(component) {
+function renderComponent(component) {
 	let vnode = component._vnode,
 		oldDom = vnode._dom,
 		parentDom = component._parentDom;
@@ -203,23 +203,22 @@ export function enqueueRender(c) {
 /** Flush the render queue by rerendering all queued components */
 function process() {
 	let c;
-	while ((process._rerenderCount = rerenderQueue.length)) {
-		rerenderQueue.sort((a, b) => a._vnode._depth - b._vnode._depth);
-		// Don't update `renderCount` yet. Keep its value non-zero to prevent unnecessary
-		// process() calls from getting scheduled while `queue` is still being consumed.
-		while ((c = rerenderQueue.shift())) {
-			if (c._dirty) {
-				let renderQueueLength = rerenderQueue.length;
-				renderComponent(c);
-				if (rerenderQueue.length > renderQueueLength) {
-					// When i.e. rerendering a provider additional new items can be injected, we want to
-					// keep the order from top to bottom with those new items so we can handle them in a
-					// single pass
-					rerenderQueue.sort((a, b) => a._vnode._depth - b._vnode._depth);
-				}
+	rerenderQueue.sort((a, b) => a._vnode._depth - b._vnode._depth);
+	// Don't update `renderCount` yet. Keep its value non-zero to prevent unnecessary
+	// process() calls from getting scheduled while `queue` is still being consumed.
+	while ((c = rerenderQueue.shift())) {
+		if (c._dirty) {
+			let renderQueueLength = rerenderQueue.length;
+			renderComponent(c);
+			if (rerenderQueue.length > renderQueueLength) {
+				// When i.e. rerendering a provider additional new items can be injected, we want to
+				// keep the order from top to bottom with those new items so we can handle them in a
+				// single pass
+				rerenderQueue.sort((a, b) => a._vnode._depth - b._vnode._depth);
 			}
 		}
 	}
+	process._rerenderCount = 0;
 }
 
 process._rerenderCount = 0;

--- a/src/component.js
+++ b/src/component.js
@@ -119,7 +119,7 @@ export function getDomSibling(vnode, childIndex) {
  * Trigger in-place re-rendering of a component.
  * @param {import('./internal').Component} component The component to rerender
  */
-function renderComponent(component) {
+export function renderComponent(component) {
 	let vnode = component._vnode,
 		oldDom = vnode._dom,
 		parentDom = component._parentDom;
@@ -202,15 +202,23 @@ export function enqueueRender(c) {
 
 /** Flush the render queue by rerendering all queued components */
 function process() {
-	let queue;
+	let c;
 	while ((process._rerenderCount = rerenderQueue.length)) {
-		queue = rerenderQueue.sort((a, b) => a._vnode._depth - b._vnode._depth);
-		rerenderQueue = [];
+		rerenderQueue.sort((a, b) => a._vnode._depth - b._vnode._depth);
 		// Don't update `renderCount` yet. Keep its value non-zero to prevent unnecessary
 		// process() calls from getting scheduled while `queue` is still being consumed.
-		queue.some(c => {
-			if (c._dirty) renderComponent(c);
-		});
+		while ((c = rerenderQueue.shift())) {
+			if (c._dirty) {
+				let renderQueueLength = rerenderQueue.length;
+				renderComponent(c);
+				if (rerenderQueue.length > renderQueueLength) {
+					// When i.e. rerendering a provider additional new items can be injected, we want to
+					// keep the order from top to bottom with those new items so we can handle them in a
+					// single pass
+					rerenderQueue.sort((a, b) => a._vnode._depth - b._vnode._depth);
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
By re-sorting the rerender queue while flushing it, we ensure we always rerender from the top-down of the vdom tree. This behavior is especially important for flushing context updates which trigger updates of nodes further down the tree. We should always process these top-down so the context updates propagate before other rerenders which may depend on the context update rerender. See the commit message in 672782adbf9ccefa7a4d7c175f0adf8580f73c92 for a more detailed description of the bug and the test that this PR adds.