### PR TITLE
When unmounting, continue with the last DOM element's nextSibling

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -213,7 +213,7 @@ export function diffChildren(
 				// If the newParentVNode.__nextDom points to a dom node that is about to
 				// be unmounted, then get the next sibling of that vnode and set
 				// _nextDom to it
-				newParentVNode._nextDom = newParentVNode._nextDom.nextSibling;
+				newParentVNode._nextDom = getLastDom(oldParentVNode).nextSibling;
 			}
 
 			unmount(oldChildren[i], oldChildren[i]);
@@ -325,4 +325,27 @@ function placeChild(
 	}
 
 	return oldDom;
+}
+
+/**
+ * @param {import('../internal').VNode} vnode
+ */
+function getLastDom(vnode) {
+	if (vnode.type == null || typeof vnode.type === 'string') {
+		return vnode._dom;
+	}
+
+	if (vnode._children) {
+		for (let i = vnode._children.length - 1; i >= 0; i--) {
+			let child = vnode._children[i];
+			if (child) {
+				let lastDom = getLastDom(child);
+				if (lastDom) {
+					return lastDom;
+				}
+			}
+		}
+	}
+
+	return null;
 }

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -2700,12 +2700,7 @@ describe('Fragment', () => {
 		render(<App condition={false} />, scratch);
 
 		expect(scratch.innerHTML).to.equal(div([div(1), div('A'), div('B')]));
-		expectDomLogToBe([
-			'<div>2.remove()',
-			'<div>3.remove()',
-			'<div>1AB.appendChild(<div>A)',
-			'<div>1BA.appendChild(<div>B)'
-		]);
+		expectDomLogToBe(['<div>2.remove()', '<div>3.remove()']);
 	});
 
 	it('should efficiently place new children and unmount nested Fragment children', () => {
@@ -2754,9 +2749,7 @@ describe('Fragment', () => {
 			'<div>.appendChild(#text)',
 			'<div>123AB.insertBefore(<div>4, <div>2)',
 			'<div>2.remove()',
-			'<div>3.remove()',
-			'<div>14AB.appendChild(<div>A)',
-			'<div>14BA.appendChild(<div>B)'
+			'<div>3.remove()'
 		]);
 	});
 


### PR DESCRIPTION
This PR is a follow up to #3875. I realized that we can't do `oldChildren[i]._dom.nextSibling` cuz `oldChildren[i]` itself could be Fragment representing a bunch of DOM nodes. We want the last dom node of `oldChildren[i]` and to get it's last sibling.