### PR TITLE
Fix parameters or JSX dev runtime

### DIFF
--- a/jsx-runtime/src/index.js
+++ b/jsx-runtime/src/index.js
@@ -20,10 +20,11 @@ let vnodeId = 0;
  * @param {VNode['type']} type
  * @param {VNode['props']} props
  * @param {VNode['key']} [key]
- * @param {string} [__self]
- * @param {string} [__source]
+ * @param {unknown} [isStaticChildren]
+ * @param {unknown} [__source]
+ * @param {unknown} [__self]
  */
-function createVNode(type, props, key, __self, __source) {
+function createVNode(type, props, key, isStaticChildren, __source, __self) {
 	// We'll want to preserve `ref` in props to get rid of the need for
 	// forwardRef components in the future, but that should happen via
 	// a separate PR.

--- a/jsx-runtime/test/browser/jsx-runtime.test.js
+++ b/jsx-runtime/test/browser/jsx-runtime.test.js
@@ -66,7 +66,7 @@ describe('Babel jsx/jsxDEV', () => {
 	});
 
 	it('should set __source and __self', () => {
-		const vnode = jsx('div', { class: 'foo' }, 'key', 'self', 'source');
+		const vnode = jsx('div', { class: 'foo' }, 'key', false, 'source', 'self');
 		expect(vnode.__source).to.equal('source');
 		expect(vnode.__self).to.equal('self');
 	});


### PR DESCRIPTION
* There was a parameter missing (`isStaticChildren: boolean`), which is not useful\*, but is still being passed
* Fix order of `source` and `self` again (incorrectly introduced in GH-3459)
* Fix some (internal JSDoc) types for these parameters

My guess is that the previous PR “fixed” the earlier problem because `self` isn’t used, so by calling `isStaticChildren` “`self`”, a bug went away.

The source for where this `jsxDEV` call is generated in Babel is here: <https://github.com/babel/babel/blob/3952486/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts#L506-L508>.
The React RFC for the transform that mentions the dev runtime is here: <https://github.com/reactjs/rfcs/blob/createlement-rfc/text/0000-create-element-changes.md#dev-only-transforms>.
React’s implementation is here: <https://github.com/facebook/react/blob/855b77c9bbee347735efcd626dda362db2ffae1d/packages/react/src/jsx/ReactJSXElementValidator.js#L306-L311>

\* `isStaticChildren` is the same as whether `jsxs` would be used, instead of `jsx`. Which is also whether there are 2 or more children passed:

*   `<a />` -> `jsx('a', {})`
*   `<a>b</a>` -> `jsx('a', {children: 'b'})`
*   `<a>{1}{2}</a>` -> `jsxs('a', {children: [1, 2]})`

Related-to: GH-3459.