### PR TITLE
fix: avoid bailing in strict equality

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -143,10 +143,16 @@ export function diff(
 						) === false) ||
 					newVNode._original === oldVNode._original
 				) {
-					c.props = newProps;
-					c.state = c._nextState;
 					// More info about this here: https://gist.github.com/JoviDeCroock/bec5f2ce93544d2e6070ef8e0036e4e8
-					if (newVNode._original !== oldVNode._original) c._dirty = false;
+					if (newVNode._original !== oldVNode._original) {
+						// When we are dealing with a bail because of sCU we have to update
+						// the props, state and dirty-state.
+						// when we are dealing with strict-equality we don't as the child could still
+						// be dirtied see #3883
+						c.props = newProps;
+						c.state = c._nextState;
+						c._dirty = false;
+					}
 					newVNode._dom = oldVNode._dom;
 					newVNode._children = oldVNode._children;
 					newVNode._children.forEach(vnode => {

--- a/test/browser/lifecycles/shouldComponentUpdate.test.js
+++ b/test/browser/lifecycles/shouldComponentUpdate.test.js
@@ -858,6 +858,53 @@ describe('Lifecycle methods', () => {
 		// ]);
 	});
 
+	it('should correctly handle double state updates', () => {
+		let updateParent, updateChild;
+		class Parent extends Component {
+			state = { text: 'parent-old' };
+
+			componentDidMount() {
+				updateParent = () => this.setState({ text: 'Parent-NEW' });
+			}
+
+			render() {
+				return (
+					<Fragment>
+						{this.props.children} and {this.state.text}
+					</Fragment>
+				);
+			}
+		}
+
+		class Child extends Component {
+			state = { text: 'child-old' };
+
+			shouldComponentUpdate(nextProps, nextState) {
+				return this.state.text !== nextState.text;
+			}
+
+			componentDidMount() {
+				updateChild = () => this.setState({ text: 'Child-NEW' });
+			}
+
+			render() {
+				return <h1>{this.state.text}</h1>;
+			}
+		}
+
+		render(
+			<Parent>
+				<Child />
+			</Parent>,
+			scratch
+		);
+
+		updateParent();
+		updateChild();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<h1>Child-NEW</h1> and Parent-NEW');
+	});
+
 	it('should maintain the order if memoised component initially rendered empty content', () => {
 		let showText, updateParent;
 		class Child extends Component {


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/3883

When we are dealing with strict equality we expect the following type of component to bail because of the reference of the vnode being the same in-between renders:

```js
const Parent = (props) => props.children
```

this component can have an internal update but because we return a static reference to the children we don't have to trickle down the render. We already avoided setting _dirty to false because we knew the static children could be dealing with their own updates, however we did update the props and state to their next one which is counter-intuitive as this would set `state = _nextState` effectively bailing out of state updates.