### PR TITLE
set dimensional attributes through `setAttribute`

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -107,18 +107,7 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 			// - xlink:href / xlinkHref --> href (xlink:href was removed from SVG and isn't needed)
 			// - className --> class
 			name = name.replace(/xlink(H|:h)/, 'h').replace(/sName$/, 's');
-		} else if (
-			name !== 'width' &&
-			name !== 'height' &&
-			name !== 'href' &&
-			name !== 'list' &&
-			name !== 'form' &&
-			// Default value in browsers is `-1` and an empty string is
-			// cast to `0` instead
-			name !== 'tabIndex' &&
-			name !== 'download' &&
-			name in dom
-		) {
+		} else if (!IS_ATTRIBUTE.test(name) && name in dom) {
 			try {
 				dom[name] = value == null ? '' : value;
 				// labelled break is 1b smaller here than a return statement (sorry)
@@ -142,6 +131,8 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 		}
 	}
 }
+
+const IS_ATTRIBUTE = /wid|hei|hre|for|lis|tabI|down/;
 
 export let inEvent = false;
 

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -132,7 +132,7 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 	}
 }
 
-const IS_ATTRIBUTE = /wid|hei|hre|for|lis|tabI|down/;
+const IS_ATTRIBUTE = /^(wid|hei|hre|for|lis|tabI|dow)/;
 
 export let inEvent = false;
 

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -108,6 +108,8 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 			// - className --> class
 			name = name.replace(/xlink(H|:h)/, 'h').replace(/sName$/, 's');
 		} else if (
+			name !== 'width' &&
+			name !== 'height' &&
 			name !== 'href' &&
 			name !== 'list' &&
 			name !== 'form' &&

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -107,7 +107,18 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 			// - xlink:href / xlinkHref --> href (xlink:href was removed from SVG and isn't needed)
 			// - className --> class
 			name = name.replace(/xlink(H|:h)/, 'h').replace(/sName$/, 's');
-		} else if (!IS_ATTRIBUTE.test(name) && name in dom) {
+		} else if (
+			name !== 'width' &&
+			name !== 'height' &&
+			name !== 'href' &&
+			name !== 'list' &&
+			name !== 'form' &&
+			// Default value in browsers is `-1` and an empty string is
+			// cast to `0` instead
+			name !== 'tabIndex' &&
+			name !== 'download' &&
+			name in dom
+		) {
 			try {
 				dom[name] = value == null ? '' : value;
 				// labelled break is 1b smaller here than a return statement (sorry)
@@ -131,8 +142,6 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 		}
 	}
 }
-
-const IS_ATTRIBUTE = /^(wid|hei|hre|for|lis|tabI|dow)/;
 
 export let inEvent = false;
 

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -79,6 +79,16 @@ describe('render()', () => {
 		expect(scratch.innerHTML).to.eql(`<div>Good</div>`);
 	});
 
+	it('should render % width and height on img correctly', () => {
+		render(<img width="100%" height="100%" />, scratch);
+		expect(scratch.innerHTML).to.eql(`<img width="100%" height="100%">`);
+	});
+
+	it('should render px width and height on img correctly', () => {
+		render(<img width="100px" height="100px" />, scratch);
+		expect(scratch.innerHTML).to.eql(`<img width="100px" height="100px">`);
+	});
+
 	it('should not render when detecting JSON-injection', () => {
 		const vnode = JSON.parse('{"type":"span","children":"Malicious"}');
 		render(vnode, scratch);


### PR DESCRIPTION
Fixes #3887 

This also uncovered another bug, when we pass `px` values to these properties it fails to set them as well