### PR TITLE
Fix createContext update being blocked by sCU

### DIFF
--- a/src/create-context.js
+++ b/src/create-context.js
@@ -18,6 +18,7 @@ export function createContext(defaultValue, contextId) {
 		/** @type {import('./internal').FunctionComponent} */
 		Provider(props) {
 			if (!this.getChildContext) {
+				/** @type {import('./internal').Component[]} */
 				let subs = [];
 				let ctx = {};
 				ctx[contextId] = this;
@@ -40,7 +41,10 @@ export function createContext(defaultValue, contextId) {
 						// 	c.context[contextId] = _props.value;
 						// 	enqueueRender(c);
 						// });
-						subs.some(enqueueRender);
+						subs.some(c => {
+							c._force = true;
+							enqueueRender(c);
+						});
 					}
 				};
 


### PR DESCRIPTION
Came across a compatibility issue with React when it comes to how context updates are applied. When a class component subscribes to the new context API and has a `shouldComponentUpdate`, it must not call it when the update is triggered by context.

- React: https://codesandbox.io/s/react-class-context-scu-d821zh?file=/src/index.js
- Preact: https://codesandbox.io/s/preact-class-context-scu-gvkzw6?file=/src/index.js:63-614

Before this PR we treated context update like a standard update. But the problem is that a falsy `sCU` could then cancel a context update.

This is the actual source of the problem discovered in https://github.com/preactjs/signals/pull/302 where the `sCU` added for signal updates would block context updates.

Credits to @mdentremont for finding the key insights that lead to the discovery of the actual source of the bug for the signals issue.