### PR TITLE
Fix hydrating textarea with value prop

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -223,6 +223,25 @@ options._render = function(vnode) {
 	currentComponent = vnode._component;
 };
 
+const oldDiffed = options.diffed;
+/** @type {(vnode: import('./internal').VNode)} */
+options.diffed = function(vnode) {
+	if (oldDiffed) {
+		oldDiffed(vnode);
+	}
+
+	const props = vnode.props;
+	const dom = vnode._dom;
+	if (
+		dom != null &&
+		vnode.type === 'textarea' &&
+		'value' in props &&
+		props.value !== dom.value
+	) {
+		dom.value = props.value ?? '';
+	}
+};
+
 // This is a very very private internal function for React it
 // is used to sort-of do runtime dependency injection. So far
 // only `react-relay` makes use of it. It uses it to read the

--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -238,7 +238,7 @@ options.diffed = function(vnode) {
 		'value' in props &&
 		props.value !== dom.value
 	) {
-		dom.value = props.value ?? '';
+		dom.value = props.value == null ? '' : props.value;
 	}
 };
 

--- a/compat/test/browser/textarea.test.js
+++ b/compat/test/browser/textarea.test.js
@@ -1,8 +1,10 @@
-import React, { render, useState } from 'preact/compat';
+import React, { render, hydrate, useState } from 'preact/compat';
+import ReactDOMServer from 'preact/compat/server';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { act } from 'preact/test-utils';
 
 describe('Textarea', () => {
+	/** @type {HTMLElement} */
 	let scratch;
 
 	beforeEach(() => {
@@ -17,6 +19,20 @@ describe('Textarea', () => {
 		render(<textarea value="foo" />, scratch);
 
 		expect(scratch.firstElementChild.value).to.equal('foo');
+	});
+
+	it('should hydrate textarea value', () => {
+		function App() {
+			return <textarea value="foo" />;
+		}
+
+		scratch.innerHTML = ReactDOMServer.renderToString(<App />);
+		expect(scratch.firstElementChild.value).to.equal('foo');
+		expect(scratch.innerHTML).to.be.equal('<textarea>foo</textarea>');
+
+		hydrate(<App />, scratch);
+		expect(scratch.firstElementChild.value).to.equal('foo');
+		expect(scratch.innerHTML).to.be.equal('<textarea></textarea>');
 	});
 
 	it('should alias defaultValue to children', () => {


### PR DESCRIPTION
If a component rendered `<textarea value="Test" />`, on the server we'd render `<textarea>Test</textarea>`, but on the client when hydrating, we'd remove the children of `<textarea>` since the component didn't specify any (`textarea value="test" />`). Further, since we don't set attributes or properties on hydration, the value property doesn't get applied either.

This PR fixes this behavior by adding a new hook to compat which checks if the VNode is a textarea and always applying the `value` if the DOM value doesn't match.