### PR TITLE
fix case where strict equality leads to a deadlock with c._force

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -153,6 +153,9 @@ export function diff(
 						c.state = c._nextState;
 						c._dirty = false;
 					}
+
+					// In cases of bailing due to strict-equality we have to reset force as well
+					c._force = false;
 					newVNode._dom = oldVNode._dom;
 					newVNode._children = oldVNode._children;
 					newVNode._children.forEach(vnode => {


### PR DESCRIPTION
In a rare case where async context providers get updated we could reach a deadlock scenario with `c._force` https://codesandbox.io/s/amazing-sunset-unlmgg?file=/src/useSubmitHook.ts