### PR TITLE
Switch back to microticks for scheduling

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -2,7 +2,6 @@ import { assign } from './util';
 import { diff, commitRoot } from './diff/index';
 import options from './options';
 import { Fragment } from './create-element';
-import { inEvent } from './diff/props';
 
 /**
  * Base Component class. Provides `setState()` and `forceUpdate()`, which
@@ -184,17 +183,10 @@ let rerenderQueue = [];
 
 let prevDebounce;
 
-const microTick =
+const defer =
 	typeof Promise == 'function'
 		? Promise.prototype.then.bind(Promise.resolve())
 		: setTimeout;
-function defer(cb) {
-	if (inEvent) {
-		setTimeout(cb);
-	} else {
-		microTick(cb);
-	}
-}
 
 /**
  * Enqueue a rerender of a component
@@ -209,7 +201,7 @@ export function enqueueRender(c) {
 		prevDebounce !== options.debounceRendering
 	) {
 		prevDebounce = options.debounceRendering;
-		(prevDebounce || defer)(process, inEvent);
+		(prevDebounce || defer)(process);
 	}
 }
 

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -143,29 +143,15 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 	}
 }
 
-export let inEvent = false;
-
 /**
  * Proxy an event to hooked event handlers
  * @param {Event} e The event object from the browser
  * @private
  */
 function eventProxy(e) {
-	inEvent = true;
-	try {
-		return this._listeners[e.type + false](
-			options.event ? options.event(e) : e
-		);
-	} finally {
-		inEvent = false;
-	}
+	return this._listeners[e.type + false](options.event ? options.event(e) : e);
 }
 
 function eventProxyCapture(e) {
-	inEvent = true;
-	try {
-		return this._listeners[e.type + true](options.event ? options.event(e) : e);
-	} finally {
-		inEvent = false;
-	}
+	return this._listeners[e.type + true](options.event ? options.event(e) : e);
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -331,7 +331,7 @@ export interface Options {
 	diffed?(vnode: VNode): void;
 	event?(e: Event): any;
 	requestAnimationFrame?(callback: () => void): void;
-	debounceRendering?(cb: () => void, inEvent: boolean): void;
+	debounceRendering?(cb: () => void): void;
 	useDebugValue?(value: string | number): void;
 	_addHookName?(name: string | number): void;
 	__suspenseDidResolve?(vnode: VNode, cb: () => void): void;


### PR DESCRIPTION
This PR replaces the `setTimeout` scheduling mechanism that was introduced in `10.10.0` with the microtick one that we had before. With us having now access to a much greater variety to Preact and React code bases we identified a couple of scenarios that were broken by the move to `setTimeout`, like scroll restoration after history navigation. Overall the microtick more closely mirrors what React is doing too, so it's likely better for compat as well.

Our plan is to add an e2e test suite to properly verify those cases and make sure we don't regress on those in the future. But to unblock projects from migrating to a version from before the `setTimeout` change to the latest version we've decided to move forward with this change before we have our a proper e2e test suite set up.