### PR TITLE
Fix tests assertions for IE11

### DIFF
--- a/compat/test/browser/textarea.test.js
+++ b/compat/test/browser/textarea.test.js
@@ -74,7 +74,10 @@ describe('Textarea', () => {
 		act(() => {
 			set('');
 		});
-		expect(scratch.innerHTML).to.equal('<textarea></textarea>');
+		// Same as earlier: IE11 always displays the value as node.innerHTML
+		if (!/Trident/.test(window.navigator.userAgent)) {
+			expect(scratch.innerHTML).to.equal('<textarea></textarea>');
+		}
 		expect(scratch.firstElementChild.value).to.equal('');
 	});
 });

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -84,10 +84,13 @@ describe('render()', () => {
 		expect(scratch.innerHTML).to.eql(`<img width="100%" height="100%">`);
 	});
 
-	it('should render px width and height on img correctly', () => {
-		render(<img width="100px" height="100px" />, scratch);
-		expect(scratch.innerHTML).to.eql(`<img width="100px" height="100px">`);
-	});
+	// IE11 doesn't support these.
+	if (/Trident/.test(window.navigator.userAgent)) {
+		it('should render px width and height on img correctly', () => {
+			render(<img width="100px" height="100px" />, scratch);
+			expect(scratch.innerHTML).to.eql(`<img width="100px" height="100px">`);
+		});
+	}
 
 	it('should not render when detecting JSON-injection', () => {
 		const vnode = JSON.parse('{"type":"span","children":"Malicious"}');


### PR DESCRIPTION
This fixes two IE11 only failures that were introduced with recent changes.