### PR TITLE
Skip over function children when rendering

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -47,7 +47,11 @@ export function diffChildren(
 	for (i = 0; i < renderResult.length; i++) {
 		childVNode = renderResult[i];
 
-		if (childVNode == null || typeof childVNode == 'boolean') {
+		if (
+			childVNode == null ||
+			typeof childVNode == 'boolean' ||
+			typeof childVNode == 'function'
+		) {
 			childVNode = newParentVNode._children[i] = null;
 		}
 		// If this newVNode is being reused (e.g. <div>{reuse}{reuse}</div>) in the same diff,

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -254,6 +254,16 @@ describe('render()', () => {
 		expect(scratch.innerHTML).to.equal('<div></div>');
 	});
 
+	it('should not render children when rerendering a function child', () => {
+		const icon = () => {};
+
+		render(<div>{icon}</div>, scratch);
+		expect(scratch.innerHTML).to.equal('<div></div>');
+
+		render(<div>{icon}</div>, scratch);
+		expect(scratch.innerHTML).to.equal('<div></div>');
+	});
+
 	it('should render NaN as text content', () => {
 		render(NaN, scratch);
 		expect(scratch.innerHTML).to.equal('NaN');


### PR DESCRIPTION
Function children that are passed as props to a component are still allowed but if that Component doesn't invoke the function and passes it a child, we'll skip over it.