### PR TITLE
synchronous forceUpdate

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -67,7 +67,7 @@ Component.prototype.forceUpdate = function(callback) {
 		// shouldComponentUpdate
 		this._force = true;
 		if (callback) this._renderCallbacks.push(callback);
-		enqueueRender(this);
+		renderComponent(this);
 	}
 };
 


### PR DESCRIPTION
The comment for the function `forceUpdate` says:
"Immediately perform a synchronous re-render of the component"

This PR restores that behavior. Does not cause any tests to fail. I cannot find much information on a "double render" problem which sounds dubious to me.

Animation libraries need timely updates and there is no reason to arbitrarily deny that. Please use setState({}) instead.

See:
https://github.com/preactjs/preact/pull/1939