### PR TITLE
Handle NaN comparison in useEffect dependency array

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -494,6 +494,16 @@ function invokeEffect(hook) {
 }
 
 /**
+ * Check if two values are the same value
+ * @param {*} x
+ * @param {*} y
+ * @returns {boolean}
+ */
+function is(x, y) {
+	return (x === y && (x !== 0 || 1 / x === 1 / y)) || (x !== x && y !== y);
+}
+
+/**
  * @param {any[]} oldArgs
  * @param {any[]} newArgs
  */
@@ -501,7 +511,7 @@ function argsChanged(oldArgs, newArgs) {
 	return (
 		!oldArgs ||
 		oldArgs.length !== newArgs.length ||
-		newArgs.some((arg, index) => arg !== oldArgs[index])
+		newArgs.some((arg, index) => !is(arg, oldArgs[index]))
 	);
 }
 

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -236,7 +236,7 @@ export function useReducer(reducer, initialState, init) {
 						const currentValue = hookItem._value[0];
 						hookItem._value = hookItem._nextValue;
 						hookItem._nextValue = undefined;
-						if (currentValue !== hookItem._value[0]) shouldUpdate = true;
+						if (!is(currentValue, hookItem._value[0])) shouldUpdate = true;
 					}
 				});
 

--- a/hooks/test/browser/useEffect.test.js
+++ b/hooks/test/browser/useEffect.test.js
@@ -591,4 +591,26 @@ describe('useEffect', () => {
 		expect(calls.length).to.equal(1);
 		expect(calls).to.deep.equal(['doing effecthi']);
 	});
+
+	it('should not rerun when receiving NaN on subsequent renders', () => {
+		const calls = [];
+		const Component = ({ value }) => {
+			const [count, setCount] = useState(0);
+			useEffect(() => {
+				calls.push('doing effect' + count);
+				setCount(count + 1);
+				return () => {
+					calls.push('cleaning up' + count);
+				};
+			}, [value]);
+			return <p>{count}</p>;
+		};
+		const App = () => <Component value={NaN} />;
+
+		act(() => {
+			render(<App />, scratch);
+		});
+		expect(calls.length).to.equal(1);
+		expect(calls).to.deep.equal(['doing effect0']);
+	});
 });

--- a/hooks/test/browser/useState.test.js
+++ b/hooks/test/browser/useState.test.js
@@ -371,4 +371,30 @@ describe('useState', () => {
 		rerender();
 		expect(scratch.innerHTML).to.equal('<p>hello world!!!</p>');
 	});
+
+	it('should limit rerenders when setting state to NaN', () => {
+		const calls = [];
+		const App = ({ i }) => {
+			calls.push('rendering' + i);
+			const [greeting, setGreeting] = useState(0);
+
+			if (i === 2) {
+				setGreeting(NaN);
+			}
+
+			return <p>{greeting}</p>;
+		};
+
+		act(() => {
+			render(<App i={1} />, scratch);
+		});
+		expect(calls.length).to.equal(1);
+		expect(calls).to.deep.equal(['rendering1']);
+
+		act(() => {
+			render(<App i={2} />, scratch);
+		});
+		expect(calls.length).to.equal(26);
+		expect(calls.slice(1).every(c => c === 'rendering2')).to.equal(true);
+	});
 });


### PR DESCRIPTION
## Summary
When comparing changes to `useEffect` dependencies, if any dependency is `NaN` it will result in the effect always being run, even if the value was `NaN` on the previous render. This is due to `NaN !== NaN` in JavaScript.

This change handles the `NaN` case using the `is` utility introduced in #3776. Presumably we don't want to use `Object.is` due to [incompatibility with IE11](https://caniuse.com/mdn-javascript_builtins_object_is) (thanks for the insight @andrewiggins!). Note that I copied the `is` utility, which is also present in `compat/src`, but I'm happy to raise it up to `src/utils` and use it in both places if that's preferred.

## Issue
Note: this will cause Preact to hang due to infinite re-renders
```js
import { render } from 'preact';
import { useState, useEffect } from 'preact/hooks';

function Component({ value }) {
  const [count, setCount] = useState(0);
  useEffect(() => {
    setCount(count + 1);
  }, [value]);
  return <p>{count}</p>;
}

function App() {
  const [value, setValue] = useState(undefined);
  setValue(NaN);

  return <Component value={NaN} />;
}

render(<App />, document.getElementById('app'));
```
**Expected behavior**
Preact runs the effect once, because `value` never changes from `NaN`.

**Actual behavior**
Preact re-renders forever, because it strictly compares `NaN` to `NaN`.