### PR TITLE
Handle NaN comparison in component state

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -236,7 +236,7 @@ export function useReducer(reducer, initialState, init) {
 						const currentValue = hookItem._value[0];
 						hookItem._value = hookItem._nextValue;
 						hookItem._nextValue = undefined;
-						if (currentValue !== hookItem._value[0]) shouldUpdate = true;
+						if (!is(currentValue, hookItem._value[0])) shouldUpdate = true;
 					}
 				});
 
@@ -491,6 +491,16 @@ function invokeEffect(hook) {
 	const comp = currentComponent;
 	hook._cleanup = hook._value();
 	currentComponent = comp;
+}
+
+/**
+ * Check if two values are the same value
+ * @param {*} x
+ * @param {*} y
+ * @returns {boolean}
+ */
+function is(x, y) {
+	return (x === y && (x !== 0 || 1 / x === 1 / y)) || (x !== x && y !== y);
 }
 
 /**

--- a/hooks/test/browser/useState.test.js
+++ b/hooks/test/browser/useState.test.js
@@ -371,4 +371,30 @@ describe('useState', () => {
 		rerender();
 		expect(scratch.innerHTML).to.equal('<p>hello world!!!</p>');
 	});
+
+	it('should limit rerenders when setting state to NaN', () => {
+		const calls = [];
+		const App = ({ i }) => {
+			calls.push('rendering' + i);
+			const [greeting, setGreeting] = useState(0);
+
+			if (i === 2) {
+				setGreeting(NaN);
+			}
+
+			return <p>{greeting}</p>;
+		};
+
+		act(() => {
+			render(<App i={1} />, scratch);
+		});
+		expect(calls.length).to.equal(1);
+		expect(calls).to.deep.equal(['rendering1']);
+
+		act(() => {
+			render(<App i={2} />, scratch);
+		});
+		expect(calls.length).to.equal(26);
+		expect(calls.slice(1).every(c => c === 'rendering2')).to.equal(true);
+	});
 });


### PR DESCRIPTION
This is a similar issue to #3954, specifically handling `NaN` comparison in state. I wasn't sure if it was more appropriate to group them together or fix them separately. I'm happy to merge these changes into the other PR if preferred, or open this for review.