### PR TITLE
Add default props in cloneElement.

### DIFF
--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -13,10 +13,21 @@ export function cloneElement(vnode, props, children) {
 		key,
 		ref,
 		i;
+
+	let defaultProps;
+
+	if (vnode.type && vnode.type.defaultProps) {
+		defaultProps = vnode.type.defaultProps;
+	}
+
 	for (i in props) {
 		if (i == 'key') key = props[i];
 		else if (i == 'ref') ref = props[i];
-		else normalizedProps[i] = props[i];
+		else if (props[i] === undefined && defaultProps !== undefined) {
+			normalizedProps[i] = defaultProps[i];
+		} else {
+			normalizedProps[i] = props[i];
+		}
 	}
 
 	if (arguments.length > 2) {

--- a/test/browser/cloneElement.test.js
+++ b/test/browser/cloneElement.test.js
@@ -1,3 +1,4 @@
+import { Component } from 'preact';
 import { createElement, cloneElement, createRef } from 'preact';
 
 /** @jsx createElement */
@@ -86,8 +87,15 @@ describe('cloneElement', () => {
 	});
 
 	it('should prevent undefined properties from overriding default props', () => {
-		const element = <div style={{ color: 'blue' }}>thing</div>;
+		class Example extends Component {
+			render(props) {
+				return <div style={{ color: props.color }}>thing</div>;
+			}
+		}
+		Example.defaultProps = { color: 'blue' };
+
+		const element = <Example color="red" />;
 		const clone = cloneElement(element, { color: undefined });
-		expect(clone.props.style.color).to.equal('blue');
+		expect(clone.props.color).to.equal('blue');
 	});
 });

--- a/test/browser/cloneElement.test.js
+++ b/test/browser/cloneElement.test.js
@@ -84,4 +84,10 @@ describe('cloneElement', () => {
 		const clone = cloneElement(div, { key: 'myKey' });
 		expect(clone.props.key).to.equal(undefined);
 	});
+
+	it('should prevent undefined properties from overriding default props', () => {
+		const element = <div style={{ color: 'blue' }}>thing</div>;
+		const clone = cloneElement(element, { color: undefined });
+		expect(clone.props.style.color).to.equal('blue');
+	});
 });

--- a/test/browser/cloneElement.test.js
+++ b/test/browser/cloneElement.test.js
@@ -1,5 +1,4 @@
-import { Component } from 'preact';
-import { createElement, cloneElement, createRef } from 'preact';
+import { createElement, cloneElement, createRef, Component } from 'preact';
 
 /** @jsx createElement */
 


### PR DESCRIPTION
**Summary**
This PR added `defaultProps` & a few adjustments how Preact handles undefined properties in `cloneElement`. Currently, any properties in props would be used to override normalizedProps in Preact without any checks. However this is being handled [differently in React](https://github.com/facebook/react/blob/4337c1c00609ec8d7ae399c736e9d37bb159fac5/packages/react/src/ReactElement.js#L514-L518) where there will be a check in place to skip the override when config[propName] (props[i] in our case) is undefined.

**Issue**
Check these 2 code sandbox, the component's color should not be override by an `undefined` property:
- Preact: https://codesandbox.io/s/preact-cloneelement-defaultprops-csr-only-ux43x8?file=/src/index.js
- React: https://codesandbox.io/s/react-cloneelement-defaultprops-csr-only-w3x0ii?file=/src/index.js