### PR TITLE
fix: `indeterminate`'s SignalLike type

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1724,7 +1724,7 @@ export namespace JSXInternal {
 		httpEquiv?: string | undefined | SignalLike<string | undefined>;
 		icon?: string | undefined | SignalLike<string | undefined>;
 		id?: string | undefined | SignalLike<string | undefined>;
-		indeterminate?: boolean | undefined | SignalLike<boolean>;
+		indeterminate?: boolean | undefined | SignalLike<boolean | undefined>;
 		inputMode?: string | undefined | SignalLike<string | undefined>;
 		integrity?: string | undefined | SignalLike<string | undefined>;
 		is?: string | undefined | SignalLike<string | undefined>;


### PR DESCRIPTION
I think we merged in the addition of `indeterminate` here only after adding `| undefined` to all the SignalLikes, but I didn't catch that it needed a touch-up.