### PR TITLE
Add a fix for context unmounting, from experimenting with our application

### DIFF
--- a/src/create-context.js
+++ b/src/create-context.js
@@ -25,7 +25,7 @@ export function createContext(defaultValue, contextId) {
 
 				this.getChildContext = () => ctx;
 
-				this.shouldComponentUpdate = function (_props) {
+				this.shouldComponentUpdate = function(_props) {
 					if (this.props.value !== _props.value) {
 						// I think the forced value propagation here was only needed when `options.debounceRendering` was being bypassed:
 						// https://github.com/preactjs/preact/commit/4d339fb803bea09e9f198abf38ca1bf8ea4b7771#diff-54682ce380935a717e41b8bfc54737f6R358
@@ -52,7 +52,9 @@ export function createContext(defaultValue, contextId) {
 					subs.push(c);
 					let old = c.componentWillUnmount;
 					c.componentWillUnmount = () => {
-						subs.splice(subs.indexOf(c), 1);
+						// This is a hot path so we want to be careful about how we're removing items from the subscriber array to keep this fast.
+						// This is faster than splicing an item out in testing.
+						subs[subs.indexOf(c)] = subs.pop();
 						if (old) old.call(c);
 					};
 				};
@@ -68,6 +70,5 @@ export function createContext(defaultValue, contextId) {
 	// of on the component itself. See:
 	// https://reactjs.org/docs/context.html#contextdisplayname
 
-	return (context.Provider._contextRef = context.Consumer.contextType =
-		context);
+	return (context.Provider._contextRef = context.Consumer.contextType = context);
 }


### PR DESCRIPTION
In testing for our application, this ended up being a fair bit faster than how it was during client routing transitions (that is, when unmounting lots of context subscribers)

I don't know if we need a benchmark specifically for having many context subscribers unmount, but that would be the use case that we ran into with this one.