### PR TITLE
Add isNaN helper for IE11

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -11,7 +11,7 @@ import {
 	getCurrentVNode,
 	getDisplayName
 } from './component-stack';
-import { assign } from './util';
+import { assign, isNaN } from './util';
 
 const isWeakMapSupported = typeof WeakMap == 'function';
 
@@ -367,7 +367,7 @@ export function initDebug() {
 					const hook = hooks[i];
 					if (hook._args) {
 						for (const arg of hook._args) {
-							if (Number.isNaN(arg)) {
+							if (isNaN(arg)) {
 								const componentName = getDisplayName(vnode);
 								throw new Error(
 									`Invalid argument passed to hook. Hooks should not be called with NaN in the dependency array. Hook index ${i} in component ${componentName} was called with NaN.`

--- a/debug/src/util.js
+++ b/debug/src/util.js
@@ -9,3 +9,7 @@ export function assign(obj, props) {
 	for (let i in props) obj[i] = props[i];
 	return /** @type {O & P} */ (obj);
 }
+
+export function isNaN(value) {
+	return value !== value;
+}

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "benchmark": "npm run test:karma:bench -- no-single-run",
     "lint": "run-s eslint",
     "eslint": "eslint src test debug compat hooks test-utils",
-    "format": "prettier --write '**/*.{js,jsx,mjs,cjs,ts,tsx,yml,json,html,md,css,scss}'",
+    "format": "prettier --write \"**/*.{js,jsx,mjs,cjs,ts,tsx,yml,json,html,md,css,scss}\"",
     "format:check": "prettier --check '**/*.{js,jsx,mjs,cjs,ts,tsx,yml,json,html,md,css,scss}'"
   },
   "eslintConfig": {


### PR DESCRIPTION
According to our [Saucelabs tests](https://github.com/preactjs/preact/actions/runs/4725027442/jobs/8487862538#step:5:1315), IE11 doesn't support `Number.isNaN` so I've added a littler helper to use instead.

Also fixed some quotes in one of our npm scripts so it works correctly on Windows