### PR TITLE
Add missing type fields for tools

### DIFF
--- a/debug/package.json
+++ b/debug/package.json
@@ -17,6 +17,7 @@
   },
   "exports": {
     ".": {
+      "types": "./src/index.d.ts",
       "browser": "./dist/debug.module.js",
       "umd": "./dist/debug.umd.js",
       "import": "./dist/debug.mjs",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
       "require": "./jsx-runtime/dist/jsxRuntime.js"
     },
     "./jsx-dev-runtime": {
+      "types": "./jsx-runtime/src/index.d.ts",
       "browser": "./jsx-runtime/dist/jsxRuntime.module.js",
       "umd": "./jsx-runtime/dist/jsxRuntime.umd.js",
       "import": "./jsx-runtime/dist/jsxRuntime.mjs",
@@ -75,10 +76,12 @@
       "require": "./compat/server.js"
     },
     "./compat/jsx-runtime": {
+      "types": "./jsx-runtime/src/index.d.ts",
       "import": "./compat/jsx-runtime.mjs",
       "require": "./compat/jsx-runtime.js"
     },
     "./compat/jsx-dev-runtime": {
+      "types": "./jsx-runtime/src/index.d.ts",
       "import": "./compat/jsx-dev-runtime.mjs",
       "require": "./compat/jsx-dev-runtime.js"
     },


### PR DESCRIPTION
It's more of a preventive measure as I didn't run into any issues or something. Just noticed that some tpe analysis tools had trouble resolving some types.