### PR TITLE
should not transform imageSourceSet to image-source-set

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -11,7 +11,7 @@ export const REACT_ELEMENT_TYPE =
 	0xeac7;
 
 const CAMEL_PROPS =
-	/^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|dominant|fill|flood|font|glyph(?!R)|horiz|image|letter|lighting|marker(?!H|W|U)|overline|paint|pointer|shape|stop|strikethrough|stroke|text(?!L)|transform|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/;
+	/^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|dominant|fill|flood|font|glyph(?!R)|horiz|image(!S)|letter|lighting|marker(?!H|W|U)|overline|paint|pointer|shape|stop|strikethrough|stroke|text(?!L)|transform|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/;
 const ON_ANI = /^on(Ani|Tra|Tou|BeforeInp|Compo)/;
 const CAMEL_REPLACE = /[A-Z0-9]/g;
 

--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -252,6 +252,21 @@ describe('compat render', () => {
 		);
 	});
 
+	it('shouldnot transform imageSrcSet', () => {
+		render(
+			<link
+				rel="preload"
+				as="image"
+				href="preact.jpg"
+				imageSrcSet="preact_400px.jpg 400w"
+			/>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal(
+			'<link rel="preload" as="image" href="preact.jpg" imagesrcset="preact_400px.jpg 400w">'
+		);
+	});
+
 	it('should correctly allow for "className"', () => {
 		const Foo = props => {
 			const { className, ...rest } = props;


### PR DESCRIPTION
fixes #3994 

This ensures that `imageSrcSet` becomes a valid attribute [`imagesrcset`](https://github.com/whatwg/html/pull/4048) as an added bonus this PR also adds support for `imagesizes`.