### PR TITLE
Fix type of SVG `animateTransform` element

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -2097,7 +2097,7 @@ export namespace JSXInternal {
 		animate: SVGAttributes<SVGAnimateElement>;
 		circle: SVGAttributes<SVGCircleElement>;
 		animateMotion: SVGAttributes<SVGAnimateMotionElement>;
-		animateTransform: SVGAttributes<SVGAnimateElement>;
+		animateTransform: SVGAttributes<SVGAnimateTransformElement>;
 		clipPath: SVGAttributes<SVGClipPathElement>;
 		defs: SVGAttributes<SVGDefsElement>;
 		desc: SVGAttributes<SVGDescElement>;


### PR DESCRIPTION
The `SVGAnimateTransformElement` interface corresponds to the `<animateTransform>`
MDN: https://svgwg.org/specs/animations/#InterfaceSVGAnimateTransformElement