### PR TITLE
Allow for DocumentFragment in createPortal

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -74,7 +74,7 @@ declare namespace React {
 
 	export function createPortal(
 		vnode: preact.VNode,
-		container: Element
+		container: Element | DocumentFragment
 	): preact.VNode<any>;
 
 	export function render(


### PR DESCRIPTION
Fixes #3869

Pulls it more inline with [React](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cb261099d9a316fb628efc7801a9d0f25451cd67/types/react-dom/index.d.ts#L28) and [ShadowRoot inherits from DocumentFragment](https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.shadowroot.html)