### PR TITLE
10.15.0

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -2,7 +2,7 @@ import { options, Fragment, Component } from 'preact';
 
 export function initDevTools() {
 	if (typeof window != 'undefined' && window.__PREACT_DEVTOOLS__) {
-		window.__PREACT_DEVTOOLS__.attachPreact('10.14.1', options, {
+		window.__PREACT_DEVTOOLS__.attachPreact('10.15.0', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "10.14.1",
+  "version": "10.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "10.14.1",
+      "version": "10.15.0",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.14.1",
+  "version": "10.15.0",
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
- Revert controlled components (#4009, thanks @JoviDeCroock)
- fix: Missing `ForwardRefExoticComponent` and `RefAttributes` types in compat (#3996, thanks @rschristian)
- fix: keep hooks index with useEffect (#4016, thanks @1o1w1)
- fix: Add types for <dialog>'s close & cancel events (#4017, thanks @rschristian)
- Add missing types of TransitionEvent (#4019, thanks @shoonia)
- Add types of PictureInPictureEvent (#4020, thanks @shoonia)