### PR TITLE
fix: keep hooks index with  useEffect

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -32,6 +32,7 @@ export function initDebug() {
 	let oldBeforeDiff = options._diff;
 	let oldDiffed = options.diffed;
 	let oldVnode = options.vnode;
+	let oldRender = options._render;
 	let oldCatchError = options._catchError;
 	let oldRoot = options._root;
 	let oldHook = options._hook;
@@ -250,6 +251,13 @@ export function initDebug() {
 		}
 
 		if (oldBeforeDiff) oldBeforeDiff(vnode);
+	};
+
+	options._render = vnode => {
+		if (oldRender) {
+			oldRender(vnode);
+		}
+		hooksAllowed = true;
 	};
 
 	options._hook = (comp, index, type) => {

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -53,6 +53,7 @@ options._render = vnode => {
 			hooks._pendingEffects.forEach(invokeCleanup);
 			hooks._pendingEffects.forEach(invokeEffect);
 			hooks._pendingEffects = [];
+			currentIndex = 0;
 		}
 	}
 	previousComponent = currentComponent;

--- a/hooks/test/browser/useEffect.test.js
+++ b/hooks/test/browser/useEffect.test.js
@@ -1,4 +1,4 @@
-import { act } from 'preact/test-utils';
+import { act, teardown as teardownAct } from 'preact/test-utils';
 import { createElement, render, Fragment, Component } from 'preact';
 import { useEffect, useState, useRef } from 'preact/hooks';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
@@ -364,6 +364,53 @@ describe('useEffect', () => {
 		});
 		await promise;
 		act(() => {});
+		expect(scratch.innerHTML).to.equal(
+			'<div><div>Count: 2</div><div><div>dummy</div></div></div>'
+		);
+	});
+
+	it('hooks should be called in right order', async () => {
+		teardownAct();
+
+		let increment;
+
+		const Counter = () => {
+			const [count, setCount] = useState(0);
+			useState('binggo!!');
+			const renderRoot = useRef();
+			useEffect(() => {
+				if (count > 0) {
+					const div = renderRoot.current;
+					render(<Dummy />, div);
+				}
+			}, [count]);
+
+			increment = () => {
+				setCount(x => x + 1);
+				return Promise.resolve().then(() => setCount(x => x + 1));
+			};
+
+			return (
+				<div>
+					<div>Count: {count}</div>
+					<div ref={renderRoot} />
+				</div>
+			);
+		};
+
+		const Dummy = () => {
+			useState();
+			return <div>dummy</div>;
+		};
+
+		render(<Counter />, scratch);
+
+		expect(scratch.innerHTML).to.equal(
+			'<div><div>Count: 0</div><div></div></div>'
+		);
+		/** Using the act function will affect the timing of the useEffect */
+		await increment();
+
 		expect(scratch.innerHTML).to.equal(
 			'<div><div>Count: 2</div><div><div>dummy</div></div></div>'
 		);

--- a/hooks/test/browser/useEffect.test.js
+++ b/hooks/test/browser/useEffect.test.js
@@ -379,10 +379,8 @@ describe('useEffect', () => {
 			useState('binggo!!');
 			const renderRoot = useRef();
 			useEffect(() => {
-				if (count > 0) {
-					const div = renderRoot.current;
-					render(<Dummy />, div);
-				}
+				const div = renderRoot.current;
+				render(<Dummy />, div);
 			}, [count]);
 
 			increment = () => {


### PR DESCRIPTION
Fixes #4015

I have submitted an [issue](https://github.com/preactjs/preact/issues/4015).

**Describe the bug**


CurrentIndex may become stale when the useEffect callback function is called in options._render


**To Reproduce**

https://github.com/1o1w1/preact/blob/hooks-order-issue-reproduction/demo/index.js

Steps to reproduce the behavior:

1. open demo in browser
2. Click the "Count" string on the page
3. See "Count: binggo!!" on the page

**Expected behavior**
expect to see “Count: 2”