### PR TITLE
fix: Add types for `<dialog>`'s close & cancel events

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1144,6 +1144,10 @@ export namespace JSXInternal {
 		// Details Events
 		onToggle?: GenericEventHandler<Target> | undefined;
 
+		// Dialog Events
+		onClose?: GenericEventHandler<Target> | undefined;
+		onCancel?: GenericEventHandler<Target> | undefined;
+
 		// Focus Events
 		onFocus?: FocusEventHandler<Target> | undefined;
 		onFocusCapture?: FocusEventHandler<Target> | undefined;


### PR DESCRIPTION
Closes #4013 

Edit: I'll add that I did some testing and `onCancel` won't work in Firefox due to `oncancel` being `undefined`, rather than `null`, on Dialog elements. Fails the [`in dom` check](https://github.com/preactjs/preact/blob/f5af72030ee1b82594a85b8f44f805e8941f6ad7/src/diff/props.js#L89). Am working to get a fix upstream, but no bugs here. Both events work fine on Chrome.