### PR TITLE
Add missing types of `TransitionEvent`

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1321,8 +1321,14 @@ export namespace JSXInternal {
 		onAnimationIterationCapture?: AnimationEventHandler<Target> | undefined;
 
 		// Transition Events
+		onTransitionCancel?: TransitionEventHandler<Target>;
+		onTransitionCancelCapture?: TransitionEventHandler<Target>;
 		onTransitionEnd?: TransitionEventHandler<Target>;
 		onTransitionEndCapture?: TransitionEventHandler<Target>;
+		onTransitionRun?: TransitionEventHandler<Target>;
+		onTransitionRunCapture?: TransitionEventHandler<Target>;
+		onTransitionStart?: TransitionEventHandler<Target>;
+		onTransitionStartCapture?: TransitionEventHandler<Target>;
 	}
 
 	// All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/


### PR DESCRIPTION
MDN: https://developer.mozilla.org/en-US/docs/Web/API/TransitionEvent#types_of_transitionevent