### PR TITLE
[v11] use Text constructor

### DIFF
--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -130,7 +130,7 @@ function mountElement(internal, dom, refs) {
 	if (flags & TYPE_TEXT) {
 		if (isNew) {
 			// @ts-ignore createTextNode returns Text, we expect PreactElement
-			dom = document.createTextNode(newProps);
+			dom = new Text(newProps);
 		} else if (dom.data !== newProps) {
 			dom.data = newProps;
 		}

--- a/src/diff/mount.js
+++ b/src/diff/mount.js
@@ -129,7 +129,7 @@ function mountElement(internal, dom, refs) {
 
 	if (flags & TYPE_TEXT) {
 		if (isNew) {
-			// @ts-ignore createTextNode returns Text, we expect PreactElement
+			// @ts-ignore returns Text, we expect PreactElement
 			dom = new Text(newProps);
 		} else if (dom.data !== newProps) {
 			dom.data = newProps;


### PR DESCRIPTION
Use `new Text(text)` instead `document.createTextNode(text)`

MDN: https://developer.mozilla.org/en-US/docs/Web/API/Text

```js
document.createTextNode('text') instanceof Text // true
```