### PR TITLE
fix: TS FunctionComponent w/ exactOptionalPropertyTypes

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -89,7 +89,7 @@ export type ComponentProps<
 export interface FunctionComponent<P = {}> {
 	(props: RenderableProps<P>, context?: any): VNode<any> | null;
 	displayName?: string;
-	defaultProps?: Partial<P>;
+	defaultProps?: Partial<P> | undefined;
 }
 export interface FunctionalComponent<P = {}> extends FunctionComponent<P> {}
 


### PR DESCRIPTION
Fixes #4024 

It looks like we need to do a #3868 over every optional property.... might do it tomorrow if I get bored at work. This will at least fix the inconsistency causing the linked issue.