### PR TITLE
Include HTML above render root for DOM validation

### DIFF
--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -15,6 +15,7 @@ const h = createElement;
 /** @jsx createElement */
 
 describe('debug', () => {
+	/** @type {HTMLDivElement} */
 	let scratch;
 	let errors = [];
 	let warnings = [];
@@ -511,6 +512,19 @@ describe('debug', () => {
 				</table>
 			);
 			render(<Table />, scratch);
+			expect(console.error).to.not.be.called;
+		});
+
+		it('should include DOM parents outside of root node', () => {
+			const Table = () => (
+				<tr>
+					<td>Head</td>
+				</tr>
+			);
+
+			const table = document.createElement('table');
+			scratch.appendChild(table);
+			render(<Table />, table);
 			expect(console.error).to.not.be.called;
 		});
 	});


### PR DESCRIPTION
This fixes debug warnings when Islands are used where the preact tree is embedded into an existing HTML structure.

```html
<table>
  <!-- preact renders here -->
</table>
```

Fixes https://github.com/denoland/fresh/issues/1140