### PR TITLE
Server compat should have a default export

### DIFF
--- a/compat/server.browser.js
+++ b/compat/server.browser.js
@@ -1,4 +1,11 @@
+import { renderToString } from 'preact-render-to-string';
+
 export {
 	renderToString,
 	renderToString as renderToStaticMarkup
 } from 'preact-render-to-string';
+
+export default {
+	renderToString,
+	renderToStaticMarkup: renderToString
+};

--- a/compat/server.mjs
+++ b/compat/server.mjs
@@ -1,4 +1,11 @@
+import { renderToString } from 'preact-render-to-string';
+
 export {
 	renderToString,
 	renderToString as renderToStaticMarkup
 } from 'preact-render-to-string';
+
+export default {
+	renderToString,
+	renderToStaticMarkup: renderToString
+};


### PR DESCRIPTION
Hi preact,

For now the use of preact/compat do not allow to use `import ReactDOM from 'react-dom/server'`, as it will fail with an error:
![image](https://github.com/preactjs/preact/assets/4429126/951240d2-69a8-4c17-b7f0-5df38b7e3551)


This PR is here to allow it, without breaking the classical use `import {renderToStaticMarkup} from 'react-dom/server'`