### PR TITLE
Fix forceUpdate edge cases

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -134,14 +134,14 @@ export function diff(
 				}
 
 				if (
-					(!c._force &&
-						c.shouldComponentUpdate != null &&
+					!c._force &&
+					((c.shouldComponentUpdate != null &&
 						c.shouldComponentUpdate(
 							newProps,
 							c._nextState,
 							componentContext
 						) === false) ||
-					newVNode._original === oldVNode._original
+						newVNode._original === oldVNode._original)
 				) {
 					// More info about this here: https://gist.github.com/JoviDeCroock/bec5f2ce93544d2e6070ef8e0036e4e8
 					if (newVNode._original !== oldVNode._original) {
@@ -154,8 +154,6 @@ export function diff(
 						c._dirty = false;
 					}
 
-					// In cases of bailing due to strict-equality we have to reset force as well
-					c._force = false;
 					newVNode._dom = oldVNode._dom;
 					newVNode._children = oldVNode._children;
 					newVNode._children.forEach(vnode => {
@@ -188,6 +186,7 @@ export function diff(
 			c.context = componentContext;
 			c.props = newProps;
 			c._parentDom = parentDom;
+			c._force = false;
 
 			let renderHook = options._render,
 				count = 0;
@@ -255,8 +254,6 @@ export function diff(
 			if (clearProcessingException) {
 				c._pendingError = c._processingException = null;
 			}
-
-			c._force = false;
 		} else if (
 			excessDomChildren == null &&
 			newVNode._original === oldVNode._original


### PR DESCRIPTION
For context: I use Preact with custom reactivity integration which makes heavy use of forceUpdate and shouldComponentUpdate.

While trying different approaches I've found two issues with `forceUpdate` and especially the `_force` flag. Minimal test case is created for each.

1. `_force` flag is reset **after** `render` and `diffChildren` are completed. Example: parent component is forceUpdated during child component creation. In this case parent component is re-enqueued but at the time of re-rendering it will have `_force` flag reset and because of that `shouldComponentUpdate` will be called while it should not. Resetting this flag **before** rendering resolves this issue.

2. `_force` flag is ignored in strict-equality bail-out. Example: parent component caches render result to benefit from bail out, parent and child components are both forceUpdated. In this case bail out resets the `_force` flag and child component `shouldComponentUpdate` is called while it should not. Not bailing out on forceUpdated components resolves this issue. But I'm afraid I miss the reason why it was allowed before.

Workaround I use for both cases:
- Set additional `isForceUpdate` flag when calling `forceUpdate`
- Return true in shouldComponentUpdate if this flag is set
- Reset this flag in render