### PR TITLE
improve VNode typings when generic is passed in

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -194,7 +194,11 @@ export function createElement(
 				ClassAttributes<HTMLInputElement>)
 		| null,
 	...children: ComponentChildren[]
-): VNode<any>;
+): VNode<
+	| (JSXInternal.DOMAttributes<HTMLInputElement> &
+			ClassAttributes<HTMLInputElement>)
+	| null
+>;
 export function createElement<
 	P extends JSXInternal.HTMLAttributes<T>,
 	T extends HTMLElement
@@ -202,7 +206,7 @@ export function createElement<
 	type: keyof JSXInternal.IntrinsicElements,
 	props: (ClassAttributes<T> & P) | null,
 	...children: ComponentChildren[]
-): VNode<any>;
+): VNode<(ClassAttributes<T> & P) | null>;
 export function createElement<
 	P extends JSXInternal.SVGAttributes<T>,
 	T extends HTMLElement
@@ -210,7 +214,7 @@ export function createElement<
 	type: keyof JSXInternal.IntrinsicElements,
 	props: (ClassAttributes<T> & P) | null,
 	...children: ComponentChildren[]
-): VNode<any>;
+): VNode<(ClassAttributes<T> & P) | null>;
 export function createElement<T extends HTMLElement>(
 	type: string,
 	props:
@@ -219,12 +223,14 @@ export function createElement<T extends HTMLElement>(
 				JSXInternal.SVGAttributes)
 		| null,
 	...children: ComponentChildren[]
-): VNode<any>;
+): VNode<
+	ClassAttributes<T> & JSXInternal.HTMLAttributes & JSXInternal.SVGAttributes
+>;
 export function createElement<P>(
 	type: ComponentType<P>,
 	props: (Attributes & P) | null,
 	...children: ComponentChildren[]
-): VNode<any>;
+): VNode<P>;
 export namespace createElement {
 	export import JSX = JSXInternal;
 }
@@ -236,7 +242,11 @@ export function h(
 				ClassAttributes<HTMLInputElement>)
 		| null,
 	...children: ComponentChildren[]
-): VNode<any>;
+): VNode<
+	| (JSXInternal.DOMAttributes<HTMLInputElement> &
+			ClassAttributes<HTMLInputElement>)
+	| null
+>;
 export function h<
 	P extends JSXInternal.HTMLAttributes<T>,
 	T extends HTMLElement
@@ -244,7 +254,7 @@ export function h<
 	type: keyof JSXInternal.IntrinsicElements,
 	props: (ClassAttributes<T> & P) | null,
 	...children: ComponentChildren[]
-): VNode<any>;
+): VNode<(ClassAttributes<T> & P) | null>;
 export function h<
 	P extends JSXInternal.SVGAttributes<T>,
 	T extends HTMLElement
@@ -252,7 +262,7 @@ export function h<
 	type: keyof JSXInternal.IntrinsicElements,
 	props: (ClassAttributes<T> & P) | null,
 	...children: ComponentChildren[]
-): VNode<any>;
+): VNode<(ClassAttributes<T> & P) | null>;
 export function h<T extends HTMLElement>(
 	type: string,
 	props:
@@ -261,12 +271,17 @@ export function h<T extends HTMLElement>(
 				JSXInternal.SVGAttributes)
 		| null,
 	...children: ComponentChildren[]
-): VNode<any>;
+): VNode<
+	| (ClassAttributes<T> &
+			JSXInternal.HTMLAttributes &
+			JSXInternal.SVGAttributes)
+	| null
+>;
 export function h<P>(
 	type: ComponentType<P>,
 	props: (Attributes & P) | null,
 	...children: ComponentChildren[]
-): VNode<any>;
+): VNode<(Attributes & P) | null>;
 export namespace h {
 	export import JSX = JSXInternal;
 }


### PR DESCRIPTION
There is also an opportunity to improve the types we infer for the second argument when we pass in a generic i.e. we probably don't need to show all attributes

Resolves #4040