### PR TITLE
fix: incorrect actDepth calculation in test-utils

### DIFF
--- a/test-utils/src/index.js
+++ b/test-utils/src/index.js
@@ -32,11 +32,19 @@ export function act(cb) {
 		// been set up.
 		//
 		// If an exception occurs, the outermost `act` will handle cleanup.
-		const result = cb();
-		if (isThenable(result)) {
-			return result.then(() => {
-				--actDepth;
-			});
+		try {
+			const result = cb();
+			if (isThenable(result)) {
+				return result.then(() => {
+					--actDepth;
+				}, (e) => {
+					--actDepth;
+					throw e;
+				})
+			}
+		} catch(e) {
+			--actDepth;
+			throw e;
 		}
 		--actDepth;
 		return Promise.resolve();

--- a/test-utils/test/shared/act.test.js
+++ b/test-utils/test/shared/act.test.js
@@ -385,6 +385,12 @@ describe('act', () => {
 			} catch (e) {}
 		};
 
+		const tryNestedRenderBroken = () => {
+			act(() => {
+				tryRenderBroken();
+			});
+		}
+
 		describe('synchronously', () => {
 			it('should rethrow the exception', () => {
 				expect(renderBroken).to.throw('BrokenWidget is broken');
@@ -396,6 +402,12 @@ describe('act', () => {
 				expect(scratch.textContent).to.equal('1');
 			});
 
+			it('should not affect state updates in future renders when nested `act` throws an exception', () => {
+				tryNestedRenderBroken();
+				renderWorking();
+				expect(scratch.textContent).to.equal('1');
+			});
+			
 			it('should not affect effects in future renders', () => {
 				tryRenderBroken();
 				renderWorking();


### PR DESCRIPTION
I am submitting this pull request to address a bug in the current implementation of the `act` method. Specifically, when the `act` method is called recursively and an inner callback throws an exception, it causes `actDepth` to be calculated incorrectly, leading to issues with subsequent `act` method calls.