### PR TITLE
fix: setting ref to null after updating it with new element

### DIFF
--- a/hooks/test/browser/combinations.test.js
+++ b/hooks/test/browser/combinations.test.js
@@ -398,4 +398,83 @@ describe('combinations', () => {
 		});
 		expect(scratch.textContent).to.equal('2');
 	});
+
+	it.skip('parent and child refs should be set before all effects', () => {
+		const anchorId = 'anchor';
+		const tooltipId = 'tooltip';
+		const effectLog = [];
+
+		let useRef2 = sinon.spy(init => {
+			const realRef = useRef(init);
+			const ref = useRef(init);
+			Object.defineProperty(ref, 'current', {
+				get: () => realRef.current,
+				set: value => {
+					realRef.current = value;
+					effectLog.push('set ref ' + value?.tagName);
+				}
+			});
+			return ref;
+		});
+
+		function Tooltip({ anchorRef, children }) {
+			// For example, used to manually position the tooltip
+			const tooltipRef = useRef2(null);
+
+			useLayoutEffect(() => {
+				expect(anchorRef.current?.id).to.equal(anchorId);
+				expect(tooltipRef.current?.id).to.equal(tooltipId);
+				effectLog.push('tooltip layout effect');
+			}, [anchorRef, tooltipRef]);
+			useEffect(() => {
+				expect(anchorRef.current?.id).to.equal(anchorId);
+				expect(tooltipRef.current?.id).to.equal(tooltipId);
+				effectLog.push('tooltip effect');
+			}, [anchorRef, tooltipRef]);
+
+			return (
+				<div class="tooltip-wrapper">
+					<div id={tooltipId} ref={tooltipRef}>
+						{children}
+					</div>
+				</div>
+			);
+		}
+
+		function App() {
+			// For example, used to define what element to anchor the tooltip to
+			const anchorRef = useRef2(null);
+
+			useLayoutEffect(() => {
+				expect(anchorRef.current?.id).to.equal(anchorId);
+				effectLog.push('anchor layout effect');
+			}, [anchorRef]);
+			useEffect(() => {
+				expect(anchorRef.current?.id).to.equal(anchorId);
+				effectLog.push('anchor effect');
+			}, [anchorRef]);
+
+			return (
+				<div>
+					<p id={anchorId} ref={anchorRef}>
+						More info
+					</p>
+					<Tooltip anchorRef={anchorRef}>a tooltip</Tooltip>
+				</div>
+			);
+		}
+
+		act(() => {
+			render(<App />, scratch);
+		});
+
+		expect(effectLog).to.deep.equal([
+			'set ref P',
+			'set ref DIV',
+			'tooltip layout effect',
+			'anchor layout effect',
+			'tooltip effect',
+			'anchor effect'
+		]);
+	});
 });

--- a/hooks/test/browser/useLayoutEffect.test.js
+++ b/hooks/test/browser/useLayoutEffect.test.js
@@ -476,4 +476,41 @@ describe('useLayoutEffect', () => {
 		expect(calls.length).to.equal(1);
 		expect(calls).to.deep.equal(['doing effecthi']);
 	});
+
+	it('should run layout affects after all refs are invoked', () => {
+		const calls = [];
+		const verifyRef = name => el => {
+			calls.push(name);
+			expect(document.body.contains(el), name).to.equal(true);
+		};
+
+		const App = () => {
+			const ref = useRef();
+			useLayoutEffect(() => {
+				expect(ref.current).to.equalNode(scratch.querySelector('p'));
+
+				calls.push('doing effect');
+				return () => {
+					calls.push('cleaning up');
+				};
+			});
+
+			return (
+				<div ref={verifyRef('callback ref outer')}>
+					<p ref={ref}>
+						<span ref={verifyRef('callback ref inner')}>Hi</span>
+					</p>
+				</div>
+			);
+		};
+
+		act(() => {
+			render(<App />, scratch);
+		});
+		expect(calls).to.deep.equal([
+			'callback ref inner',
+			'callback ref outer',
+			'doing effect'
+		]);
+	});
 });

--- a/src/component.js
+++ b/src/component.js
@@ -1,5 +1,5 @@
 import { assign } from './util';
-import { diff, commitRoot, applyRef } from './diff/index';
+import { diff, commitRoot } from './diff/index';
 import options from './options';
 import { Fragment } from './create-element';
 

--- a/src/component.js
+++ b/src/component.js
@@ -1,5 +1,5 @@
 import { assign } from './util';
-import { diff, commitRoot } from './diff/index';
+import { diff, commitRoot, applyRef } from './diff/index';
 import options from './options';
 import { Fragment } from './create-element';
 
@@ -126,6 +126,7 @@ function renderComponent(component) {
 
 	if (parentDom) {
 		let commitQueue = [];
+		let refQueue = [];
 		const oldVNode = assign({}, vnode);
 		oldVNode._original = vnode._original + 1;
 
@@ -138,8 +139,15 @@ function renderComponent(component) {
 			vnode._hydrating != null ? [oldDom] : null,
 			commitQueue,
 			oldDom == null ? getDomSibling(vnode) : oldDom,
-			vnode._hydrating
+			vnode._hydrating,
+			refQueue
 		);
+
+		refQueue.some(refs => {
+			for (let i = 0; i < refs.length; i++) {
+				applyRef(refs[i], refs[++i], refs[++i]);
+			}
+		});
 		commitRoot(commitQueue, vnode);
 
 		if (vnode._dom != oldDom) {

--- a/src/component.js
+++ b/src/component.js
@@ -143,10 +143,7 @@ function renderComponent(component) {
 			refQueue
 		);
 
-		for (let i = 0; i < refQueue.length; i++) {
-			applyRef(refQueue[i], refQueue[++i], refQueue[++i]);
-		}
-		commitRoot(commitQueue, vnode);
+		commitRoot(commitQueue, vnode, refQueue);
 
 		if (vnode._dom != oldDom) {
 			updateParentDomPointers(vnode);

--- a/src/component.js
+++ b/src/component.js
@@ -143,11 +143,9 @@ function renderComponent(component) {
 			refQueue
 		);
 
-		refQueue.some(refs => {
-			for (let i = 0; i < refs.length; i++) {
-				applyRef(refs[i], refs[++i], refs[++i]);
-			}
-		});
+		for (let i = 0; i < refQueue.length; i++) {
+			applyRef(refQueue[i], refQueue[++i], refQueue[++i]);
+		}
 		commitRoot(commitQueue, vnode);
 
 		if (vnode._dom != oldDom) {

--- a/src/component.js
+++ b/src/component.js
@@ -125,8 +125,8 @@ function renderComponent(component) {
 		parentDom = component._parentDom;
 
 	if (parentDom) {
-		let commitQueue = [];
-		let refQueue = [];
+		let commitQueue = [],
+			refQueue = [];
 		const oldVNode = assign({}, vnode);
 		oldVNode._original = vnode._original + 1;
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -22,6 +22,7 @@ import { isArray } from '../util';
  * render (except when hydrating). Can be a sibling DOM element when diffing
  * Fragments that have siblings. In most cases, it starts out as `oldChildren[0]._dom`.
  * @param {boolean} isHydrating Whether or not we are in hydration
+ * @param {Array<any>} refQueue an array of elements needed to invoke refs
  */
 export function diffChildren(
 	parentDom,

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -33,7 +33,8 @@ export function diffChildren(
 	excessDomChildren,
 	commitQueue,
 	oldDom,
-	isHydrating
+	isHydrating,
+	refQueue
 ) {
 	let i,
 		j,
@@ -138,7 +139,8 @@ export function diffChildren(
 			excessDomChildren,
 			commitQueue,
 			oldDom,
-			isHydrating
+			isHydrating,
+			refQueue
 		);
 
 		newDom = childVNode._dom;
@@ -246,9 +248,7 @@ export function diffChildren(
 
 	// Set refs only after unmount
 	if (refs) {
-		for (i = 0; i < refs.length; i++) {
-			applyRef(refs[i], refs[++i], refs[++i]);
-		}
+		refQueue.push(refs);
 	}
 }
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -42,7 +42,6 @@ export function diffChildren(
 		childVNode,
 		newDom,
 		firstChildDom,
-		refs,
 		skew = 0;
 
 	// This is a compression of oldParentVNode!=null && oldParentVNode != EMPTY_OBJ && oldParentVNode._children || EMPTY_ARR
@@ -147,8 +146,7 @@ export function diffChildren(
 
 		if ((j = childVNode.ref) && oldVNode.ref != j) {
 			if (oldVNode.ref) {
-				if (!refs) refs = [];
-				refs.push(oldVNode.ref, null, childVNode);
+				applyRef(oldVNode.ref, null, childVNode);
 			}
 			refQueue.push(j, childVNode._component || newDom, childVNode);
 		}
@@ -245,13 +243,6 @@ export function diffChildren(
 			}
 
 			unmount(oldChildren[i], oldChildren[i]);
-		}
-	}
-
-	// Set refs only after unmount
-	if (refs) {
-		for (i = 0; i < refs.length; i++) {
-			applyRef(refs[i], refs[++i], refs[++i]);
 		}
 	}
 }

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -248,7 +248,13 @@ export function diffChildren(
 
 	// Set refs only after unmount
 	if (refs) {
-		refQueue.push(refs);
+		for (let i = 0; i < refs.length; i++) {
+			if (refs[i + 1]) {
+				refQueue.push(refs[i], refs[++i], refs[++i]);
+			} else {
+				applyRef(refs[i], refs[++i], refs[++i]);
+			}
+		}
 	}
 }
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -146,9 +146,11 @@ export function diffChildren(
 		newDom = childVNode._dom;
 
 		if ((j = childVNode.ref) && oldVNode.ref != j) {
-			if (!refs) refs = [];
-			if (oldVNode.ref) refs.push(oldVNode.ref, null, childVNode);
-			refs.push(j, childVNode._component || newDom, childVNode);
+			if (oldVNode.ref) {
+				if (!refs) refs = [];
+				refs.push(oldVNode.ref, null, childVNode);
+			}
+			refQueue.push(j, childVNode._component || newDom, childVNode);
 		}
 
 		if (newDom != null) {
@@ -248,12 +250,8 @@ export function diffChildren(
 
 	// Set refs only after unmount
 	if (refs) {
-		for (let i = 0; i < refs.length; i++) {
-			if (refs[i + 1]) {
-				refQueue.push(refs[i], refs[++i], refs[++i]);
-			} else {
-				applyRef(refs[i], refs[++i], refs[++i]);
-			}
+		for (i = 0; i < refs.length; i++) {
+			applyRef(refs[i], refs[++i], refs[++i]);
 		}
 	}
 }

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -521,7 +521,6 @@ export function unmount(vnode, parentVNode, skipRemove) {
 
 	if ((r = vnode.ref)) {
 		if (!r.current || r.current === vnode._dom) {
-			console.log('applying', r, 'null');
 			applyRef(r, null, parentVNode);
 		}
 	}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -521,6 +521,7 @@ export function unmount(vnode, parentVNode, skipRemove) {
 
 	if ((r = vnode.ref)) {
 		if (!r.current || r.current === vnode._dom) {
+			console.log('applying', r, 'null');
 			applyRef(r, null, parentVNode);
 		}
 	}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -296,7 +296,11 @@ export function diff(
  * which have callbacks to invoke in commitRoot
  * @param {import('../internal').VNode} root
  */
-export function commitRoot(commitQueue, root) {
+export function commitRoot(commitQueue, root, refQueue) {
+	for (let i = 0; i < refQueue.length; i++) {
+		applyRef(refQueue[i], refQueue[++i], refQueue[++i]);
+	}
+
 	if (options._commit) options._commit(root, commitQueue);
 
 	commitQueue.some(c => {

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -20,7 +20,8 @@ import options from '../options';
  * element any new dom elements should be placed around. Likely `null` on first
  * render (except when hydrating). Can be a sibling DOM element when diffing
  * Fragments that have siblings. In most cases, it starts out as `oldChildren[0]._dom`.
- * @param {boolean} [isHydrating] Whether or not we are in hydration
+ * @param {boolean} isHydrating Whether or not we are in hydration
+ * @param {Array<any>} refQueue an array of elements needed to invoke refs
  */
 export function diff(
 	parentDom,
@@ -330,6 +331,7 @@ export function commitRoot(commitQueue, root, refQueue) {
  * @param {Array<import('../internal').Component>} commitQueue List of components
  * which have callbacks to invoke in commitRoot
  * @param {boolean} isHydrating Whether or not we are in hydration
+ * @param {Array<any>} refQueue an array of elements needed to invoke refs
  * @returns {import('../internal').PreactElement}
  */
 function diffElementNodes(

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -31,7 +31,8 @@ export function diff(
 	excessDomChildren,
 	commitQueue,
 	oldDom,
-	isHydrating
+	isHydrating,
+	refQueue
 ) {
 	let tmp,
 		newType = newVNode.type;
@@ -239,7 +240,8 @@ export function diff(
 				excessDomChildren,
 				commitQueue,
 				oldDom,
-				isHydrating
+				isHydrating,
+				refQueue
 			);
 
 			c.base = newVNode._dom;
@@ -269,7 +271,8 @@ export function diff(
 				isSvg,
 				excessDomChildren,
 				commitQueue,
-				isHydrating
+				isHydrating,
+				refQueue
 			);
 		}
 
@@ -333,7 +336,8 @@ function diffElementNodes(
 	isSvg,
 	excessDomChildren,
 	commitQueue,
-	isHydrating
+	isHydrating,
+	refQueue
 ) {
 	let oldProps = oldVNode.props;
 	let newProps = newVNode.props;
@@ -445,7 +449,8 @@ function diffElementNodes(
 				excessDomChildren
 					? excessDomChildren[0]
 					: oldVNode._children && getDomSibling(oldVNode, 0),
-				isHydrating
+				isHydrating,
+				refQueue
 			);
 
 			// Remove children that are not part of any vnode.

--- a/src/render.js
+++ b/src/render.js
@@ -33,8 +33,8 @@ export function render(vnode, parentDom, replaceNode) {
 		createElement(Fragment, null, [vnode]);
 
 	// List of effects that need to be called after diffing.
-	let commitQueue = [];
-	let refQueue = [];
+	let commitQueue = [],
+		refQueue = [];
 	diff(
 		parentDom,
 		// Determine the new vnode tree and store it on the DOM element on

--- a/src/render.js
+++ b/src/render.js
@@ -60,11 +60,9 @@ export function render(vnode, parentDom, replaceNode) {
 		refQueue
 	);
 
-	refQueue.some(refs => {
-		for (let i = 0; i < refs.length; i++) {
-			applyRef(refs[i], refs[++i], refs[++i]);
-		}
-	});
+	for (let i = 0; i < refQueue.length; i++) {
+		applyRef(refQueue[i], refQueue[++i], refQueue[++i]);
+	}
 	// Flush all queued effects
 	commitRoot(commitQueue, vnode);
 }

--- a/src/render.js
+++ b/src/render.js
@@ -60,11 +60,8 @@ export function render(vnode, parentDom, replaceNode) {
 		refQueue
 	);
 
-	for (let i = 0; i < refQueue.length; i++) {
-		applyRef(refQueue[i], refQueue[++i], refQueue[++i]);
-	}
 	// Flush all queued effects
-	commitRoot(commitQueue, vnode);
+	commitRoot(commitQueue, vnode, refQueue);
 }
 
 /**

--- a/src/render.js
+++ b/src/render.js
@@ -1,5 +1,5 @@
 import { EMPTY_OBJ } from './constants';
-import { commitRoot, diff } from './diff/index';
+import { applyRef, commitRoot, diff } from './diff/index';
 import { createElement, Fragment } from './create-element';
 import options from './options';
 import { slice } from './util';
@@ -34,6 +34,7 @@ export function render(vnode, parentDom, replaceNode) {
 
 	// List of effects that need to be called after diffing.
 	let commitQueue = [];
+	let refQueue = [];
 	diff(
 		parentDom,
 		// Determine the new vnode tree and store it on the DOM element on
@@ -55,9 +56,15 @@ export function render(vnode, parentDom, replaceNode) {
 			: oldVNode
 			? oldVNode._dom
 			: parentDom.firstChild,
-		isHydrating
+		isHydrating,
+		refQueue
 	);
 
+	refQueue.some(refs => {
+		for (let i = 0; i < refs.length; i++) {
+			applyRef(refs[i], refs[++i], refs[++i]);
+		}
+	});
 	// Flush all queued effects
 	commitRoot(commitQueue, vnode);
 }

--- a/src/render.js
+++ b/src/render.js
@@ -1,5 +1,5 @@
 import { EMPTY_OBJ } from './constants';
-import { applyRef, commitRoot, diff } from './diff/index';
+import { commitRoot, diff } from './diff/index';
 import { createElement, Fragment } from './create-element';
 import options from './options';
 import { slice } from './util';

--- a/test/browser/refs.test.js
+++ b/test/browser/refs.test.js
@@ -628,9 +628,9 @@ describe('refs', () => {
 		rerender();
 		expect(calls).to.deep.equal([
 			'removing ref from two',
+			'adding ref to one',
 			'adding ref to two',
-			'adding ref to three',
-			'adding ref to one'
+			'adding ref to three'
 		]);
 	});
 });


### PR DESCRIPTION
fixes #4049 

As explained in https://github.com/preactjs/preact/issues/4049#issuecomment-1605314450 we did all unsetting/setting logic during diff which meant that if we changed the level of an element we would set --> unset if the level moved lower down.

To counter-act this we execute unsetting first and setting later, which is also inline with how [react does it](https://codesandbox.io/s/blissful-franklin-tq2n95?file=/src/App.js) in React you see a series of unsets and only after you see a series of sets.

Because we queue `useLayoutEffect` to the commit phase we still ensures that refs are set correctly.