### PR TITLE
10.16.0

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -2,7 +2,7 @@ import { options, Fragment, Component } from 'preact';
 
 export function initDevTools() {
 	if (typeof window != 'undefined' && window.__PREACT_DEVTOOLS__) {
-		window.__PREACT_DEVTOOLS__.attachPreact('10.15.1', options, {
+		window.__PREACT_DEVTOOLS__.attachPreact('10.16.0', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "10.15.1",
+  "version": "10.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "10.15.1",
+      "version": "10.16.0",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.15.1",
+  "version": "10.16.0",
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
## Improved child diffing

- Port skew based child diffing (#4010, thanks @JoviDeCroock)

We have noticed a few scenario's where children would get unmounted and remounted eagerly due to some offset bugs in our child-diffing, with skew-based diffing we plan to address those. This is already part of v11 and has been introduced there by @andrewiggins. This has now been backported to Preact X so we can benefit from the consistency improvements here as well.

## Defer setting refs

- fix: setting ref to null after updating it with new element (#4054, thanks @JoviDeCroock)

We used to set refs as part of the children, synchronously this caused several issues when a ref would go down a level, i.e. the following example

```
const App = () => {
  return phase === 1 ? <div ref={x}><p>Foo</p></div> : <div><div ref={x}><p>Foo</p></div>
}
```

In this example when we go from phase 1 to phase 2 we would mount a new ref but only after we bubble back up diffing clean up the outer ref making the ref reset to null.

## Fixes


- fix: incorrect actDepth calculation in test-utils (#4051, thanks @ottomao)
- Server compat should have a default export (#4047, thanks @MikaFima)
- Fix forceUpdate edge cases (#4048, thanks @dmitrage)
- Include HTML above render root for DOM validation (#4043, thanks @marvinhagemeister)


## Types

- Types: add missing aria attributes (#4032, thanks @shoonia)
- improve VNode typings when generic is passed in (#4050, thanks @JoviDeCroock)