### PR TITLE
'Improve' code quality by changing syntax to a more accurate one

### DIFF
--- a/jsx-runtime/test/browser/jsx-runtime.test.js
+++ b/jsx-runtime/test/browser/jsx-runtime.test.js
@@ -14,10 +14,10 @@ describe('Babel jsx/jsxDEV', () => {
 	});
 
 	it('should have needed exports', () => {
-		expect(typeof jsx).to.equal('function');
-		expect(typeof jsxs).to.equal('function');
-		expect(typeof jsxDEV).to.equal('function');
-		expect(typeof Fragment).to.equal('function');
+		expect(jsx).to.be.a('function');
+		expect(jsxs).to.be.a('function');
+		expect(jsxDEV).to.be.a('function');
+		expect(Fragment).to.be.a('function');
 	});
 
 	it('should keep ref in props', () => {


### PR DESCRIPTION
I've found that the test asserition could be 'improved' by changing the typeof by a to.be.a('function') and i found it to be quite easy to read and understand plus also deleting some unnecessary checks (typeof).

Hope is somehow useful, thanks!