### PR TITLE
reduce stack size of try catch by excluding non components

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -53,8 +53,8 @@ export function diff(
 
 	if ((tmp = options._diff)) tmp(newVNode);
 
-	try {
-		outer: if (typeof newType == 'function') {
+	outer: if (typeof newType == 'function') {
+		try {
 			let c, isNew, oldProps, oldState, snapshot, clearProcessingException;
 			let newProps = newVNode.props;
 
@@ -257,39 +257,39 @@ export function diff(
 			if (clearProcessingException) {
 				c._pendingError = c._processingException = null;
 			}
-		} else if (
-			excessDomChildren == null &&
-			newVNode._original === oldVNode._original
-		) {
-			newVNode._children = oldVNode._children;
-			newVNode._dom = oldVNode._dom;
-		} else {
-			newVNode._dom = diffElementNodes(
-				oldVNode._dom,
-				newVNode,
-				oldVNode,
-				globalContext,
-				isSvg,
-				excessDomChildren,
-				commitQueue,
-				isHydrating,
-				refQueue
-			);
+		} catch (e) {
+			newVNode._original = null;
+			// if hydrating or creating initial tree, bailout preserves DOM:
+			if (isHydrating || excessDomChildren != null) {
+				newVNode._dom = oldDom;
+				newVNode._hydrating = !!isHydrating;
+				excessDomChildren[excessDomChildren.indexOf(oldDom)] = null;
+				// ^ could possibly be simplified to:
+				// excessDomChildren.length = 0;
+			}
+			options._catchError(e, newVNode, oldVNode);
 		}
-
-		if ((tmp = options.diffed)) tmp(newVNode);
-	} catch (e) {
-		newVNode._original = null;
-		// if hydrating or creating initial tree, bailout preserves DOM:
-		if (isHydrating || excessDomChildren != null) {
-			newVNode._dom = oldDom;
-			newVNode._hydrating = !!isHydrating;
-			excessDomChildren[excessDomChildren.indexOf(oldDom)] = null;
-			// ^ could possibly be simplified to:
-			// excessDomChildren.length = 0;
-		}
-		options._catchError(e, newVNode, oldVNode);
+	} else if (
+		excessDomChildren == null &&
+		newVNode._original === oldVNode._original
+	) {
+		newVNode._children = oldVNode._children;
+		newVNode._dom = oldVNode._dom;
+	} else {
+		newVNode._dom = diffElementNodes(
+			oldVNode._dom,
+			newVNode,
+			oldVNode,
+			globalContext,
+			isSvg,
+			excessDomChildren,
+			commitQueue,
+			isHydrating,
+			refQueue
+		);
 	}
+
+	if ((tmp = options.diffed)) tmp(newVNode);
 }
 
 /**

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -54,8 +54,8 @@ export function diff(
 	if ((tmp = options._diff)) tmp(newVNode);
 
 	outer: if (typeof newType == 'function') {
-		let c, isNew, oldProps, oldState, snapshot, clearProcessingException;
 		try {
+			let c, isNew, oldProps, oldState, snapshot, clearProcessingException;
 			let newProps = newVNode.props;
 
 			// Necessary for createContext api. Setting this property will pass
@@ -226,6 +226,37 @@ export function diff(
 			if (!isNew && c.getSnapshotBeforeUpdate != null) {
 				snapshot = c.getSnapshotBeforeUpdate(oldProps, oldState);
 			}
+
+			let isTopLevelFragment =
+				tmp != null && tmp.type === Fragment && tmp.key == null;
+			let renderResult = isTopLevelFragment ? tmp.props.children : tmp;
+
+			diffChildren(
+				parentDom,
+				isArray(renderResult) ? renderResult : [renderResult],
+				newVNode,
+				oldVNode,
+				globalContext,
+				isSvg,
+				excessDomChildren,
+				commitQueue,
+				oldDom,
+				isHydrating,
+				refQueue
+			);
+
+			c.base = newVNode._dom;
+
+			// We successfully rendered this VNode, unset any stored hydration/bailout state:
+			newVNode._hydrating = null;
+
+			if (c._renderCallbacks.length) {
+				commitQueue.push(c);
+			}
+
+			if (clearProcessingException) {
+				c._pendingError = c._processingException = null;
+			}
 		} catch (e) {
 			newVNode._original = null;
 			// if hydrating or creating initial tree, bailout preserves DOM:
@@ -237,38 +268,6 @@ export function diff(
 				// excessDomChildren.length = 0;
 			}
 			options._catchError(e, newVNode, oldVNode);
-			return;
-		}
-
-		let isTopLevelFragment =
-			tmp != null && tmp.type === Fragment && tmp.key == null;
-		let renderResult = isTopLevelFragment ? tmp.props.children : tmp;
-
-		diffChildren(
-			parentDom,
-			isArray(renderResult) ? renderResult : [renderResult],
-			newVNode,
-			oldVNode,
-			globalContext,
-			isSvg,
-			excessDomChildren,
-			commitQueue,
-			oldDom,
-			isHydrating,
-			refQueue
-		);
-
-		c.base = newVNode._dom;
-
-		// We successfully rendered this VNode, unset any stored hydration/bailout state:
-		newVNode._hydrating = null;
-
-		if (c._renderCallbacks.length) {
-			commitQueue.push(c);
-		}
-
-		if (clearProcessingException) {
-			c._pendingError = c._processingException = null;
 		}
 	} else if (
 		excessDomChildren == null &&


### PR DESCRIPTION
Been thinking about solutions for https://github.com/preactjs/preact/issues/2323, wrapping only when `componentDidCatch` is present does not work as we don't render other children then i.e. Suspense would lose the parallel capabilities and componentDidCatch would throw once when two children error...

Thinking about more ways we can improve this atm