### PR TITLE
add missing SvgProps and make the generics mandatory

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -65,9 +65,13 @@ declare namespace React {
 	export function startTransition(cb: () => void): void;
 
 	// HTML
-	export import HTMLAttributes = JSXInternal.HTMLAttributes;
+	export interface HTMLAttributes<T extends EventTarget>
+		extends JSXInternal.HTMLAttributes<T> {}
 	export import DetailedHTMLProps = JSXInternal.DetailedHTMLProps;
 	export import CSSProperties = JSXInternal.CSSProperties;
+	export interface SVGProps<T extends EventTarget>
+		extends JSXInternal.SVGAttributes<T>,
+			preact.ClassAttributes<T> {}
 
 	// Events
 	export import TargetedEvent = JSXInternal.TargetedEvent;


### PR DESCRIPTION
fixes https://github.com/preactjs/preact/issues/3932

- [HtmlAttributes](https://www.runpkg.com/?@types/react@17.0.25/index.d.ts#1821)
- [SvgProps](https://www.runpkg.com/?@types/react@17.0.25/index.d.ts#1349)