### PR TITLE
[bug]: empty result of lazy component doubles next node

### DIFF
--- a/compat/test/browser/suspense-hydration.test.js
+++ b/compat/test/browser/suspense-hydration.test.js
@@ -121,6 +121,37 @@ describe('suspense hydration', () => {
 		});
 	});
 
+	it('should correct processed empty result of lazy component', () => {
+		scratch.innerHTML = '<main><p>i am not from lazy</p></main>';
+		clearLog();
+
+		const [Lazy, resolve] = createLazy();
+		hydrate(
+			<main>
+				<Suspense fallback={<p>will be never showed while hydration</p>}>
+					<Lazy />
+				</Suspense>
+				<p>i am not from lazy</p>
+			</main>,
+			scratch
+		);
+		rerender(); // Flush rerender queue to mimic what preact will really do
+		expect(scratch.innerHTML).to.equal(
+			'<main><p>i am not from lazy</p></main>'
+		);
+		expect(getLog()).to.deep.equal([]);
+		clearLog();
+
+		return resolve(() => null).then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.equal(
+				'<main><p>i am not from lazy</p></main>'
+			);
+			expect(getLog()).to.deep.equal([]);
+			clearLog();
+		});
+	});
+
 	it('should properly attach event listeners when suspending while hydrating', () => {
 		scratch.innerHTML = '<div>Hello</div><div>World</div>';
 		clearLog();


### PR DESCRIPTION
I added test, which shows that empty result of `Lazy` component doubles next node while hydration. 
``` html
<main>
  <Suspense fallback={<p>will be never showed while hydration</p>}>
    <Lazy /> <!-- if it returns null, the next dom node will be doubled -->
  </Suspense>
  <p>will be rendered twice after hydration</p>
</main>
```

This seems, it happens because error, when rendering a lazy component:

```javascript
// compat/src/suspense.js:261
if (!component) {
  throw prom;
}
```

Maybe we incorrect handle this error. I don't understand, why we need to remove last node from `excessDomChildren` and assing a value of `oldDom` to `newVNode._dom`
```javascript
// src/diff/index.js:260
catch (e) {
  newVNode._original = null;
  if (isHydrating || excessDomChildren != null) {
    newVNode._hydrating = !!isHydrating;
    
    // We think, that oldDom will be replaced
    // a new node, which will be returned by Lazy. 
    // But this may be not so, because Lazy can return null
    newVNode._dom = oldDom;
    excessDomChildren[excessDomChildren.indexOf(oldDom)] = null;
  }
}
```

I tried to add additional handling for this error, but it breaks some of tests for suspense-hydration, despite the fact current test begun work
```javascript
// src/diff/index.js:260
catch (e) {
  newVNode._original = null;
  if (isHydrating || excessDomChildren != null) {
    newVNode._hydrating = !!isHydrating;
    
    if (newVNode.type.displayName !== 'Lazy') {  // it breaks other tests
      newVNode._dom = oldDom;
      excessDomChildren[excessDomChildren.indexOf(oldDom)] = null;
    }
  }
}
```

I am looking for a solution and **i need help of community**. Now i think it can not fix by additional error handling, because at moment of processing node when hydration we don't know, what will return Lazy

P.S. I understand, that lazy component with empty result is not the best idea. But it give unpredictable result with doubles nodes. I think, it should working or throw error