### PR TITLE
fix: Re-export `ComponentChild` as `ReactNode` in compat's types

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -53,6 +53,7 @@ declare namespace React {
 	export import createElement = preact.createElement;
 	export import cloneElement = preact.cloneElement;
 	export import ComponentProps = preact.ComponentProps;
+	export import ReactNode = preact.ComponentChild;
 
 	// Suspense
 	export import Suspense = _Suspense.Suspense;


### PR DESCRIPTION
[React's types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a4df80cc8e40ad9448b83f923cd6c43133da56f5/types/react/index.d.ts#L257-L266), for comparison.