### PR TITLE
10.17.0

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -2,7 +2,7 @@ import { options, Fragment, Component } from 'preact';
 
 export function initDevTools() {
 	if (typeof window != 'undefined' && window.__PREACT_DEVTOOLS__) {
-		window.__PREACT_DEVTOOLS__.attachPreact('10.16.0', options, {
+		window.__PREACT_DEVTOOLS__.attachPreact('10.17.0', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "10.16.0",
+  "version": "10.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "10.16.0",
+      "version": "10.17.0",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^5.0.0",
@@ -3746,7 +3746,7 @@
         "duplexer": "0.1.1"
       },
       "engines": {
-        "node": ">= 10.16.0"
+        "node": ">= 10.17.0"
       }
     },
     "node_modules/brotli-size/node_modules/duplexer": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.16.0",
+  "version": "10.17.0",
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
## Features

- Support the `isElement` function in preact/compat (#4041, thanks @cbbfcd)
- Support the `isFragment` function in preact/compat (#4042, thanks @cbbfcd)

## Types

- Support the HTML search element (#4092, thanks @JoviDeCroock)
- Re-export `ComponentChild` as `ReactNode` in the preact/compat types (#4077, thanks @rschristian)
- Add missing SvgProps and make the generics mandatory (#4071, thanks @JoviDeCroock)
- Fix dom-event types(#4066, thanks @JoviDeCroock)

## Fixes

- Eagerly unmount placeholders (#4090, thanks @andrewiggins)
- Avoid skipping re-orders in child diffing (#4088, thanks @JoviDeCroock)
- reduce stack size of try catch by excluding non components (#4067, thanks @JoviDeCroock)
- Fix react-frame-component by supporting nullish portals (#3896, thanks @JoviDeCroock)

## Maintenance

- Fix running our benchmarks since the branch rename (#4089, thanks @JoviDeCroock)
- Fix IE11 attribute test by sorting them (#4070, thanks @marvinhagemeister)
- Switch default branch to `main` (#4069, thanks @marvinhagemeister)
