### PR TITLE
fix: Don't rename `gotpointercapture` and `lostpointercapture` events

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -83,7 +83,11 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 	}
 	// Benchmark for comparison: https://esbench.com/bench/574c954bdb965b9a00965ac6
 	else if (name[0] === 'o' && name[1] === 'n') {
-		useCapture = name !== (name = name.replace(/Capture$/, ''));
+		if (/PointerCapture$/.test(name)) {
+			useCapture = false;
+		} else {
+			useCapture = name !== (name = name.replace(/Capture$/, ''));
+		}
 
 		// Infer correct casing for DOM built-in events:
 		if (name.toLowerCase() in dom) name = name.toLowerCase().slice(2);

--- a/test/browser/events.test.js
+++ b/test/browser/events.test.js
@@ -95,35 +95,6 @@ describe('event handling', () => {
 		expect(click).to.have.been.calledOnce.and.calledWith(1);
 	});
 
-	// Uniquely named in that the base event names end with 'Capture'
-	it('should support got/lost pointer capture', () => {
-		let ongotpointercapture = sinon.spy(),
-			onlostpointercapture = sinon.spy();
-
-		let firePointerEvent = (on, type) =>
-			on.dispatchEvent(new PointerEvent(type, { pointerId: 1 }));
-
-		render(
-			<div
-				onPointerDown={e => e.target.setPointerCapture(e.pointerId)}
-				onGotPointerCapture={ongotpointercapture}
-				onLostPointerCapture={onlostpointercapture}
-			/>,
-			scratch
-		);
-
-		firePointerEvent(scratch.childNodes[0], 'pointerdown');
-		expect(ongotpointercapture).to.have.been.calledOnce;
-		expect(onlostpointercapture).to.not.have.been.called;
-
-		ongotpointercapture.resetHistory();
-		onlostpointercapture.resetHistory();
-
-		firePointerEvent(scratch.childNodes[0], 'pointerup');
-		expect(ongotpointercapture).to.not.have.been.called;
-		expect(onlostpointercapture).to.have.been.calledOnce;
-	});
-
 	it('should update event handlers', () => {
 		let click1 = sinon.spy();
 		let click2 = sinon.spy();
@@ -228,4 +199,38 @@ describe('event handling', () => {
 			expect(click, 'click').to.have.been.calledOnce;
 		});
 	}
+
+	// Uniquely named in that the base event names end with 'Capture'
+	it('should support (got|lost)PointerCapture events', () => {
+		let gotPointerCapture = sinon.spy(),
+			gotPointerCaptureCapture = sinon.spy(),
+			lostPointerCapture = sinon.spy(),
+			lostPointerCaptureCapture = sinon.spy();
+
+		render(
+			<div
+				onGotPointerCapture={gotPointerCapture}
+				onLostPointerCapture={lostPointerCapture}
+			/>,
+			scratch
+		);
+
+		expect(proto.addEventListener)
+			.to.have.been.calledTwice.and.to.have.been.calledWith('gotpointercapture')
+			.and.calledWith('lostpointercapture');
+
+		proto.addEventListener.resetHistory();
+
+		render(
+			<div
+				onGotPointerCaptureCapture={gotPointerCaptureCapture}
+				onLostPointerCaptureCapture={lostPointerCaptureCapture}
+			/>,
+			scratch
+		);
+
+		expect(proto.addEventListener)
+			.to.have.been.calledTwice.and.to.have.been.calledWith('gotpointercapture')
+			.and.calledWith('lostpointercapture');
+	});
 });

--- a/test/browser/events.test.js
+++ b/test/browser/events.test.js
@@ -100,6 +100,9 @@ describe('event handling', () => {
 		let ongotpointercapture = sinon.spy(),
 			onlostpointercapture = sinon.spy();
 
+		let firePointerEvent = (on, type) =>
+			on.dispatchEvent(new PointerEvent(type, { pointerId: 1 }));
+
 		render(
 			<div
 				onPointerDown={e => e.target.setPointerCapture(e.pointerId)}
@@ -109,14 +112,14 @@ describe('event handling', () => {
 			scratch
 		);
 
-		fireEvent(scratch.childNodes[0], 'pointerdown');
+		firePointerEvent(scratch.childNodes[0], 'pointerdown');
 		expect(ongotpointercapture).to.have.been.calledOnce;
 		expect(onlostpointercapture).to.not.have.been.called;
 
 		ongotpointercapture.resetHistory();
 		onlostpointercapture.resetHistory();
 
-		fireEvent(scratch.childNodes[0], 'pointerup');
+		firePointerEvent(scratch.childNodes[0], 'pointerup');
 		expect(ongotpointercapture).to.not.have.been.called;
 		expect(onlostpointercapture).to.have.been.calledOnce;
 	});

--- a/test/browser/events.test.js
+++ b/test/browser/events.test.js
@@ -95,6 +95,32 @@ describe('event handling', () => {
 		expect(click).to.have.been.calledOnce.and.calledWith(1);
 	});
 
+	// Uniquely named in that the base event names end with 'Capture'
+	it('should support got/lost pointer capture', () => {
+		let ongotpointercapture = sinon.spy(),
+			onlostpointercapture = sinon.spy();
+
+		render(
+			<div
+				onPointerDown={e => e.target.setPointerCapture(e.pointerId)}
+				onGotPointerCapture={ongotpointercapture}
+				onLostPointerCapture={onlostpointercapture}
+			/>,
+			scratch
+		);
+
+		fireEvent(scratch.childNodes[0], 'pointerdown');
+		expect(ongotpointercapture).to.have.been.calledOnce;
+		expect(onlostpointercapture).to.not.have.been.called;
+
+		ongotpointercapture.resetHistory();
+		onlostpointercapture.resetHistory();
+
+		fireEvent(scratch.childNodes[0], 'pointerup');
+		expect(ongotpointercapture).to.not.have.been.called;
+		expect(onlostpointercapture).to.have.been.calledOnce;
+	});
+
 	it('should update event handlers', () => {
 		let click1 = sinon.spy();
 		let click2 = sinon.spy();


### PR DESCRIPTION
Fixes part of #4095 

`onGotPointerCapture` and `onLostPointerCapture` have their names incorrectly altered to `GotPointer` and `LostPointer` respectively with the current state of things. They'll need to be skipped over in some fashion.

I'm a code golf scrub, might be (probably is) a better way to correct these.