### PR TITLE
Fix double unmount

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -115,6 +115,7 @@ export function diffChildren(
 				}
 
 				unmount(oldVNode, oldVNode, false);
+				oldChildren[i] = null;
 			}
 
 			continue;


### PR DESCRIPTION
This should fix #4104.

I believe the issue is that `unmount()` is triggered for the VNode at `oldChildren[i]`, but that VNode remains in `oldChildren`. When we hit the end of `diffChildren()`, a loop invokes `unmount()` on every non-null vnode in `oldChildren`, which still includes the eagerly-unmounted VNode.

I didn't have a chance to add a test as I'm doing this from GH web, if someone gets around to it before me we can likely just use the example from #4104.