### PR TITLE
types: Adds `HTMLProps` to compat

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -68,7 +68,7 @@ declare namespace React {
 	// HTML
 	export interface HTMLAttributes<T extends EventTarget>
 		extends JSXInternal.HTMLAttributes<T> {}
-	export interface HTMLProps<T>
+	export interface HTMLProps<T extends EventTarget>
 		extends JSXInternal.HTMLAttributes<T>,
 			preact.ClassAttributes<T> {}
 	export import DetailedHTMLProps = JSXInternal.DetailedHTMLProps;

--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -68,6 +68,9 @@ declare namespace React {
 	// HTML
 	export interface HTMLAttributes<T extends EventTarget>
 		extends JSXInternal.HTMLAttributes<T> {}
+	export interface HTMLProps<T>
+		extends JSXInternal.HTMLAttributes<T>,
+			preact.ClassAttributes<T> {}
 	export import DetailedHTMLProps = JSXInternal.DetailedHTMLProps;
 	export import CSSProperties = JSXInternal.CSSProperties;
 	export interface SVGProps<T extends EventTarget>


### PR DESCRIPTION
Closes #4114 

[React's type](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f772356c149b3becb0fbc35ced7ecfcad167bbf4/types/react/index.d.ts#L1409), for comparison. Just HTML attrs + ref