### PR TITLE
fix: ordering issue with Component re-render

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -103,7 +103,9 @@ export function getDomSibling(vnode, childIndex) {
 			// Since updateParentDomPointers keeps _dom pointer correct,
 			// we can rely on _dom to tell us if this subtree contains a
 			// rendered DOM node, and what the first rendered DOM node is
-			return sibling._dom;
+			return typeof sibling.type == 'function'
+				? sibling._nextDom || sibling._dom
+				: sibling._dom;
 		}
 	}
 

--- a/src/component.js
+++ b/src/component.js
@@ -103,9 +103,7 @@ export function getDomSibling(vnode, childIndex) {
 			// Since updateParentDomPointers keeps _dom pointer correct,
 			// we can rely on _dom to tell us if this subtree contains a
 			// rendered DOM node, and what the first rendered DOM node is
-			return typeof sibling.type == 'function'
-				? sibling._nextDom || sibling._dom
-				: sibling._dom;
+			return sibling._nextDom || sibling._dom;
 		}
 	}
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -111,6 +111,7 @@ export function diffChildren(
 			oldVNode = oldChildren[i];
 			if (oldVNode && oldVNode.key == null && oldVNode._dom) {
 				if (oldVNode._dom == oldDom) {
+					oldVNode._parent = oldParentVNode;
 					oldDom = getDomSibling(oldVNode);
 				}
 
@@ -200,6 +201,7 @@ export function diffChildren(
 				(matchingIndex !== skewedIndex ||
 					oldVNode._children === childVNode._children)
 			) {
+				console.log('reorder');
 				oldDom = reorderChildren(childVNode, oldDom, parentDom);
 			} else if (
 				typeof childVNode.type != 'function' &&

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -201,7 +201,6 @@ export function diffChildren(
 				(matchingIndex !== skewedIndex ||
 					oldVNode._children === childVNode._children)
 			) {
-				console.log('reorder');
 				oldDom = reorderChildren(childVNode, oldDom, parentDom);
 			} else if (
 				typeof childVNode.type != 'function' &&

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -677,37 +677,6 @@ describe('Fragment', () => {
 		);
 	});
 
-	it('should preserver order 2', () => {
-		let set;
-		class Foo extends Component {
-			constructor(props) {
-				super(props);
-				this.state = { isLoading: true, data: null };
-				set = this.setState.bind(this);
-			}
-			render(props, { isLoading, data }) {
-				return (
-					<div>
-						<div>HEADER</div>
-						{isLoading ? <div>Loading...</div> : null}
-						{data ? <div>Content: {data}</div> : null}
-					</div>
-				);
-			}
-		}
-
-		render(<Foo />, scratch);
-		expect(scratch.firstChild.innerHTML).to.equal(
-			'<div>HEADER</div><div>Loading...</div>'
-		);
-
-		set({ isLoading: false, data: 2 });
-		rerender();
-		expect(scratch.firstChild.innerHTML).to.equal(
-			'<div>HEADER</div><div>Content: 2</div>'
-		);
-	});
-
 	it('should preserve state with reordering in multiple levels', () => {
 		function Foo({ condition }) {
 			return condition ? (

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -646,6 +646,68 @@ describe('Fragment', () => {
 		expect(scratch.innerHTML).to.equal('<div>Hello</div>');
 	});
 
+	it('should preserver order', () => {
+		let set;
+		class Foo extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { isLoading: true, data: null };
+				set = this.setState.bind(this);
+			}
+			render(props, { isLoading, data }) {
+				return (
+					<Fragment>
+						<div>HEADER</div>
+						{isLoading ? <div>Loading...</div> : null}
+						{data ? <div>Content: {data}</div> : null}
+					</Fragment>
+				);
+			}
+		}
+
+		render(<Foo />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<div>HEADER</div><div>Loading...</div>'
+		);
+
+		set({ isLoading: false, data: 2 });
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div>HEADER</div><div>Content: 2</div>'
+		);
+	});
+
+	it('should preserver order 2', () => {
+		let set;
+		class Foo extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { isLoading: true, data: null };
+				set = this.setState.bind(this);
+			}
+			render(props, { isLoading, data }) {
+				return (
+					<div>
+						<div>HEADER</div>
+						{isLoading ? <div>Loading...</div> : null}
+						{data ? <div>Content: {data}</div> : null}
+					</div>
+				);
+			}
+		}
+
+		render(<Foo />, scratch);
+		expect(scratch.firstChild.innerHTML).to.equal(
+			'<div>HEADER</div><div>Loading...</div>'
+		);
+
+		set({ isLoading: false, data: 2 });
+		rerender();
+		expect(scratch.firstChild.innerHTML).to.equal(
+			'<div>HEADER</div><div>Content: 2</div>'
+		);
+	});
+
 	it('should preserve state with reordering in multiple levels', () => {
 		function Foo({ condition }) {
 			return condition ? (

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -646,7 +646,7 @@ describe('Fragment', () => {
 		expect(scratch.innerHTML).to.equal('<div>Hello</div>');
 	});
 
-	it('should preserver order', () => {
+	it('should preserve order for fragment switching', () => {
 		let set;
 		class Foo extends Component {
 			constructor(props) {
@@ -666,6 +666,79 @@ describe('Fragment', () => {
 		}
 
 		render(<Foo />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<div>HEADER</div><div>Loading...</div>'
+		);
+
+		set({ isLoading: false, data: 2 });
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div>HEADER</div><div>Content: 2</div>'
+		);
+	});
+
+	it('should preserve order for nested fragment switching w/ child return', () => {
+		let set;
+		const Wrapper = ({ children }) => <Fragment>{children}</Fragment>;
+		class Foo extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { isLoading: true, data: null };
+				set = this.setState.bind(this);
+			}
+			render(props, { isLoading, data }) {
+				return (
+					<Fragment>
+						<div>HEADER</div>
+						{isLoading ? <div>Loading...</div> : null}
+						{data ? <div>Content: {data}</div> : null}
+					</Fragment>
+				);
+			}
+		}
+
+		render(
+			<Wrapper>
+				<Foo />
+			</Wrapper>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal(
+			'<div>HEADER</div><div>Loading...</div>'
+		);
+
+		set({ isLoading: false, data: 2 });
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div>HEADER</div><div>Content: 2</div>'
+		);
+	});
+
+	it('should preserve order for nested fragment switching', () => {
+		let set;
+		const Wrapper = () => (
+			<Fragment>
+				<Foo />
+			</Fragment>
+		);
+		class Foo extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { isLoading: true, data: null };
+				set = this.setState.bind(this);
+			}
+			render(props, { isLoading, data }) {
+				return (
+					<Fragment>
+						<div>HEADER</div>
+						{isLoading ? <div>Loading...</div> : null}
+						{data ? <div>Content: {data}</div> : null}
+					</Fragment>
+				);
+			}
+		}
+
+		render(<Wrapper />, scratch);
 		expect(scratch.innerHTML).to.equal(
 			'<div>HEADER</div><div>Loading...</div>'
 		);


### PR DESCRIPTION
When we have a Fragment as the top-level return from a render function we assign the underlying dom-children with the rendering function as their `_parent`. This however means that when we run `getDomSibling` like we do in our `null` placeholder unmount case https://github.com/preactjs/preact/blob/main/src/diff/children.js#L114 that we will move onto the wrapping root-fragment here which can refer to a stale dom-node, in this case we should leverage the potentially set `_nextDom` property to ensure we transfer `oldDom` back into a valid state.

fixes #4123 