### PR TITLE
skip comment nodes for placeChild

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -367,12 +367,11 @@ function insert(parentVNode, oldDom, parentDom) {
 		oldDom = parentVNode._dom;
 	}
 
-	let nextDom = oldDom;
 	do {
-		nextDom = nextDom && nextDom.nextSibling;
-	} while (nextDom != null && nextDom.nodeType === 8);
+		oldDom = oldDom && oldDom.nextSibling;
+	} while (oldDom != null && oldDom.nodeType === 8);
 
-	return nextDom
+	return oldDom;
 }
 
 /**

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -367,7 +367,12 @@ function insert(parentVNode, oldDom, parentDom) {
 		oldDom = parentVNode._dom;
 	}
 
-	return oldDom && oldDom.nextSibling;
+	let nextDom = oldDom;
+	do {
+		nextDom = nextDom && nextDom.nextSibling;
+	} while (nextDom != null && nextDom.nodeType === 8);
+
+	return nextDom
 }
 
 /**

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -50,11 +50,11 @@ describe('hydrate()', () => {
 	beforeEach(() => {
 		scratch = setupScratch();
 		attributesSpy = spyOnElementAttributes();
+		clearLog();
 	});
 
 	afterEach(() => {
 		teardown(scratch);
-		clearLog();
 	});
 
 	it('should reuse existing DOM', () => {
@@ -92,6 +92,7 @@ describe('hydrate()', () => {
 			scratch
 		);
 		expect(scratch.innerHTML).to.equal('<p><i>0</i><b>1</b></p>');
+		expect(getLog()).to.deep.equal(['Comment.remove()']);
 	});
 
 	it('should reuse existing DOM when given components', () => {
@@ -458,5 +459,13 @@ describe('hydrate()', () => {
 		scratch.innerHTML = '<p>hello <!-- c -->foo</p>';
 		hydrate(<p>hello {'foo'}</p>, scratch);
 		expect(scratch.innerHTML).to.equal('<p>hello foo</p>');
+		expect(getLog()).to.deep.equal(['Comment.remove()']);
+	});
+
+	it('should skip over multiple comment nodes', () => {
+		scratch.innerHTML = '<p>hello <!-- a --><!-- b -->foo</p>';
+		hydrate(<p>hello {'foo'}</p>, scratch);
+		expect(scratch.innerHTML).to.equal('<p>hello foo</p>');
+		expect(getLog()).to.deep.equal(['Comment.remove()', 'Comment.remove()']);
 	});
 });


### PR DESCRIPTION
Supersedes #3771
Enables https://github.com/preactjs/preact-render-to-string/pull/296

currently the comment-nodes that we use so our custom-element can attach the new dom in the right place gets removed during hydration and gets a few `insertBefore`, ... You can try this branch out in a streaming renderer scenario by

- checking out https://github.com/preactjs/preact-render-to-string/pull/296
- going to the `demo` folder in RTS
- running `npm i`
- building Preact on this branch
- pasting in the `/dist` into `demo/node_modules/preact`
- `npm run dev` in RTS