### PR TITLE
feat: Add `SetStateAction` & `PropsWithoutRef` types to compat

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -19,7 +19,7 @@ declare namespace React {
 	export import Reducer = _hooks.Reducer;
 	export import Dispatch = _hooks.Dispatch;
 	export import Ref = _hooks.Ref;
-	export import StateUpdater = _hooks.StateUpdater;
+	export import SetStateAction = _hooks.StateUpdater;
 	export import useCallback = _hooks.useCallback;
 	export import useContext = _hooks.useContext;
 	export import useDebugValue = _hooks.useDebugValue;
@@ -155,7 +155,9 @@ declare namespace React {
 
 	export function forwardRef<R, P = {}>(
 		fn: ForwardFn<P, R>
-	): preact.FunctionalComponent<Omit<P, 'ref'> & { ref?: preact.Ref<R> }>;
+	): preact.FunctionalComponent<PropsWithoutRef<P> & { ref?: preact.Ref<R> }>;
+
+	export type PropsWithoutRef<P> = Omit<P, 'ref'>;
 
 	interface MutableRefObject<T> {
 		current: T;


### PR DESCRIPTION
Closes #4131
Closes #4124 

---

[React's `SetStateAction`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d7179600ae784fd9cd291dad48d4da2437716b79/types/react/index.d.ts#L899) vs [our `StateUpdater`](https://github.com/preactjs/preact/blob/7748dcb83cedd02e37b3713634e35b97b26028fd/hooks/src/index.d.ts#L5). I elected to replace `StateUpdater`'s export as it was never a type offered by React -- I believe this was simply a mistake that we missed, it always should've been re-exported as `SetStateAction`. If the breaking change is a concern I'll be happy to revert but I don't imagine it's seeing any use.

[React's `PropsWithoutRef`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/05094b6df4fb6f4404333725f13d63dd8aabeb34/types/react/index.d.ts#L825-L830) is a bit more complex than what we've been using (as it's used for `forwardRef`'s types), but seeing as how we have no issues in our tracker as far as I can tell, I chose to keep using our (perhaps naive) version for now. Can change if desired though.