### PR TITLE
chore: Update link & verbiage for reproduction in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,7 +13,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 
-If possible, please provide a CodeSandbox/Codepen that demonstrates the issue. You can use the following template: https://codesandbox.io/s/preact-x-preact-cli-3-starter-vj285y2rn3
+If possible, please provide a link to a StackBlitz/CodeSandbox/Codepen project or a GitHub repository that demonstrates the issue. You can use the following template on StackBlitz to get started: https://stackblitz.com/edit/create-preact-starter
 
 Steps to reproduce the behavior:
 


### PR DESCRIPTION
This is the result of a plain `create-preact` project initialization.

I figured the fewer the files the better, as it would (hopefully) result in cleaner repros, so I cut out the routing. I do have a [separate template](https://stackblitz.com/edit/create-preact-starter-routing) if we want to keep that around though, I'm not opinionated. Same thing goes for ESLint, figured the faster startup time might be preferable but happy to add it in too if we want it.