### PR TITLE
fix: remove `role` attribute when it's `null` or `undefined`

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -123,6 +123,7 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 			name !== 'download' &&
 			name !== 'rowSpan' &&
 			name !== 'colSpan' &&
+			name !== 'role' &&
 			name in dom
 		) {
 			try {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1282,6 +1282,7 @@ describe('render()', () => {
 		expect(scratch.firstChild.tabIndex).to.equal(defaultValue);
 	});
 
+	// #4137
 	it('should unset role if null || undefined', () => {
 		render(
 			<section>

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1281,4 +1281,20 @@ describe('render()', () => {
 		render(<div tabindex={null} />, scratch);
 		expect(scratch.firstChild.tabIndex).to.equal(defaultValue);
 	});
+
+	it('should unset role if null || undefined', () => {
+		render(
+			<section>
+				<div role="status">role="status"</div>
+				<div role={undefined}>role="undefined"</div>
+				<div role={null}>role="null"</div>
+			</section>,
+			scratch
+		);
+
+		const divs = scratch.querySelectorAll('div');
+		expect(divs[0].hasAttribute('role')).to.equal(true);
+		expect(divs[1].hasAttribute('role')).to.equal(false);
+		expect(divs[2].hasAttribute('role')).to.equal(false);
+	});
 });


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/4136.

Most browsers now implement the attributes defined in the [ARIAMixin interface](https://www.w3.org/TR/wai-aria-1.2/#ARIAMixin), which includes [`Element.role`](https://caniuse.com/mdn-api_element_role). In such a case, the current code assigns an empty string to the `role` property when it's `null` or `undefined` instead of removing it.

This PR prevents that so the `role` prop can be removed as normal.

