### PR TITLE
suspense fix: Cannot read property 'insertBefore' of undefined

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -70,7 +70,7 @@ function detachedClone(vnode, detachedParent, parentDom) {
 }
 
 function removeOriginal(vnode, detachedParent, originalParent) {
-	if (vnode) {
+	if (vnode && originalParent) {
 		vnode._original = null;
 		vnode._children =
 			vnode._children &&

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -2102,13 +2102,7 @@ describe('suspense', () => {
 	});
 
 	it('originalParent undefined should not crash', () => {
-		const C = lazy(async () => {
-			await new Promise(r => setTimeout(r, 1000));
-			const Comp = () => <p>hello world</p>;
-			return {
-				default: Comp
-			};
-		});
+		const [Lazy, resolveLazy] = createLazy();
 
 		const App = () => {
 			const [, setTest] = useState(false);
@@ -2117,12 +2111,19 @@ describe('suspense', () => {
 			return (
 				<Suspense fallback={<div />}>
 					<div>
-						<C />
+						<Lazy />
 					</div>
 				</Suspense>
 			);
 		};
 
 		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal('<div></div>');
+		rerender();
+
+		return resolveLazy(() => <p>hello world</p>).then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.equal('<div><p>hello world</p></div>');
+		});
 	});
 });

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -2101,7 +2101,7 @@ describe('suspense', () => {
 		});
 	});
 
-	it('originalParent undefined should not crash', () => {
+	it('should not crash if fallback has same DOM as suspended nodes', () => {
 		const [Lazy, resolveLazy] = createLazy();
 
 		const App = () => {

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -2100,4 +2100,29 @@ describe('suspense', () => {
 			expect(scratch.innerHTML).to.eql(`<p>hello new world</p>`);
 		});
 	});
+
+	it('originalParent undefined should not crash', () => {
+		const C = lazy(async () => {
+			await new Promise(r => setTimeout(r, 1000));
+			const Comp = () => <p>hello world</p>;
+			return {
+				default: Comp
+			};
+		});
+
+		const App = () => {
+			const [, setTest] = useState(false);
+			useLayoutEffect(() => setTest(true), []);
+
+			return (
+				<Suspense fallback={<div />}>
+					<div>
+						<C />
+					</div>
+				</Suspense>
+			);
+		};
+
+		render(<App />, scratch);
+	});
 });


### PR DESCRIPTION
Please see #3149 & #3105 for context. 

Migrating from React to Preact, our suspense boundaries are failing everywhere with this problem still on latest Preact. 

Looking into those specific issues and not finding a solution that worked, I delved into the `suspense.js` file and played around. The only solution I could find was adding a check for `originalParent` at the top level of `removeOriginal()`. 

I've created a test from the repro in #3149, their way was the only way i could find to simply reproduce.

The change to `suspense.js` fixes the test. 

I'm currently patching preact dist code with this change to make our app work, if this change is wrong and can't be merged, any way of getting round the problem would be greatly appreciated, it's the only thing I've found to work!