### PR TITLE
Fix: "Improper nesting of paragraph" for span under a paragraph

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -489,7 +489,7 @@ function isTableElement(type) {
 }
 
 const ILLEGAL_PARAGRAPH_CHILD_ELEMENTS =
-	/address|article|aside|blockquote|details|div|dl|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|header|hgroup|hr|main|menu|nav|ol|p|pre|search|section|table|ul/;
+	/^(address|article|aside|blockquote|details|div|dl|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|header|hgroup|hr|main|menu|nav|ol|p|pre|search|section|table|ul)$/;
 
 const forceUpdate = Component.prototype.forceUpdate;
 Component.prototype.forceUpdate = function (callback) {

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -581,6 +581,17 @@ describe('debug', () => {
 			render(<Paragraph />, scratch);
 			expect(console.error).to.be.calledOnce;
 		});
+
+		it('should not warn for nesting span under a paragraph', () => {
+			const Paragraph = () => (
+				<p>
+					<span>Hello world</span>
+				</p>
+			);
+
+			render(<Paragraph />, scratch);
+			expect(console.error).to.not.be.called;
+		});
 	});
 
 	describe('PropTypes', () => {


### PR DESCRIPTION
I upgraded to Preact v10.18.0 and got quite a number of warnings. There's one warning that seems wrong:

```
Improper nesting of paragraph. Your <p> should not have span as child-elements.
```

I looked at the code and the regex is:

```
/address|article|aside|blockquote|details|div|dl|fieldset|figcaption|figure|footer|form|h1|h2|h3|h4|h5|h6|header|hgroup|hr|main|menu|nav|ol|p|pre|search|section|table|ul/
```

Testing it on browser console:

![Screenshot 2023-09-29 at 12 19 28 PM](https://github.com/preactjs/preact/assets/2296/4641e07e-a856-4fee-9e2d-ec0719db5726)

Turns out it returns true because `span` contains `p` 🫣

Changes made:
- Add start, end and round brackets to regex so that it does exact matching.
  - I'm not sure if the non-exact matching was intentional, but I ran the tests (`npm run test:karma`), everything seems passing.
- Add test specifically for span under a paragraph.
  - There could be other tags that might be wrongly matched, but as of now, I only know `span` has this issue.