### PR TITLE
10.18.1

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -2,7 +2,7 @@ import { options, Fragment, Component } from 'preact';
 
 export function initDevTools() {
 	if (typeof window != 'undefined' && window.__PREACT_DEVTOOLS__) {
-		window.__PREACT_DEVTOOLS__.attachPreact('10.18.0', options, {
+		window.__PREACT_DEVTOOLS__.attachPreact('10.18.1', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "10.18.0",
+  "version": "10.18.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "10.18.0",
+      "version": "10.18.1",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.18.0",
+  "version": "10.18.1",
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
## Fixes

- Avoid crashing when there is no _children (#4147, thanks @JoviDeCroock)
- Fix regex for "Improper nesting of paragraph" for span under a paragraph (#4144, thanks @cheeaun)    