### PR TITLE
Add support for new String() as a child

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -69,7 +69,7 @@ export function diffChildren(
 		// or we are rendering a component (e.g. setState) copy the oldVNodes so it can have
 		// it's own DOM & etc. pointers
 		else if (
-			typeof childVNode == 'string' ||
+			childVNode.constructor === String ||
 			typeof childVNode == 'number' ||
 			// eslint-disable-next-line valid-typeof
 			typeof childVNode == 'bigint'

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -533,6 +533,18 @@ describe('Components', () => {
 		expect(scratch.innerHTML).to.equal('42');
 	});
 
+	it('should render a new String()', () => {
+		class ConstructedStringComponent extends Component {
+			render() {
+				/* eslint-disable no-new-wrappers */
+				return new String('Hi from a constructed string!');
+			}
+		}
+
+		render(<ConstructedStringComponent />, scratch);
+		expect(scratch.innerHTML).to.equal('Hi from a constructed string!');
+	});
+
 	it('should render null as empty string', () => {
 		class NullComponent extends Component {
 			render() {


### PR DESCRIPTION
```typescript
'abc'.constructor === String
```

Therefore, testing the constructor is a more inclusive way of finding strings.  It allows `new String('hi')` and `'hi'` to be treated equally.

Note: this improves [interchangability with React](https://colab.research.google.com/gist/appsforartists/21d0171efedf3f1193fe2d750747f28a/preact-vs-react-rendering-string-objects.ipynb).

Fixes #4151