### PR TITLE
golf: Switch `===` to `==` in a few places where not needed

### DIFF
--- a/src/create-element.js
+++ b/src/create-element.js
@@ -95,4 +95,4 @@ export function Fragment(props) {
  * @returns {vnode is import('./internal').VNode}
  */
 export const isValidElement = vnode =>
-	vnode != null && vnode.constructor === undefined;
+	vnode != null && vnode.constructor == undefined;

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -69,7 +69,7 @@ export function diffChildren(
 		// or we are rendering a component (e.g. setState) copy the oldVNodes so it can have
 		// it's own DOM & etc. pointers
 		else if (
-			childVNode.constructor === String ||
+			childVNode.constructor == String ||
 			typeof childVNode == 'number' ||
 			// eslint-disable-next-line valid-typeof
 			typeof childVNode == 'bigint'

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -140,7 +140,7 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 		// amount of exceptions would cost too many bytes. On top of
 		// that other frameworks generally stringify `false`.
 
-		if (typeof value === 'function') {
+		if (typeof value == 'function') {
 			// never serialize functions as attribute values
 		} else if (value != null && (value !== false || name[4] === '-')) {
 			dom.setAttribute(name, value);

--- a/src/render.js
+++ b/src/render.js
@@ -18,7 +18,7 @@ export function render(vnode, parentDom, replaceNode) {
 	// We abuse the `replaceNode` parameter in `hydrate()` to signal if we are in
 	// hydration mode or not by passing the `hydrate` function instead of a DOM
 	// element..
-	let isHydrating = typeof replaceNode === 'function';
+	let isHydrating = typeof replaceNode == 'function';
 
 	// To be able to support calling `render()` multiple times on the same
 	// DOM node, we need to obtain a reference to the previous tree. We do


### PR DESCRIPTION
Sort of a follow-up to #4152, I don't believe there's a need for `===` in `.constructor` or `typeof` checks, and locally I saw a 3-4 byte reduction that I'd like to check.