### PR TITLE
fix vnode type coercion

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -195,9 +195,8 @@ export function createElement(
 		| null,
 	...children: ComponentChildren[]
 ): VNode<
-	| (JSXInternal.DOMAttributes<HTMLInputElement> &
-			ClassAttributes<HTMLInputElement>)
-	| null
+	| JSXInternal.DOMAttributes<HTMLInputElement> &
+			ClassAttributes<HTMLInputElement>
 >;
 export function createElement<
 	P extends JSXInternal.HTMLAttributes<T>,
@@ -206,7 +205,7 @@ export function createElement<
 	type: keyof JSXInternal.IntrinsicElements,
 	props: (ClassAttributes<T> & P) | null,
 	...children: ComponentChildren[]
-): VNode<(ClassAttributes<T> & P) | null>;
+): VNode<ClassAttributes<T> & P>;
 export function createElement<
 	P extends JSXInternal.SVGAttributes<T>,
 	T extends HTMLElement
@@ -214,7 +213,7 @@ export function createElement<
 	type: keyof JSXInternal.IntrinsicElements,
 	props: (ClassAttributes<T> & P) | null,
 	...children: ComponentChildren[]
-): VNode<(ClassAttributes<T> & P) | null>;
+): VNode<ClassAttributes<T> & P>;
 export function createElement<T extends HTMLElement>(
 	type: string,
 	props:
@@ -243,9 +242,8 @@ export function h(
 		| null,
 	...children: ComponentChildren[]
 ): VNode<
-	| (JSXInternal.DOMAttributes<HTMLInputElement> &
-			ClassAttributes<HTMLInputElement>)
-	| null
+	| JSXInternal.DOMAttributes<HTMLInputElement> &
+			ClassAttributes<HTMLInputElement>
 >;
 export function h<
 	P extends JSXInternal.HTMLAttributes<T>,
@@ -254,7 +252,7 @@ export function h<
 	type: keyof JSXInternal.IntrinsicElements,
 	props: (ClassAttributes<T> & P) | null,
 	...children: ComponentChildren[]
-): VNode<(ClassAttributes<T> & P) | null>;
+): VNode<ClassAttributes<T> & P>;
 export function h<
 	P extends JSXInternal.SVGAttributes<T>,
 	T extends HTMLElement
@@ -262,7 +260,7 @@ export function h<
 	type: keyof JSXInternal.IntrinsicElements,
 	props: (ClassAttributes<T> & P) | null,
 	...children: ComponentChildren[]
-): VNode<(ClassAttributes<T> & P) | null>;
+): VNode<ClassAttributes<T> & P>;
 export function h<T extends HTMLElement>(
 	type: string,
 	props:
@@ -281,7 +279,7 @@ export function h<P>(
 	type: ComponentType<P>,
 	props: (Attributes & P) | null,
 	...children: ComponentChildren[]
-): VNode<(Attributes & P) | null>;
+): VNode<Attributes & P>;
 export namespace h {
 	export import JSX = JSXInternal;
 }

--- a/test/ts/VNode-test.tsx
+++ b/test/ts/VNode-test.tsx
@@ -39,9 +39,15 @@ describe('VNode TS types', () => {
 		expect(actual).to.include.all.keys('type', 'props', 'key');
 	});
 
-	it('has a nodeName of string when html element', () => {
-		const div = <div>Hi!</div>;
-		expect(div.type).to.equal('div');
+	it('is returned by h', () => {
+		const actual = <div className="wow" />;
+		expect(actual).to.include.all.keys('type', 'props', 'key');
+	});
+
+	it('createElement conforms to the VNode type', () => {
+		const arr: VNode[] = [];
+		arr.push(createElement('div', null));
+		expect(true).to.be.true;
 	});
 
 	it('has a nodeName equal to the construction function when SFC', () => {


### PR DESCRIPTION
fixes #4154 

I am not sure what this `| null` is for but it looks like this refers to the props generic which shouldn't be set to null imho