### PR TITLE
fix(child-diffing): bail out should be wary of differing children lengths

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -115,7 +115,6 @@ export function diffChildren(
 					oldDom = getDomSibling(oldVNode);
 				}
 
-				console.log('unmounting', i);
 				unmount(oldVNode, oldVNode, false);
 				oldChildren[i] = null;
 			}
@@ -200,14 +199,9 @@ export function diffChildren(
 			if (
 				typeof childVNode.type == 'function' &&
 				(matchingIndex !== skewedIndex ||
-					oldVNode._children === childVNode._children)
+					(oldVNode._children === childVNode._children &&
+						oldChildrenLength <= newChildrenLength))
 			) {
-				console.log(
-					'reordering',
-					matchingIndex !== skewedIndex,
-					oldVNode._children === childVNode._children
-				);
-				console.log(childVNode._dom, oldDom, parentDom);
 				oldDom = reorderChildren(childVNode, oldDom, parentDom);
 			} else if (
 				typeof childVNode.type != 'function' &&
@@ -259,7 +253,6 @@ export function diffChildren(
 				newParentVNode._nextDom = oldChildren[i]._dom.nextSibling;
 			}
 
-			console.log('unmounting', i);
 			unmount(oldChildren[i], oldChildren[i]);
 		}
 	}
@@ -282,7 +275,6 @@ function reorderChildren(childVNode, oldDom, parentDom) {
 			if (typeof vnode.type == 'function') {
 				oldDom = reorderChildren(vnode, oldDom, parentDom);
 			} else {
-				console.log('placing child', parentDom, vnode._dom, oldDom);
 				oldDom = placeChild(parentDom, vnode._dom, oldDom);
 			}
 		}

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -115,6 +115,7 @@ export function diffChildren(
 					oldDom = getDomSibling(oldVNode);
 				}
 
+				console.log('unmounting', i);
 				unmount(oldVNode, oldVNode, false);
 				oldChildren[i] = null;
 			}
@@ -201,6 +202,12 @@ export function diffChildren(
 				(matchingIndex !== skewedIndex ||
 					oldVNode._children === childVNode._children)
 			) {
+				console.log(
+					'reordering',
+					matchingIndex !== skewedIndex,
+					oldVNode._children === childVNode._children
+				);
+				console.log(childVNode._dom, oldDom, parentDom);
 				oldDom = reorderChildren(childVNode, oldDom, parentDom);
 			} else if (
 				typeof childVNode.type != 'function' &&
@@ -252,6 +259,7 @@ export function diffChildren(
 				newParentVNode._nextDom = oldChildren[i]._dom.nextSibling;
 			}
 
+			console.log('unmounting', i);
 			unmount(oldChildren[i], oldChildren[i]);
 		}
 	}
@@ -274,6 +282,7 @@ function reorderChildren(childVNode, oldDom, parentDom) {
 			if (typeof vnode.type == 'function') {
 				oldDom = reorderChildren(vnode, oldDom, parentDom);
 			} else {
+				console.log('placing child', parentDom, vnode._dom, oldDom);
 				oldDom = placeChild(parentDom, vnode._dom, oldDom);
 			}
 		}

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1106,7 +1106,7 @@ describe('render()', () => {
 		]);
 	});
 
-	it.only('should not remove iframe with memoized components', () => {
+	it('should not remove iframe with memoized components', () => {
 		function renderLeaf(props) {
 			if (props.text === '') {
 				return null;


### PR DESCRIPTION
fixes #4156 

When we encounter a bailout scenario where a VNode `_children` are equal across renders we should only reorder the children when the items could have shifted, this can only happen when the list grows or shrinks... Thinking more about this, in theory a list could shrink while shifting an element to the bottom...

EDIT: the above is correct, when changing the test to switch between the following two values, the issue re-surfaces

```
		const value = [
			{
				id: 1,
				type: 'h2',
				children: [{ text: 'foo' }]
			},
			{
				id: 2,
				type: 'paragraph',
				children: [{ text: 'hello world' }]
			},
			{
				id: 3,
				type: 'iframe',
				url: 'https://codesandbox.io/embed/sweet-haze-6izou?fontsize=14&hidenavigation=1&theme=dark',
				children: [{ text: '' }]
			}
		];

		const value2 = [
			{
				id: 1,
				type: 'h2',
				children: [{ text: 'foo' }]
			},
			{
				id: 3,
				type: 'iframe',
				url: 'https://codesandbox.io/embed/sweet-haze-6izou?fontsize=14&hidenavigation=1&theme=dark',
				children: [{ text: '' }]
			},
			{
				id: 4,
				type: 'h2',
				children: [{ text: 'foo' }]
			}
		];
```

The root cause of this issue is that we aren't using placeholders and hence aren't detecting that item[0] is gone, from a DOM point of view we see the dom of [0] in oldChildren and the dom of [1] in newChildren and hence it thinks they have switched positions so we perform an insertBefore.