### PR TITLE
fix: prevent invalid DOM nesting false positives

### DIFF
--- a/debug/test/browser/component-stack.test.js
+++ b/debug/test/browser/component-stack.test.js
@@ -79,7 +79,7 @@ describe('component stack', () => {
 		render(<Bar />, scratch);
 
 		let lines = getStack(errors).split('\n');
-		expect(lines[0].indexOf('td') > -1).to.equal(true);
+		expect(lines[0].indexOf('tr') > -1).to.equal(true);
 		expect(lines[1].indexOf('Thrower') > -1).to.equal(true);
 		expect(lines[2].indexOf('Bar') > -1).to.equal(true);
 	});

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -355,9 +355,11 @@ describe('debug', () => {
 	describe('table markup', () => {
 		it('missing <tbody>/<thead>/<tfoot>/<table>', () => {
 			const Table = () => (
-				<tr>
-					<td>hi</td>
-				</tr>
+				<div>
+					<tr>
+						<td>hi</td>
+					</tr>
+				</div>
 			);
 			render(<Table />, scratch);
 			expect(console.error).to.be.calledOnce;
@@ -365,11 +367,13 @@ describe('debug', () => {
 
 		it('missing <table> with <thead>', () => {
 			const Table = () => (
-				<thead>
-					<tr>
-						<td>hi</td>
-					</tr>
-				</thead>
+				<div>
+					<thead>
+						<tr>
+							<td>hi</td>
+						</tr>
+					</thead>
+				</div>
 			);
 			render(<Table />, scratch);
 			expect(console.error).to.be.calledOnce;
@@ -377,11 +381,13 @@ describe('debug', () => {
 
 		it('missing <table> with <tbody>', () => {
 			const Table = () => (
-				<tbody>
-					<tr>
-						<td>hi</td>
-					</tr>
-				</tbody>
+				<div>
+					<tbody>
+						<tr>
+							<td>hi</td>
+						</tr>
+					</tbody>
+				</div>
 			);
 			render(<Table />, scratch);
 			expect(console.error).to.be.calledOnce;
@@ -389,11 +395,13 @@ describe('debug', () => {
 
 		it('missing <table> with <tfoot>', () => {
 			const Table = () => (
-				<tfoot>
-					<tr>
-						<td>hi</td>
-					</tr>
-				</tfoot>
+				<div>
+					<tfoot>
+						<tr>
+							<td>hi</td>
+						</tr>
+					</tfoot>
+				</div>
 			);
 			render(<Table />, scratch);
 			expect(console.error).to.be.calledOnce;


### PR DESCRIPTION
When Preact is rendering into a container in the middle of the page we attempted to walk outside the render root via the DOM tree. Problem is that that doesn't work on the server where there is no DOM, which lead to us spamming the terminal with false positive warnings.

So this skips the DOM validation if we reach the render root and thereby partially reverts https://github.com/preactjs/preact/pull/4043 . For SPAs this should work as the offending elements very likely have another DOM parent node anyway. For rendering into an existing DOM tree, this skips validation if we reach the render root eagerly. This seems like an ok tradeoff to make.

Fixes https://github.com/denoland/fresh/issues/1773, fixes https://github.com/preactjs/preact-render-to-string/issues/320