### PR TITLE
Update `contentEditable` attribute values

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -2118,8 +2118,13 @@ export namespace JSXInternal {
 		colSpan?: number | undefined | SignalLike<number | undefined>;
 		colspan?: number | undefined | SignalLike<number | undefined>;
 		content?: string | undefined | SignalLike<string | undefined>;
-		contentEditable?: boolean | undefined | SignalLike<boolean | undefined>;
-		contenteditable?: boolean | undefined | SignalLike<boolean | undefined>;
+		contentEditable?:
+			| Booleanish
+			| ''
+			| 'plaintext-only'
+			| undefined
+			| SignalLike<Booleanish | '' | 'plaintext-only' | undefined>;
+		contenteditable?: HTMLAttributes['contentEditable'];
 		/** @deprecated See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contextmenu */
 		contextMenu?: string | undefined | SignalLike<string | undefined>;
 		/** @deprecated See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contextmenu */


### PR DESCRIPTION
The `contenteditable` content attribute is an [enumerated attribute](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute) whose keywords are the empty string, `true`, `plaintext-only` and `false`. 

https://html.spec.whatwg.org/multipage/interaction.html#contenteditable

```ts
contenteditable?: '' | 'true' | 'false' | 'plaintext-only';
```