### PR TITLE
Add `elementTiming` attribute/property

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -2176,6 +2176,8 @@ export namespace JSXInternal {
 					| 'send'
 					| undefined
 			  >;
+		elementTiming?: string | undefined | SignalLike<string | undefined>;
+		elementtiming?: HTMLAttributes['elementTiming'];
 		for?: string | undefined | SignalLike<string | undefined>;
 		form?: string | undefined | SignalLike<string | undefined>;
 		formAction?: string | undefined | SignalLike<string | undefined>;


### PR DESCRIPTION
HTML `elementtiming` attribute - https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/elementtiming
Element `elementTiming` property - https://developer.mozilla.org/en-US/docs/Web/API/Element/elementTiming