### PR TITLE
Use copied VNode as newVNode instead of oldVNode when rerendering

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -120,39 +120,35 @@ export function getDomSibling(vnode, childIndex) {
  * @param {Component} component The component to rerender
  */
 function renderComponent(component) {
-	let vnode = component._vnode,
-		oldDom = vnode._dom,
+	let oldVNode = component._vnode,
+		oldDom = oldVNode._dom,
 		parentDom = component._parentDom;
 
 	if (parentDom) {
 		let commitQueue = [],
 			refQueue = [];
-		const oldVNode = assign({}, vnode);
-		oldVNode._original = vnode._original + 1;
 
-		if (oldVNode._children) {
-			oldVNode._children.forEach(child => {
-				if (child) child._parent = oldVNode;
-			});
-		}
+		const newVNode = assign({}, oldVNode);
+		newVNode._original = oldVNode._original + 1;
 
 		diff(
 			parentDom,
-			vnode,
+			newVNode,
 			oldVNode,
 			component._globalContext,
 			parentDom.ownerSVGElement !== undefined,
-			vnode._hydrating != null ? [oldDom] : null,
+			oldVNode._hydrating != null ? [oldDom] : null,
 			commitQueue,
-			oldDom == null ? getDomSibling(vnode) : oldDom,
-			vnode._hydrating,
+			oldDom == null ? getDomSibling(oldVNode) : oldDom,
+			oldVNode._hydrating,
 			refQueue
 		);
 
-		commitRoot(commitQueue, vnode, refQueue);
+		newVNode._parent._children[newVNode._index] = newVNode;
+		commitRoot(commitQueue, newVNode, refQueue);
 
-		if (vnode._dom != oldDom) {
-			updateParentDomPointers(vnode);
+		if (newVNode._dom != oldDom) {
+			updateParentDomPointers(newVNode);
 		}
 	}
 }


### PR DESCRIPTION
As described to in #4170, when rerendering components, we copy the component's VNode to diff against. Currently we use this copy as the oldVNode. One problem with that approach is that the copy no longer exists in the parent component's child array, so attempts to navigate around the tree using the oldVNode may break if functions like `indexOf` are used.

This PR changes how we do rerendering so that the copied VNode is used as the newVNode and the existing VNode is used as the oldVNode. This preserves all the links (children arrays and parent pointers) while we perform the diff.

Stated another way, this mechanism more closely matches how we typically render, where a new element is created with `createElement`. That new element starts as the newVNode and after diffing is attached to the tree (i.e. added to its parent child array). This new approach mirrors that by adding the newVNode to it's parent array at the right index after rerendering.