### PR TITLE
Improve place child

### DIFF
--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -308,7 +308,9 @@ describe('suspense', () => {
 
 		const FuncWrapper = props => <div id="func-wrapper">{props.children}</div>;
 
-		const [Suspender, suspend] = createSuspender(() => <div>Hello</div>);
+		const [Suspender, suspend] = createSuspender(() => (
+			<div id="initial-contents">Hello</div>
+		));
 
 		render(
 			<Suspense fallback={<div>Suspended...</div>}>
@@ -322,7 +324,7 @@ describe('suspense', () => {
 		);
 
 		expect(scratch.innerHTML).to.eql(
-			`<div id="class-wrapper"><div id="func-wrapper"><div>Hello</div></div></div>`
+			`<div id="class-wrapper"><div id="func-wrapper"><div id="initial-contents">Hello</div></div></div>`
 		);
 
 		const [resolve] = suspend();
@@ -330,10 +332,10 @@ describe('suspense', () => {
 
 		expect(scratch.innerHTML).to.eql(`<div>Suspended...</div>`);
 
-		return resolve(() => <div>Hello2</div>).then(() => {
+		return resolve(() => <div id="resolved-contents">Hello2</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(
-				`<div id="class-wrapper"><div id="func-wrapper"><div>Hello2</div></div></div>`
+				`<div id="class-wrapper"><div id="func-wrapper"><div id="resolved-contents">Hello2</div></div></div>`
 			);
 		});
 	});

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -322,9 +322,12 @@ export function toChildArray(children, out) {
  * @returns {PreactElement}
  */
 function placeChild(parentDom, newDom, oldDom) {
+	// TODO: How do we enter here when oldDom isn't in parentDom? We should fix
+	// that such that it never happens. Changing `oldDom.parentNode !== parentDom`
+	// to `!oldDom.isConnected` also passes our test suite.
 	if (oldDom == null || oldDom.parentNode !== parentDom) {
 		parentDom.insertBefore(newDom, null);
-	} else if (newDom != oldDom || newDom.parentNode == null) {
+	} else if (newDom != oldDom) {
 		parentDom.insertBefore(newDom, oldDom);
 	}
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -328,13 +328,8 @@ export function toChildArray(children, out) {
  * @returns {PreactElement}
  */
 function placeChild(parentDom, newDom, oldDom) {
-	// TODO: How do we enter here when oldDom isn't in parentDom? We should fix
-	// that such that it never happens. Changing `oldDom.parentNode !== parentDom`
-	// to `!oldDom.isConnected` also passes our test suite.
-	if (oldDom == null || oldDom.parentNode !== parentDom) {
-		parentDom.insertBefore(newDom, null);
-	} else if (newDom != oldDom) {
-		parentDom.insertBefore(newDom, oldDom);
+	if (newDom != oldDom) {
+		parentDom.insertBefore(newDom, oldDom || null);
 	}
 
 	return newDom.nextSibling;


### PR DESCRIPTION
NOTE: Might be easier to review by adding `?w=1` to the URL

When unmounting DOM, we need to move `oldDom`/`_nextDom` past the unmounted DOM so the diff can continue by comparing the next VNodes to DOM nodes that are mounted. We did this in the unmount loop but we missed a couple other places where this needs to happen as well.

Let's say we have the following components:
```jsx
function Conditional({ condition }) {
  return condition ? (
      <>
        <p>2</p>
        <p>3</p>
      </>
    ) : null;
  }

function App() { return <>... <Conditional/> ... </>; }
```

Here, Conditional will switch from a group of DOM nodes and `null`. When doing this, diffChildren would hit our null placeholder code which does update oldDom past the unmounted DOM, but it doesn't update `_nextDom`, so `App` wouldn't see this move and try to continue diffing from an unmounted DOM node.

Further, even if we set `_nextDOM`, diffChildren on App wouldn't see it because `Conditional` returned `null`. Since Conditional returned `null`, it would return `null` for `newDom`,  meaning diffChildren on App would skip over all the code that was previously under a `if (newDom)` check, including the code that reads `_nextDom`. This PR also fixes that issue so even if a component returns `null`, we update the skewed index, and will read `_nextDom` if necessary.

Also, the test "should efficiently unmount & mount components that conditionally return null with null first child" contains an additional edge case where Conditional switching to null, matches it's previous null first child. We need to ensure we detect we still need to move oldDom and update `_nextDom`.

Previously we attempted to handle all of these cases by checking `oldDom.parentNode !== parentDom` in `placeChild`. However, in our entire test case, this was only occurred when oldDom was unmounted. So this update prevents unmounted oldDom from ever reaching `placeChild` removing the need for that condition entirely, dramatically simplifying `placeChild`.