### PR TITLE
Improve internal JSDoc types

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -84,23 +84,23 @@ declare namespace React {
 
 	export function createPortal(
 		vnode: preact.VNode,
-		container: Element | DocumentFragment
+		container: preact.ContainerNode
 	): preact.VNode<any>;
 
 	export function render(
 		vnode: preact.VNode<any>,
-		parent: Element,
+		parent: preact.ContainerNode,
 		callback?: () => void
 	): Component | null;
 
 	export function hydrate(
 		vnode: preact.VNode<any>,
-		parent: Element,
+		parent: preact.ContainerNode,
 		callback?: () => void
 	): Component | null;
 
 	export function unmountComponentAtNode(
-		container: Element | Document | ShadowRoot | DocumentFragment
+		container: preact.ContainerNode
 	): boolean;
 
 	export function createFactory(

--- a/compat/test/ts/index.tsx
+++ b/compat/test/ts/index.tsx
@@ -1,0 +1,17 @@
+import React from '../../src';
+
+React.render(<div />, document.createElement('div'));
+React.render(<div />, document.createDocumentFragment());
+React.render(<div />, document.body.shadowRoot!);
+
+React.hydrate(<div />, document.createElement('div'));
+React.hydrate(<div />, document.createDocumentFragment());
+React.hydrate(<div />, document.body.shadowRoot!);
+
+React.unmountComponentAtNode(document.createElement('div'));
+React.unmountComponentAtNode(document.createDocumentFragment());
+React.unmountComponentAtNode(document.body.shadowRoot!);
+
+React.createPortal(<div />, document.createElement('div'));
+React.createPortal(<div />, document.createDocumentFragment());
+React.createPortal(<div />, document.body.shadowRoot!);

--- a/jsconfig-lint.json
+++ b/jsconfig-lint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./jsconfig.json",
+  "include": ["src/**/*"]
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,15 +3,17 @@
     "baseUrl": ".",
     "checkJs": true,
     "jsx": "react",
+    "jsxFactory": "createElement",
+    "jsxFragmentFactory": "Fragment",
     "lib": ["dom", "es5"],
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "paths": {
       "preact": ["."],
       "preact/*": ["./*"]
     },
-    "reactNamespace": "createElement",
     "target": "es5",
     "noEmit": true
   },
-  "exclude": ["node_modules", "dist", "demo"]
+  "exclude": ["**/node_modules/**", "**/dist/**", "**/coverage/**", "demo"]
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -10,7 +10,8 @@
       "preact/*": ["./*"]
     },
     "reactNamespace": "createElement",
-    "target": "es5"
+    "target": "es5",
+    "noEmit": true
   },
   "exclude": ["node_modules", "dist", "demo"]
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -15,5 +15,5 @@
     "target": "es5",
     "noEmit": true
   },
-  "exclude": ["node_modules", "dist", "coverage", "demo"]
+  "exclude": ["**/node_modules/**", "**/dist/**", "coverage", "demo"]
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -15,5 +15,5 @@
     "target": "es5",
     "noEmit": true
   },
-  "exclude": ["**/node_modules/**", "**/dist/**", "**/coverage/**", "demo"]
+  "exclude": ["node_modules", "dist", "coverage", "demo"]
 }

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "test:karma:bench": "cross-env PERFORMANCE=true COVERAGE=false BABEL_NO_MODULES=true karma start karma.conf.js --grep=test/benchmarks/**.js --single-run",
     "benchmark": "npm run test:karma:bench -- no-single-run",
     "lint": "run-s eslint",
+    "lint:tsc": "tsc -p jsconfig-lint.json",
     "eslint": "eslint src test debug compat hooks test-utils",
     "format": "prettier --write \"**/*.{js,jsx,mjs,cjs,ts,tsx,yml,json,html,md,css,scss}\"",
     "format:check": "prettier --check '**/*.{js,jsx,mjs,cjs,ts,tsx,yml,json,html,md,css,scss}'"

--- a/package.json
+++ b/package.json
@@ -132,8 +132,8 @@
     "test:karma:test-utils": "cross-env PERFORMANCE=false COVERAGE=false BABEL_NO_MODULES=true karma start karma.conf.js --grep=test-utils/test/shared/**.js --no-single-run",
     "test:karma:bench": "cross-env PERFORMANCE=true COVERAGE=false BABEL_NO_MODULES=true karma start karma.conf.js --grep=test/benchmarks/**.js --single-run",
     "benchmark": "npm run test:karma:bench -- no-single-run",
-    "lint": "run-s eslint",
-    "lint:tsc": "tsc -p jsconfig-lint.json",
+    "lint": "run-s eslint tsc",
+    "tsc": "tsc -p jsconfig-lint.json",
     "eslint": "eslint src test debug compat hooks test-utils",
     "format": "prettier --write \"**/*.{js,jsx,mjs,cjs,ts,tsx,yml,json,html,md,css,scss}\"",
     "format:check": "prettier --check '**/*.{js,jsx,mjs,cjs,ts,tsx,yml,json,html,md,css,scss}'"

--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -2,11 +2,13 @@ import { assign, slice } from './util';
 import { createVNode } from './create-element';
 
 /**
- * Clones the given VNode, optionally adding attributes/props and replacing its children.
- * @param {import('./internal').VNode} vnode The virtual DOM element to clone
+ * Clones the given VNode, optionally adding attributes/props and replacing its
+ * children.
+ * @param {VNode} vnode The virtual DOM element to clone
  * @param {object} props Attributes/props to add when cloning
- * @param {Array<import('./internal').ComponentChildren>} rest Any additional arguments will be used as replacement children.
- * @returns {import('./internal').VNode}
+ * @param {Array<ComponentChildren>} rest Any additional arguments will be used
+ * as replacement children.
+ * @returns {VNode}
  */
 export function cloneElement(vnode, props, children) {
 	let normalizedProps = assign({}, vnode.props),

--- a/src/component.js
+++ b/src/component.js
@@ -10,21 +10,21 @@ import { Fragment } from './create-element';
  * @param {object} context The initial context from parent components'
  * getChildContext
  */
-export function Component(props, context) {
+export function BaseComponent(props, context) {
 	this.props = props;
 	this.context = context;
 }
 
 /**
  * Update component state and schedule a re-render.
- * @this {import('./internal').Component}
+ * @this {Component}
  * @param {object | ((s: object, p: object) => object)} update A hash of state
  * properties to update with new values or a function that given the current
  * state and props returns a new partial state
  * @param {() => void} [callback] A function to be called once component state is
  * updated
  */
-Component.prototype.setState = function (update, callback) {
+BaseComponent.prototype.setState = function (update, callback) {
 	// only clone state when copying to nextState the first time.
 	let s;
 	if (this._nextState != null && this._nextState !== this.state) {
@@ -56,11 +56,11 @@ Component.prototype.setState = function (update, callback) {
 
 /**
  * Immediately perform a synchronous re-render of the component
- * @this {import('./internal').Component}
+ * @this {Component}
  * @param {() => void} [callback] A function to be called after component is
  * re-rendered
  */
-Component.prototype.forceUpdate = function (callback) {
+BaseComponent.prototype.forceUpdate = function (callback) {
 	if (this._vnode) {
 		// Set render mode so that we can differentiate where the render request
 		// is coming from. We need this because forceUpdate should never call
@@ -79,12 +79,12 @@ Component.prototype.forceUpdate = function (callback) {
  * @param {object} state The component's current state
  * @param {object} context Context object, as returned by the nearest
  * ancestor's `getChildContext()`
- * @returns {import('./index').ComponentChildren | void}
+ * @returns {ComponentChildren | void}
  */
-Component.prototype.render = Fragment;
+BaseComponent.prototype.render = Fragment;
 
 /**
- * @param {import('./internal').VNode} vnode
+ * @param {VNode} vnode
  * @param {number | null} [childIndex]
  */
 export function getDomSibling(vnode, childIndex) {
@@ -117,7 +117,7 @@ export function getDomSibling(vnode, childIndex) {
 
 /**
  * Trigger in-place re-rendering of a component.
- * @param {import('./internal').Component} component The component to rerender
+ * @param {Component} component The component to rerender
  */
 function renderComponent(component) {
 	let vnode = component._vnode,
@@ -158,7 +158,7 @@ function renderComponent(component) {
 }
 
 /**
- * @param {import('./internal').VNode} vnode
+ * @param {VNode} vnode
  */
 function updateParentDomPointers(vnode) {
 	if ((vnode = vnode._parent) != null && vnode._component != null) {
@@ -177,7 +177,7 @@ function updateParentDomPointers(vnode) {
 
 /**
  * The render queue
- * @type {Array<import('./internal').Component>}
+ * @type {Array<Component>}
  */
 let rerenderQueue = [];
 
@@ -199,7 +199,7 @@ const defer =
 
 /**
  * Enqueue a rerender of a component
- * @param {import('./internal').Component} c The component to rerender
+ * @param {Component} c The component to rerender
  */
 export function enqueueRender(c) {
 	if (
@@ -215,8 +215,8 @@ export function enqueueRender(c) {
 }
 
 /**
- * @param {import('./internal').Component} a
- * @param {import('./internal').Component} b
+ * @param {Component} a
+ * @param {Component} b
  */
 const depthSort = (a, b) => a._vnode._depth - b._vnode._depth;
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-export const EMPTY_OBJ = {};
+export const EMPTY_OBJ = /** @type {any} */ ({});
 export const EMPTY_ARR = [];
 export const IS_NON_DIMENSIONAL =
 	/acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i;

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -8,17 +8,17 @@ export function createContext(defaultValue, contextId) {
 	const context = {
 		_id: contextId,
 		_defaultValue: defaultValue,
-		/** @type {import('./internal').FunctionComponent} */
+		/** @type {FunctionComponent} */
 		Consumer(props, contextValue) {
 			// return props.children(
 			// 	context[contextId] ? context[contextId].props.value : defaultValue
 			// );
 			return props.children(contextValue);
 		},
-		/** @type {import('./internal').FunctionComponent} */
+		/** @type {FunctionComponent} */
 		Provider(props) {
 			if (!this.getChildContext) {
-				/** @type {import('./internal').Component[]} */
+				/** @type {Component[]} */
 				let subs = [];
 				let ctx = {};
 				ctx[contextId] = this;

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -55,6 +55,7 @@ export function createElement(type, props, children) {
 export function createVNode(type, props, key, ref, original) {
 	// V8 seems to be better at detecting type shapes if the object is allocated from the same call site
 	// Do not inline into createElement and coerceToVNode!
+	/** @type {import('./internal').VNode} */
 	const vnode = {
 		type,
 		props,

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -5,11 +5,12 @@ let vnodeId = 0;
 
 /**
  * Create an virtual node (used for JSX)
- * @param {import('./internal').VNode["type"]} type The node name or Component
- * constructor for this virtual node
+ * @param {VNode["type"]} type The node name or Component constructor for this
+ * virtual node
  * @param {object | null | undefined} [props] The properties of the virtual node
- * @param {Array<import('.').ComponentChildren>} [children] The children of the virtual node
- * @returns {import('./internal').VNode}
+ * @param {Array<import('.').ComponentChildren>} [children] The children of the
+ * virtual node
+ * @returns {VNode}
  */
 export function createElement(type, props, children) {
 	let normalizedProps = {},
@@ -42,20 +43,20 @@ export function createElement(type, props, children) {
 
 /**
  * Create a VNode (used internally by Preact)
- * @param {import('./internal').VNode["type"]} type The node name or Component
+ * @param {VNode["type"]} type The node name or Component
  * Constructor for this virtual node
  * @param {object | string | number | null} props The properties of this virtual node.
  * If this virtual node represents a text node, this is the text of the node (string or number).
  * @param {string | number | null} key The key for this virtual node, used when
  * diffing it against its children
- * @param {import('./internal').VNode["ref"]} ref The ref property that will
+ * @param {VNode["ref"]} ref The ref property that will
  * receive a reference to its created child
- * @returns {import('./internal').VNode}
+ * @returns {VNode}
  */
 export function createVNode(type, props, key, ref, original) {
 	// V8 seems to be better at detecting type shapes if the object is allocated from the same call site
 	// Do not inline into createElement and coerceToVNode!
-	/** @type {import('./internal').VNode} */
+	/** @type {VNode} */
 	const vnode = {
 		type,
 		props,
@@ -94,7 +95,7 @@ export function Fragment(props) {
 /**
  * Check if a the argument is a valid Preact VNode.
  * @param {*} vnode
- * @returns {vnode is import('./internal').VNode}
+ * @returns {vnode is VNode}
  */
 export const isValidElement = vnode =>
 	vnode != null && vnode.constructor == undefined;

--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -1,14 +1,14 @@
 /**
  * Find the closest error boundary to a thrown error and call it
  * @param {object} error The thrown value
- * @param {import('../internal').VNode} vnode The vnode that threw
- * the error that was caught (except for unmounting when this parameter
- * is the highest parent that was being unmounted)
- * @param {import('../internal').VNode} [oldVNode]
- * @param {import('../internal').ErrorInfo} [errorInfo]
+ * @param {VNode} vnode The vnode that threw the error that was caught (except
+ * for unmounting when this parameter is the highest parent that was being
+ * unmounted)
+ * @param {VNode} [oldVNode]
+ * @param {ErrorInfo} [errorInfo]
  */
 export function _catchError(error, vnode, oldVNode, errorInfo) {
-	/** @type {import('../internal').Component} */
+	/** @type {Component} */
 	let component, ctor, handled;
 
 	for (; (vnode = vnode._parent); ) {

--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -9,7 +9,11 @@
  */
 export function _catchError(error, vnode, oldVNode, errorInfo) {
 	/** @type {Component} */
-	let component, ctor, handled;
+	let component,
+		/** @type {ComponentType} */
+		ctor,
+		/** @type {boolean} */
+		handled;
 
 	for (; (vnode = vnode._parent); ) {
 		if ((component = vnode._component) && !component._processingException) {

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -6,22 +6,23 @@ import { getDomSibling } from '../component';
 
 /**
  * Diff the children of a virtual node
- * @param {import('../internal').PreactElement} parentDom The DOM element whose
- * children are being diffed
- * @param {import('../internal').ComponentChildren[]} renderResult
- * @param {import('../internal').VNode} newParentVNode The new virtual
- * node whose children should be diff'ed against oldParentVNode
- * @param {import('../internal').VNode} oldParentVNode The old virtual
- * node whose children should be diff'ed against newParentVNode
- * @param {object} globalContext The current context object - modified by getChildContext
+ * @param {PreactElement} parentDom The DOM element whose children are being
+ * diffed
+ * @param {ComponentChildren[]} renderResult
+ * @param {VNode} newParentVNode The new virtual node whose children should be
+ * diff'ed against oldParentVNode
+ * @param {VNode} oldParentVNode The old virtual node whose children should be
+ * diff'ed against newParentVNode
+ * @param {object} globalContext The current context object - modified by
+ * getChildContext
  * @param {boolean} isSvg Whether or not this DOM node is an SVG node
- * @param {Array<import('../internal').PreactElement>} excessDomChildren
- * @param {Array<import('../internal').Component>} commitQueue List of components
- * which have callbacks to invoke in commitRoot
- * @param {import('../internal').PreactElement} oldDom The current attached DOM
- * element any new dom elements should be placed around. Likely `null` on first
- * render (except when hydrating). Can be a sibling DOM element when diffing
- * Fragments that have siblings. In most cases, it starts out as `oldChildren[0]._dom`.
+ * @param {Array<PreactElement>} excessDomChildren
+ * @param {Array<Component>} commitQueue List of components which have callbacks
+ * to invoke in commitRoot
+ * @param {PreactElement} oldDom The current attached DOM element any new dom
+ * elements should be placed around. Likely `null` on first render (except when
+ * hydrating). Can be a sibling DOM element when diffing Fragments that have
+ * siblings. In most cases, it starts out as `oldChildren[0]._dom`.
  * @param {boolean} isHydrating Whether or not we are in hydration
  * @param {Array<any>} refQueue an array of elements needed to invoke refs
  */
@@ -40,9 +41,9 @@ export function diffChildren(
 ) {
 	let i,
 		j,
-		/** @type {import('../internal').VNode} */
+		/** @type {VNode} */
 		oldVNode,
-		/** @type {import('../internal').VNode} */
+		/** @type {VNode} */
 		childVNode,
 		newDom,
 		firstChildDom,
@@ -262,10 +263,10 @@ export function diffChildren(
 }
 
 /**
- * @param {import('../internal').VNode} childVNode
- * @param {import('../internal').PreactElement} oldDom
- * @param {import('../internal').PreactElement} parentDom
- * @returns {import('../internal').PreactElement}
+ * @param {VNode} childVNode
+ * @param {PreactElement} oldDom
+ * @param {PreactElement} parentDom
+ * @returns {PreactElement}
  */
 function reorderChildren(childVNode, oldDom, parentDom) {
 	// Note: VNodes in nested suspended trees may be missing _children.
@@ -294,9 +295,9 @@ function reorderChildren(childVNode, oldDom, parentDom) {
 
 /**
  * Flatten and loop through the children of a virtual node
- * @param {import('../index').ComponentChildren} children The unflattened
- * children of a virtual node
- * @returns {import('../internal').VNode[]}
+ * @param {ComponentChildren} children The unflattened children of a virtual
+ * node
+ * @returns {VNode[]}
  */
 export function toChildArray(children, out) {
 	out = out || [];
@@ -312,10 +313,10 @@ export function toChildArray(children, out) {
 }
 
 /**
- * @param {import('../internal').PreactElement} parentDom
- * @param {import('../internal').PreactElement} newDom
- * @param {import('../internal').PreactElement} oldDom
- * @returns {import('../internal').PreactElement}
+ * @param {PreactElement} parentDom
+ * @param {PreactElement} newDom
+ * @param {PreactElement} oldDom
+ * @returns {PreactElement}
  */
 function placeChild(parentDom, newDom, oldDom) {
 	if (oldDom == null || oldDom.parentNode !== parentDom) {
@@ -328,8 +329,8 @@ function placeChild(parentDom, newDom, oldDom) {
 }
 
 /**
- * @param {import('../internal').VNode} childVNode
- * @param {import('../internal').VNode[]} oldChildren
+ * @param {VNode} childVNode
+ * @param {VNode[]} oldChildren
  * @param {number} skewedIndex
  * @param {number} remainingOldChildren
  * @returns {number}

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -259,6 +259,12 @@ export function diffChildren(
 	}
 }
 
+/**
+ * @param {import('../internal').VNode} childVNode
+ * @param {import('../internal').PreactElement} oldDom
+ * @param {import('../internal').PreactElement} parentDom
+ * @returns {import('../internal').PreactElement}
+ */
 function reorderChildren(childVNode, oldDom, parentDom) {
 	// Note: VNodes in nested suspended trees may be missing _children.
 	let c = childVNode._children;
@@ -303,6 +309,12 @@ export function toChildArray(children, out) {
 	return out;
 }
 
+/**
+ * @param {import('../internal').PreactElement} parentDom
+ * @param {import('../internal').PreactElement} newDom
+ * @param {import('../internal').PreactElement} oldDom
+ * @returns {import('../internal').PreactElement}
+ */
 function placeChild(parentDom, newDom, oldDom) {
 	if (oldDom == null || oldDom.parentNode !== parentDom) {
 		parentDom.insertBefore(newDom, null);

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -24,7 +24,7 @@ import { getDomSibling } from '../component';
  * hydrating). Can be a sibling DOM element when diffing Fragments that have
  * siblings. In most cases, it starts out as `oldChildren[0]._dom`.
  * @param {boolean} isHydrating Whether or not we are in hydration
- * @param {Array<any>} refQueue an array of elements needed to invoke refs
+ * @param {any[]} refQueue an array of elements needed to invoke refs
  */
 export function diffChildren(
 	parentDom,
@@ -45,12 +45,15 @@ export function diffChildren(
 		oldVNode,
 		/** @type {VNode} */
 		childVNode,
+		/** @type {PreactElement} */
 		newDom,
+		/** @type {PreactElement} */
 		firstChildDom,
 		skew = 0;
 
 	// This is a compression of oldParentVNode!=null && oldParentVNode != EMPTY_OBJ && oldParentVNode._children || EMPTY_ARR
 	// as EMPTY_OBJ._children should be `undefined`.
+	/** @type {VNode[]} */
 	let oldChildren = (oldParentVNode && oldParentVNode._children) || EMPTY_ARR;
 
 	let oldChildrenLength = oldChildren.length,

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -58,6 +58,8 @@ export function diffChildren(
 
 	newParentVNode._children = [];
 	for (i = 0; i < newChildrenLength; i++) {
+		// @ts-expect-error We are reusing the childVNode variable to hold both the
+		// pre and post normalized childVNode
 		childVNode = renderResult[i];
 
 		if (
@@ -326,7 +328,7 @@ function placeChild(parentDom, newDom, oldDom) {
 }
 
 /**
- * @param {import('../internal').VNode | string} childVNode
+ * @param {import('../internal').VNode} childVNode
  * @param {import('../internal').VNode[]} oldChildren
  * @param {number} skewedIndex
  * @param {number} remainingOldChildren

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -1,5 +1,5 @@
 import { EMPTY_OBJ } from '../constants';
-import { Component, getDomSibling } from '../component';
+import { BaseComponent, getDomSibling } from '../component';
 import { Fragment } from '../create-element';
 import { diffChildren } from './children';
 import { diffProps, setProperty } from './props';
@@ -8,18 +8,19 @@ import options from '../options';
 
 /**
  * Diff two virtual nodes and apply proper changes to the DOM
- * @param {import('../internal').PreactElement} parentDom The parent of the DOM element
- * @param {import('../internal').VNode} newVNode The new virtual node
- * @param {import('../internal').VNode} oldVNode The old virtual node
- * @param {object} globalContext The current context object. Modified by getChildContext
+ * @param {PreactElement} parentDom The parent of the DOM element
+ * @param {VNode} newVNode The new virtual node
+ * @param {VNode} oldVNode The old virtual node
+ * @param {object} globalContext The current context object. Modified by
+ * getChildContext
  * @param {boolean} isSvg Whether or not this element is an SVG node
- * @param {Array<import('../internal').PreactElement>} excessDomChildren
- * @param {Array<import('../internal').Component>} commitQueue List of components
- * which have callbacks to invoke in commitRoot
- * @param {import('../internal').PreactElement} oldDom The current attached DOM
- * element any new dom elements should be placed around. Likely `null` on first
- * render (except when hydrating). Can be a sibling DOM element when diffing
- * Fragments that have siblings. In most cases, it starts out as `oldChildren[0]._dom`.
+ * @param {Array<PreactElement>} excessDomChildren
+ * @param {Array<Component>} commitQueue List of components which have callbacks
+ * to invoke in commitRoot
+ * @param {PreactElement} oldDom The current attached DOM element any new dom
+ * elements should be placed around. Likely `null` on first render (except when
+ * hydrating). Can be a sibling DOM element when diffing Fragments that have
+ * siblings. In most cases, it starts out as `oldChildren[0]._dom`.
  * @param {boolean} isHydrating Whether or not we are in hydration
  * @param {Array<any>} refQueue an array of elements needed to invoke refs
  */
@@ -79,7 +80,10 @@ export function diff(
 					newVNode._component = c = new newType(newProps, componentContext); // eslint-disable-line new-cap
 				} else {
 					// @ts-expect-error Trust me, Component implements the interface we want
-					newVNode._component = c = new Component(newProps, componentContext);
+					newVNode._component = c = new BaseComponent(
+						newProps,
+						componentContext
+					);
 					c.constructor = newType;
 					c.render = doRender;
 				}
@@ -293,9 +297,9 @@ export function diff(
 }
 
 /**
- * @param {Array<import('../internal').Component>} commitQueue List of components
+ * @param {Array<Component>} commitQueue List of components
  * which have callbacks to invoke in commitRoot
- * @param {import('../internal').VNode} root
+ * @param {VNode} root
  */
 export function commitRoot(commitQueue, root, refQueue) {
 	root._nextDom = undefined;
@@ -323,18 +327,18 @@ export function commitRoot(commitQueue, root, refQueue) {
 
 /**
  * Diff two virtual nodes representing DOM element
- * @param {import('../internal').PreactElement} dom The DOM element representing
- * the virtual nodes being diffed
- * @param {import('../internal').VNode} newVNode The new virtual node
- * @param {import('../internal').VNode} oldVNode The old virtual node
+ * @param {PreactElement} dom The DOM element representing the virtual nodes
+ * being diffed
+ * @param {VNode} newVNode The new virtual node
+ * @param {VNode} oldVNode The old virtual node
  * @param {object} globalContext The current context object
  * @param {boolean} isSvg Whether or not this DOM node is an SVG node
  * @param {*} excessDomChildren
- * @param {Array<import('../internal').Component>} commitQueue List of components
- * which have callbacks to invoke in commitRoot
+ * @param {Array<Component>} commitQueue List of components which have callbacks
+ * to invoke in commitRoot
  * @param {boolean} isHydrating Whether or not we are in hydration
  * @param {Array<any>} refQueue an array of elements needed to invoke refs
- * @returns {import('../internal').PreactElement}
+ * @returns {PreactElement}
  */
 function diffElementNodes(
 	dom,
@@ -496,7 +500,7 @@ function diffElementNodes(
  * Invoke or update a ref, depending on whether it is a function or object ref.
  * @param {object|function} ref
  * @param {any} value
- * @param {import('../internal').VNode} vnode
+ * @param {VNode} vnode
  */
 export function applyRef(ref, value, vnode) {
 	try {
@@ -509,9 +513,8 @@ export function applyRef(ref, value, vnode) {
 
 /**
  * Unmount a virtual node from the tree and apply DOM changes
- * @param {import('../internal').VNode} vnode The virtual node to unmount
- * @param {import('../internal').VNode} parentVNode The parent of the VNode that
- * initiated the unmount
+ * @param {VNode} vnode The virtual node to unmount
+ * @param {VNode} parentVNode The parent of the VNode that initiated the unmount
  * @param {boolean} [skipRemove] Flag that indicates that a parent node of the
  * current element is already detached from the DOM.
  */

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -22,7 +22,7 @@ import options from '../options';
  * hydrating). Can be a sibling DOM element when diffing Fragments that have
  * siblings. In most cases, it starts out as `oldChildren[0]._dom`.
  * @param {boolean} isHydrating Whether or not we are in hydration
- * @param {Array<any>} refQueue an array of elements needed to invoke refs
+ * @param {any[]} refQueue an array of elements needed to invoke refs
  */
 export function diff(
 	parentDom,
@@ -36,6 +36,7 @@ export function diff(
 	isHydrating,
 	refQueue
 ) {
+	/** @type {any} */
 	let tmp,
 		newType = newVNode.type;
 
@@ -333,11 +334,11 @@ export function commitRoot(commitQueue, root, refQueue) {
  * @param {VNode} oldVNode The old virtual node
  * @param {object} globalContext The current context object
  * @param {boolean} isSvg Whether or not this DOM node is an SVG node
- * @param {*} excessDomChildren
+ * @param {Array<PreactElement>} excessDomChildren
  * @param {Array<Component>} commitQueue List of components which have callbacks
  * to invoke in commitRoot
  * @param {boolean} isHydrating Whether or not we are in hydration
- * @param {Array<any>} refQueue an array of elements needed to invoke refs
+ * @param {any[]} refQueue an array of elements needed to invoke refs
  * @returns {PreactElement}
  */
 function diffElementNodes(
@@ -498,7 +499,7 @@ function diffElementNodes(
 
 /**
  * Invoke or update a ref, depending on whether it is a function or object ref.
- * @param {object|function} ref
+ * @param {Ref<any>} ref
  * @param {any} value
  * @param {VNode} vnode
  */

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -312,7 +312,7 @@ export function commitRoot(commitQueue, root, refQueue) {
 			commitQueue = c._renderCallbacks;
 			c._renderCallbacks = [];
 			commitQueue.some(cb => {
-				// @ts-expect-error See above ts-expect-error on commitQueue
+				// @ts-expect-error See above comment on commitQueue
 				cb.call(c);
 			});
 		} catch (e) {
@@ -349,7 +349,8 @@ function diffElementNodes(
 ) {
 	let oldProps = oldVNode.props;
 	let newProps = newVNode.props;
-	let nodeType = newVNode.type;
+	let nodeType = /** @type {string} */ (newVNode.type);
+	/** @type {any} */
 	let i = 0;
 
 	// Tracks entering and exiting SVG namespace when descending through the tree.
@@ -376,22 +377,13 @@ function diffElementNodes(
 
 	if (dom == null) {
 		if (nodeType === null) {
-			// @ts-expect-error createTextNode returns Text, we expect PreactElement
 			return document.createTextNode(newProps);
 		}
 
 		if (isSvg) {
-			dom = document.createElementNS(
-				'http://www.w3.org/2000/svg',
-				// @ts-expect-error We know `newVNode.type` is a string
-				nodeType
-			);
+			dom = document.createElementNS('http://www.w3.org/2000/svg', nodeType);
 		} else {
-			dom = document.createElement(
-				// @ts-expect-error We know `newVNode.type` is a string
-				nodeType,
-				newProps.is && newProps
-			);
+			dom = document.createElement(nodeType, newProps.is && newProps);
 		}
 
 		// we created a new parent, so none of the previously attached children can be reused:

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -75,10 +75,10 @@ export function diff(
 			} else {
 				// Instantiate the new component
 				if ('prototype' in newType && newType.prototype.render) {
-					// @ts-ignore The check above verifies that newType is suppose to be constructed
+					// @ts-expect-error The check above verifies that newType is suppose to be constructed
 					newVNode._component = c = new newType(newProps, componentContext); // eslint-disable-line new-cap
 				} else {
-					// @ts-ignore Trust me, Component implements the interface we want
+					// @ts-expect-error Trust me, Component implements the interface we want
 					newVNode._component = c = new Component(newProps, componentContext);
 					c.constructor = newType;
 					c.render = doRender;
@@ -308,11 +308,11 @@ export function commitRoot(commitQueue, root, refQueue) {
 
 	commitQueue.some(c => {
 		try {
-			// @ts-ignore Reuse the commitQueue variable here so the type changes
+			// @ts-expect-error Reuse the commitQueue variable here so the type changes
 			commitQueue = c._renderCallbacks;
 			c._renderCallbacks = [];
 			commitQueue.some(cb => {
-				// @ts-ignore See above ts-ignore on commitQueue
+				// @ts-expect-error See above ts-expect-error on commitQueue
 				cb.call(c);
 			});
 		} catch (e) {
@@ -376,19 +376,19 @@ function diffElementNodes(
 
 	if (dom == null) {
 		if (nodeType === null) {
-			// @ts-ignore createTextNode returns Text, we expect PreactElement
+			// @ts-expect-error createTextNode returns Text, we expect PreactElement
 			return document.createTextNode(newProps);
 		}
 
 		if (isSvg) {
 			dom = document.createElementNS(
 				'http://www.w3.org/2000/svg',
-				// @ts-ignore We know `newVNode.type` is a string
+				// @ts-expect-error We know `newVNode.type` is a string
 				nodeType
 			);
 		} else {
 			dom = document.createElement(
-				// @ts-ignore We know `newVNode.type` is a string
+				// @ts-expect-error We know `newVNode.type` is a string
 				nodeType,
 				newProps.is && newProps
 			);

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -173,6 +173,11 @@ function eventProxy(e) {
 	return eventHandler(options.event ? options.event(e) : e);
 }
 
+/**
+ * Proxy an event to hooked event handlers
+ * @param {PreactEvent} e The event object from the browser
+ * @private
+ */
 function eventProxyCapture(e) {
 	return this._listeners[e.type + true](options.event ? options.event(e) : e);
 }

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -152,7 +152,7 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 
 /**
  * Proxy an event to hooked event handlers
- * @param {Event} e The event object from the browser
+ * @param {import('../internal').PreactEvent} e The event object from the browser
  * @private
  */
 function eventProxy(e) {

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -3,8 +3,7 @@ import options from '../options';
 
 /**
  * Diff the old and new properties of a VNode and apply changes to the DOM node
- * @param {import('../internal').PreactElement} dom The DOM node to apply
- * changes to
+ * @param {PreactElement} dom The DOM node to apply changes to
  * @param {object} newProps The new props
  * @param {object} oldProps The old props
  * @param {boolean} isSvg Whether or not this node is an SVG node
@@ -47,7 +46,7 @@ function setStyle(style, key, value) {
 
 /**
  * Set a property value on a DOM node
- * @param {import('../internal').PreactElement} dom The DOM node to modify
+ * @param {PreactElement} dom The DOM node to modify
  * @param {string} name The name of the property to set
  * @param {*} value The value to set the property to
  * @param {*} oldValue The old value the property had
@@ -152,7 +151,7 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 
 /**
  * Proxy an event to hooked event handlers
- * @param {import('../internal').PreactEvent} e The event object from the browser
+ * @param {PreactEvent} e The event object from the browser
  * @private
  */
 function eventProxy(e) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -291,7 +291,6 @@ interface ContainerNode {
 	readonly nodeType: number;
 	readonly parentNode: ContainerNode | null;
 	readonly firstChild: ContainerNode | null;
-	readonly nextSibling: ChildNode | null;
 	readonly childNodes: ArrayLike<ContainerNode>;
 
 	insertBefore(node: ContainerNode, child: ContainerNode | null): ContainerNode;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -287,15 +287,16 @@ export namespace h {
 //
 // Preact render
 // -----------------------------------
-
 interface ContainerNode {
-	nodeType: Node['nodeType'];
-	parentNode: Node['parentNode'];
-	firstChild: Node['firstChild'];
-	insertBefore: Node['insertBefore'];
-	appendChild: Node['appendChild'];
-	removeChild: Node['removeChild'];
-	childNodes: ArrayLike<Node>;
+	readonly nodeType: number;
+	readonly parentNode: ContainerNode | null;
+	readonly firstChild: ContainerNode | null;
+	readonly nextSibling: ChildNode | null;
+	readonly childNodes: ArrayLike<ContainerNode>;
+
+	insertBefore(node: ContainerNode, child: ContainerNode | null): ContainerNode;
+	appendChild(node: ContainerNode): ContainerNode;
+	removeChild(child: ContainerNode): ContainerNode;
 }
 
 export function render(vnode: ComponentChild, parent: ContainerNode): void;

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ export {
 	createRef,
 	isValidElement
 } from './create-element';
-export { Component } from './component';
+export { BaseComponent as Component } from './component';
 export { cloneElement } from './clone-element';
 export { createContext } from './create-context';
 export { toChildArray } from './diff/children';

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -82,11 +82,11 @@ export type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
 
 export interface PreactElement extends preact.ContainerNode {
 	// SVG detection
-	readonly ownerSVGElement?: SVGSVGElement | null;
+	readonly ownerSVGElement?: SVGElement['ownerSVGElement'];
 	// Property used to update Text nodes
-	data?: string;
+	data?: CharacterData['data'];
 	// Property to set __dangerouslySetInnerHTML
-	innerHTML?: string;
+	innerHTML?: Element['innerHTML'];
 
 	// Attribute reading and setting
 	readonly attributes?: Element['attributes'];

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -26,10 +26,7 @@ export interface ErrorInfo {
 
 export interface Options extends preact.Options {
 	/** Attach a hook that is invoked before render, mainly to check the arguments. */
-	_root?(
-		vnode: ComponentChild,
-		parent: Element | Document | ShadowRoot | DocumentFragment
-	): void;
+	_root?(vnode: ComponentChild, parent: preact.ContainerNode): void;
 	/** Attach a hook that is invoked before a vnode is diffed. */
 	_diff?(vnode: VNode): void;
 	/** Attach a hook that is invoked after a tree was mounted or was updated. */
@@ -44,8 +41,8 @@ export interface Options extends preact.Options {
 	_catchError(
 		error: any,
 		vnode: VNode,
-		oldVNode: VNode | undefined,
-		errorInfo: ErrorInfo | undefined
+		oldVNode?: VNode | undefined,
+		errorInfo?: ErrorInfo | undefined
 	): void;
 }
 
@@ -83,17 +80,34 @@ export interface ComponentClass<P = {}> extends preact.ComponentClass<P> {
 // Redefine ComponentType using our new internal FunctionComponent interface above
 export type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
 
-export interface PreactElement extends HTMLElement {
+export interface PreactElement extends preact.ContainerNode {
+	// SVG detection
+	readonly ownerSVGElement?: SVGSVGElement | null;
+	// Property used to update Text nodes
+	data?: string;
+	// Property to set __dangerouslySetInnerHTML
+	innerHTML?: string;
+
+	// Attribute reading and setting
+	readonly attributes?: Element['attributes'];
+	setAttribute?: Element['setAttribute'];
+	removeAttribute?: Element['removeAttribute'];
+
+	// Event listeners
+	addEventListener?: Element['addEventListener'];
+	removeEventListener?: Element['removeEventListener'];
+
+	// Setting styles
+	readonly style?: CSSStyleDeclaration;
+
+	// Input handling
+	value?: HTMLInputElement['value'];
+	checked?: HTMLInputElement['checked'];
+
+	// Internal properties
 	_children?: VNode<any> | null;
 	/** Event listeners to support event delegation */
 	_listeners?: Record<string, (e: Event) => void>;
-
-	// Preact uses this attribute to detect SVG nodes
-	ownerSVGElement?: SVGElement | null;
-
-	// style: HTMLElement["style"]; // From HTMLElement
-
-	data?: string | number; // From Text node
 }
 
 // We use the `current` property to differentiate between the two kinds of Refs so

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -100,6 +100,9 @@ export interface PreactElement extends preact.ContainerNode {
 	// Setting styles
 	readonly style?: CSSStyleDeclaration;
 
+	// nextSibling required for inserting nodes
+	readonly nextSibling: ContainerNode | null;
+
 	// Input handling
 	value?: HTMLInputElement['value'];
 	checked?: HTMLInputElement['checked'];

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -105,6 +105,10 @@ declare global {
 		// nextSibling required for inserting nodes
 		readonly nextSibling: ContainerNode | null;
 
+		// Used to match DOM nodes to VNodes during hydration. Note: doesn't exist
+		// on Text nodes
+		readonly localName?: string;
+
 		// Input handling
 		value?: HTMLInputElement['value'];
 		checked?: HTMLInputElement['checked'];

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -113,6 +113,10 @@ export interface PreactElement extends preact.ContainerNode {
 	_listeners?: Record<string, (e: Event) => void>;
 }
 
+export interface PreactEvent extends Event {
+	_dispatched?: number;
+}
+
 // We use the `current` property to differentiate between the two kinds of Refs so
 // internally we'll define `current` on both to make TypeScript happy
 type RefObject<T> = { current: T | null };
@@ -120,8 +124,9 @@ type RefCallback<T> = { (instance: T | null): void; current: undefined };
 type Ref<T> = RefObject<T> | RefCallback<T>;
 
 export interface VNode<P = {}> extends preact.VNode<P> {
-	// Redefine type here using our internal ComponentType type
-	type: string | ComponentType<P>;
+	// Redefine type here using our internal ComponentType type, and specify
+	// string has an undefined `defaultProps` property to make TS happy
+	type: (string & { defaultProps: undefined }) | ComponentType<P>;
 	props: P & { children: ComponentChildren };
 	ref?: Ref<any> | null;
 	_children: Array<VNode<any>> | null;
@@ -134,7 +139,7 @@ export interface VNode<P = {}> extends preact.VNode<P> {
 	/**
 	 * The last dom child of a Fragment, or components that return a Fragment
 	 */
-	_nextDom: PreactElement | null;
+	_nextDom: PreactElement | null | undefined;
 	_component: Component | null;
 	_hydrating: boolean | null;
 	constructor: undefined;

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -1,179 +1,182 @@
 import * as preact from './index';
 
-export enum HookType {
-	useState = 1,
-	useReducer = 2,
-	useEffect = 3,
-	useLayoutEffect = 4,
-	useRef = 5,
-	useImperativeHandle = 6,
-	useMemo = 7,
-	useCallback = 8,
-	useContext = 9,
-	useErrorBoundary = 10,
-	// Not a real hook, but the devtools treat is as such
-	useDebugvalue = 11
-}
+declare global {
+	export enum HookType {
+		useState = 1,
+		useReducer = 2,
+		useEffect = 3,
+		useLayoutEffect = 4,
+		useRef = 5,
+		useImperativeHandle = 6,
+		useMemo = 7,
+		useCallback = 8,
+		useContext = 9,
+		useErrorBoundary = 10,
+		// Not a real hook, but the devtools treat is as such
+		useDebugvalue = 11
+	}
 
-export interface DevSource {
-	fileName: string;
-	lineNumber: number;
-}
+	export interface DevSource {
+		fileName: string;
+		lineNumber: number;
+	}
 
-export interface ErrorInfo {
-	componentStack?: string;
-}
+	export interface ErrorInfo {
+		componentStack?: string;
+	}
 
-export interface Options extends preact.Options {
-	/** Attach a hook that is invoked before render, mainly to check the arguments. */
-	_root?(vnode: ComponentChild, parent: preact.ContainerNode): void;
-	/** Attach a hook that is invoked before a vnode is diffed. */
-	_diff?(vnode: VNode): void;
-	/** Attach a hook that is invoked after a tree was mounted or was updated. */
-	_commit?(vnode: VNode, commitQueue: Component[]): void;
-	/** Attach a hook that is invoked before a vnode has rendered. */
-	_render?(vnode: VNode): void;
-	/** Attach a hook that is invoked before a hook's state is queried. */
-	_hook?(component: Component, index: number, type: HookType): void;
-	/** Bypass effect execution. Currenty only used in devtools for hooks inspection */
-	_skipEffects?: boolean;
-	/** Attach a hook that is invoked after an error is caught in a component but before calling lifecycle hooks */
-	_catchError(
-		error: any,
-		vnode: VNode,
-		oldVNode?: VNode | undefined,
-		errorInfo?: ErrorInfo | undefined
-	): void;
-}
+	export interface Options extends preact.Options {
+		/** Attach a hook that is invoked before render, mainly to check the arguments. */
+		_root?(vnode: ComponentChild, parent: preact.ContainerNode): void;
+		/** Attach a hook that is invoked before a vnode is diffed. */
+		_diff?(vnode: VNode): void;
+		/** Attach a hook that is invoked after a tree was mounted or was updated. */
+		_commit?(vnode: VNode, commitQueue: Component[]): void;
+		/** Attach a hook that is invoked before a vnode has rendered. */
+		_render?(vnode: VNode): void;
+		/** Attach a hook that is invoked before a hook's state is queried. */
+		_hook?(component: Component, index: number, type: HookType): void;
+		/** Bypass effect execution. Currenty only used in devtools for hooks inspection */
+		_skipEffects?: boolean;
+		/** Attach a hook that is invoked after an error is caught in a component but before calling lifecycle hooks */
+		_catchError(
+			error: any,
+			vnode: VNode,
+			oldVNode?: VNode | undefined,
+			errorInfo?: ErrorInfo | undefined
+		): void;
+	}
 
-export type ComponentChild =
-	| VNode<any>
-	| string
-	| number
-	| boolean
-	| null
-	| undefined;
-export type ComponentChildren = ComponentChild[] | ComponentChild;
+	export type ComponentChild =
+		| VNode<any>
+		| string
+		| number
+		| boolean
+		| null
+		| undefined;
+	export type ComponentChildren = ComponentChild[] | ComponentChild;
 
-export interface FunctionComponent<P = {}> extends preact.FunctionComponent<P> {
-	// Internally, createContext uses `contextType` on a Function component to
-	// implement the Consumer component
-	contextType?: PreactContext;
+	export interface FunctionComponent<P = {}>
+		extends preact.FunctionComponent<P> {
+		// Internally, createContext uses `contextType` on a Function component to
+		// implement the Consumer component
+		contextType?: PreactContext;
 
-	// Internally, createContext stores a ref to the context object on the Provider
-	// Function component to help devtools
-	_contextRef?: PreactContext;
+		// Internally, createContext stores a ref to the context object on the Provider
+		// Function component to help devtools
+		_contextRef?: PreactContext;
 
-	// Define these properties as undefined on FunctionComponent to get rid of
-	// some errors in `diff()`
-	getDerivedStateFromProps?: undefined;
-	getDerivedStateFromError?: undefined;
-}
+		// Define these properties as undefined on FunctionComponent to get rid of
+		// some errors in `diff()`
+		getDerivedStateFromProps?: undefined;
+		getDerivedStateFromError?: undefined;
+	}
 
-export interface ComponentClass<P = {}> extends preact.ComponentClass<P> {
-	_contextRef?: any;
+	export interface ComponentClass<P = {}> extends preact.ComponentClass<P> {
+		_contextRef?: any;
 
-	// Override public contextType with internal PreactContext type
-	contextType?: PreactContext;
-}
+		// Override public contextType with internal PreactContext type
+		contextType?: PreactContext;
+	}
 
-// Redefine ComponentType using our new internal FunctionComponent interface above
-export type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
+	// Redefine ComponentType using our new internal FunctionComponent interface above
+	export type ComponentType<P = {}> = ComponentClass<P> | FunctionComponent<P>;
 
-export interface PreactElement extends preact.ContainerNode {
-	// SVG detection
-	readonly ownerSVGElement?: SVGElement['ownerSVGElement'];
-	// Property used to update Text nodes
-	data?: CharacterData['data'];
-	// Property to set __dangerouslySetInnerHTML
-	innerHTML?: Element['innerHTML'];
+	export interface PreactElement extends preact.ContainerNode {
+		// SVG detection
+		readonly ownerSVGElement?: SVGElement['ownerSVGElement'];
+		// Property used to update Text nodes
+		data?: CharacterData['data'];
+		// Property to set __dangerouslySetInnerHTML
+		innerHTML?: Element['innerHTML'];
 
-	// Attribute reading and setting
-	readonly attributes?: Element['attributes'];
-	setAttribute?: Element['setAttribute'];
-	removeAttribute?: Element['removeAttribute'];
+		// Attribute reading and setting
+		readonly attributes?: Element['attributes'];
+		setAttribute?: Element['setAttribute'];
+		removeAttribute?: Element['removeAttribute'];
 
-	// Event listeners
-	addEventListener?: Element['addEventListener'];
-	removeEventListener?: Element['removeEventListener'];
+		// Event listeners
+		addEventListener?: Element['addEventListener'];
+		removeEventListener?: Element['removeEventListener'];
 
-	// Setting styles
-	readonly style?: CSSStyleDeclaration;
+		// Setting styles
+		readonly style?: CSSStyleDeclaration;
 
-	// nextSibling required for inserting nodes
-	readonly nextSibling: ContainerNode | null;
+		// nextSibling required for inserting nodes
+		readonly nextSibling: ContainerNode | null;
 
-	// Input handling
-	value?: HTMLInputElement['value'];
-	checked?: HTMLInputElement['checked'];
+		// Input handling
+		value?: HTMLInputElement['value'];
+		checked?: HTMLInputElement['checked'];
 
-	// Internal properties
-	_children?: VNode<any> | null;
-	/** Event listeners to support event delegation */
-	_listeners?: Record<string, (e: Event) => void>;
-}
+		// Internal properties
+		_children?: VNode<any> | null;
+		/** Event listeners to support event delegation */
+		_listeners?: Record<string, (e: Event) => void>;
+	}
 
-export interface PreactEvent extends Event {
-	_dispatched?: number;
-}
+	export interface PreactEvent extends Event {
+		_dispatched?: number;
+	}
 
-// We use the `current` property to differentiate between the two kinds of Refs so
-// internally we'll define `current` on both to make TypeScript happy
-type RefObject<T> = { current: T | null };
-type RefCallback<T> = { (instance: T | null): void; current: undefined };
-type Ref<T> = RefObject<T> | RefCallback<T>;
+	// We use the `current` property to differentiate between the two kinds of Refs so
+	// internally we'll define `current` on both to make TypeScript happy
+	type RefObject<T> = { current: T | null };
+	type RefCallback<T> = { (instance: T | null): void; current: undefined };
+	type Ref<T> = RefObject<T> | RefCallback<T>;
 
-export interface VNode<P = {}> extends preact.VNode<P> {
-	// Redefine type here using our internal ComponentType type, and specify
-	// string has an undefined `defaultProps` property to make TS happy
-	type: (string & { defaultProps: undefined }) | ComponentType<P>;
-	props: P & { children: ComponentChildren };
-	ref?: Ref<any> | null;
-	_children: Array<VNode<any>> | null;
-	_parent: VNode | null;
-	_depth: number | null;
-	/**
-	 * The [first (for Fragments)] DOM child of a VNode
-	 */
-	_dom: PreactElement | null;
-	/**
-	 * The last dom child of a Fragment, or components that return a Fragment
-	 */
-	_nextDom: PreactElement | null | undefined;
-	_component: Component | null;
-	_hydrating: boolean | null;
-	constructor: undefined;
-	_original: number;
-	_index: number;
-}
+	export interface VNode<P = {}> extends preact.VNode<P> {
+		// Redefine type here using our internal ComponentType type, and specify
+		// string has an undefined `defaultProps` property to make TS happy
+		type: (string & { defaultProps: undefined }) | ComponentType<P>;
+		props: P & { children: ComponentChildren };
+		ref?: Ref<any> | null;
+		_children: Array<VNode<any>> | null;
+		_parent: VNode | null;
+		_depth: number | null;
+		/**
+		 * The [first (for Fragments)] DOM child of a VNode
+		 */
+		_dom: PreactElement | null;
+		/**
+		 * The last dom child of a Fragment, or components that return a Fragment
+		 */
+		_nextDom: PreactElement | null | undefined;
+		_component: Component | null;
+		_hydrating: boolean | null;
+		constructor: undefined;
+		_original: number;
+		_index: number;
+	}
 
-export interface Component<P = {}, S = {}> extends preact.Component<P, S> {
-	// When component is functional component, this is reset to functional component
-	constructor: ComponentType<P>;
-	state: S; // Override Component["state"] to not be readonly for internal use, specifically Hooks
-	base?: PreactElement;
+	export interface Component<P = {}, S = {}> extends preact.Component<P, S> {
+		// When component is functional component, this is reset to functional component
+		constructor: ComponentType<P>;
+		state: S; // Override Component["state"] to not be readonly for internal use, specifically Hooks
+		base?: PreactElement;
 
-	_dirty: boolean;
-	_force?: boolean;
-	_renderCallbacks: Array<() => void>; // Only class components
-	_stateCallbacks: Array<() => void>; // Only class components
-	_globalContext?: any;
-	_vnode?: VNode<P> | null;
-	_nextState?: S | null; // Only class components
-	/** Only used in the devtools to later dirty check if state has changed */
-	_prevState?: S | null;
-	/**
-	 * Pointer to the parent dom node. This is only needed for top-level Fragment
-	 * components or array returns.
-	 */
-	_parentDom?: PreactElement | null;
-	// Always read, set only when handling error
-	_processingException?: Component<any, any> | null;
-	// Always read, set only when handling error. This is used to indicate at diffTime to set _processingException
-	_pendingError?: Component<any, any> | null;
-}
+		_dirty: boolean;
+		_force?: boolean;
+		_renderCallbacks: Array<() => void>; // Only class components
+		_stateCallbacks: Array<() => void>; // Only class components
+		_globalContext?: any;
+		_vnode?: VNode<P> | null;
+		_nextState?: S | null; // Only class components
+		/** Only used in the devtools to later dirty check if state has changed */
+		_prevState?: S | null;
+		/**
+		 * Pointer to the parent dom node. This is only needed for top-level Fragment
+		 * components or array returns.
+		 */
+		_parentDom?: PreactElement | null;
+		// Always read, set only when handling error
+		_processingException?: Component<any, any> | null;
+		// Always read, set only when handling error. This is used to indicate at diffTime to set _processingException
+		_pendingError?: Component<any, any> | null;
+	}
 
-export interface PreactContext extends preact.Context<any> {
-	_id: string;
-	_defaultValue: any;
+	export interface PreactContext extends preact.Context<any> {
+		_id: string;
+		_defaultValue: any;
+	}
 }

--- a/src/jsconfig.json
+++ b/src/jsconfig.json
@@ -1,5 +1,0 @@
-{
-  "extends": "../jsconfig.json",
-  "compilerOptions": {},
-  "exclude": ["node_modules", "dist", "demo"]
-}

--- a/src/jsconfig.json
+++ b/src/jsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../jsconfig.json",
-	"compilerOptions": {},
-	"exclude": ["node_modules", "dist", "demo"]
+  "extends": "../jsconfig.json",
+  "compilerOptions": {},
+  "exclude": ["node_modules", "dist", "demo"]
 }

--- a/src/jsconfig.json
+++ b/src/jsconfig.json
@@ -1,0 +1,5 @@
+{
+	"extends": "../jsconfig.json",
+	"compilerOptions": {},
+	"exclude": ["node_modules", "dist", "demo"]
+}

--- a/src/options.js
+++ b/src/options.js
@@ -7,7 +7,7 @@ import { _catchError } from './diff/catch-error';
  * and `preact/hooks` are based on. See the `Options` type in `internal.d.ts`
  * for a full list of available option hooks (most editors/IDEs allow you to
  * ctrl+click or cmd+click on mac the type definition below).
- * @type {import('./internal').Options}
+ * @type {Options}
  */
 const options = {
 	_catchError

--- a/src/render.js
+++ b/src/render.js
@@ -6,10 +6,9 @@ import { slice } from './util';
 
 /**
  * Render a Preact virtual node into a DOM element
- * @param {import('./internal').ComponentChild} vnode The virtual node to render
- * @param {import('./internal').PreactElement} parentDom The DOM element to
- * render into
- * @param {import('./internal').PreactElement | object} [replaceNode] Optional: Attempt to re-use an
+ * @param {ComponentChild} vnode The virtual node to render
+ * @param {PreactElement} parentDom The DOM element to render into
+ * @param {PreactElement | object} [replaceNode] Optional: Attempt to re-use an
  * existing DOM tree rooted at `replaceNode`
  */
 export function render(vnode, parentDom, replaceNode) {
@@ -66,9 +65,8 @@ export function render(vnode, parentDom, replaceNode) {
 
 /**
  * Update an existing DOM element with data from a Preact virtual node
- * @param {import('./internal').ComponentChild} vnode The virtual node to render
- * @param {import('./internal').PreactElement} parentDom The DOM element to
- * update
+ * @param {ComponentChild} vnode The virtual node to render
+ * @param {PreactElement} parentDom The DOM element to update
  */
 export function hydrate(vnode, parentDom) {
 	render(vnode, parentDom, hydrate);

--- a/src/util.js
+++ b/src/util.js
@@ -19,7 +19,7 @@ export function assign(obj, props) {
  * Remove a child node from its parent if attached. This is a workaround for
  * IE11 which doesn't support `Element.prototype.remove()`. Using this function
  * is smaller than including a dedicated polyfill.
- * @param {Node} node The node to remove
+ * @param {import('./index').ContainerNode} node The node to remove
  */
 export function removeNode(node) {
 	let parentNode = node.parentNode;

--- a/src/util.js
+++ b/src/util.js
@@ -10,7 +10,7 @@ export const isArray = Array.isArray;
  * @returns {O & P}
  */
 export function assign(obj, props) {
-	// @ts-ignore We change the type of `obj` to be `O & P`
+	// @ts-expect-error We change the type of `obj` to be `O & P`
 	for (let i in props) obj[i] = props[i];
 	return /** @type {O & P} */ (obj);
 }

--- a/src/util.js
+++ b/src/util.js
@@ -19,7 +19,7 @@ export function assign(obj, props) {
  * Remove a child node from its parent if attached. This is a workaround for
  * IE11 which doesn't support `Element.prototype.remove()`. Using this function
  * is smaller than including a dedicated polyfill.
- * @param {import('./index').ContainerNode} node The node to remove
+ * @param {preact.ContainerNode} node The node to remove
  */
 export function removeNode(node) {
 	let parentNode = node.parentNode;

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -85,6 +85,34 @@ render(h('div', {}), document);
 render(h('div', {}), document.createElement('div').shadowRoot!);
 render(h('div', {}), document.createDocumentFragment());
 
+// From https://gist.github.com/developit/f4c67a2ede71dc2fab7f357f39cff28c, modified to be TypeScript compliant
+function createRootFragment(parent: Element, replaceNode: Element | Element[]) {
+	const replaceNodes: Element[] = ([] as Element[]).concat(replaceNode);
+	const s = replaceNodes[replaceNodes.length - 1].nextSibling;
+	function insert(c: Node, r: Node | null) {
+		return parent.insertBefore(c, r || s);
+	}
+	return ((parent as any).__k = {
+		nodeType: 1,
+		parentNode: parent,
+		firstChild: replaceNodes[0],
+		childNodes: replaceNodes,
+		insertBefore: insert,
+		appendChild: (c: Node) => insert(c, null),
+		removeChild: function (c: Node) {
+			return parent.removeChild(c);
+		}
+	});
+}
+
+render(
+	h('div', {}),
+	createRootFragment(
+		document.createElement('div'),
+		document.createElement('div')
+	)
+);
+
 // Accessing children
 const ComponentWithChildren: FunctionalComponent<DummerComponentProps> = ({
 	input,


### PR DESCRIPTION
This PR improves the internal JSDoc types of the core source. It puts all internal types into the global namespace so you no longer need to do `import('../internal')` in the core source files as well as adds some additional JSDoc and ts-expect-error to improve typing.

I've added a "tsc" script that runs the TypeScript type checker against the core source files to validate their types. I don't know if we want to keep this as a merge check, but figured we'd give it a shot.