### PR TITLE
Rework children diffing to run in multiple phases

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -1,4 +1,5 @@
 import { Component, createElement, options, Fragment } from 'preact';
+import { MODE_HYDRATE } from 'preact/src/constants';
 import { assign } from './util';
 
 const oldCatchError = options._catchError;
@@ -34,7 +35,7 @@ options.unmount = function (vnode) {
 	// most likely it is because the component is suspended
 	// we set the vnode.type as `null` so that it is not a typeof function
 	// so the unmount will remove the vnode._dom
-	if (component && vnode._hydrating === true) {
+	if (component && vnode._flags & MODE_HYDRATE) {
 		vnode.type = null;
 	}
 
@@ -166,7 +167,7 @@ Suspense.prototype._childDidSuspend = function (promise, suspendingVNode) {
 	 * to remain on screen and hydrate it when the suspense actually gets resolved.
 	 * While in non-hydration cases the usual fallback -> component flow would occour.
 	 */
-	const wasHydrating = suspendingVNode._hydrating === true;
+	const wasHydrating = (suspendingVNode._flags & MODE_HYDRATE) === MODE_HYDRATE;
 	if (!c._pendingSuspensionCount++ && !wasHydrating) {
 		c.setState({ _suspended: (c._detachOnNextRender = c._vnode._children[0]) });
 	}
@@ -204,7 +205,7 @@ Suspense.prototype.render = function (props, state) {
 	/** @type {import('./internal').VNode} */
 	const fallback =
 		state._suspended && createElement(Fragment, null, props.fallback);
-	if (fallback) fallback._hydrating = null;
+	if (fallback) fallback._flags &= ~MODE_HYDRATE;
 
 	return [
 		createElement(Fragment, null, state._suspended ? null : props.children),

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -167,8 +167,7 @@ Suspense.prototype._childDidSuspend = function (promise, suspendingVNode) {
 	 * to remain on screen and hydrate it when the suspense actually gets resolved.
 	 * While in non-hydration cases the usual fallback -> component flow would occour.
 	 */
-	const wasHydrating = (suspendingVNode._flags & MODE_HYDRATE) === MODE_HYDRATE;
-	if (!c._pendingSuspensionCount++ && !wasHydrating) {
+	if (!c._pendingSuspensionCount++ && !(suspendingVNode._flags & MODE_HYDRATE)) {
 		c.setState({ _suspended: (c._detachOnNextRender = c._vnode._children[0]) });
 	}
 	promise.then(onResolved, onResolved);

--- a/compat/test/browser/hydrate.test.js
+++ b/compat/test/browser/hydrate.test.js
@@ -17,10 +17,10 @@ describe('compat hydrate', () => {
 		const input = document.createElement('input');
 		scratch.appendChild(input);
 		input.focus();
-		expect(document.activeElement).to.equal(input);
+		expect(document.activeElement).to.equalNode(input);
 
 		hydrate(<input />, scratch);
-		expect(document.activeElement).to.equal(input);
+		expect(document.activeElement).to.equalNode(input);
 	});
 
 	it('should call the callback', () => {

--- a/compat/test/browser/suspense-utils.js
+++ b/compat/test/browser/suspense-utils.js
@@ -114,3 +114,46 @@ export function createSuspender(DefaultComponent) {
 
 	return [Suspender, suspend];
 }
+
+/**
+ * @returns {[() => any, (data: any) => Promise<any>, (error: Error) => Promise<any>]}
+ */
+export function createSuspenseLoader() {
+	/** @type {(data: any) => Promise<any>} */
+	let resolver;
+	/** @type {(error: Error) => Promise<any>} */
+	let rejecter;
+	/** @type {any} */
+	let data = null;
+	/** @type {Error} */
+	let error = null;
+
+	/** @type {Promise<any>} */
+	let promise = new Promise((resolve, reject) => {
+		resolver = result => {
+			data = result;
+			resolve(result);
+			return promise;
+		};
+
+		rejecter = e => {
+			error = e;
+			reject(e);
+			return promise;
+		};
+	});
+
+	function useSuspenseLoader() {
+		if (error) {
+			throw error;
+		}
+
+		if (!data) {
+			throw promise;
+		}
+
+		return data;
+	}
+
+	return [useSuspenseLoader, resolver, rejecter];
+}

--- a/jsx-runtime/src/index.js
+++ b/jsx-runtime/src/index.js
@@ -54,8 +54,7 @@ function createVNode(type, props, key, isStaticChildren, __source, __self) {
 		constructor: undefined,
 		_original: --vnodeId,
 		_index: -1,
-		_insert: false,
-		_matched: false,
+		_flags: 0,
 		__source,
 		__self
 	};

--- a/jsx-runtime/src/index.js
+++ b/jsx-runtime/src/index.js
@@ -54,6 +54,8 @@ function createVNode(type, props, key, isStaticChildren, __source, __self) {
 		constructor: undefined,
 		_original: --vnodeId,
 		_index: -1,
+		_insert: false,
+		_matched: false,
 		__source,
 		__self
 	};

--- a/jsx-runtime/src/index.js
+++ b/jsx-runtime/src/index.js
@@ -1,7 +1,5 @@
 import { options, Fragment } from 'preact';
 
-/** @typedef {import('preact').VNode} VNode */
-
 let vnodeId = 0;
 
 /**
@@ -39,6 +37,7 @@ function createVNode(type, props, key, isStaticChildren, __source, __self) {
 		}
 	}
 
+	/** @type {VNode & { __source: any; __self: any }} */
 	const vnode = {
 		type,
 		props: normalizedProps,
@@ -50,7 +49,6 @@ function createVNode(type, props, key, isStaticChildren, __source, __self) {
 		_dom: null,
 		_nextDom: undefined,
 		_component: null,
-		_hydrating: null,
 		constructor: undefined,
 		_original: --vnodeId,
 		_index: -1,

--- a/mangle.json
+++ b/mangle.json
@@ -55,6 +55,7 @@
       "$_hydrating": "__h",
       "$_component": "__c",
       "$_index": "__i",
+      "$_flags": "__u",
       "$__html": "__html",
       "$_parent": "__",
       "$_pendingError": "__E",

--- a/mangle.json
+++ b/mangle.json
@@ -52,7 +52,6 @@
       "$_onResolve": "__R",
       "$_suspended": "__a",
       "$_dom": "__e",
-      "$_hydrating": "__h",
       "$_component": "__c",
       "$_index": "__i",
       "$_flags": "__u",

--- a/src/component.js
+++ b/src/component.js
@@ -122,12 +122,11 @@ export function getDomSibling(vnode, childIndex) {
 function renderComponent(component) {
 	let oldVNode = component._vnode,
 		oldDom = oldVNode._dom,
-		parentDom = component._parentDom;
+		parentDom = component._parentDom,
+		commitQueue = [],
+		refQueue = [];
 
 	if (parentDom) {
-		let commitQueue = [],
-			refQueue = [];
-
 		const newVNode = assign({}, oldVNode);
 		newVNode._original = oldVNode._original + 1;
 

--- a/src/component.js
+++ b/src/component.js
@@ -2,6 +2,7 @@ import { assign } from './util';
 import { diff, commitRoot } from './diff/index';
 import options from './options';
 import { Fragment } from './create-element';
+import { MODE_HYDRATE } from './constants';
 
 /**
  * Base Component class. Provides `setState()` and `forceUpdate()`, which
@@ -136,10 +137,10 @@ function renderComponent(component) {
 			oldVNode,
 			component._globalContext,
 			parentDom.ownerSVGElement !== undefined,
-			oldVNode._hydrating != null ? [oldDom] : null,
+			oldVNode._flags & MODE_HYDRATE ? [oldDom] : null,
 			commitQueue,
 			oldDom == null ? getDomSibling(oldVNode) : oldDom,
-			oldVNode._hydrating,
+			(oldVNode._flags & MODE_HYDRATE) === MODE_HYDRATE,
 			refQueue
 		);
 

--- a/src/component.js
+++ b/src/component.js
@@ -140,7 +140,7 @@ function renderComponent(component) {
 			oldVNode._flags & MODE_HYDRATE ? [oldDom] : null,
 			commitQueue,
 			oldDom == null ? getDomSibling(oldVNode) : oldDom,
-			(oldVNode._flags & MODE_HYDRATE) === MODE_HYDRATE,
+			!!(oldVNode._flags & MODE_HYDRATE),
 			refQueue
 		);
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,10 +1,14 @@
+/** Normal hydration that attaches to a DOM tree but does not diff it. */
+export const MODE_HYDRATE = 1 << 5;
+/** Signifies this VNode suspended on the previous render */
+export const MODE_SUSPENDED = 1 << 7;
 /** Indicates that this node needs to be inserted while patching children */
 export const INSERT_VNODE = 1 << 16;
 /** Indicates a VNode has been matched with another VNode in the diff */
 export const MATCHED = 1 << 17;
 
 /** Reset all mode flags */
-export const RESET_MODE = ~(INSERT_VNODE | MATCHED);
+export const RESET_MODE = ~(MODE_HYDRATE | MODE_SUSPENDED);
 
 export const EMPTY_OBJ = /** @type {any} */ ({});
 export const EMPTY_ARR = [];

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,11 @@
+/** Indicates that this node needs to be inserted while patching children */
+export const INSERT_VNODE = 1 << 16;
+/** Indicates a VNode has been matched with another VNode in the diff */
+export const MATCHED = 1 << 17;
+
+/** Reset all mode flags */
+export const RESET_MODE = ~(INSERT_VNODE | MATCHED);
+
 export const EMPTY_OBJ = /** @type {any} */ ({});
 export const EMPTY_ARR = [];
 export const IS_NON_DIMENSIONAL =

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -76,8 +76,7 @@ export function createVNode(type, props, key, ref, original) {
 		constructor: undefined,
 		_original: original == null ? ++vnodeId : original,
 		_index: -1,
-		_insert: false,
-		_matched: false
+		_flags: 0
 	};
 
 	// Only invoke the vnode hook if this was *not* a direct copy:

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -72,7 +72,6 @@ export function createVNode(type, props, key, ref, original) {
 		// a _nextDom that has been set to `null`
 		_nextDom: undefined,
 		_component: null,
-		_hydrating: null,
 		constructor: undefined,
 		_original: original == null ? ++vnodeId : original,
 		_index: -1,

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -75,7 +75,9 @@ export function createVNode(type, props, key, ref, original) {
 		_hydrating: null,
 		constructor: undefined,
 		_original: original == null ? ++vnodeId : original,
-		_index: -1
+		_index: -1,
+		_insert: false,
+		_matched: false
 	};
 
 	// Only invoke the vnode hook if this was *not* a direct copy:

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -269,7 +269,7 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 		childVNode._parent = newParentVNode;
 		childVNode._depth = newParentVNode._depth + 1;
 
-		let skewedIndex = i + skew;
+		const skewedIndex = i + skew;
 		const matchingIndex = findMatchingIndex(
 			childVNode,
 			oldChildren,
@@ -292,7 +292,7 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 		// Here, we define isMounting for the purposes of the skew diffing
 		// algorithm. Nodes that are unsuspending are considered mounting and we detect
 		// this by checking if oldVNode._original === null
-		let isMounting =
+		const isMounting =
 			matchingIndex === -1 ||
 			oldChildren[matchingIndex] == null ||
 			oldChildren[matchingIndex]._original === null;
@@ -323,7 +323,7 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 		}
 
 		// Move this VNode's DOM if the original index (matchingIndex) doesn't match
-		// the new skew index (i + skew) or it's a mounting component VNode
+		// the new skew index (i + new skew) or it's a mounting DOM VNode
 		if (
 			matchingIndex !== i + skew ||
 			(typeof childVNode.type != 'function' && isMounting)

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -169,8 +169,8 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 	let oldVNode;
 
 	const newChildrenLength = renderResult.length;
-	const oldChildrenLength = oldChildren.length;
-	let remainingOldChildren = oldChildren.length;
+	let oldChildrenLength = oldChildren.length,
+		remainingOldChildren = oldChildrenLength
 
 	let skew = 0;
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -40,7 +40,6 @@ export function diffChildren(
 	refQueue
 ) {
 	let i,
-		j,
 		/** @type {VNode} */
 		oldVNode,
 		/** @type {VNode} */
@@ -48,8 +47,7 @@ export function diffChildren(
 		/** @type {PreactElement} */
 		newDom,
 		/** @type {PreactElement} */
-		firstChildDom,
-		skew = 0;
+		firstChildDom;
 
 	// This is a compression of oldParentVNode!=null && oldParentVNode != EMPTY_OBJ && oldParentVNode._children || EMPTY_ARR
 	// as EMPTY_OBJ._children should be `undefined`.
@@ -57,104 +55,65 @@ export function diffChildren(
 	let oldChildren = (oldParentVNode && oldParentVNode._children) || EMPTY_ARR;
 
 	let oldChildrenLength = oldChildren.length,
-		remainingOldChildren = oldChildrenLength,
 		newChildrenLength = renderResult.length;
 
-	newParentVNode._children = [];
+	// TODO: Consider replacing with newParentVNode._nextDom;
+	// TODO: Is there a better way to track oldDom then a ref? Since
+	// constructNewChildrenArray can unmount DOM nodes while looping (to handle
+	// null placeholders, i.e. VNode => null in unkeyed children), we need to adjust
+	// oldDom in that method.
+	const oldDomRef = { _current: oldDom };
+	const newChildren = (newParentVNode._children = constructNewChildrenArray(
+		newParentVNode,
+		renderResult,
+		oldChildren,
+		oldDomRef
+	));
+	oldDom = oldDomRef._current;
+
+	// Remove remaining oldChildren if there are any. Loop forwards so that as we
+	// unmount DOM from the beginning of the oldChildren, we can adjust oldDom to
+	// point to the next child, which needs to be the first DOM node that won't be
+	// unmounted.
+	for (i = 0; i < oldChildrenLength; i++) {
+		oldVNode = oldChildren[i];
+		if (oldVNode != null && !oldVNode._matched) {
+			if (oldDom == oldVNode._dom) {
+				oldDom = getDomSibling(oldVNode);
+
+				if (typeof newParentVNode.type == 'function') {
+					// If the parent VNode is a component/fragment, make sure its diff
+					// continues with a DOM node that is still mounted in case this loop
+					// exits here because the rest of the new children are `null`.
+					newParentVNode._nextDom = oldDom;
+				}
+			}
+
+			unmount(oldVNode, oldVNode);
+		}
+	}
+
 	for (i = 0; i < newChildrenLength; i++) {
-		// @ts-expect-error We are reusing the childVNode variable to hold both the
-		// pre and post normalized childVNode
-		childVNode = renderResult[i];
+		childVNode = newChildren[i];
 
 		if (
 			childVNode == null ||
 			typeof childVNode == 'boolean' ||
 			typeof childVNode == 'function'
 		) {
-			childVNode = newParentVNode._children[i] = null;
-		}
-		// If this newVNode is being reused (e.g. <div>{reuse}{reuse}</div>) in the same diff,
-		// or we are rendering a component (e.g. setState) copy the oldVNodes so it can have
-		// it's own DOM & etc. pointers
-		else if (
-			childVNode.constructor == String ||
-			typeof childVNode == 'number' ||
-			// eslint-disable-next-line valid-typeof
-			typeof childVNode == 'bigint'
-		) {
-			childVNode = newParentVNode._children[i] = createVNode(
-				null,
-				childVNode,
-				null,
-				null,
-				childVNode
-			);
-		} else if (isArray(childVNode)) {
-			childVNode = newParentVNode._children[i] = createVNode(
-				Fragment,
-				{ children: childVNode },
-				null,
-				null,
-				null
-			);
-		} else if (childVNode._depth > 0) {
-			// VNode is already in use, clone it. This can happen in the following
-			// scenario:
-			//   const reuse = <div />
-			//   <div>{reuse}<span />{reuse}</div>
-			childVNode = newParentVNode._children[i] = createVNode(
-				childVNode.type,
-				childVNode.props,
-				childVNode.key,
-				childVNode.ref ? childVNode.ref : null,
-				childVNode._original
-			);
-		} else {
-			childVNode = newParentVNode._children[i] = childVNode;
-		}
-
-		// Terser removes the `continue` here and wraps the loop body
-		// in a `if (childVNode) { ... } condition
-		if (childVNode == null) {
-			oldVNode = oldChildren[i];
-			if (oldVNode && oldVNode.key == null && oldVNode._dom) {
-				if (oldVNode._dom == oldDom) {
-					oldDom = getDomSibling(oldVNode);
-
-					if (typeof newParentVNode.type == 'function') {
-						// If the parent VNode is a component/fragment, make sure its diff
-						// continues with a DOM node that is still mounted in case this loop
-						// exits here because the rest of the new children are `null`.
-						newParentVNode._nextDom = oldDom;
-					}
-				}
-
-				unmount(oldVNode, oldVNode, false);
-				oldChildren[i] = null;
-			}
-
 			continue;
 		}
 
-		childVNode._parent = newParentVNode;
-		childVNode._depth = newParentVNode._depth + 1;
-		childVNode._index = i;
-
-		let skewedIndex = i + skew;
-		const matchingIndex = findMatchingIndex(
-			childVNode,
-			oldChildren,
-			skewedIndex,
-			remainingOldChildren
-		);
-
-		if (matchingIndex === -1) {
+		// At this point, constructNewChildrenArray has assigned _index to be the
+		// matchingIndex for this VNode's oldVNode (or -1 if there is no oldVNode).
+		if (childVNode._index === -1) {
 			oldVNode = EMPTY_OBJ;
 		} else {
-			oldVNode = oldChildren[matchingIndex] || EMPTY_OBJ;
-			oldChildren[matchingIndex] = undefined;
-			remainingOldChildren--;
+			oldVNode = oldChildren[childVNode._index] || EMPTY_OBJ;
 		}
+
+		// Update childVNode._index to its final index
+		childVNode._index = i;
 
 		// Morph the old element into the new one, but don't append it to the dom yet
 		diff(
@@ -170,19 +129,211 @@ export function diffChildren(
 			refQueue
 		);
 
+		// Adjust DOM nodes
 		newDom = childVNode._dom;
-		if ((j = childVNode.ref) && oldVNode.ref != j) {
+		if (childVNode.ref && oldVNode.ref != childVNode.ref) {
 			if (oldVNode.ref) {
 				applyRef(oldVNode.ref, null, childVNode);
 			}
-			refQueue.push(j, childVNode._component || newDom, childVNode);
+			refQueue.push(
+				childVNode.ref,
+				childVNode._component || newDom,
+				childVNode
+			);
 		}
 
 		if (firstChildDom == null && newDom != null) {
 			firstChildDom = newDom;
 		}
 
-		let isMounting = oldVNode === EMPTY_OBJ || oldVNode._original === null;
+		if (typeof childVNode.type == 'function') {
+			if (childVNode._insert || oldVNode._children === childVNode._children) {
+				oldDom = reorderChildren(childVNode, oldDom, parentDom);
+			} else if (childVNode._nextDom !== undefined) {
+				// Only Fragments or components that return Fragment like VNodes will
+				// have a non-undefined _nextDom. Continue the diff from the sibling
+				// of last DOM child of this child VNode
+				oldDom = childVNode._nextDom;
+			} else if (newDom) {
+				oldDom = newDom.nextSibling;
+			}
+
+			// Eagerly cleanup _nextDom. We don't need to persist the value because
+			// it is only used by `diffChildren` to determine where to resume the diff after
+			// diffing Components and Fragments. Once we store it the nextDOM local var, we
+			// can clean up the property
+			childVNode._nextDom = undefined;
+		} else if (newDom) {
+			if (childVNode._insert) {
+				oldDom = placeChild(parentDom, newDom, oldDom);
+			} else {
+				oldDom = newDom.nextSibling;
+			}
+		}
+
+		// TODO: With new child diffing algo, consider alt ways to diff Fragments.
+		// Such as dropping oldDom and moving fragments in place
+		if (typeof newParentVNode.type == 'function') {
+			// Because the newParentVNode is Fragment-like, we need to set it's
+			// _nextDom property to the nextSibling of its last child DOM node.
+			//
+			// `oldDom` contains the correct value here because if the last child
+			// is a Fragment-like, then oldDom has already been set to that child's _nextDom.
+			// If the last child is a DOM VNode, then oldDom will be set to that DOM
+			// node's nextSibling.
+			newParentVNode._nextDom = oldDom;
+		}
+
+		// Unset diffing flags
+		childVNode._insert = false;
+	}
+
+	newParentVNode._dom = firstChildDom;
+}
+
+/**
+ * @param {VNode} newParentVNode
+ * @param {ComponentChildren[]} renderResult
+ * @param {VNode[]} oldChildren
+ * @param {{ _current: PreactElement }} oldDomRef
+ * @returns {VNode[]}
+ */
+function constructNewChildrenArray(
+	newParentVNode,
+	renderResult,
+	oldChildren,
+	oldDomRef
+) {
+	/** @type {number} */
+	let i;
+	/** @type {VNode} */
+	let childVNode;
+	let newChildrenLength = renderResult.length;
+	let remainingOldChildren = oldChildren.length;
+	let skew = 0;
+
+	/** @type {VNode[]} */
+	const newChildren = [];
+	for (i = 0; i < newChildrenLength; i++) {
+		// @ts-expect-error We are reusing the childVNode variable to hold both the
+		// pre and post normalized childVNode
+		childVNode = renderResult[i];
+
+		if (
+			childVNode == null ||
+			typeof childVNode == 'boolean' ||
+			typeof childVNode == 'function'
+		) {
+			childVNode = newChildren[i] = null;
+		}
+		// If this newVNode is being reused (e.g. <div>{reuse}{reuse}</div>) in the same diff,
+		// or we are rendering a component (e.g. setState) copy the oldVNodes so it can have
+		// it's own DOM & etc. pointers
+		else if (
+			childVNode.constructor == String ||
+			typeof childVNode == 'number' ||
+			// eslint-disable-next-line valid-typeof
+			typeof childVNode == 'bigint'
+		) {
+			childVNode = newChildren[i] = createVNode(
+				null,
+				childVNode,
+				null,
+				null,
+				childVNode
+			);
+		} else if (isArray(childVNode)) {
+			childVNode = newChildren[i] = createVNode(
+				Fragment,
+				{ children: childVNode },
+				null,
+				null,
+				null
+			);
+		} else if (childVNode._depth > 0) {
+			// VNode is already in use, clone it. This can happen in the following
+			// scenario:
+			//   const reuse = <div />
+			//   <div>{reuse}<span />{reuse}</div>
+			childVNode = newChildren[i] = createVNode(
+				childVNode.type,
+				childVNode.props,
+				childVNode.key,
+				childVNode.ref ? childVNode.ref : null,
+				childVNode._original
+			);
+		} else {
+			childVNode = newChildren[i] = childVNode;
+		}
+
+		// Handle unmounting null placeholders, i.e. VNode => null in unkeyed children
+		if (childVNode == null) {
+			const oldVNode = oldChildren[i];
+			if (oldVNode && oldVNode.key == null && oldVNode._dom) {
+				if (oldVNode._dom == oldDomRef._current) {
+					oldDomRef._current = getDomSibling(oldVNode);
+
+					if (typeof newParentVNode.type == 'function') {
+						// If the parent VNode is a component/fragment, make sure its diff
+						// continues with a DOM node that is still mounted in case this loop
+						// exits here because the rest of the new children are `null`.
+						newParentVNode._nextDom = oldDomRef._current;
+					}
+				}
+
+				unmount(oldVNode, oldVNode, false);
+
+				// Explicitly nullify this position in oldChildren instead of just
+				// setting `_match=true` to prevent other routines (e.g.
+				// `findMatchingIndex` or `getDomSibling`) from thinking VNodes or DOM
+				// nodes in this position are still available to be used in diffing when
+				// they have actually already been unmounted. For example, by only
+				// setting `_match=true` here, the unmounting loop later would attempt
+				// to unmount this VNode again seeing `_match==true`.  Further,
+				// getDomSibling doesn't know about _match and so would incorrectly
+				// assume DOM nodes in this subtree are mounted and usable.
+				oldChildren[i] = null;
+				remainingOldChildren--;
+			}
+
+			continue;
+		}
+
+		childVNode._parent = newParentVNode;
+		childVNode._depth = newParentVNode._depth + 1;
+
+		let skewedIndex = i + skew;
+		const matchingIndex = findMatchingIndex(
+			childVNode,
+			oldChildren,
+			skewedIndex,
+			remainingOldChildren
+		);
+
+		// Temporarily store the matchingIndex on the _index property so we can pull
+		// out the oldVNode in diffChildren. We'll override this to the VNode's
+		// final index after using this property to get the oldVNode
+		childVNode._index = matchingIndex;
+
+		if (matchingIndex !== -1) {
+			remainingOldChildren--;
+			if (oldChildren[matchingIndex]) {
+				// TODO: Can we somehow not use this property? or override another
+				// property? We need it now so we can pull off the matchingIndex in
+				// diffChildren and when unmounting we can get the next DOM element by
+				// calling getDomSibling, which needs a complete oldTree
+				oldChildren[matchingIndex]._matched = true;
+			}
+		}
+
+		// Here, we define isMounting for the purposes of the skew diffing
+		// algorithm. Nodes that are unsuspending are considered mounting and we detect
+		// this by checking if oldVNode._original === null
+		let isMounting =
+			matchingIndex === -1 ||
+			oldChildren[matchingIndex] == null ||
+			oldChildren[matchingIndex]._original === null;
+
 		if (isMounting) {
 			if (matchingIndex == -1) {
 				skew--;
@@ -208,67 +359,17 @@ export function diffChildren(
 			}
 		}
 
-		skewedIndex = i + skew;
-
-		if (typeof childVNode.type == 'function') {
-			if (
-				matchingIndex !== skewedIndex ||
-				oldVNode._children === childVNode._children
-			) {
-				oldDom = reorderChildren(childVNode, oldDom, parentDom);
-			} else if (childVNode._nextDom !== undefined) {
-				// Only Fragments or components that return Fragment like VNodes will
-				// have a non-undefined _nextDom. Continue the diff from the sibling
-				// of last DOM child of this child VNode
-				oldDom = childVNode._nextDom;
-			} else if (newDom) {
-				oldDom = newDom.nextSibling;
-			}
-
-			// Eagerly cleanup _nextDom. We don't need to persist the value because
-			// it is only used by `diffChildren` to determine where to resume the diff after
-			// diffing Components and Fragments. Once we store it the nextDOM local var, we
-			// can clean up the property
-			childVNode._nextDom = undefined;
-		} else if (newDom) {
-			if (matchingIndex !== skewedIndex || isMounting) {
-				oldDom = placeChild(parentDom, newDom, oldDom);
-			} else {
-				oldDom = newDom.nextSibling;
-			}
-		}
-
-		if (typeof newParentVNode.type == 'function') {
-			// Because the newParentVNode is Fragment-like, we need to set it's
-			// _nextDom property to the nextSibling of its last child DOM node.
-			//
-			// `oldDom` contains the correct value here because if the last child
-			// is a Fragment-like, then oldDom has already been set to that child's _nextDom.
-			// If the last child is a DOM VNode, then oldDom will be set to that DOM
-			// node's nextSibling.
-			newParentVNode._nextDom = oldDom;
+		// Move this VNode's DOM if the original index (matchingIndex) doesn't match
+		// the new skew index (i + skew) or it's a mounting component VNode
+		if (
+			matchingIndex !== i + skew ||
+			(typeof childVNode.type != 'function' && isMounting)
+		) {
+			childVNode._insert = true;
 		}
 	}
 
-	newParentVNode._dom = firstChildDom;
-
-	// Remove remaining oldChildren if there are any.
-	for (i = oldChildrenLength; i--; ) {
-		if (oldChildren[i] != null) {
-			if (
-				typeof newParentVNode.type == 'function' &&
-				oldChildren[i]._dom != null &&
-				oldChildren[i]._dom == oldDom
-			) {
-				// If oldDom points to a dom node that is about to be unmounted, then
-				// get the next sibling of that vnode and set _nextDom to it, so the
-				// parent's diff continues diffing an existing DOM node
-				newParentVNode._nextDom = oldChildren[i]._dom.nextSibling;
-			}
-
-			unmount(oldChildren[i], oldChildren[i]);
-		}
-	}
+	return newChildren;
 }
 
 /**
@@ -354,16 +455,32 @@ function findMatchingIndex(
 	let y = skewedIndex + 1;
 	let oldVNode = oldChildren[skewedIndex];
 
+	// We only need to perform a search if there are more children
+	// (remainingOldChildren) to search. However, if the oldVNode we just looked
+	// at skewedIndex was not already used in this diff, then there must be at
+	// least 1 other (so greater than 1) remainingOldChildren to attempt to match
+	// against. So the following condition checks that ensuring
+	// remainingOldChildren > 1 if the oldVNode is not already used/matched. Else
+	// if the oldVNode was null or matched, then there could needs to be at least
+	// 1 (aka `remainingOldChildren > 0`) children to find and compare against.
+	let shouldSearch =
+		remainingOldChildren > (oldVNode != null && !oldVNode._matched ? 1 : 0);
+
 	if (
 		oldVNode === null ||
 		(oldVNode && key == oldVNode.key && type === oldVNode.type)
 	) {
 		return skewedIndex;
-	} else if (remainingOldChildren > (oldVNode != null ? 1 : 0)) {
+	} else if (shouldSearch) {
 		while (x >= 0 || y < oldChildren.length) {
 			if (x >= 0) {
 				oldVNode = oldChildren[x];
-				if (oldVNode && key == oldVNode.key && type === oldVNode.type) {
+				if (
+					oldVNode &&
+					!oldVNode._matched &&
+					key == oldVNode.key &&
+					type === oldVNode.type
+				) {
 					return x;
 				}
 				x--;
@@ -371,7 +488,12 @@ function findMatchingIndex(
 
 			if (y < oldChildren.length) {
 				oldVNode = oldChildren[y];
-				if (oldVNode && key == oldVNode.key && type === oldVNode.type) {
+				if (
+					oldVNode &&
+					!oldVNode._matched &&
+					key == oldVNode.key &&
+					type === oldVNode.type
+				) {
 					return y;
 				}
 				y++;

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -1,12 +1,6 @@
 import { diff, unmount, applyRef } from './index';
 import { createVNode, Fragment } from '../create-element';
-import {
-	EMPTY_OBJ,
-	EMPTY_ARR,
-	INSERT_VNODE,
-	MATCHED,
-	RESET_MODE
-} from '../constants';
+import { EMPTY_OBJ, EMPTY_ARR, INSERT_VNODE, MATCHED } from '../constants';
 import { isArray } from '../util';
 import { getDomSibling } from '../component';
 
@@ -144,7 +138,7 @@ export function diffChildren(
 		childVNode._nextDom = undefined;
 
 		// Unset diffing flags
-		childVNode._flags &= RESET_MODE;
+		childVNode._flags &= ~(INSERT_VNODE | MATCHED);
 	}
 
 	// TODO: With new child diffing algo, consider alt ways to diff Fragments.

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -170,7 +170,7 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 
 	const newChildrenLength = renderResult.length;
 	let oldChildrenLength = oldChildren.length,
-		remainingOldChildren = oldChildrenLength
+		remainingOldChildren = oldChildrenLength;
 
 	let skew = 0;
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -62,17 +62,12 @@ export function diffChildren(
 
 	let newChildrenLength = renderResult.length;
 
-	// TODO: Could we drop oldDom all together and just use _nextDom?
 	newParentVNode._nextDom = oldDom;
-	const newChildren = (newParentVNode._children = constructNewChildrenArray(
-		newParentVNode,
-		renderResult,
-		oldChildren
-	));
+	constructNewChildrenArray(newParentVNode, renderResult, oldChildren);
 	oldDom = newParentVNode._nextDom;
 
 	for (i = 0; i < newChildrenLength; i++) {
-		childVNode = newChildren[i];
+		childVNode = newParentVNode._children[i];
 
 		if (
 			childVNode == null ||
@@ -170,7 +165,6 @@ export function diffChildren(
  * @param {VNode} newParentVNode
  * @param {ComponentChildren[]} renderResult
  * @param {VNode[]} oldChildren
- * @returns {VNode[]}
  */
 function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 	/** @type {number} */
@@ -186,8 +180,7 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 
 	let skew = 0;
 
-	/** @type {VNode[]} */
-	const newChildren = [];
+	newParentVNode._children = [];
 	for (i = 0; i < newChildrenLength; i++) {
 		// @ts-expect-error We are reusing the childVNode variable to hold both the
 		// pre and post normalized childVNode
@@ -198,7 +191,7 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 			typeof childVNode == 'boolean' ||
 			typeof childVNode == 'function'
 		) {
-			childVNode = newChildren[i] = null;
+			childVNode = newParentVNode._children[i] = null;
 		}
 		// If this newVNode is being reused (e.g. <div>{reuse}{reuse}</div>) in the same diff,
 		// or we are rendering a component (e.g. setState) copy the oldVNodes so it can have
@@ -209,7 +202,7 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 			// eslint-disable-next-line valid-typeof
 			typeof childVNode == 'bigint'
 		) {
-			childVNode = newChildren[i] = createVNode(
+			childVNode = newParentVNode._children[i] = createVNode(
 				null,
 				childVNode,
 				null,
@@ -217,7 +210,7 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 				childVNode
 			);
 		} else if (isArray(childVNode)) {
-			childVNode = newChildren[i] = createVNode(
+			childVNode = newParentVNode._children[i] = createVNode(
 				Fragment,
 				{ children: childVNode },
 				null,
@@ -229,7 +222,7 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 			// scenario:
 			//   const reuse = <div />
 			//   <div>{reuse}<span />{reuse}</div>
-			childVNode = newChildren[i] = createVNode(
+			childVNode = newParentVNode._children[i] = createVNode(
 				childVNode.type,
 				childVNode.props,
 				childVNode.key,
@@ -237,7 +230,7 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 				childVNode._original
 			);
 		} else {
-			childVNode = newChildren[i] = childVNode;
+			childVNode = newParentVNode._children[i] = childVNode;
 		}
 
 		// Handle unmounting null placeholders, i.e. VNode => null in unkeyed children
@@ -346,8 +339,6 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 			unmount(oldVNode, oldVNode);
 		}
 	}
-
-	return newChildren;
 }
 
 /**

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -131,9 +131,9 @@ export function diffChildren(
 			) {
 				oldDom = reorderChildren(childVNode, oldDom, parentDom);
 			} else if (childVNode._nextDom !== undefined) {
-				// Only Fragments or components that return Fragment like VNodes will
-				// have a non-undefined _nextDom. Continue the diff from the sibling
-				// of last DOM child of this child VNode
+				// Since Fragments or components that return Fragment like VNodes can
+				// contain multiple DOM nodes as the same level, continue the diff from
+				// the sibling of last DOM child of this child VNode
 				oldDom = childVNode._nextDom;
 			} else if (newDom) {
 				oldDom = newDom.nextSibling;
@@ -144,19 +144,6 @@ export function diffChildren(
 			} else {
 				oldDom = newDom.nextSibling;
 			}
-		}
-
-		// TODO: With new child diffing algo, consider alt ways to diff Fragments.
-		// Such as dropping oldDom and moving fragments in place
-		if (typeof newParentVNode.type == 'function') {
-			// Because the newParentVNode is Fragment-like, we need to set it's
-			// _nextDom property to the nextSibling of its last child DOM node.
-			//
-			// `oldDom` contains the correct value here because if the last child
-			// is a Fragment-like, then oldDom has already been set to that child's _nextDom.
-			// If the last child is a DOM VNode, then oldDom will be set to that DOM
-			// node's nextSibling.
-			newParentVNode._nextDom = oldDom;
 		}
 
 		// Eagerly cleanup _nextDom. We don't need to persist the value because it
@@ -170,6 +157,17 @@ export function diffChildren(
 		childVNode._flags &= RESET_MODE;
 	}
 
+	// TODO: With new child diffing algo, consider alt ways to diff Fragments.
+	// Such as dropping oldDom and moving fragments in place
+	//
+	// Because the newParentVNode is Fragment-like, we need to set it's
+	// _nextDom property to the nextSibling of its last child DOM node.
+	//
+	// `oldDom` contains the correct value here because if the last child
+	// is a Fragment-like, then oldDom has already been set to that child's _nextDom.
+	// If the last child is a DOM VNode, then oldDom will be set to that DOM
+	// node's nextSibling.
+	newParentVNode._nextDom = oldDom;
 	newParentVNode._dom = firstChildDom;
 }
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -51,7 +51,7 @@ export function diff(
 
 	// If the previous diff bailed out, resume creating/hydrating.
 	if (oldVNode._flags & MODE_SUSPENDED) {
-		isHydrating = (oldVNode._flags & MODE_HYDRATE) === MODE_HYDRATE;
+		isHydrating = !!(oldVNode._flags & MODE_HYDRATE);
 		oldDom = newVNode._dom = oldVNode._dom;
 		// if we resume, we want the tree to be "unlocked"
 		// newVNode._hydrating = null;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -53,8 +53,6 @@ export function diff(
 	if (oldVNode._flags & MODE_SUSPENDED) {
 		isHydrating = !!(oldVNode._flags & MODE_HYDRATE);
 		oldDom = newVNode._dom = oldVNode._dom;
-		// if we resume, we want the tree to be "unlocked"
-		// newVNode._hydrating = null;
 		excessDomChildren = [oldDom];
 	}
 

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -147,7 +147,6 @@ declare global {
 		 */
 		_nextDom: PreactElement | null | undefined;
 		_component: Component | null;
-		_hydrating: boolean | null;
 		constructor: undefined;
 		_original: number;
 		_index: number;

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -151,8 +151,7 @@ declare global {
 		constructor: undefined;
 		_original: number;
 		_index: number;
-		_insert: boolean;
-		_matched: boolean;
+		_flags: number;
 	}
 
 	export interface Component<P = {}, S = {}> extends preact.Component<P, S> {

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -151,6 +151,8 @@ declare global {
 		constructor: undefined;
 		_original: number;
 		_index: number;
+		_insert: boolean;
+		_matched: boolean;
 	}
 
 	export interface Component<P = {}, S = {}> extends preact.Component<P, S> {

--- a/test/browser/createContext.test.js
+++ b/test/browser/createContext.test.js
@@ -877,8 +877,8 @@ describe('createContext', () => {
 			expect(events).to.deep.equal([
 				'render 0',
 				'mount 0',
-				'render 1',
 				'unmount 0',
+				'render 1',
 				'mount 1'
 			]);
 		});

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -1,7 +1,7 @@
 import { setupRerender } from 'preact/test-utils';
 import { createElement, render, Component, Fragment } from 'preact';
 import { setupScratch, teardown } from '../_util/helpers';
-import { span, div, ul, ol, li, section, p } from '../_util/dom';
+import { span, div, ul, ol, li, section } from '../_util/dom';
 import { logCall, clearLog, getLog } from '../_util/logCall';
 
 /** @jsx createElement */
@@ -235,9 +235,9 @@ describe('Fragment', () => {
 
 		expect(scratch.innerHTML).to.equal(div([div(1), span(2), span(2)]));
 		expectDomLogToBe([
+			'<span>1.remove()',
 			'<div>.appendChild(#text)',
-			'<div>122.insertBefore(<div>1, <span>1)',
-			'<span>1.remove()'
+			'<div>22.insertBefore(<div>1, <span>2)'
 		]);
 	});
 
@@ -357,9 +357,9 @@ describe('Fragment', () => {
 		expect(ops).to.deep.equal([]);
 		expect(scratch.innerHTML).to.equal('<div>Hello</div>');
 		expectDomLogToBe([
+			'<div>Hello.remove()',
 			'<div>.appendChild(#text)',
-			'<div>Hello.insertBefore(<div>Hello, <div>Hello)',
-			'<div>Hello.remove()'
+			'<div>.appendChild(<div>Hello)'
 		]);
 
 		clearLog();
@@ -368,10 +368,10 @@ describe('Fragment', () => {
 		expect(ops).to.deep.equal([]);
 		expect(scratch.innerHTML).to.equal('<div>Hello</div>');
 		expectDomLogToBe([
+			'<div>Hello.remove()',
 			'<div>.appendChild(#text)',
 			// Re-append the Stateful DOM since it has been re-parented
-			'<div>Hello.insertBefore(<div>Hello, <div>Hello)',
-			'<div>Hello.remove()'
+			'<div>.appendChild(<div>Hello)'
 		]);
 	});
 
@@ -396,9 +396,9 @@ describe('Fragment', () => {
 		expect(ops).to.deep.equal([]);
 		expect(scratch.innerHTML).to.equal('<div>Hello</div>');
 		expectDomLogToBe([
+			'<div>Hello.remove()',
 			'<div>.appendChild(#text)',
-			'<div>Hello.insertBefore(<div>Hello, <div>Hello)',
-			'<div>Hello.remove()'
+			'<div>.appendChild(<div>Hello)'
 		]);
 
 		clearLog();
@@ -407,9 +407,9 @@ describe('Fragment', () => {
 		expect(ops).to.deep.equal([]);
 		expect(scratch.innerHTML).to.equal('<div>Hello</div>');
 		expectDomLogToBe([
+			'<div>Hello.remove()',
 			'<div>.appendChild(#text)',
-			'<div>Hello.insertBefore(<div>Hello, <div>Hello)',
-			'<div>Hello.remove()'
+			'<div>.appendChild(<div>Hello)'
 		]);
 	});
 
@@ -647,7 +647,6 @@ describe('Fragment', () => {
 	});
 
 	it('should preserve order for fragment switching', () => {
-		/** @type {(newState: { isLoading: boolean; data: number | null }) => void} */
 		let set;
 		class Foo extends Component {
 			constructor(props) {
@@ -675,84 +674,6 @@ describe('Fragment', () => {
 		rerender();
 		expect(scratch.innerHTML).to.equal(
 			'<div>HEADER</div><div>Content: 2</div>'
-		);
-	});
-
-	it('should preserve order for fragment switching with sibling DOM', () => {
-		/** @type {(newState: { isLoading: boolean; data: number | null }) => void} */
-		let set;
-		class Foo extends Component {
-			constructor(props) {
-				super(props);
-				this.state = { isLoading: true, data: null };
-				set = this.setState.bind(this);
-			}
-			render(props, { isLoading, data }) {
-				return (
-					<Fragment>
-						<div>HEADER</div>
-						{isLoading ? <div>Loading...</div> : null}
-						{data ? <div>Content: {data}</div> : null}
-						<div>FOOTER</div>
-					</Fragment>
-				);
-			}
-		}
-
-		render(<Foo />, scratch);
-		expect(scratch.innerHTML).to.equal(
-			'<div>HEADER</div><div>Loading...</div><div>FOOTER</div>'
-		);
-
-		set({ isLoading: false, data: 2 });
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div>HEADER</div><div>Content: 2</div><div>FOOTER</div>'
-		);
-	});
-
-	it('should preserve order for fragment switching with sibling Components', () => {
-		/** @type {(newState: { isLoading: boolean; data: number | null }) => void} */
-		let set;
-		class Foo extends Component {
-			constructor(props) {
-				super(props);
-				this.state = { isLoading: true, data: null };
-				set = this.setState.bind(this);
-			}
-			render(props, { isLoading, data }) {
-				return (
-					<Fragment>
-						<div>HEADER</div>
-						{isLoading ? <div>Loading...</div> : null}
-						{data ? <div>Content: {data}</div> : null}
-					</Fragment>
-				);
-			}
-		}
-
-		function Footer() {
-			return <div>FOOTER</div>;
-		}
-
-		function App() {
-			return (
-				<Fragment>
-					<Foo />
-					<Footer />
-				</Fragment>
-			);
-		}
-
-		render(<App />, scratch);
-		expect(scratch.innerHTML).to.equal(
-			'<div>HEADER</div><div>Loading...</div><div>FOOTER</div>'
-		);
-
-		set({ isLoading: false, data: 2 });
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div>HEADER</div><div>Content: 2</div><div>FOOTER</div>'
 		);
 	});
 
@@ -922,12 +843,12 @@ describe('Fragment', () => {
 		expect(ops).to.deep.equal([]); // Component should not have updated (empty op log)
 		expect(scratch.innerHTML).to.equal(html);
 		expectDomLogToBe([
-			'<span>.appendChild(#text)',
-			'<div>1Hello2.insertBefore(<span>1, <span>1)',
-			'<div>.appendChild(#text)',
-			'<div>11Hello2.insertBefore(<div>Hello, <span>1)',
 			'<span>1.remove()',
-			'<div>Hello.remove()'
+			'<div>Hello.remove()',
+			'<span>.appendChild(#text)',
+			'<div>2.insertBefore(<span>1, <span>2)',
+			'<div>.appendChild(#text)',
+			'<div>12.insertBefore(<div>Hello, <span>2)'
 		]);
 
 		clearLog();
@@ -936,12 +857,12 @@ describe('Fragment', () => {
 		expect(ops).to.deep.equal([]); // Component should not have updated (empty op log)
 		expect(scratch.innerHTML).to.equal(html);
 		expectDomLogToBe([
-			'<span>.appendChild(#text)',
-			'<div>1Hello2.insertBefore(<span>1, <span>1)',
-			'<div>.appendChild(#text)',
-			'<div>11Hello2.insertBefore(<div>Hello, <span>1)',
 			'<span>1.remove()',
-			'<div>Hello.remove()'
+			'<div>Hello.remove()',
+			'<span>.appendChild(#text)',
+			'<div>2.insertBefore(<span>1, <span>2)',
+			'<div>.appendChild(#text)',
+			'<div>12.insertBefore(<div>Hello, <span>2)'
 		]);
 	});
 
@@ -1004,9 +925,9 @@ describe('Fragment', () => {
 
 		expect(scratch.innerHTML).to.equal('foobar');
 		expectDomLogToBe([
-			'<div>spamfoobar.insertBefore(#text, #text)',
 			'#text.remove()',
-			'#text.remove()'
+			'#text.remove()',
+			'<div>foo.appendChild(#text)'
 		]);
 	});
 
@@ -1528,14 +1449,14 @@ describe('Fragment', () => {
 			'rendering from false to true'
 		);
 		expectDomLogToBe([
-			// Insert 0 and 1
-			'<li>.appendChild(#text)',
-			'<ol>2234.insertBefore(<li>0, <li>2)',
-			'<li>.appendChild(#text)',
-			'<ol>02234.insertBefore(<li>1, <li>2)',
 			// Remove 3 & 4 (replaced by null)
 			'<li>3.remove()',
-			'<li>4.remove()'
+			'<li>4.remove()',
+			// Insert 0 and 1
+			'<li>.appendChild(#text)',
+			'<ol>22.insertBefore(<li>0, <li>2)',
+			'<li>.appendChild(#text)',
+			'<ol>022.insertBefore(<li>1, <li>2)'
 		]);
 	});
 
@@ -1599,14 +1520,14 @@ describe('Fragment', () => {
 			'rendering from false to true'
 		);
 		expectDomLogToBe([
-			// Insert 0 and 1 back into the DOM
-			'<li>.appendChild(#text)',
-			'<ol>2345.insertBefore(<li>0, <li>2)',
-			'<li>.appendChild(#text)',
-			'<ol>02345.insertBefore(<li>1, <li>2)',
 			// Remove 4 & 5 (replaced by null)
 			'<li>4.remove()',
-			'<li>5.remove()'
+			'<li>5.remove()',
+			// Insert 0 and 1 back into the DOM
+			'<li>.appendChild(#text)',
+			'<ol>23.insertBefore(<li>0, <li>2)',
+			'<li>.appendChild(#text)',
+			'<ol>023.insertBefore(<li>1, <li>2)'
 		]);
 	});
 
@@ -1660,10 +1581,10 @@ describe('Fragment', () => {
 		);
 		expectDomLogToBe(
 			[
-				'<div>barHellobeepboop.insertBefore(<div>bar, <div>beep)',
-				'<div>Hellobarbeepboop.insertBefore(<div>Hello, <div>boop)',
-				'<div>barbeepHelloboop.insertBefore(<div>bar, <div>boop)',
-				'<div>boop.remove()'
+				'<div>boop.remove()',
+				'<div>barHellobeep.insertBefore(<div>bar, <div>beep)',
+				'<div>Hellobarbeep.appendChild(<div>Hello)',
+				'<div>barbeepHello.appendChild(<div>bar)'
 			],
 			'rendering from true to false'
 		);
@@ -1855,12 +1776,12 @@ describe('Fragment', () => {
 		expect(scratch.innerHTML).to.equal(htmlForFalse);
 		expectDomLogToBe(
 			[
-				'<div>.appendChild(#text)',
-				'<div>1.insertBefore(<div>3, #text)',
-				'<div>.appendChild(#text)',
-				'<div>31.insertBefore(<div>4, #text)',
+				'<div>2.remove()',
 				'#text.remove()',
-				'<div>2.remove()'
+				'<div>.appendChild(#text)',
+				'<div>.appendChild(<div>3)',
+				'<div>.appendChild(#text)',
+				'<div>3.appendChild(<div>4)'
 			],
 			'rendering from true to false'
 		);
@@ -1871,9 +1792,9 @@ describe('Fragment', () => {
 		expect(scratch.innerHTML).to.equal(htmlForTrue);
 		expectDomLogToBe(
 			[
-				'<div>34.insertBefore(#text, <div>3)',
-				'<div>4.remove()',
 				'<div>3.remove()',
+				'<div>4.remove()',
+				'<div>.appendChild(#text)',
 				'<div>.appendChild(#text)',
 				'<div>1.appendChild(<div>2)'
 			],
@@ -2135,9 +2056,9 @@ describe('Fragment', () => {
 			`<div><div>A</div><section>B2</section><div>C</div></div>`
 		);
 		expectDomLogToBe([
+			'<div>B1.remove()',
 			'<section>.appendChild(#text)',
-			'<div>AB1C.insertBefore(<section>B2, <div>B1)',
-			'<div>B1.remove()'
+			'<div>AC.insertBefore(<section>B2, <div>C)'
 		]);
 	});
 
@@ -2185,12 +2106,12 @@ describe('Fragment', () => {
 			div([div('A'), section('B3'), section('B4'), div('C')])
 		);
 		expectDomLogToBe([
-			'<section>.appendChild(#text)',
-			'<div>AB1B2C.insertBefore(<section>B3, <div>B1)',
-			'<section>.appendChild(#text)',
-			'<div>AB3B1B2C.insertBefore(<section>B4, <div>B1)',
+			'<div>B1.remove()',
 			'<div>B2.remove()',
-			'<div>B1.remove()'
+			'<section>.appendChild(#text)',
+			'<div>AC.insertBefore(<section>B3, <div>C)',
+			'<section>.appendChild(#text)',
+			'<div>AB3C.insertBefore(<section>B4, <div>C)'
 		]);
 	});
 
@@ -2503,9 +2424,9 @@ describe('Fragment', () => {
 
 		expect(scratch.innerHTML).to.eql(`<div><span>A2</span><div>C</div></div>`);
 		expectDomLogToBe([
+			'<div>A.remove()',
 			'<span>.appendChild(#text)',
-			'<div>AC.insertBefore(<span>A2, <div>A)',
-			'<div>A.remove()'
+			'<div>C.insertBefore(<span>A2, <div>C)'
 		]);
 	});
 
@@ -2570,12 +2491,12 @@ describe('Fragment', () => {
 			`<div><span>A3</span><span>A4</span><div>C</div></div>`
 		);
 		expectDomLogToBe([
-			'<span>.appendChild(#text)',
-			'<div>A1A2C.insertBefore(<span>A3, <div>A1)',
-			'<span>.appendChild(#text)',
-			'<div>A3A1A2C.insertBefore(<span>A4, <div>A1)',
+			'<div>A1.remove()',
 			'<div>A2.remove()',
-			'<div>A1.remove()'
+			'<span>.appendChild(#text)',
+			'<div>C.insertBefore(<span>A3, <div>C)',
+			'<span>.appendChild(#text)',
+			'<div>A3C.insertBefore(<span>A4, <div>C)'
 		]);
 	});
 
@@ -2651,9 +2572,9 @@ describe('Fragment', () => {
 			'updateA'
 		);
 		expectDomLogToBe([
+			'<div>A.remove()',
 			'<span>.appendChild(#text)',
-			'<div>ABC.insertBefore(<span>A2, <div>A)',
-			'<div>A.remove()'
+			'<div>BC.insertBefore(<span>A2, <div>B)'
 		]);
 	});
 
@@ -2708,12 +2629,12 @@ describe('Fragment', () => {
 			'updateA'
 		);
 		expectDomLogToBe([
-			'<span>.appendChild(#text)',
-			'<div>A1A2.insertBefore(<span>A3, <div>A1)',
-			'<span>.appendChild(#text)',
-			'<div>A3A1A2.insertBefore(<span>A4, <div>A1)',
+			'<div>A1.remove()',
 			'<div>A2.remove()',
-			'<div>A1.remove()'
+			'<span>.appendChild(#text)',
+			'<div>.appendChild(<span>A3)',
+			'<span>.appendChild(#text)',
+			'<div>A3.appendChild(<span>A4)'
 		]);
 
 		clearLog();
@@ -2731,7 +2652,8 @@ describe('Fragment', () => {
 	});
 
 	it('should properly place conditional elements around strictly equal vnodes', () => {
-		let set;
+		/** @type {() => void} */
+		let toggle;
 
 		const Children = () => (
 			<Fragment>
@@ -2744,7 +2666,7 @@ describe('Fragment', () => {
 			constructor(props) {
 				super(props);
 				this.state = { panelPosition: 'bottom' };
-				set = this.tooglePanelPosition = this.tooglePanelPosition.bind(this);
+				toggle = this.tooglePanelPosition = this.tooglePanelPosition.bind(this);
 			}
 
 			tooglePanelPosition() {
@@ -2778,17 +2700,17 @@ describe('Fragment', () => {
 		expect(scratch.innerHTML).to.equal(bottom);
 
 		clearLog();
-		set();
+		toggle();
 		rerender();
 		expect(scratch.innerHTML).to.equal(top);
 		expectDomLogToBe([
+			'<div>bottom panel.remove()',
 			'<div>.appendChild(#text)',
-			'<div>NavigationContentbottom panel.insertBefore(<div>top panel, <div>Navigation)',
-			'<div>bottom panel.remove()'
+			'<div>NavigationContent.insertBefore(<div>top panel, <div>Navigation)'
 		]);
 
 		clearLog();
-		set();
+		toggle();
 		rerender();
 		expect(scratch.innerHTML).to.equal(bottom);
 		expectDomLogToBe([
@@ -2798,13 +2720,13 @@ describe('Fragment', () => {
 		]);
 
 		clearLog();
-		set();
+		toggle();
 		rerender();
 		expect(scratch.innerHTML).to.equal(top);
 		expectDomLogToBe([
+			'<div>bottom panel.remove()',
 			'<div>.appendChild(#text)',
-			'<div>NavigationContentbottom panel.insertBefore(<div>top panel, <div>Navigation)',
-			'<div>bottom panel.remove()'
+			'<div>NavigationContent.insertBefore(<div>top panel, <div>Navigation)'
 		]);
 	});
 
@@ -3020,10 +2942,10 @@ describe('Fragment', () => {
 			div([div(1), div(4), div('A'), div('B')])
 		);
 		expectDomLogToBe([
-			'<div>.appendChild(#text)',
-			'<div>123AB.insertBefore(<div>4, <div>2)',
 			'<div>2.remove()',
-			'<div>3.remove()'
+			'<div>3.remove()',
+			'<div>.appendChild(#text)',
+			'<div>1AB.insertBefore(<div>4, <div>A)'
 		]);
 	});
 
@@ -3118,11 +3040,11 @@ describe('Fragment', () => {
 
 		expect(scratch.innerHTML).to.equal(div([span(1), div('A'), div('B')]));
 		expectDomLogToBe([
-			'<span>.appendChild(#text)',
-			'<div>123AB.insertBefore(<span>1, <div>1)',
+			'<div>1.remove()',
 			'<div>2.remove()',
 			'<div>3.remove()',
-			'<div>1.remove()'
+			'<span>.appendChild(#text)',
+			'<div>AB.insertBefore(<span>1, <div>A)'
 		]);
 	});
 
@@ -3227,102 +3149,5 @@ describe('Fragment', () => {
 
 		expect(scratch.innerHTML).to.equal([div('A'), div(1), div(2)].join(''));
 		expectDomLogToBe(['<div>B.remove()', '<div>2A1.appendChild(<div>2)']);
-	});
-
-	it('should efficiently unmount & mount components that conditionally return null', () => {
-		function Conditional({ condition }) {
-			return condition ? (
-				<Fragment>
-					<p>2</p>
-					<p>3</p>
-				</Fragment>
-			) : null;
-		}
-
-		/** @type {() => void} */
-		let toggle;
-		class App extends Component {
-			constructor(props) {
-				super(props);
-				this.state = { condition: true };
-				toggle = () =>
-					this.setState(prevState => ({ condition: !prevState.condition }));
-			}
-
-			render() {
-				const { condition } = this.state;
-				return (
-					<Fragment>
-						<p>1</p>
-						<Conditional condition={condition} />
-						{condition ? null : <p>A</p>}
-						<p>4</p>
-					</Fragment>
-				);
-			}
-		}
-
-		render(<App />, scratch);
-		expect(scratch.innerHTML).to.equal([1, 2, 3, 4].map(p).join(''));
-
-		clearLog();
-		toggle();
-		rerender();
-
-		expect(scratch.innerHTML).to.equal([1, 'A', 4].map(p).join(''));
-		expectDomLogToBe([
-			'<p>2.remove()',
-			'<p>3.remove()',
-			'<p>.appendChild(#text)',
-			'<div>14.insertBefore(<p>A, <p>4)'
-		]);
-	});
-
-	it('should efficiently unmount & mount components that conditionally return null with null first child', () => {
-		function Conditional({ condition }) {
-			return condition ? (
-				<Fragment>
-					{null}
-					<p>3</p>
-				</Fragment>
-			) : null;
-		}
-
-		/** @type {() => void} */
-		let toggle;
-		class App extends Component {
-			constructor(props) {
-				super(props);
-				this.state = { condition: true };
-				toggle = () =>
-					this.setState(prevState => ({ condition: !prevState.condition }));
-			}
-
-			render() {
-				const { condition } = this.state;
-				return (
-					<Fragment>
-						<p>1</p>
-						<Conditional condition={condition} />
-						{condition ? null : <p>A</p>}
-						<p>4</p>
-					</Fragment>
-				);
-			}
-		}
-
-		render(<App />, scratch);
-		expect(scratch.innerHTML).to.equal([1, 3, 4].map(p).join(''));
-
-		clearLog();
-		toggle();
-		rerender();
-
-		expect(scratch.innerHTML).to.equal([1, 'A', 4].map(p).join(''));
-		expectDomLogToBe([
-			'<p>3.remove()',
-			'<p>.appendChild(#text)',
-			'<div>14.insertBefore(<p>A, <p>4)'
-		]);
 	});
 });

--- a/test/browser/keys.test.js
+++ b/test/browser/keys.test.js
@@ -1,8 +1,8 @@
 import { createElement, Component, render, createRef } from 'preact';
+import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../_util/helpers';
 import { logCall, clearLog, getLog } from '../_util/logCall';
 import { div } from '../_util/dom';
-import { setupRerender } from 'preact/test-utils';
 
 /** @jsx createElement */
 
@@ -73,8 +73,8 @@ describe('keys', () => {
 	});
 
 	beforeEach(() => {
-		rerender = setupRerender();
 		scratch = setupScratch();
+		rerender = setupRerender();
 		ops = [];
 	});
 
@@ -85,9 +85,37 @@ describe('keys', () => {
 
 	// https://fb.me/react-special-props
 	it('should not pass key in props', () => {
-		const Foo = sinon.spy(() => null);
+		const Foo = sinon.spy(function Foo() {
+			return null;
+		});
 		render(<Foo key="foo" />, scratch);
 		expect(Foo.args[0][0]).to.deep.equal({});
+	});
+
+	it('should update in-place keyed DOM nodes', () => {
+		render(
+			<ul>
+				<li key="0">a</li>
+				<li key="1">b</li>
+				<li key="2">c</li>
+			</ul>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal(
+			'<ul><li>a</li><li>b</li><li>c</li></ul>'
+		);
+
+		render(
+			<ul>
+				<li key="0">x</li>
+				<li key="1">y</li>
+				<li key="2">z</li>
+			</ul>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal(
+			'<ul><li>x</li><li>y</li><li>z</li></ul>'
+		);
 	});
 
 	// See preactjs/preact-compat#21
@@ -258,6 +286,56 @@ describe('keys', () => {
 		]);
 	});
 
+	it('should move keyed children to the beginning', () => {
+		const values = ['b', 'c', 'd', 'a'];
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('bcda');
+
+		move(values, values.length - 1, 0);
+		clearLog();
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('abcd');
+		// A perfect algorithm would do this in one move. Our algorithm is a
+		// compromise of size vs common case perf
+		//
+		// expect(getLog()).to.deep.equal(['<ol>bcda.insertBefore(<li>a, <li>b)']);
+		expect(getLog()).to.deep.equal([
+			'<ol>bcda.insertBefore(<li>b, Null)',
+			'<ol>cdab.insertBefore(<li>c, Null)',
+			'<ol>dabc.insertBefore(<li>d, Null)'
+		]);
+	});
+
+	it('should move multiple keyed children to the beginning', () => {
+		const values = ['c', 'd', 'e', 'a', 'b'];
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('cdeab');
+
+		move(values, values.length - 1, 0);
+		move(values, values.length - 1, 0);
+		clearLog();
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('abcde');
+		// A perfect algorithm would do this in two moves. Our algorithm is a
+		// compromise of size vs common case perf
+		//
+		//```
+		// expect(getLog()).to.deep.equal([
+		//  '<ol>cdeab.insertBefore(<li>a, <li>c)',
+		//  '<ol>acdeb.insertBefore(<li>b, <li>c)'
+		// ]);
+		// ```
+		expect(getLog()).to.deep.equal([
+			'<ol>cdeab.insertBefore(<li>c, Null)',
+			'<ol>deabc.insertBefore(<li>d, Null)',
+			'<ol>eabcd.insertBefore(<li>e, Null)'
+		]);
+	});
+
 	it('should swap keyed children efficiently', () => {
 		render(<List values={['a', 'b']} />, scratch);
 		expect(scratch.textContent).to.equal('ab');
@@ -322,10 +400,55 @@ describe('keys', () => {
 
 		render(<List values={values} />, scratch);
 		expect(scratch.textContent).to.equal('abcd', 'move to beginning');
+		// A perfect algorithm would do this in one move. Our algorithm is a
+		// compromise of size vs common case perf.
+		//
+		// expect(getLog()).to.deep.equal(['<ol>bcda.insertBefore(<li>a, <li>b)']);
 		expect(getLog()).to.deep.equal(
-			['<ol>bcda.insertBefore(<li>a, <li>b)'],
+			[
+				'<ol>bcda.insertBefore(<li>b, Null)',
+				'<ol>cdab.insertBefore(<li>c, Null)',
+				'<ol>dabc.insertBefore(<li>d, Null)'
+			],
 			'move to beginning'
 		);
+	});
+
+	it('should move keyed children to the beginning on longer list', () => {
+		// Preact v10 worst case
+		const values = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('abcdef');
+
+		move(values, 4, 1);
+		clearLog();
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('aebcdf');
+		// A perfect algorithm would do this in one move. Our algorithm is a
+		// compromise of size vs common case perf.
+		//
+		// expect(getLog()).to.deep.equal(['<ol>abcdef.insertBefore(<li>e, <li>b)']);
+		expect(getLog()).to.deep.equal([
+			'<ol>abcdef.insertBefore(<li>b, <li>f)',
+			'<ol>acdebf.insertBefore(<li>c, <li>f)',
+			'<ol>adebcf.insertBefore(<li>d, <li>f)'
+		]);
+	});
+
+	it('should move keyed children to the end on longer list', () => {
+		const values = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('abcdef');
+
+		move(values, 1, values.length - 2);
+		clearLog();
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('acdebf');
+		expect(getLog()).to.deep.equal(['<ol>abcdef.insertBefore(<li>b, <li>f)']);
 	});
 
 	it('should reverse keyed children effectively', () => {
@@ -340,6 +463,7 @@ describe('keys', () => {
 
 		render(<List values={values} />, scratch);
 		expect(scratch.textContent).to.equal(values.join(''));
+		// expect(getLog()).to.have.lengthOf(9);
 		expect(getLog()).to.deep.equal([
 			'<ol>abcdefghij.insertBefore(<li>j, <li>a)',
 			'<ol>jabcdefghi.insertBefore(<li>i, <li>a)',

--- a/test/browser/keys.test.js
+++ b/test/browser/keys.test.js
@@ -297,15 +297,7 @@ describe('keys', () => {
 
 		render(<List values={values} />, scratch);
 		expect(scratch.textContent).to.equal('abcd');
-		// A perfect algorithm would do this in one move. Our algorithm is a
-		// compromise of size vs common case perf
-		//
-		// expect(getLog()).to.deep.equal(['<ol>bcda.insertBefore(<li>a, <li>b)']);
-		expect(getLog()).to.deep.equal([
-			'<ol>bcda.insertBefore(<li>b, Null)',
-			'<ol>cdab.insertBefore(<li>c, Null)',
-			'<ol>dabc.insertBefore(<li>d, Null)'
-		]);
+		expect(getLog()).to.deep.equal(['<ol>bcda.insertBefore(<li>a, <li>b)']);
 	});
 
 	it('should move multiple keyed children to the beginning', () => {
@@ -320,19 +312,9 @@ describe('keys', () => {
 
 		render(<List values={values} />, scratch);
 		expect(scratch.textContent).to.equal('abcde');
-		// A perfect algorithm would do this in two moves. Our algorithm is a
-		// compromise of size vs common case perf
-		//
-		//```
-		// expect(getLog()).to.deep.equal([
-		//  '<ol>cdeab.insertBefore(<li>a, <li>c)',
-		//  '<ol>acdeb.insertBefore(<li>b, <li>c)'
-		// ]);
-		// ```
 		expect(getLog()).to.deep.equal([
-			'<ol>cdeab.insertBefore(<li>c, Null)',
-			'<ol>deabc.insertBefore(<li>d, Null)',
-			'<ol>eabcd.insertBefore(<li>e, Null)'
+			'<ol>cdeab.insertBefore(<li>a, <li>c)',
+			'<ol>acdeb.insertBefore(<li>b, <li>c)'
 		]);
 	});
 
@@ -400,16 +382,8 @@ describe('keys', () => {
 
 		render(<List values={values} />, scratch);
 		expect(scratch.textContent).to.equal('abcd', 'move to beginning');
-		// A perfect algorithm would do this in one move. Our algorithm is a
-		// compromise of size vs common case perf.
-		//
-		// expect(getLog()).to.deep.equal(['<ol>bcda.insertBefore(<li>a, <li>b)']);
 		expect(getLog()).to.deep.equal(
-			[
-				'<ol>bcda.insertBefore(<li>b, Null)',
-				'<ol>cdab.insertBefore(<li>c, Null)',
-				'<ol>dabc.insertBefore(<li>d, Null)'
-			],
+			['<ol>bcda.insertBefore(<li>a, <li>b)'],
 			'move to beginning'
 		);
 	});
@@ -426,15 +400,7 @@ describe('keys', () => {
 
 		render(<List values={values} />, scratch);
 		expect(scratch.textContent).to.equal('aebcdf');
-		// A perfect algorithm would do this in one move. Our algorithm is a
-		// compromise of size vs common case perf.
-		//
-		// expect(getLog()).to.deep.equal(['<ol>abcdef.insertBefore(<li>e, <li>b)']);
-		expect(getLog()).to.deep.equal([
-			'<ol>abcdef.insertBefore(<li>b, <li>f)',
-			'<ol>acdebf.insertBefore(<li>c, <li>f)',
-			'<ol>adebcf.insertBefore(<li>d, <li>f)'
-		]);
+		expect(getLog()).to.deep.equal(['<ol>abcdef.insertBefore(<li>e, <li>b)']);
 	});
 
 	it('should move keyed children to the end on longer list', () => {

--- a/test/browser/keys.test.js
+++ b/test/browser/keys.test.js
@@ -252,9 +252,9 @@ describe('keys', () => {
 		render(<List values={values} />, scratch);
 		expect(scratch.textContent).to.equal('abcd');
 		expect(getLog()).to.deep.equal([
-			'<li>z.remove()',
+			'<li>x.remove()',
 			'<li>y.remove()',
-			'<li>x.remove()'
+			'<li>z.remove()'
 		]);
 	});
 
@@ -462,8 +462,8 @@ describe('keys', () => {
 
 		expect(scratch.innerHTML).to.equal(expectedHtml);
 		expect(ops).to.deep.equal([
-			'Unmount Stateful2',
 			'Unmount Stateful1',
+			'Unmount Stateful2',
 			'Mount Stateful1',
 			'Mount Stateful2'
 		]);
@@ -475,8 +475,8 @@ describe('keys', () => {
 
 		expect(scratch.innerHTML).to.equal(expectedHtml);
 		expect(ops).to.deep.equal([
-			'Unmount Stateful2',
 			'Unmount Stateful1',
+			'Unmount Stateful2',
 			'Mount Stateful1',
 			'Mount Stateful2'
 		]);
@@ -731,8 +731,8 @@ describe('keys', () => {
 
 		expect(scratch.innerHTML).to.equal(expectedHtml);
 		expect(ops).to.deep.equal([
-			'Unmount Stateful2',
 			'Unmount Stateful1',
+			'Unmount Stateful2',
 			'Mount Stateful1',
 			'Mount Stateful2'
 		]);
@@ -744,8 +744,8 @@ describe('keys', () => {
 
 		expect(scratch.innerHTML).to.equal(expectedHtml);
 		expect(ops).to.deep.equal([
-			'Unmount Stateful2',
 			'Unmount Stateful1',
+			'Unmount Stateful2',
 			'Mount Stateful1',
 			'Mount Stateful2'
 		]);


### PR DESCRIPTION
Restart of #4162 on top of lastest main.

Rework children diffing to run in multiple phases:

1. First, find matches for all new VNodes in the old VNode tree, and determine which VNodes moved
2. Second, remove any unmatched VNodes in the old tree from the DOM
3. Finally, diff, move, and insert all VNodes in the new tree

A couple additional changes to highlight
* fd710b8beb3703a4aafca5b87fc6f65c8c81e827 Add new _flags VNode field to capture some diffing state (whether an oldVNode was matched and whether to insert a newVNode)
* b6a10729b7931bb125f25ce54c0b0456370ea40e Combine `placeChild` and `reorderChildren` into a single `insert` function & simplify insertion logic in diffChildren
* cd0127fe41a97ce07c3efed7c6e838ee5112ed7c Simplify some _nextDom logic by always setting & clearing it
* 6eef30b3723201b37cb717700bcc9ba795b962a0 Fold _hydrating field into _flags field (+12 B)

Fixes #4156 