### PR TITLE
fix case where parent catches error and switches vnode return type

### DIFF
--- a/hooks/test/browser/errorBoundary.test.js
+++ b/hooks/test/browser/errorBoundary.test.js
@@ -1,6 +1,6 @@
-import { createElement, render } from 'preact';
+import { Fragment, createElement, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { useErrorBoundary, useLayoutEffect } from 'preact/hooks';
+import { useErrorBoundary, useLayoutEffect, useState } from 'preact/hooks';
 import { setupRerender } from 'preact/test-utils';
 
 /** @jsx createElement */
@@ -151,5 +151,82 @@ describe('errorBoundary', () => {
 		expect(thrower).to.be.calledOnce;
 		expect(badEffect).to.be.calledOnce;
 		expect(goodEffect).to.be.calledOnce;
+	});
+
+	it('should not duplicate in lists where an item throws and the parent catches and returns a differing type', () => {
+		const baseTodos = [
+			{ text: 'first item', completed: false },
+			{ text: 'Test the feature', completed: false },
+			{ text: 'another item', completed: false }
+		];
+
+		function TodoList() {
+			const [todos, setTodos] = useState([...baseTodos]);
+
+			return (
+				<Fragment>
+					<ul>
+						{todos.map((todo, index) => (
+							<TodoItem
+								key={index}
+								toggleTodo={() => {
+									todos[index] = {
+										...todos[index],
+										completed: !todos[index].completed
+									};
+									setTodos([...todos]);
+								}}
+								todo={todo}
+								index={index}
+							/>
+						))}
+					</ul>
+				</Fragment>
+			);
+		}
+
+		function TodoItem(props) {
+			const [error] = useErrorBoundary();
+
+			if (error) {
+				return <li>An error occurred: {error}</li>;
+			}
+
+			return <TodoItemInner {...props} />;
+		}
+		let set;
+		function TodoItemInner({ todo, index, toggleTodo }) {
+			if (todo.completed) {
+				throw new Error('Todo completed!');
+			}
+
+			if (index === 1) {
+				set = toggleTodo;
+			}
+
+			return (
+				<li>
+					<label>
+						<input
+							type="checkbox"
+							checked={todo.completed}
+							onInput={toggleTodo}
+						/>
+						{todo.completed ? <s>{todo.text}</s> : todo.text}
+					</label>
+				</li>
+			);
+		}
+
+		render(<TodoList />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<ul><li><label><input type="checkbox">first item</label></li><li><label><input type="checkbox">Test the feature</label></li><li><label><input type="checkbox">another item</label></li></ul>'
+		);
+
+		set();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<ul><li><label><input type="checkbox">first item</label></li><li>An error occurred: </li><li><label><input type="checkbox">another item</label></li></ul>'
+		);
 	});
 });

--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -1,4 +1,3 @@
-import { unmount } from '.';
 
 /**
  * Find the closest error boundary to a thrown error and call it

--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -1,3 +1,5 @@
+import { unmount } from '.';
+
 /**
  * Find the closest error boundary to a thrown error and call it
  * @param {object} error The thrown value

--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -1,4 +1,3 @@
-
 /**
  * Find the closest error boundary to a thrown error and call it
  * @param {object} error The thrown value

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -271,6 +271,9 @@ export function diff(
 				excessDomChildren[excessDomChildren.indexOf(oldDom)] = null;
 				// ^ could possibly be simplified to:
 				// excessDomChildren.length = 0;
+			} else {
+				newVNode._dom = oldVNode._dom;
+				newVNode._children = oldVNode._children;
 			}
 			options._catchError(e, newVNode, oldVNode);
 		}


### PR DESCRIPTION
fixes #4178 

When we throw in a child and the parent of that child catches the error it would have `newVNode._dom` and `newVNode._children` unset meaning we don't derive `oldDom` correctly. This lead to us just appending a new item. This is similar to what we do in `Suspense`