### PR TITLE
Fix benchmark debug action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
         description: 'Branch or tag ref to check out'
         type: string
         required: false
-        default: 'main'
+        default: ''
       artifact_name:
         description: 'Name of the artifact to upload'
         type: string

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -53,6 +53,9 @@ jobs:
         with:
           name: results
           path: benches/results/${{ inputs.benchmark }}.json
+      - name: Anaylze logs if present
+        working-directory: benches
+        run: '[ -d logs ] && npm run analyze || echo "No logs to analyze"'
       - name: Tar logs if present
         working-directory: benches
         run: '[ -d logs ] && tar -zcvf ${{ inputs.benchmark}}_logs.tgz logs || echo "No logs found"'

--- a/.github/workflows/single-bench.yml
+++ b/.github/workflows/single-bench.yml
@@ -26,11 +26,15 @@ on:
         type: boolean
         default: true
         required: false
-      timeout:
-        description: 'How many minutes to give the benchmark to run before timing out and failing'
-        type: number
-        default: 20
-        required: false
+      # A bug in GitHub actions prevents us from passing numbers (as either
+      # number or string type) to called workflows. So disabling this for now.
+      # See: https://github.com/orgs/community/discussions/67182
+      #
+      # timeout:
+      #   description: 'How many minutes to give the benchmark to run before timing out and failing'
+      #   type: number
+      #   default: 20
+      #   required: false
 
 jobs:
   build_local:
@@ -57,17 +61,17 @@ jobs:
         with:
           name: npm-package
       - run: mv preact.tgz preact-local.tgz
+      - name: Upload locally built preact package
+        uses: actions/upload-artifact@v3
+        with:
+          name: bench-environment
+          path: preact-local.tgz
       - name: Clear working directory
         run: |
           ls -al
           rm -rf *
           echo "===================="
           ls -al
-      - name: Upload locally built preact package
-        uses: actions/upload-artifact@v3
-        with:
-          name: bench-environment
-          path: preact-local.tgz
       - name: Download base package
         uses: actions/download-artifact@v3
         with:
@@ -80,10 +84,10 @@ jobs:
           path: preact-main.tgz
 
   benchmark:
-    name: Bench ${{ inputs.benchmark}}
+    name: Bench ${{ inputs.benchmark }}
     uses: ./.github/workflows/run-bench.yml
     needs: prepare
     with:
-      benchmark: ${{ inputs.benchmark}}
-      timeout: ${{ inputs.timeout }}
+      benchmark: ${{ inputs.benchmark }}
       trace: ${{ inputs.trace }}
+      # timeout: ${{ inputs.timeout }}


### PR DESCRIPTION
Couple issues found in the "Benchmark Debug" & related changes to "CI" workflow:

- CI `ref` input should default to empty string so by default it checkouts whatever the default commit of the event that triggered it (e.g. merge commit for pull_request event, pushed commit for push event)
- Add `npm run analyze` command for benchmarks that include logs to analyze
- There is a bug in GitHub workflow parser that doesn't properly handle number-like inputs being passed as an input to a called workflow. Comment out timeout input for now
- Fix ordering of tarballing and clearing directory.