### PR TITLE
10.18.2

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -2,7 +2,7 @@ import { options, Fragment, Component } from 'preact';
 
 export function initDevTools() {
 	if (typeof window != 'undefined' && window.__PREACT_DEVTOOLS__) {
-		window.__PREACT_DEVTOOLS__.attachPreact('10.18.1', options, {
+		window.__PREACT_DEVTOOLS__.attachPreact('10.18.2', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "10.18.1",
+  "version": "10.18.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "10.18.1",
+      "version": "10.18.2",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.18.1",
+  "version": "10.18.2",
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
## Types

- Update `contentEditable` attribute values (#4163, thanks @shoonia)
- Add `elementTiming` attribute/property (#4165, thanks @shoonia)
- Add the `exportparts` global attribute (#4164, thanks @shoonia)
- Fix vnode type coercion (#4158, thanks @JoviDeCroock)

## Fixes

- Fix case where parent catches error and switches vnode return type (#4182, thanks @JoviDeCroock)
- Allow handling errors in getSnapshot of useSyncExternalStore & add more tests (#4175, thanks @andrewiggins)
- Prevent invalid DOM nesting false positives (#4160, thanks @marvinhagemeister)

## Improvements

- Improve place child (#4172, thanks @andrewiggins)
- Use copied VNode as newVNode instead of oldVNode when rerendering (#4171, thanks @andrewiggins)
- Manually track children's index & fix parent pointers when rerendering components (#4170, thanks @andrewiggins)
- Always clear `_nextDom` field on VNodes (#4166, thanks @andrewiggins)
- Switch `===` to `==` in a few places where not needed (#4157, thanks @rschristian)
- Add support for new String() as a child (#4152, thanks @appsforartists)

## Maintenance

- Update deopt script to generate log for usage in DeoptExplorer VSCode extension (#4188, thanks @andrewiggins)
- Fix benchmark debug action (#4187, thanks @andrewiggins)
- Add Benchmark Debug workflow (#4185, thanks @andrewiggins)
- Upgrade workflow actions (#4184, thanks @andrewiggins)
- Use import.meta.resolve in benchmark setup (#4179, thanks @andrewiggins)
- Improve code coverage (#4174, thanks @andrewiggins)
- Improve internal JSDoc types (#4173, thanks @andrewiggins)
- Upgrade to node@20 for development (#4167, thanks @andrewiggins)