### PR TITLE
Only run unmounting loop if any children remain to unmont (+2 B)

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -323,14 +323,16 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 	// unmount DOM from the beginning of the oldChildren, we can adjust oldDom to
 	// point to the next child, which needs to be the first DOM node that won't be
 	// unmounted.
-	for (i = 0; i < oldChildrenLength; i++) {
-		oldVNode = oldChildren[i];
-		if (oldVNode != null && (oldVNode._flags & MATCHED) === 0) {
-			if (oldVNode._dom == newParentVNode._nextDom) {
-				newParentVNode._nextDom = getDomSibling(oldVNode);
-			}
+	if (remainingOldChildren) {
+		for (i = 0; i < oldChildrenLength; i++) {
+			oldVNode = oldChildren[i];
+			if (oldVNode != null && (oldVNode._flags & MATCHED) === 0) {
+				if (oldVNode._dom == newParentVNode._nextDom) {
+					newParentVNode._nextDom = getDomSibling(oldVNode);
+				}
 
-			unmount(oldVNode, oldVNode);
+				unmount(oldVNode, oldVNode);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Since we are now looping through children 3 times, I'm hoping skipping a loop on update scenarios provides a small improvement