### PR TITLE
Inline `diffProps` function

### DIFF
--- a/.github/workflows/single-bench.yml
+++ b/.github/workflows/single-bench.yml
@@ -8,7 +8,7 @@ on:
         type: choice
         options:
           - 02_replace1k
-          - 03_update10k
+          - 03_update10th1k_x16
           - 07_create10k
           - filter_list
           - hydrate1k

--- a/benches/src/03_update10th1k_x16.html
+++ b/benches/src/03_update10th1k_x16.html
@@ -27,7 +27,9 @@
 				afterFrameAsync,
 				getRowLinkSel,
 				testElement,
-				testElementTextContains
+				testElementTextContains,
+				markRunStart,
+				markRunEnd
 			} from './util.js';
 			import * as framework from 'framework';
 			import { render } from '../src/keyed-children/index.js';
@@ -53,7 +55,9 @@
 				testElement(getRowLinkSel(1000));
 
 				for (let i = 0; i < 3; i++) {
+					markRunStart(`warmup-${i}`);
 					update();
+					await markRunEnd(`warmup-${i}`);
 
 					await afterFrameAsync();
 					testElementTextContains(getRowLinkSel(991), repeat(' !!!', i + 1));
@@ -61,9 +65,11 @@
 			}
 
 			async function run() {
+				markRunStart('final');
 				performance.mark('start');
 				update();
 
+				await markRunEnd('final');
 				await afterFrameAsync();
 				testElementTextContains(getRowLinkSel(991), repeat(' !!!', 3 + 1));
 				performance.mark('stop');

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -502,28 +502,29 @@ function diffElementNodes(
 
 		// (as above, don't diff props during hydration)
 		if (!isHydrating) {
-			if (
-				'value' in newProps &&
-				(value = newProps.value) !== undefined &&
-				// #2756 For the <progress>-element the initial value is 0,
-				// despite the attribute not being present. When the attribute
-				// is missing the progress bar is treated as indeterminate.
-				// To fix that we'll always update it when it is 0 for progress elements
-				(value !== dom.value ||
-					(nodeType === 'progress' && !value) ||
-					// This is only for IE 11 to fix <select> value not being updated.
-					// To avoid a stale select value we need to set the option.value
-					// again, which triggers IE11 to re-evaluate the select value
-					(nodeType === 'option' && value !== oldProps.value))
-			) {
-				setProperty(dom, 'value', value, oldProps.value, false);
-			}
-			if (
-				'checked' in newProps &&
-				(value = newProps.checked) !== undefined &&
-				value !== dom.checked
-			) {
-				setProperty(dom, 'checked', value, oldProps.checked, false);
+			for (i in newProps) {
+				if (
+					i === 'value' &&
+					(value = newProps[i]) !== undefined &&
+					// #2756 For the <progress>-element the initial value is 0,
+					// despite the attribute not being present. When the attribute
+					// is missing the progress bar is treated as indeterminate.
+					// To fix that we'll always update it when it is 0 for progress elements
+					(value !== dom[i] ||
+						(nodeType === 'progress' && !value) ||
+						// This is only for IE 11 to fix <select> value not being updated.
+						// To avoid a stale select value we need to set the option.value
+						// again, which triggers IE11 to re-evaluate the select value
+						(nodeType === 'option' && value !== oldProps[i]))
+				) {
+					setProperty(dom, i, value, oldProps[i], false);
+				} else if (
+					i === 'checked' &&
+					(value = newProps[i]) !== undefined &&
+					value !== dom[i]
+				) {
+					setProperty(dom, i, value, oldProps[i], false);
+				}
 			}
 		}
 	}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -429,25 +429,27 @@ function diffElementNodes(
 			}
 		}
 
-		let oldHtml, newHtml;
+		let oldHtml, newHtml, newChildren;
 
 		for (i in oldProps) {
-			if (i == 'dangerouslySetInnerHTML') {
+			if (i == 'children') {
+			} else if (i == 'dangerouslySetInnerHTML') {
 				oldHtml = oldProps[i];
-			} else if (i !== 'children' && i !== 'key' && !(i in newProps)) {
+			} else if (i !== 'key' && !(i in newProps)) {
 				setProperty(dom, i, null, oldProps[i], isSvg);
 			}
 		}
 
 		for (i in newProps) {
-			if (i == 'dangerouslySetInnerHTML') {
+			if (i == 'children') {
+				newChildren = newProps[i];
+			} else if (i == 'dangerouslySetInnerHTML') {
 				newHtml = newProps[i];
 			} else if (
-				(!isHydrating || typeof newProps[i] == 'function') &&
-				i !== 'children' &&
 				i !== 'key' &&
 				i !== 'value' &&
 				i !== 'checked' &&
+				(!isHydrating || typeof newProps[i] == 'function') &&
 				oldProps[i] !== newProps[i]
 			) {
 				setProperty(dom, i, newProps[i], oldProps[i], isSvg);
@@ -470,10 +472,9 @@ function diffElementNodes(
 		} else {
 			if (oldHtml) dom.innerHTML = '';
 
-			i = newVNode.props.children;
 			diffChildren(
 				dom,
-				isArray(i) ? i : [i],
+				isArray(newChildren) ? newChildren : [newChildren],
 				newVNode,
 				oldVNode,
 				globalContext,

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -7,7 +7,7 @@ import {
 import { BaseComponent, getDomSibling } from '../component';
 import { Fragment } from '../create-element';
 import { diffChildren } from './children';
-import { diffProps, setProperty } from './props';
+import { setProperty } from './props';
 import { assign, isArray, removeNode, slice } from '../util';
 import options from '../options';
 
@@ -443,7 +443,24 @@ function diffElementNodes(
 			}
 		}
 
-		diffProps(dom, newProps, oldProps, isSvg, isHydrating);
+		for (i in oldProps) {
+			if (i !== 'children' && i !== 'key' && !(i in newProps)) {
+				setProperty(dom, i, null, oldProps[i], isSvg);
+			}
+		}
+
+		for (i in newProps) {
+			if (
+				(!isHydrating || typeof newProps[i] == 'function') &&
+				i !== 'children' &&
+				i !== 'key' &&
+				i !== 'value' &&
+				i !== 'checked' &&
+				oldProps[i] !== newProps[i]
+			) {
+				setProperty(dom, i, newProps[i], oldProps[i], isSvg);
+			}
+		}
 
 		// If the new vnode didn't have dangerouslySetInnerHTML, diff its children
 		if (newHtml) {

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -454,21 +454,22 @@ function diffElementNodes(
 			}
 		}
 
-		if ((!isHydrating && newHtml) || oldHtml) {
-			// Avoid re-applying the same '__html' if it did not changed between re-render
-			if (
-				!newHtml ||
-				((!oldHtml || newHtml.__html != oldHtml.__html) &&
-					newHtml.__html !== dom.innerHTML)
-			) {
-				dom.innerHTML = (newHtml && newHtml.__html) || '';
-			}
-		}
-
 		// If the new vnode didn't have dangerouslySetInnerHTML, diff its children
 		if (newHtml) {
+			// Avoid re-applying the same '__html' if it did not changed between re-render
+			if (
+				!isHydrating &&
+				(!oldHtml ||
+					(newHtml.__html !== oldHtml.__html &&
+						newHtml.__html !== dom.innerHTML))
+			) {
+				dom.innerHTML = newHtml.__html;
+			}
+
 			newVNode._children = [];
 		} else {
+			if (oldHtml) dom.innerHTML = '';
+
 			i = newVNode.props.children;
 			diffChildren(
 				dom,

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -364,7 +364,7 @@ function diffElementNodes(
 	let newProps = newVNode.props;
 	let nodeType = /** @type {string} */ (newVNode.type);
 	/** @type {any} */
-	let i = 0;
+	let i;
 	/** @type {{ __html?: string }} */
 	let newHtml;
 	/** @type {{ __html?: string }} */
@@ -379,18 +379,18 @@ function diffElementNodes(
 	if (nodeType === 'svg') isSvg = true;
 
 	if (excessDomChildren != null) {
-		for (; i < excessDomChildren.length; i++) {
-			const child = excessDomChildren[i];
+		for (i = 0; i < excessDomChildren.length; i++) {
+			value = excessDomChildren[i];
 
 			// if newVNode matches an element in excessDomChildren or the `dom`
 			// argument matches an element in excessDomChildren, remove it from
 			// excessDomChildren so it isn't later removed in diffChildren
 			if (
-				child &&
-				'setAttribute' in child === !!nodeType &&
-				(nodeType ? child.localName === nodeType : child.nodeType === 3)
+				value &&
+				'setAttribute' in value === !!nodeType &&
+				(nodeType ? value.localName === nodeType : value.nodeType === 3)
 			) {
-				dom = child;
+				dom = value;
 				excessDomChildren[i] = null;
 				break;
 			}
@@ -410,7 +410,8 @@ function diffElementNodes(
 
 		// we created a new parent, so none of the previously attached children can be reused:
 		excessDomChildren = null;
-		// we are creating a new node, so we can assume this is a new subtree (in case we are hydrating), this deopts the hydrate
+		// we are creating a new node, so we can assume this is a new subtree (in
+		// case we are hydrating), this deopts the hydrate
 		isHydrating = false;
 	}
 
@@ -431,7 +432,8 @@ function diffElementNodes(
 		if (!isHydrating && excessDomChildren != null) {
 			oldProps = {};
 			for (i = 0; i < dom.attributes.length; i++) {
-				oldProps[dom.attributes[i].name] = dom.attributes[i].value;
+				value = dom.attributes[i];
+				oldProps[value.name] = value.value;
 			}
 		}
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -365,6 +365,10 @@ function diffElementNodes(
 	let nodeType = /** @type {string} */ (newVNode.type);
 	/** @type {any} */
 	let i = 0;
+	let newHtml;
+	let oldHtml;
+	let newChildren;
+	let value;
 
 	// Tracks entering and exiting SVG namespace when descending through the tree.
 	if (nodeType === 'svg') isSvg = true;
@@ -429,30 +433,30 @@ function diffElementNodes(
 			}
 		}
 
-		let oldHtml, newHtml, newChildren;
-
 		for (i in oldProps) {
+			value = oldProps[i];
 			if (i == 'children') {
 			} else if (i == 'dangerouslySetInnerHTML') {
-				oldHtml = oldProps[i];
+				oldHtml = value;
 			} else if (i !== 'key' && !(i in newProps)) {
-				setProperty(dom, i, null, oldProps[i], isSvg);
+				setProperty(dom, i, null, value, isSvg);
 			}
 		}
 
 		for (i in newProps) {
+			value = newProps[i];
 			if (i == 'children') {
-				newChildren = newProps[i];
+				newChildren = value;
 			} else if (i == 'dangerouslySetInnerHTML') {
-				newHtml = newProps[i];
+				newHtml = value;
 			} else if (
 				i !== 'key' &&
 				i !== 'value' &&
 				i !== 'checked' &&
-				(!isHydrating || typeof newProps[i] == 'function') &&
-				oldProps[i] !== newProps[i]
+				(!isHydrating || typeof value == 'function') &&
+				oldProps[i] !== value
 			) {
-				setProperty(dom, i, newProps[i], oldProps[i], isSvg);
+				setProperty(dom, i, value, oldProps[i], isSvg);
 			}
 		}
 
@@ -500,26 +504,26 @@ function diffElementNodes(
 		if (!isHydrating) {
 			if (
 				'value' in newProps &&
-				(i = newProps.value) !== undefined &&
+				(value = newProps.value) !== undefined &&
 				// #2756 For the <progress>-element the initial value is 0,
 				// despite the attribute not being present. When the attribute
 				// is missing the progress bar is treated as indeterminate.
 				// To fix that we'll always update it when it is 0 for progress elements
-				(i !== dom.value ||
-					(nodeType === 'progress' && !i) ||
+				(value !== dom.value ||
+					(nodeType === 'progress' && !value) ||
 					// This is only for IE 11 to fix <select> value not being updated.
 					// To avoid a stale select value we need to set the option.value
 					// again, which triggers IE11 to re-evaluate the select value
-					(nodeType === 'option' && i !== oldProps.value))
+					(nodeType === 'option' && value !== oldProps.value))
 			) {
-				setProperty(dom, 'value', i, oldProps.value, false);
+				setProperty(dom, 'value', value, oldProps.value, false);
 			}
 			if (
 				'checked' in newProps &&
-				(i = newProps.checked) !== undefined &&
-				i !== dom.checked
+				(value = newProps.checked) !== undefined &&
+				value !== dom.checked
 			) {
-				setProperty(dom, 'checked', i, oldProps.checked, false);
+				setProperty(dom, 'checked', value, oldProps.checked, false);
 			}
 		}
 	}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -365,8 +365,11 @@ function diffElementNodes(
 	let nodeType = /** @type {string} */ (newVNode.type);
 	/** @type {any} */
 	let i = 0;
+	/** @type {{ __html?: string }} */
 	let newHtml;
+	/** @type {{ __html?: string }} */
 	let oldHtml;
+	/** @type {ComponentChildren} */
 	let newChildren;
 	let value;
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -423,16 +423,13 @@ function diffElementNodes(
 
 		oldProps = oldVNode.props || EMPTY_OBJ;
 
-		// During hydration, props are not diffed at all (including dangerouslySetInnerHTML)
-		// @TODO we should warn in debug mode when props don't match here.
-		if (!isHydrating) {
-			// But, if we are in a situation where we are using existing DOM (e.g. replaceNode)
-			// we should read the existing DOM attributes to diff them
-			if (excessDomChildren != null) {
-				oldProps = {};
-				for (i = 0; i < dom.attributes.length; i++) {
-					oldProps[dom.attributes[i].name] = dom.attributes[i].value;
-				}
+		// If we are in a situation where we are not hydrating but are using
+		// existing DOM (e.g. replaceNode) we should read the existing DOM
+		// attributes to diff them
+		if (!isHydrating && excessDomChildren != null) {
+			oldProps = {};
+			for (i = 0; i < dom.attributes.length; i++) {
+				oldProps[dom.attributes[i].name] = dom.attributes[i].value;
 			}
 		}
 
@@ -446,6 +443,8 @@ function diffElementNodes(
 			}
 		}
 
+		// During hydration, props are not diffed at all (including dangerouslySetInnerHTML)
+		// @TODO we should warn in debug mode when props don't match here.
 		for (i in newProps) {
 			value = newProps[i];
 			if (i == 'children') {

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -73,7 +73,7 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 			const handler = useCapture ? eventProxyCapture : eventProxy;
 			dom.removeEventListener(name, handler, useCapture);
 		}
-	} else if (name !== 'dangerouslySetInnerHTML') {
+	} else {
 		if (isSvg) {
 			// Normalize incorrect prop usage for SVG:
 			// - xlink:href / xlinkHref --> href (xlink:href was removed from SVG and isn't needed)

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -1,37 +1,6 @@
 import { IS_NON_DIMENSIONAL } from '../constants';
 import options from '../options';
 
-/**
- * Diff the old and new properties of a VNode and apply changes to the DOM node
- * @param {PreactElement} dom The DOM node to apply changes to
- * @param {object} newProps The new props
- * @param {object} oldProps The old props
- * @param {boolean} isSvg Whether or not this node is an SVG node
- * @param {boolean} hydrate Whether or not we are in hydration mode
- */
-export function diffProps(dom, newProps, oldProps, isSvg, hydrate) {
-	let i;
-
-	for (i in oldProps) {
-		if (i !== 'children' && i !== 'key' && !(i in newProps)) {
-			setProperty(dom, i, null, oldProps[i], isSvg);
-		}
-	}
-
-	for (i in newProps) {
-		if (
-			(!hydrate || typeof newProps[i] == 'function') &&
-			i !== 'children' &&
-			i !== 'key' &&
-			i !== 'value' &&
-			i !== 'checked' &&
-			oldProps[i] !== newProps[i]
-		) {
-			setProperty(dom, i, newProps[i], oldProps[i], isSvg);
-		}
-	}
-}
-
 function setStyle(style, key, value) {
 	if (key[0] === '-') {
 		style.setProperty(key, value == null ? '' : value);


### PR DESCRIPTION
Inline `diffProps` to take advantage of the props loop to read values and use later in the diff. This avoids duplicate megamorphic reads for props like `dangerouslySetInnerHTML`, `children`, `value`, and `checked` since we can reuse reading the value in the props loop for handling elsewhere.