### PR TITLE
Make `children` optional in `Provider`'s typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -380,7 +380,7 @@ export interface PreactConsumer<T> extends Consumer<T> {}
 export interface Provider<T>
 	extends FunctionComponent<{
 		value: T;
-		children: ComponentChildren;
+		children?: ComponentChildren;
 	}> {}
 export interface PreactProvider<T> extends Provider<T> {}
 export type ContextType<C extends Context<any>> = C extends Context<infer T>


### PR DESCRIPTION
Without this, it's an error to write `<Context.Provider value={...}>` since TypeScript expects a `children` prop to be explicitly provided.  It's easy enough to work around by adding `children={[]}`, but this shouldn't be necessary.