### PR TITLE
10.19.1

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -2,7 +2,7 @@ import { options, Fragment, Component } from 'preact';
 
 export function initDevTools() {
 	if (typeof window != 'undefined' && window.__PREACT_DEVTOOLS__) {
-		window.__PREACT_DEVTOOLS__.attachPreact('10.19.0', options, {
+		window.__PREACT_DEVTOOLS__.attachPreact('10.19.1', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "10.19.0",
+  "version": "10.19.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "10.19.0",
+      "version": "10.19.1",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.19.0",
+  "version": "10.19.1",
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
## Fixes

- Missing preact import error when using compat (#4206, thanks @JoviDeCroock)

## Types

- Make `children` optional in `Provider`'s typings (#4205, thanks @shicks)