### PR TITLE
Fix access to undefined exception

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -212,7 +212,7 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 				null,
 				null
 			);
-		} else if (childVNode._depth > 0) {
+		} else if (childVNode.constructor === undefined && childVNode._depth > 0) {
 			// VNode is already in use, clone it. This can happen in the following
 			// scenario:
 			//   const reuse = <div />

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -405,7 +405,10 @@ function diffElementNodes(
 		if (isSvg) {
 			dom = document.createElementNS('http://www.w3.org/2000/svg', nodeType);
 		} else {
-			dom = document.createElement(nodeType, newProps.is && newProps);
+			dom = document.createElement(
+				nodeType,
+				newProps && newProps.is && newProps
+			);
 		}
 
 		// we created a new parent, so none of the previously attached children can be reused:

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -405,10 +405,7 @@ function diffElementNodes(
 		if (isSvg) {
 			dom = document.createElementNS('http://www.w3.org/2000/svg', nodeType);
 		} else {
-			dom = document.createElement(
-				nodeType,
-				newProps && newProps.is && newProps
-			);
+			dom = document.createElement(nodeType, newProps.is && newProps);
 		}
 
 		// we created a new parent, so none of the previously attached children can be reused:

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -1897,6 +1897,28 @@ describe('Components', () => {
 		expect(unmounted).to.equal(',0,1,2,3');
 	});
 
+	it('should ignore invalid vnodes in children array', () => {
+		/** @type { (() => void)} */
+		let update;
+
+		const obj = { a: 10, b: 'hello' };
+		class App extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { i: 0 };
+				update = () => this.setState({ i: this.state.i + 1 });
+			}
+
+			render() {
+				return <p>{obj}</p>;
+			}
+		}
+
+		render(<App />, scratch);
+		update();
+		expect(() => rerender()).not.to.throw();
+	});
+
 	describe('c.base', () => {
 		/* eslint-disable lines-around-comment */
 		/** @type {import('../../src').Component} */


### PR DESCRIPTION
Running some code locally and I was regularly hitting an error `Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'is')`. I tracked it down to the line fixed in this PR. 

It would appear that sometimes `newVNode.props` may be undefined, so guarding against that.