### PR TITLE
Improve types of hook source

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -85,7 +85,8 @@ options.diffed = vnode => {
 	previousComponent = currentComponent = null;
 };
 
-/** @type {(vnode: import('./internal').VNode) => void} */
+// TODO: Improve typing of commitQueue parameter
+/** @type {(vnode: import('./internal').VNode, commitQueue: any) => void} */
 options._commit = (vnode, commitQueue) => {
 	commitQueue.some(component => {
 		try {
@@ -158,6 +159,7 @@ function getHookState(index, type) {
 /**
  * @template {unknown} S
  * @param {import('./index').StateUpdater<S>} [initialState]
+ * @returns {[S, (state: S) => void]}
  */
 export function useState(initialState) {
 	currentHook = 1;
@@ -230,8 +232,7 @@ export function useReducer(reducer, initialState, init) {
 			function updateHookState(p, s, c) {
 				if (!hookState._component.__hooks) return true;
 
-				/**
-				 * @type {(x: import('./internal').HookState) => x is import('./internal').ReducerHookState} */
+				/** @type {(x: import('./internal').HookState) => x is import('./internal').ReducerHookState} */
 				const isStateHook = x => !!x._component;
 				const stateHooks =
 					hookState._component.__hooks._list.filter(isStateHook);
@@ -273,6 +274,7 @@ export function useReducer(reducer, initialState, init) {
 /**
  * @param {import('./internal').Effect} callback
  * @param {unknown[]} args
+ * @returns {void}
  */
 export function useEffect(callback, args) {
 	/** @type {import('./internal').EffectHookState} */
@@ -288,6 +290,7 @@ export function useEffect(callback, args) {
 /**
  * @param {import('./internal').Effect} callback
  * @param {unknown[]} args
+ * @returns {void}
  */
 export function useLayoutEffect(callback, args) {
 	/** @type {import('./internal').EffectHookState} */
@@ -310,6 +313,7 @@ export function useRef(initialValue) {
  * @param {object} ref
  * @param {() => object} createHandle
  * @param {unknown[]} args
+ * @returns {void}
  */
 export function useImperativeHandle(ref, createHandle, args) {
 	currentHook = 6;
@@ -328,11 +332,13 @@ export function useImperativeHandle(ref, createHandle, args) {
 }
 
 /**
- * @param {() => unknown} factory
+ * @template {unknown} T
+ * @param {() => T} factory
  * @param {unknown[]} args
+ * @returns {T}
  */
 export function useMemo(factory, args) {
-	/** @type {import('./internal').MemoHookState} */
+	/** @type {import('./internal').MemoHookState<T>} */
 	const state = getHookState(currentIndex++, 7);
 	if (argsChanged(state._args, args)) {
 		state._pendingValue = factory();
@@ -347,6 +353,7 @@ export function useMemo(factory, args) {
 /**
  * @param {() => void} callback
  * @param {unknown[]} args
+ * @returns {() => void}
  */
 export function useCallback(callback, args) {
 	currentHook = 8;
@@ -390,6 +397,7 @@ export function useDebugValue(value, formatter) {
 
 /**
  * @param {(error: unknown, errorInfo: import('preact').ErrorInfo) => void} cb
+ * @returns {[unknown, () => void]}
  */
 export function useErrorBoundary(cb) {
 	/** @type {import('./internal').ErrorBoundaryHookState} */
@@ -479,6 +487,7 @@ function afterNextFrame(callback) {
 /**
  * Schedule afterPaintEffects flush after the browser paints
  * @param {number} newQueueLength
+ * @returns {void}
  */
 function afterPaint(newQueueLength) {
 	if (newQueueLength === 1 || prevRaf !== options.requestAnimationFrame) {
@@ -489,6 +498,7 @@ function afterPaint(newQueueLength) {
 
 /**
  * @param {import('./internal').HookState} hook
+ * @returns {void}
  */
 function invokeCleanup(hook) {
 	// A hook cleanup can introduce a call to render which creates a new root, this will call options.vnode
@@ -506,6 +516,7 @@ function invokeCleanup(hook) {
 /**
  * Invoke a Hook's effect
  * @param {import('./internal').EffectHookState} hook
+ * @returns {void}
  */
 function invokeEffect(hook) {
 	// A hook call can introduce a call to render which creates a new root, this will call options.vnode
@@ -518,6 +529,7 @@ function invokeEffect(hook) {
 /**
  * @param {unknown[]} oldArgs
  * @param {unknown[]} newArgs
+ * @returns {boolean}
  */
 function argsChanged(oldArgs, newArgs) {
 	return (

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -1,9 +1,3 @@
-import {
-	Component as PreactComponent,
-	PreactContext,
-	ErrorInfo,
-	VNode as PreactVNode
-} from '../../src/internal';
 import { Reducer } from '.';
 
 export { PreactContext };
@@ -34,11 +28,14 @@ export interface ComponentHooks {
 	_pendingEffects: EffectHookState[];
 }
 
-export interface Component extends PreactComponent<any, any> {
+export interface Component extends globalThis.Component<any, any> {
 	__hooks?: ComponentHooks;
+	// Extend to include HookStates
+	_renderCallbacks?: Array<HookState | (() => void)>;
+	_hasScuFromHooks?: boolean;
 }
 
-export interface VNode extends PreactVNode {
+export interface VNode extends globalThis.VNode {
 	_mask?: [number, number];
 }
 
@@ -47,19 +44,28 @@ export type HookState =
 	| MemoHookState
 	| ReducerHookState
 	| ContextHookState
-	| ErrorBoundaryHookState;
+	| ErrorBoundaryHookState
+	| IdHookState;
+
+interface BaseHookState {
+	_value?: unknown;
+	_component?: undefined;
+	_nextValue?: undefined;
+	_pendingValue?: undefined;
+	_pendingArgs?: undefined;
+}
 
 export type Effect = () => void | Cleanup;
 export type Cleanup = () => void;
 
-export interface EffectHookState {
+export interface EffectHookState extends BaseHookState {
 	_value?: Effect;
 	_args?: any[];
 	_pendingArgs?: any[];
 	_cleanup?: Cleanup | void;
 }
 
-export interface MemoHookState {
+export interface MemoHookState extends BaseHookState {
 	_value?: any;
 	_pendingValue?: any;
 	_args?: any[];
@@ -67,19 +73,23 @@ export interface MemoHookState {
 	_factory?: () => any;
 }
 
-export interface ReducerHookState {
+export interface ReducerHookState extends BaseHookState {
 	_nextValue?: any;
 	_value?: any;
 	_component?: Component;
 	_reducer?: Reducer<any, any>;
 }
 
-export interface ContextHookState {
+export interface ContextHookState extends BaseHookState {
 	/** Whether this hooks as subscribed to updates yet */
 	_value?: boolean;
 	_context?: PreactContext;
 }
 
-export interface ErrorBoundaryHookState {
+export interface ErrorBoundaryHookState extends BaseHookState {
 	_value?: (error: any, errorInfo: ErrorInfo) => void;
+}
+
+export interface IdHookState extends BaseHookState {
+	_value?: string;
 }

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -64,12 +64,12 @@ export interface EffectHookState extends BaseHookState {
 	_cleanup?: Cleanup | void;
 }
 
-export interface MemoHookState extends BaseHookState {
-	_value?: unknown;
-	_pendingValue?: unknown;
+export interface MemoHookState<T = unknown> extends BaseHookState {
+	_value?: T;
+	_pendingValue?: T;
 	_args?: unknown[];
 	_pendingArgs?: unknown[];
-	_factory?: () => unknown;
+	_factory?: () => T;
 }
 
 export interface ReducerHookState<S = unknown, A = unknown>

--- a/jsconfig-lint.json
+++ b/jsconfig-lint.json
@@ -1,4 +1,4 @@
 {
   "extends": "./jsconfig.json",
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "hooks/src/**/*"]
 }


### PR DESCRIPTION
Improve the typing in hooks source file and add it to the jsconfig for linting on each PR.

One big change, that others may have opinions about, is that here I used `unknown` for types where we explicitly don't know what it is because it is user provided (e.g. the return type of the callback given to `useMemo`). Meaning, usages of `any` in hooks are places where we could improve the types, but I couldn't be bothered cuz it wasn't straightforward. Something to consider improving for later lol.

I wanted to to do this cuz I was recently looking at a compat bug in hooks and was working on a fix but refactoring things in hooks was slightly more difficult given I couldn't trust the red squiggles to be meaningful or not. After this PR they are hopefully more helpful (or at least mean you should double check this before adding an `any` override lol).