### PR TITLE
Update README.md with code fragments formatted with Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ With Preact, you create user interfaces by assembling trees of components and el
 To get started using Preact, first look at the render() function. This function accepts a tree description and creates the structure described. Next, it appends this structure to a parent DOM element provided as the second argument. Future calls to render() will reuse the existing tree and update it in-place in the DOM. Internally, render() will calculate the difference from previous outputted structures in an attempt to perform as few DOM operations as possible.
 
 ```js
-import { h, render } from 'preact';
+import { h, render } from "preact";
 // Tells babel to use h for JSX. It's better to configure this globally.
 // See https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#usage
 // In tsconfig you can specify this with the jsxFactory
@@ -65,18 +65,18 @@ import { h, render } from 'preact';
 
 // create our tree and append it to document.body:
 render(
-	<main>
-		<h1>Hello</h1>
-	</main>,
-	document.body
+  <main>
+    <h1>Hello</h1>
+  </main>,
+  document.body,
 );
 
 // update the tree in-place:
 render(
-	<main>
-		<h1>Hello World!</h1>
-	</main>,
-	document.body
+  <main>
+    <h1>Hello World!</h1>
+  </main>,
+  document.body,
 );
 // ^ this second invocation of render(...) will use a single DOM call to update the text of the <h1>
 ```
@@ -84,20 +84,20 @@ render(
 Hooray! render() has taken our structure and output a User Interface! This approach demonstrates a simple case, but would be difficult to use as an application grows in complexity. Each change would be forced to calculate the difference between the current and updated structure for the entire application. Components can help here – by dividing the User Interface into nested Components each can calculate their difference from their mounted point. Here's an example:
 
 ```js
-import { render, h } from 'preact';
-import { useState } from 'preact/hooks';
+import { render, h } from "preact";
+import { useState } from "preact/hooks";
 
 /** @jsx h */
 
 const App = () => {
-	const [input, setInput] = useState('');
+  const [input, setInput] = useState("");
 
-	return (
-		<div>
-			<p>Do you agree to the statement: "Preact is awesome"?</p>
-			<input value={input} onInput={e => setInput(e.target.value)} />
-		</div>
-	);
+  return (
+    <div>
+      <p>Do you agree to the statement: "Preact is awesome"?</p>
+      <input value={input} onInput={(e) => setInput(e.target.value)} />
+    </div>
+  );
 };
 
 render(<App />, document.body);


### PR DESCRIPTION
When reading through your README I noticed some crazy spacing in the code examples. I thought huh, that seems awfully odd. So I checked my Github settings and the width is set to 4, but I can see the examples are rendering what appears to be 8 character width tabs. I'm not sure why that would be.

I decided to try running it through Prettier (v3.1.1) and compare the result. Prettier is using spaces which means the result will look the same across all browsers. Many devs use Prettier for formatting so I don't think it would be out of line to propose this change, even if it isn't your favourite choice of formatting.

I'm only proposing this for the front page (README) code examples because when devs view the source for most other files I would assume they are opening them in their IDE via jump to declaration (which then would apply their editors set tab width).

Before:
![Screenshot from 2023-12-13 18-32-33](https://github.com/preactjs/preact/assets/4543390/eae3fb7b-bd41-4b77-a057-f75e9409eaeb)

After:
![image](https://github.com/preactjs/preact/assets/4543390/857e9cb3-e09c-4265-90af-eb9df820a064)

Also:
![image](https://github.com/preactjs/preact/assets/4543390/ac095b03-3fec-470d-bc57-c8bdc174b099)


