### PR TITLE
WIP: batch commit callbacks from all components in the render queue

### DIFF
--- a/compat/test/browser/useSyncExternalStore.test.js
+++ b/compat/test/browser/useSyncExternalStore.test.js
@@ -658,10 +658,6 @@ describe('useSyncExternalStore', () => {
 			await act(() => {
 				store.set(1);
 			});
-			// // Preact logs differ from React here cuz of how we do rerendering. We
-			// // rerender subtrees and then commit effects so Child2 never sees the
-			// // update to 1 cuz Child1 rerenders and runs its layout effects first.
-			// assertLog([1, /*1,*/ 'Reset back to 0', 0, 0]);
 			assertLog([1, 1, 'Reset back to 0', 0, 0]);
 			expect(container.textContent).to.equal('00');
 		});

--- a/compat/test/browser/useSyncExternalStore.test.js
+++ b/compat/test/browser/useSyncExternalStore.test.js
@@ -658,10 +658,11 @@ describe('useSyncExternalStore', () => {
 			await act(() => {
 				store.set(1);
 			});
-			// Preact logs differ from React here cuz of how we do rerendering. We
-			// rerender subtrees and then commit effects so Child2 never sees the
-			// update to 1 cuz Child1 rerenders and runs its layout effects first.
-			assertLog([1, /*1,*/ 'Reset back to 0', 0, 0]);
+			// // Preact logs differ from React here cuz of how we do rerendering. We
+			// // rerender subtrees and then commit effects so Child2 never sees the
+			// // update to 1 cuz Child1 rerenders and runs its layout effects first.
+			// assertLog([1, /*1,*/ 'Reset back to 0', 0, 0]);
+			assertLog([1, 1, 'Reset back to 0', 0, 0]);
 			expect(container.textContent).to.equal('00');
 		});
 

--- a/src/component.js
+++ b/src/component.js
@@ -233,7 +233,10 @@ function process() {
 		if (c._dirty) {
 			let renderQueueLength = rerenderQueue.length;
 			root = renderComponent(c, commitQueue, refQueue) || root;
-			if (rerenderQueue.length > renderQueueLength) {
+			// If this WAS the last component in the queue, run commit callbacks *before* we exit the tight loop.
+			// This is required in order for `componentDidMount(){this.setState()}` to be batched into one flush.
+			// Otherwise, also run commit callbacks if the render queue was mutated.
+			if (renderQueueLength === 0 || rerenderQueue.length > renderQueueLength) {
 				commitRoot(commitQueue, root, refQueue);
 				commitQueue.length = 0;
 				refQueue.length = 0;
@@ -247,7 +250,7 @@ function process() {
 			}
 		}
 	}
-	commitRoot(commitQueue, root, refQueue);
+	if (root) commitRoot(commitQueue, root, refQueue);
 	// if (root) commitRoot(commitQueue, root, refQueue);
 	process._rerenderCount = 0;
 }

--- a/src/component.js
+++ b/src/component.js
@@ -236,8 +236,7 @@ function process() {
 			// Otherwise, also run commit callbacks if the render queue was mutated.
 			if (renderQueueLength === 0 || rerenderQueue.length > renderQueueLength) {
 				commitRoot(commitQueue, root, refQueue);
-				commitQueue.length = 0;
-				refQueue.length = 0;
+				refQueue.length = commitQueue.length = 0;
 				root = undefined;
 				// When i.e. rerendering a provider additional new items can be injected, we want to
 				// keep the order from top to bottom with those new items so we can handle them in a

--- a/src/component.js
+++ b/src/component.js
@@ -146,8 +146,6 @@ function renderComponent(component, commitQueue, refQueue) {
 		newVNode._parent._children[newVNode._index] = newVNode;
 
 		newVNode._nextDom = undefined;
-		// if (options._commit) options._commit(newVNode, EMPTY_ARR);
-		// commitRoot(EMPTY_ARR, newVNode, EMPTY_ARR);
 
 		if (newVNode._dom != oldDom) {
 			updateParentDomPointers(newVNode);

--- a/src/component.js
+++ b/src/component.js
@@ -248,7 +248,6 @@ function process() {
 		}
 	}
 	if (root) commitRoot(commitQueue, root, refQueue);
-	// if (root) commitRoot(commitQueue, root, refQueue);
 	process._rerenderCount = 0;
 }
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -311,7 +311,7 @@ export function diff(
  * @param {VNode} root
  */
 export function commitRoot(commitQueue, root, refQueue) {
-	root._nextDom = undefined;
+	if (root) root._nextDom = undefined;
 
 	for (let i = 0; i < refQueue.length; i++) {
 		applyRef(refQueue[i], refQueue[++i], refQueue[++i]);

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -311,8 +311,6 @@ export function diff(
  * @param {VNode} root
  */
 export function commitRoot(commitQueue, root, refQueue) {
-	if (root) root._nextDom = undefined;
-
 	for (let i = 0; i < refQueue.length; i++) {
 		applyRef(refQueue[i], refQueue[++i], refQueue[++i]);
 	}

--- a/src/render.js
+++ b/src/render.js
@@ -60,6 +60,8 @@ export function render(vnode, parentDom, replaceNode) {
 	);
 
 	// Flush all queued effects
+	// vnode._nextDom = undefined;
+	// if (options._commit) options._commit(vnode, EMPTY_ARR);
 	commitRoot(commitQueue, vnode, refQueue);
 }
 

--- a/src/render.js
+++ b/src/render.js
@@ -62,6 +62,7 @@ export function render(vnode, parentDom, replaceNode) {
 	// Flush all queued effects
 	// vnode._nextDom = undefined;
 	// if (options._commit) options._commit(vnode, EMPTY_ARR);
+	vnode._nextDom = undefined;
 	commitRoot(commitQueue, vnode, refQueue);
 }
 

--- a/src/render.js
+++ b/src/render.js
@@ -59,9 +59,6 @@ export function render(vnode, parentDom, replaceNode) {
 		refQueue
 	);
 
-	// Flush all queued effects
-	// vnode._nextDom = undefined;
-	// if (options._commit) options._commit(vnode, EMPTY_ARR);
 	vnode._nextDom = undefined;
 	commitRoot(commitQueue, vnode, refQueue);
 }


### PR DESCRIPTION
Still one failing test, and we'll want to decide how best to alter the semantics of `options._commit`. Right now I have it attempting to emulate the old calling order, so _commit(vnode) gets called for every component with a dummy queue. 