### PR TITLE
Add ComponentType to preact/compat

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -46,7 +46,7 @@ declare namespace React {
 	export import RefObject = preact.RefObject;
 	export import Component = preact.Component;
 	export import FunctionComponent = preact.FunctionComponent;
-	export import preact.ComponentType;
+	export import ComponentType = preact.ComponentType;
 	export import FC = preact.FunctionComponent;
 	export import createContext = preact.createContext;
 	export import createRef = preact.createRef;

--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -46,6 +46,7 @@ declare namespace React {
 	export import RefObject = preact.RefObject;
 	export import Component = preact.Component;
 	export import FunctionComponent = preact.FunctionComponent;
+	export type ComponentType<Props = {}> = Component<Props> | FunctionComponent<Props>;
 	export import FC = preact.FunctionComponent;
 	export import createContext = preact.createContext;
 	export import createRef = preact.createRef;

--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -46,7 +46,7 @@ declare namespace React {
 	export import RefObject = preact.RefObject;
 	export import Component = preact.Component;
 	export import FunctionComponent = preact.FunctionComponent;
-	export type ComponentType<Props = {}> = Component<Props> | FunctionComponent<Props>;
+	export import preact.ComponentType;
 	export import FC = preact.FunctionComponent;
 	export import createContext = preact.createContext;
 	export import createRef = preact.createRef;


### PR DESCRIPTION
Add the `ComponentType` type that represents a class or function component with optional props to mirror the same type in `@types/react`: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0818c3f7de545c6b6431e9745dd9910618bba918/types/react/index.d.ts#L43