### PR TITLE
ensure we are able to support capture events from compat

### DIFF
--- a/compat/test/browser/events.test.js
+++ b/compat/test/browser/events.test.js
@@ -2,7 +2,8 @@ import { render } from 'preact';
 import {
 	setupScratch,
 	teardown,
-	createEvent
+	createEvent,
+	supportsPassiveEvents
 } from '../../../test/_util/helpers';
 
 import React, { createElement } from 'preact/compat';
@@ -309,4 +310,24 @@ describe('preact/compat events', () => {
 		scratch.firstChild.dispatchEvent(createEvent('focusout'));
 		expect(spy).to.be.calledOnce;
 	});
+
+	if (supportsPassiveEvents()) {
+		it('should use capturing for event props ending with *Capture', () => {
+			let click = sinon.spy();
+
+			render(
+				<div onTouchMoveCapture={click}>
+					<button type="button">Click me</button>
+				</div>,
+				scratch
+			);
+
+			expect(proto.addEventListener).to.have.been.calledOnce;
+			expect(proto.addEventListener).to.have.been.calledWithExactly(
+				'touchmove',
+				sinon.match.func,
+				true
+			);
+		});
+	}
 });

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -52,7 +52,7 @@ export function setProperty(dom, name, value, oldValue, isSvg) {
 	// Benchmark for comparison: https://esbench.com/bench/574c954bdb965b9a00965ac6
 	else if (name[0] === 'o' && name[1] === 'n') {
 		useCapture =
-			name !== (name = name.replace(/(PointerCapture)$|Capture$/, '$1'));
+			name !== (name = name.replace(/(PointerCapture)$|Capture$/i, '$1'));
 
 		// Infer correct casing for DOM built-in events:
 		if (name.toLowerCase() in dom) name = name.toLowerCase().slice(2);


### PR DESCRIPTION
Resolves #4237 

In compat we always lower-case our events, this prevents us from supporting events ending with `Capture` (which is our heuristic to make the events passive). We could stop doing this but the change would be a lot bigger as opposed to performing a case insensitive check.

One concern I have here would be custom-elements 😅 