### PR TITLE
retain masks across render invocations

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -25,6 +25,7 @@ let oldBeforeRender = options._render;
 let oldAfterDiff = options.diffed;
 let oldCommit = options._commit;
 let oldBeforeUnmount = options.unmount;
+let oldRoot = options._root;
 
 const RAF_TIMEOUT = 100;
 let prevRaf;
@@ -33,6 +34,14 @@ let prevRaf;
 options._diff = vnode => {
 	currentComponent = null;
 	if (oldBeforeDiff) oldBeforeDiff(vnode);
+};
+
+options._root = (vnode, parentDom) => {
+	if (parentDom._children && parentDom._children._mask) {
+		vnode._mask = parentDom._children._mask;
+	}
+
+	if (oldRoot) oldRoot(vnode, parentDom);
 };
 
 /** @type {(vnode: import('./internal').VNode) => void} */

--- a/hooks/test/browser/useId.test.js
+++ b/hooks/test/browser/useId.test.js
@@ -433,4 +433,27 @@ describe('useId', () => {
 		rerender();
 		expect(first).not.to.equal(scratch.innerHTML);
 	});
+
+	it('should return a unique id across invocations of render', () => {
+		const Id = () => {
+			const id = useId();
+			return <div>My id is {id}</div>;
+		};
+
+		const App = props => {
+			return (
+				<div>
+					<Id />
+					{props.secondId ? <Id /> : null}
+				</div>
+			);
+		};
+
+		render(createElement(App, { secondId: false }), scratch);
+		expect(scratch.innerHTML).to.equal('<div><div>My id is P0-0</div></div>');
+		render(createElement(App, { secondId: true }), scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<div><div>My id is P0-0</div><div>My id is P0-1</div></div>'
+		);
+	});
 });


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/4223

This carries over the existing `mask` to the root