### PR TITLE
fix: correctly restore _original

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -143,6 +143,7 @@ function renderComponent(component, commitQueue, refQueue) {
 			refQueue
 		);
 
+		newVNode._original = oldVNode._original;
 		newVNode._parent._children[newVNode._index] = newVNode;
 
 		newVNode._nextDom = undefined;

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -340,6 +340,50 @@ describe('Components', () => {
 			expect(scratch.innerHTML).to.equal('<p>B</p>');
 		});
 
+		it('should update children props correct', () => {
+			let update, update2;
+			class Counter extends Component {
+				constructor(props) {
+					super(props);
+					this.state = { counter: 0 };
+					update2 = () => {
+						this.setState({ counter: this.state.counter + 1 });
+					};
+				}
+
+				render({ counter }) {
+					if (!counter) return null;
+					return (
+						<p>
+							{counter}-{this.state.counter}
+						</p>
+					);
+				}
+			}
+			class App extends Component {
+				constructor(props) {
+					super(props);
+					this.state = { counter: 0 };
+					update = () => {
+						this.setState({ counter: this.state.counter + 1 });
+					};
+				}
+
+				render() {
+					return <Counter counter={this.state.counter} />;
+				}
+			}
+
+			render(<App />, scratch);
+			expect(scratch.innerHTML).to.equal('');
+
+			update2();
+			rerender();
+			update();
+			rerender();
+			expect(scratch.innerHTML).to.equal('<p>1-1</p>');
+		});
+
 		it("should render components that don't pass args into the Component constructor (unistore pattern)", () => {
 			// Pattern unistore uses for connect: https://github.com/developit/unistore/blob/1df7cf60ac6fa1a70859d745fbaea7ea3f1b8d30/src/integrations/preact.js#L23
 			function Wrapper() {

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -340,7 +340,7 @@ describe('Components', () => {
 			expect(scratch.innerHTML).to.equal('<p>B</p>');
 		});
 
-		it('should update children props correct', () => {
+		it('should update children props correctly in subsequent renders', () => {
 			let update, update2;
 			class Counter extends Component {
 				constructor(props) {


### PR DESCRIPTION
We have to restore `_original` to the `oldVNode` value else the counter in `createElement` gets outdated. We did this implicitly before https://github.com/preactjs/preact/pull/4171 by copying the oldVNode rather than the new one.

fixes https://github.com/preactjs/preact/issues/4279