### PR TITLE
fix: address scenario where we would crash when replacing a matched vnode with null

### DIFF
--- a/hooks/test/browser/combinations.test.js
+++ b/hooks/test/browser/combinations.test.js
@@ -477,4 +477,44 @@ describe('combinations', () => {
 			'anchor effect'
 		]);
 	});
+
+	it.only('should not crash', () => {
+		const B = () => <div>B</div>;
+
+		let update;
+		const Test = () => {
+			const [state, setState] = useState(true);
+			update = () => setState(s => !s);
+
+			if (state) {
+				return (
+					<div>
+						<B />
+						<div />
+					</div>
+				);
+			}
+			return (
+				<div>
+					<div />
+					{null}
+					<B />
+				</div>
+			);
+		};
+		render(<Test />, scratch);
+		expect(scratch.innerHTML).to.equal('<div><div>B</div><div></div></div>');
+
+		update();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div><div></div><div>B</div></div>');
+
+		update();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div><div></div><div>B</div></div>');
+
+		update();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div><div></div><div>B</div></div>');
+	});
 });

--- a/hooks/test/browser/combinations.test.js
+++ b/hooks/test/browser/combinations.test.js
@@ -502,18 +502,22 @@ describe('combinations', () => {
 				</div>
 			);
 		};
+
 		render(<Test />, scratch);
 		expect(scratch.innerHTML).to.equal('<div><div>B</div><div></div></div>');
 
 		update();
+		console.log('--- RENDER');
 		rerender();
 		expect(scratch.innerHTML).to.equal('<div><div></div><div>B</div></div>');
 
 		update();
+		console.log('--- RENDER');
 		rerender();
 		expect(scratch.innerHTML).to.equal('<div><div></div><div>B</div></div>');
 
 		update();
+		console.log('--- RENDER');
 		rerender();
 		expect(scratch.innerHTML).to.equal('<div><div></div><div>B</div></div>');
 	});

--- a/hooks/test/browser/combinations.test.js
+++ b/hooks/test/browser/combinations.test.js
@@ -514,7 +514,7 @@ describe('combinations', () => {
 		update();
 		console.log('--- RENDER');
 		rerender();
-		expect(scratch.innerHTML).to.equal('<div><div></div><div>B</div></div>');
+		expect(scratch.innerHTML).to.equal('<div><div>B</div><div></div></div>');
 
 		update();
 		console.log('--- RENDER');

--- a/hooks/test/browser/combinations.test.js
+++ b/hooks/test/browser/combinations.test.js
@@ -478,7 +478,7 @@ describe('combinations', () => {
 		]);
 	});
 
-	it.only('should not crash', () => {
+	it('should not crash or repeatedly add the same child when replacing a matched vnode with null', () => {
 		const B = () => <div>B</div>;
 
 		let update;
@@ -507,17 +507,14 @@ describe('combinations', () => {
 		expect(scratch.innerHTML).to.equal('<div><div>B</div><div></div></div>');
 
 		update();
-		console.log('--- RENDER');
 		rerender();
 		expect(scratch.innerHTML).to.equal('<div><div></div><div>B</div></div>');
 
 		update();
-		console.log('--- RENDER');
 		rerender();
 		expect(scratch.innerHTML).to.equal('<div><div>B</div><div></div></div>');
 
 		update();
-		console.log('--- RENDER');
 		rerender();
 		expect(scratch.innerHTML).to.equal('<div><div></div><div>B</div></div>');
 	});

--- a/hooks/test/browser/combinations.test.js
+++ b/hooks/test/browser/combinations.test.js
@@ -477,45 +477,4 @@ describe('combinations', () => {
 			'anchor effect'
 		]);
 	});
-
-	it('should not crash or repeatedly add the same child when replacing a matched vnode with null', () => {
-		const B = () => <div>B</div>;
-
-		let update;
-		const Test = () => {
-			const [state, setState] = useState(true);
-			update = () => setState(s => !s);
-
-			if (state) {
-				return (
-					<div>
-						<B />
-						<div />
-					</div>
-				);
-			}
-			return (
-				<div>
-					<div />
-					{null}
-					<B />
-				</div>
-			);
-		};
-
-		render(<Test />, scratch);
-		expect(scratch.innerHTML).to.equal('<div><div>B</div><div></div></div>');
-
-		update();
-		rerender();
-		expect(scratch.innerHTML).to.equal('<div><div></div><div>B</div></div>');
-
-		update();
-		rerender();
-		expect(scratch.innerHTML).to.equal('<div><div>B</div><div></div></div>');
-
-		update();
-		rerender();
-		expect(scratch.innerHTML).to.equal('<div><div></div><div>B</div></div>');
-	});
 });

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -62,7 +62,6 @@ export function diffChildren(
 
 	for (i = 0; i < newChildrenLength; i++) {
 		childVNode = newParentVNode._children[i];
-
 		if (
 			childVNode == null ||
 			typeof childVNode == 'boolean' ||
@@ -98,6 +97,13 @@ export function diffChildren(
 
 		// Adjust DOM nodes
 		newDom = childVNode._dom;
+		console.log(
+			'compared',
+			newDom,
+			childVNode._index,
+			childVNode && childVNode.type,
+			oldVNode && oldVNode.type
+		);
 		if (childVNode.ref && oldVNode.ref != childVNode.ref) {
 			if (oldVNode.ref) {
 				applyRef(oldVNode.ref, null, childVNode);
@@ -113,6 +119,7 @@ export function diffChildren(
 			firstChildDom = newDom;
 		}
 
+		console.log(newDom, childVNode._flags & INSERT_VNODE);
 		if (
 			childVNode._flags & INSERT_VNODE ||
 			oldVNode._children === childVNode._children
@@ -235,7 +242,7 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 				if (oldVNode._dom == newParentVNode._nextDom) {
 					newParentVNode._nextDom = getDomSibling(oldVNode);
 				}
-
+				console.log('unmounting', oldVNode.type);
 				unmount(oldVNode, oldVNode, false);
 
 				// Explicitly nullify this position in oldChildren instead of just
@@ -250,7 +257,6 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 				oldChildren[i] = null;
 				remainingOldChildren--;
 			}
-
 			continue;
 		}
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -97,13 +97,6 @@ export function diffChildren(
 
 		// Adjust DOM nodes
 		newDom = childVNode._dom;
-		console.log(
-			'compared',
-			newDom,
-			childVNode._index,
-			childVNode && childVNode.type,
-			oldVNode && oldVNode.type
-		);
 		if (childVNode.ref && oldVNode.ref != childVNode.ref) {
 			if (oldVNode.ref) {
 				applyRef(oldVNode.ref, null, childVNode);
@@ -119,7 +112,6 @@ export function diffChildren(
 			firstChildDom = newDom;
 		}
 
-		console.log(newDom, childVNode._flags & INSERT_VNODE);
 		if (
 			childVNode._flags & INSERT_VNODE ||
 			oldVNode._children === childVNode._children
@@ -238,11 +230,15 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 		// Handle unmounting null placeholders, i.e. VNode => null in unkeyed children
 		if (childVNode == null) {
 			oldVNode = oldChildren[i];
-			if (oldVNode && oldVNode.key == null && oldVNode._dom) {
+			if (
+				oldVNode &&
+				oldVNode.key == null &&
+				oldVNode._dom &&
+				!oldVNode._flags & MATCHED
+			) {
 				if (oldVNode._dom == newParentVNode._nextDom) {
 					newParentVNode._nextDom = getDomSibling(oldVNode);
 				}
-				console.log('unmounting', oldVNode.type);
 				unmount(oldVNode, oldVNode, false);
 
 				// Explicitly nullify this position in oldChildren instead of just

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -234,7 +234,7 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 				oldVNode &&
 				oldVNode.key == null &&
 				oldVNode._dom &&
-				!oldVNode._flags & MATCHED
+				(oldVNode._flags & MATCHED) === 0
 			) {
 				if (oldVNode._dom == newParentVNode._nextDom) {
 					newParentVNode._nextDom = getDomSibling(oldVNode);

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1308,4 +1308,52 @@ describe('render()', () => {
 		expect(divs[1].hasAttribute('role')).to.equal(false);
 		expect(divs[2].hasAttribute('role')).to.equal(false);
 	});
+
+	it('should not crash or repeatedly add the same child when replacing a matched vnode with null', () => {
+		const B = () => <div>B</div>;
+
+		let update;
+		class App extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { show: true };
+				update = () => {
+					this.setState(state => ({ show: !state.show }));
+				};
+			}
+
+			render() {
+				if (this.state.show) {
+					return (
+						<div>
+							<B />
+							<div />
+						</div>
+					);
+				}
+				return (
+					<div>
+						<div />
+						{null}
+						<B />
+					</div>
+				);
+			}
+		}
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal('<div><div>B</div><div></div></div>');
+
+		update();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div><div></div><div>B</div></div>');
+
+		update();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div><div>B</div><div></div></div>');
+
+		update();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div><div></div><div>B</div></div>');
+	});
 });


### PR DESCRIPTION
Fixes #4274
Fixes #4194

This change adds one crucial change to our child-diffing, when an oldVNode has already been matched we won't unmount it