### PR TITLE
10.19.5

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -2,7 +2,7 @@ import { options, Fragment, Component } from 'preact';
 
 export function initDevTools() {
 	if (typeof window != 'undefined' && window.__PREACT_DEVTOOLS__) {
-		window.__PREACT_DEVTOOLS__.attachPreact('10.19.4', options, {
+		window.__PREACT_DEVTOOLS__.attachPreact('10.19.5', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "10.19.4",
+  "version": "10.19.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "10.19.4",
+      "version": "10.19.5",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.19.4",
+  "version": "10.19.5",
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
## Fixes

- Address scenario where we would crash when replacing a matched vnode with null (#4281, thanks @JoviDeCroock)
- Correctly restore _original (#4280, thanks @JoviDeCroock)
- Protect against nullish render (#4278, thanks @JoviDeCroock)
- Support setting translate through direct access (#3800, thanks @JoviDeCroock)

## Types

- Add dpub aria 1.0 role JSX types (#4276, thanks @novari)
