### PR TITLE
fix: invalid vnode id for text nodes

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -201,7 +201,7 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 				childVNode,
 				null,
 				null,
-				childVNode
+				null
 			);
 		} else if (isArray(childVNode)) {
 			childVNode = newParentVNode._children[i] = createVNode(


### PR DESCRIPTION
Materialized text vnodes would pass their content as the original vnode id which is wrong and turns the vnode id into a string. The vnode id is expected to be a number instead though.

This had no effect on correctness or anything, just an unnecessary type conversion.