### PR TITLE
bring consistency to our focus events

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1563,10 +1563,10 @@ export namespace JSXInternal {
 		// Focus Events
 		onFocus?: FocusEventHandler<Target> | undefined;
 		onFocusCapture?: FocusEventHandler<Target> | undefined;
-		onfocusin?: FocusEventHandler<Target> | undefined;
-		onfocusinCapture?: FocusEventHandler<Target> | undefined;
-		onfocusout?: FocusEventHandler<Target> | undefined;
-		onfocusoutCapture?: FocusEventHandler<Target> | undefined;
+		onFocusIn?: FocusEventHandler<Target> | undefined;
+		onFocusInCapture?: FocusEventHandler<Target> | undefined;
+		onFocusOut?: FocusEventHandler<Target> | undefined;
+		onFocusOutCapture?: FocusEventHandler<Target> | undefined;
 		onBlur?: FocusEventHandler<Target> | undefined;
 		onBlurCapture?: FocusEventHandler<Target> | undefined;
 


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/4289

We could leave the lower cased ones in for backwards compatibility, floating this to have a consistent file