### PR TITLE
fix: case where shrinking a list would cause an exception

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -116,6 +116,9 @@ export function diffChildren(
 			childVNode._flags & INSERT_VNODE ||
 			oldVNode._children === childVNode._children
 		) {
+			if (!newDom && oldVNode._dom == oldDom) {
+				oldDom = getDomSibling(oldVNode);
+			}
 			oldDom = insert(childVNode, oldDom, parentDom);
 		} else if (
 			typeof childVNode.type == 'function' &&
@@ -229,11 +232,6 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 
 		const skewedIndex = i + skew;
 
-		console.log(
-			'hi',
-			childVNode && childVNode.type,
-			childVNode && childVNode.key
-		);
 		// Handle unmounting null placeholders, i.e. VNode => null in unkeyed children
 		if (childVNode == null) {
 			oldVNode = oldChildren[skewedIndex];
@@ -244,17 +242,8 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 				(oldVNode._flags & MATCHED) === 0
 			) {
 				if (oldVNode._dom == newParentVNode._nextDom) {
-					console.log(newParentVNode._parent._nextDom);
-					if (newParentVNode._parent._nextDom === oldVNode._dom) {
-						newParentVNode._parent._nextDom = getDomSibling(oldVNode);
-					}
 					newParentVNode._nextDom = getDomSibling(oldVNode);
 				}
-				console.log(
-					'setting early unmount',
-					newParentVNode.type,
-					newParentVNode._nextDom
-				);
 
 				unmount(oldVNode, oldVNode, false);
 
@@ -386,7 +375,6 @@ function insert(parentVNode, oldDom, parentDom) {
 		oldDom = oldDom && oldDom.nextSibling;
 	} while (oldDom != null && oldDom.nodeType === 8);
 
-	console.log('returning from insert', oldDom);
 	return oldDom;
 }
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -229,6 +229,11 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 
 		const skewedIndex = i + skew;
 
+		console.log(
+			'hi',
+			childVNode && childVNode.type,
+			childVNode && childVNode.key
+		);
 		// Handle unmounting null placeholders, i.e. VNode => null in unkeyed children
 		if (childVNode == null) {
 			oldVNode = oldChildren[skewedIndex];
@@ -239,8 +244,18 @@ function constructNewChildrenArray(newParentVNode, renderResult, oldChildren) {
 				(oldVNode._flags & MATCHED) === 0
 			) {
 				if (oldVNode._dom == newParentVNode._nextDom) {
+					console.log(newParentVNode._parent._nextDom);
+					if (newParentVNode._parent._nextDom === oldVNode._dom) {
+						newParentVNode._parent._nextDom = getDomSibling(oldVNode);
+					}
 					newParentVNode._nextDom = getDomSibling(oldVNode);
 				}
+				console.log(
+					'setting early unmount',
+					newParentVNode.type,
+					newParentVNode._nextDom
+				);
+
 				unmount(oldVNode, oldVNode, false);
 
 				// Explicitly nullify this position in oldChildren instead of just
@@ -371,6 +386,7 @@ function insert(parentVNode, oldDom, parentDom) {
 		oldDom = oldDom && oldDom.nextSibling;
 	} while (oldDom != null && oldDom.nodeType === 8);
 
+	console.log('returning from insert', oldDom);
 	return oldDom;
 }
 

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1538,7 +1538,7 @@ describe('render()', () => {
 		);
 	});
 
-	it.only('should shrink lists', () => {
+	it('should shrink lists', () => {
 		function RenderedItem({ item }) {
 			if (item.renderAsNullInComponent) {
 				return null;
@@ -1576,7 +1576,6 @@ describe('render()', () => {
 			'<div><div>One</div><div>Two</div><div>Three</div><div>Four</div></div>'
 		);
 
-		console.log('---');
 		render(<App list={secondList} />, scratch);
 		expect(scratch.innerHTML).to.equal(
 			'<div><div>One</div><div>Six</div><div>Seven</div></div>'

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1481,8 +1481,8 @@ describe('render()', () => {
 
 		expect(serializeHtml(scratch)).to.equal(
 			'<div><p>_B1</p><p>_B2</p><p>_B3</p><h2>_B4</h2><p>_B5</p><p>_B6</p><p>_B7</p><h2>_B8</h2><p>_B9</p><p>_B10</p><p>_B11</p><p>_B12</p><h2>_B13</h2></div>'
-    );
-  });
+		);
+	});
 
 	it('should not crash or repeatedly add the same child when replacing a matched vnode with null (mixed dom-types)', () => {
 		const B = () => <div>B</div>;
@@ -1535,6 +1535,51 @@ describe('render()', () => {
 		rerender();
 		expect(scratch.innerHTML).to.equal(
 			'<div><span>A</span><div>B</div><div>C</div></div>'
+		);
+	});
+
+	it.only('should shrink lists', () => {
+		function RenderedItem({ item }) {
+			if (item.renderAsNullInComponent) {
+				return null;
+			}
+
+			return <div>{item.id}</div>;
+		}
+
+		function App({ list }) {
+			return (
+				<div>
+					{list.map(item => (
+						<RenderedItem key={item.id} item={item} />
+					))}
+				</div>
+			);
+		}
+
+		const firstList = [
+			{ id: 'One' },
+			{ id: 'Two' },
+			{ id: 'Three' },
+			{ id: 'Four' }
+		];
+
+		const secondList = [
+			{ id: 'One' },
+			{ id: 'Four', renderAsNullInComponent: true },
+			{ id: 'Six' },
+			{ id: 'Seven' }
+		];
+
+		render(<App list={firstList} />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<div><div>One</div><div>Two</div><div>Three</div><div>Four</div></div>'
+		);
+
+		console.log('---');
+		render(<App list={secondList} />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<div><div>One</div><div>Six</div><div>Seven</div></div>'
 		);
 	});
 });


### PR DESCRIPTION
Basically what happens is the following

```
item-1
item-2
item-3
item-4
```

as keyed items transitions to 

```
item-1
item-4 --> is a functional component returning null
item-5
item-6
```

In the first pass we see that items 2 and 3 can be removed and we set the `_nextDom` to the `_dom` of item-4. When we render item-1 we see that we can let it stay in place, we render `item-4` and see we can unmount it... However... Our `_nextDom` will be set to `item-4` due to [this line](https://github.com/preactjs/preact/blob/main/src/diff/children.js#L129). That by extension means that `oldDom` will always be set to an unmounted item which will cause crashes.

This PR adds safeguards so that if we see that we are dealing with an unmounted dom-node that we transition the `oldDom` to the next sibling

Fixes #4221