### PR TITLE
fix: check whether `oldDom` is present in the DOM

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -116,7 +116,7 @@ export function diffChildren(
 			childVNode._flags & INSERT_VNODE ||
 			oldVNode._children === childVNode._children
 		) {
-			if (!newDom && oldVNode._dom == oldDom) {
+			if (oldDom && !oldDom.isConnected) {
 				oldDom = getDomSibling(oldVNode);
 			}
 			oldDom = insert(childVNode, oldDom, parentDom);

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -116,6 +116,7 @@ export function diffChildren(
 			childVNode._flags & INSERT_VNODE ||
 			oldVNode._children === childVNode._children
 		) {
+			// @ts-expect-error olDom should be present on a DOM node
 			if (oldDom && !oldDom.isConnected) {
 				oldDom = getDomSibling(oldVNode);
 			}


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/4194

This was a bit of a tricky one and haven't been able to reproduce this in tests but the base case looks like the following

```
Suspense
  Component --> Fragment-like
    Component --> Fragment-like
      some-dom-node
  LazyComponent --> Fragment-like
    LazyComponent --> Fragment-like
      some-dom-node
```

The main issue is that in nested fragment-like children we can have a very deep chain of components where the last one eventually resolves to unmounting the children. This is problematic because we bubble back up to the `_parent` where the `_nextDom`/`oldDom` is already set but can be unmounted by a later `Fragment-like` child.

This effectively means that _nextDom on all parents is going to be invalid, we however can't course-correct as we've already higher-up in the [stack assigned oldDom](https://github.com/preactjs/preact/blob/main/src/diff/children.js#L61) which now in-turn can become invalid by the [first call to diff](https://github.com/preactjs/preact/blob/main/src/diff/children.js#L85).

My naive solution for this is to check `isConnected` and get a new DOM-Sibling, this re-checks the children and shouldn't come up with an old-node as we are post-diff. Open to any other solutions here.

For debugging I copied the sandbox attached in the issue in our `demo` and logged that way.