### PR TITLE
Add missing PropsWithRef type to fix #4293

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -178,7 +178,7 @@ declare namespace React {
 		C extends ComponentType<any> | keyof JSXInternal.IntrinsicElements
 	> = C extends new (props: infer P) => Component<any, any>
 		? PropsWithoutRef<P> & RefAttributes<InstanceType<C>>
-		: ComponentProps<C>;
+		: PropsWithRef<ComponentProps<C>>;
 
 	export function flushSync<R>(fn: () => R): R;
 	export function flushSync<A, R>(fn: (a: A) => R, a: A): R;


### PR DESCRIPTION
#4271 introduces a bug where some types are incorrectly resolved.

Compared to the original types/react [implementation](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/41aa59f8e323a93b98ecea69fcf67a7a0a2cfa67/types/react/index.d.ts#L1643C5-L1645C43), #4271's is missing an enclosing PropsWithRef in the return statement. The problems appear to resolve after restoring that line.

Fixes #4293