### PR TITLE
fix(types): add template tag JSX type

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -2986,6 +2986,7 @@ export namespace JSXInternal {
 		table: HTMLAttributes<HTMLTableElement>;
 		tbody: HTMLAttributes<HTMLTableSectionElement>;
 		td: HTMLAttributes<HTMLTableCellElement>;
+		template: HTMLAttributes<HTMLTemplateElement>;
 		textarea: HTMLAttributes<HTMLTextAreaElement>;
 		tfoot: HTMLAttributes<HTMLTableSectionElement>;
 		th: HTMLAttributes<HTMLTableCellElement>;


### PR DESCRIPTION
Noticed that we're missing typings for the `<template>` tag: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template