### PR TITLE
10.20.2

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -2,7 +2,7 @@ import { options, Fragment, Component } from 'preact';
 
 export function initDevTools() {
 	if (typeof window != 'undefined' && window.__PREACT_DEVTOOLS__) {
-		window.__PREACT_DEVTOOLS__.attachPreact('10.20.1', options, {
+		window.__PREACT_DEVTOOLS__.attachPreact('10.20.2', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "10.20.1",
+  "version": "10.20.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "10.20.1",
+      "version": "10.20.2",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.20.1",
+  "version": "10.20.2",
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
## Fixes

- Check whether `oldDom` is present in the DOM (#4318, thanks @JoviDeCroock)
- Simplify the logic introduced in #4322 & use eventClock for capture events too (#4324, thanks @jviide)
- Use a virtual clock instead of Date.now() for event dispatch times (#4322, thanks @jviide)

## Types

- Add template tag JSX type (#4334, thanks @marvinhagemeister)

## Maintenance

- Integrate the new benchmarks repo and update  (#4310, thanks @andrewiggins)
- Some byte improvements (#4321, thanks @JoviDeCroock)