### PR TITLE
provide event handler types

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -58,6 +58,21 @@ declare namespace React {
 	export import ReactNode = preact.ComponentChild;
 	export import ReactElement = preact.VNode;
 	export import Consumer = preact.Consumer;
+	export import ClipboardEventHandler = preact.ClipboardEventHandler;
+	export import CompositionEventHandler = preact.CompositionEventHandler;
+	export import DragEventHandler = preact.DragEventHandler;
+	export import FocusEventHandler = preact.FocusEventHandler;
+	export import FormEventHandler = preact.FormEventHandler;
+	export import ChangeEventHandler = preact.ChangeEventHandler;
+	export import InputEventHandler = preact.InputEventHandler;
+	export import KeyboardEventHandler = preact.KeyboardEventHandler;
+	export import MouseEventHandler = preact.MouseEventHandler;
+	export import TouchEventHandler = preact.TouchEventHandler;
+	export import PointerEventHandler = preact.PointerEventHandler;
+	export import UIEventHandler = preact.UIEventHandler;
+	export import WheelEventHandler = preact.WheelEventHandler;
+	export import AnimationEventHandler = preact.AnimationEventHandler;
+	export import TransitionEventHandler = preact.TransitionEventHandler;
 
 	// Suspense
 	export import Suspense = _Suspense.Suspense;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -395,3 +395,28 @@ export interface Context<T> {
 export interface PreactContext<T> extends Context<T> {}
 
 export function createContext<T>(defaultValue: T): Context<T>;
+
+type EventHandler<E extends Event<any>> = (event: E) => void;
+export type ClipboardEventHandler<T = Element> = EventHandler<
+	ClipboardEvent<T>
+>;
+export type CompositionEventHandler<T = Element> = EventHandler<
+	CompositionEvent<T>
+>;
+export type DragEventHandler<T = Element> = EventHandler<DragEvent<T>>;
+export type FocusEventHandler<T = Element> = EventHandler<FocusEvent<T>>;
+export type FormEventHandler<T = Element> = EventHandler<FormEvent<T>>;
+export type ChangeEventHandler<T = Element> = EventHandler<ChangeEvent<T>>;
+export type InputEventHandler<T = Element> = EventHandler<InputEvent<T>>;
+export type KeyboardEventHandler<T = Element> = EventHandler<KeyboardEvent<T>>;
+export type MouseEventHandler<T = Element> = EventHandler<MouseEvent<T>>;
+export type TouchEventHandler<T = Element> = EventHandler<TouchEvent<T>>;
+export type PointerEventHandler<T = Element> = EventHandler<PointerEvent<T>>;
+export type UIEventHandler<T = Element> = EventHandler<UIEvent<T>>;
+export type WheelEventHandler<T = Element> = EventHandler<WheelEvent<T>>;
+export type AnimationEventHandler<T = Element> = EventHandler<
+	AnimationEvent<T>
+>;
+export type TransitionEventHandler<T = Element> = EventHandler<
+	TransitionEvent<T>
+>;

--- a/test/ts/dom-attributes-test.tsx
+++ b/test/ts/dom-attributes-test.tsx
@@ -1,4 +1,4 @@
-import { createElement, Fragment, JSX } from 'preact';
+import { ChangeEventHandler, createElement, Fragment, JSX } from 'preact';
 
 function createSignal<T>(value: T): JSX.SignalLike<T> {
 	return {
@@ -45,3 +45,20 @@ const booleanishTest = (
 		<div aria-haspopup={'dialog'} />
 	</>
 );
+
+const onChange: ChangeEventHandler<HTMLInputElement> = e => {
+	return e.currentTarget.value;
+};
+
+const Test = () => {
+	return (
+		<div>
+			<input onInput={onChange} />
+			<input
+				onInput={e => {
+					return e.currentTarget.value;
+				}}
+			/>
+		</div>
+	);
+};


### PR DESCRIPTION
This provides typings that are exported from `preact` that can be used to type functions that will be fed into event handlers.