### PR TITLE
feat: Add compat/client types

### DIFF
--- a/compat/client.d.ts
+++ b/compat/client.d.ts
@@ -1,0 +1,11 @@
+import * as preact from '../src';
+
+export function createRoot(container: preact.ContainerNode): {
+	render(children: preact.VNode<any>): void;
+	unmount(): void;
+};
+
+export function hydrateRoot(
+	container: preact.ContainerNode,
+	children: preact.VNode<any>
+): typeof createRoot;

--- a/compat/package.json
+++ b/compat/package.json
@@ -25,6 +25,7 @@
       "require": "./dist/compat.js"
     },
     "./client": {
+      "types": "./client.d.ts",
       "import": "./client.mjs",
       "require": "./client.js"
     },

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
       "require": "./jsx-runtime/dist/jsxRuntime.js"
     },
     "./compat/client": {
+      "types": "./compat/client.d.ts",
       "import": "./compat/client.mjs",
       "require": "./compat/client.js"
     },
@@ -209,6 +210,7 @@
     "dist",
     "compat/dist",
     "compat/src",
+    "compat/client.d.ts",
     "compat/client.js",
     "compat/client.mjs",
     "compat/server.browser.js",


### PR DESCRIPTION
Closes #3845 (but for real this time)

Semi-related: is it intentional that Preact can take a [`ComponentChild`](https://github.com/preactjs/preact/blob/e2c8a4564ef75e544735a96f88c250002f99f1ff/src/index.d.ts#L301) as a render arg whilst compat can only take [`VNode<any>`](https://github.com/preactjs/preact/blob/e2c8a4564ef75e544735a96f88c250002f99f1ff/compat/src/index.d.ts#L94-L95)? Doesn't seem like there's an immediately obvious issue w/ compat rendering a string, etc., as it's passed straight through to the core `render()`, more or less.