### PR TITLE
refactor: Support ComponentChild(ren) in compat render/hydrate/createPortal

### DIFF
--- a/compat/client.d.ts
+++ b/compat/client.d.ts
@@ -1,11 +1,11 @@
 import * as preact from '../src';
 
 export function createRoot(container: preact.ContainerNode): {
-	render(children: preact.VNode<any>): void;
+	render(children: preact.ComponentChild): void;
 	unmount(): void;
 };
 
 export function hydrateRoot(
 	container: preact.ContainerNode,
-	children: preact.VNode<any>
+	children: preact.ComponentChild
 ): typeof createRoot;

--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -87,18 +87,18 @@ declare namespace React {
 	export import ChangeEventHandler = JSXInternal.GenericEventHandler;
 
 	export function createPortal(
-		vnode: preact.VNode,
+		vnode: preact.ComponentChildren,
 		container: preact.ContainerNode
 	): preact.VNode<any>;
 
 	export function render(
-		vnode: preact.VNode<any>,
+		vnode: preact.ComponentChild,
 		parent: preact.ContainerNode,
 		callback?: () => void
 	): Component | null;
 
 	export function hydrate(
-		vnode: preact.VNode<any>,
+		vnode: preact.ComponentChild,
 		parent: preact.ContainerNode,
 		callback?: () => void
 	): Component | null;


### PR DESCRIPTION
Re: #4345 

Unlikely to really matter, but every now and then we do see a user or two still using React imports in their apps for whatever reason so this'll fix their types if they're trying to render a string or whatnot.

`createPortal` does support `ComponentChildren`, that change isn't a typo.

---

Unrelated, but I'll make a note to run through one day and make our use of `parent` & `container` consistent -- I noticed we use them interchangeably, which, while not an issue per se, might confuse someone new to the API.