### PR TITLE
fix: Incorrect "missing `transform-jsx-source`" warning

### DIFF
--- a/debug/src/component-stack.js
+++ b/debug/src/component-stack.js
@@ -58,7 +58,7 @@ export function getCurrentVNode() {
  * location of a component. In that case we just omit that, but we'll
  * print a helpful message to the console, notifying the user of it.
  */
-let shouldShowJsxSourceWarning = true;
+let showJsxSourcePluginWarning = true;
 
 /**
  * Check if a `vnode` is a possible owner.
@@ -87,12 +87,12 @@ export function getOwnerStack(vnode) {
 		const source = owner.__source;
 		if (source) {
 			acc += ` (at ${source.fileName}:${source.lineNumber})`;
-		} else if (shouldShowJsxSourceWarning) {
+		} else if (showJsxSourcePluginWarning) {
 			console.warn(
 				'Add @babel/plugin-transform-react-jsx-source to get a more detailed component stack. Note that you should not add it to production builds of your App for bundle size reasons.'
 			);
 		}
-		shouldShowJsxSourceWarning = false;
+		showJsxSourcePluginWarning = false;
 
 		return (acc += '\n');
 	}, '');

--- a/debug/src/component-stack.js
+++ b/debug/src/component-stack.js
@@ -58,7 +58,7 @@ export function getCurrentVNode() {
  * location of a component. In that case we just omit that, but we'll
  * print a helpful message to the console, notifying the user of it.
  */
-let hasBabelPlugin = false;
+let shouldShowJsxSourceWarning = true;
 
 /**
  * Check if a `vnode` is a possible owner.
@@ -87,12 +87,12 @@ export function getOwnerStack(vnode) {
 		const source = owner.__source;
 		if (source) {
 			acc += ` (at ${source.fileName}:${source.lineNumber})`;
-		} else if (!hasBabelPlugin) {
-			hasBabelPlugin = true;
+		} else if (shouldShowJsxSourceWarning) {
 			console.warn(
 				'Add @babel/plugin-transform-react-jsx-source to get a more detailed component stack. Note that you should not add it to production builds of your App for bundle size reasons.'
 			);
 		}
+		shouldShowJsxSourceWarning = false;
 
 		return (acc += '\n');
 	}, '');

--- a/debug/test/browser/component-stack.test.js
+++ b/debug/test/browser/component-stack.test.js
@@ -83,4 +83,19 @@ describe('component stack', () => {
 		expect(lines[1].indexOf('Thrower') > -1).to.equal(true);
 		expect(lines[2].indexOf('Bar') > -1).to.equal(true);
 	});
+
+	it('should not print a warning when "@babel/plugin-transform-react-jsx-source" is installed', () => {
+		function Thrower() {
+			throw 'foo';
+			return <div>foo</div>;
+		}
+
+		try {
+			render(<Thrower />, scratch);
+		} catch {}
+
+		expect(warnings.join(' ')).to.not.include(
+			'@babel/plugin-transform-react-jsx-source'
+		);
+	});
 });

--- a/debug/test/browser/component-stack.test.js
+++ b/debug/test/browser/component-stack.test.js
@@ -86,8 +86,7 @@ describe('component stack', () => {
 
 	it('should not print a warning when "@babel/plugin-transform-react-jsx-source" is installed', () => {
 		function Thrower() {
-			throw 'foo';
-			return <div>foo</div>;
+			throw new Error('foo');
 		}
 
 		try {


### PR DESCRIPTION
Fixes #3818

The Preact-CLI usage from the issue is unfortunately borked and not fixable really: CLI has users export their root component which it (CLI) then renders using `h()` -- no JSX source info is going to be added to that. That creates a situation in which there might not have been any vnodes with `.__source` set to flow through before `getOwnerStack()` is called.