### PR TITLE
major(core): remove removeNode hack

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -8,7 +8,7 @@ import { BaseComponent, getDomSibling } from '../component';
 import { Fragment } from '../create-element';
 import { diffChildren } from './children';
 import { setProperty } from './props';
-import { assign, isArray, removeNode, slice } from '../util';
+import { assign, isArray, slice } from '../util';
 import options from '../options';
 
 /**
@@ -509,7 +509,7 @@ function diffElementNodes(
 			// Remove children that are not part of any vnode.
 			if (excessDomChildren != null) {
 				for (i = excessDomChildren.length; i--; ) {
-					if (excessDomChildren[i] != null) removeNode(excessDomChildren[i]);
+					if (excessDomChildren[i] != null) excessDomChildren[i].remove();
 				}
 			}
 		}
@@ -600,7 +600,7 @@ export function unmount(vnode, parentVNode, skipRemove) {
 	}
 
 	if (!skipRemove && vnode._dom != null) {
-		removeNode(vnode._dom);
+		vnode._dom.remove();
 	}
 
 	// Must be set to `undefined` to properly clean up `_nextDom`

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -509,7 +509,9 @@ function diffElementNodes(
 			// Remove children that are not part of any vnode.
 			if (excessDomChildren != null) {
 				for (i = excessDomChildren.length; i--; ) {
-					if (excessDomChildren[i] != null) excessDomChildren[i].remove();
+					if (excessDomChildren[i] != null) {
+						excessDomChildren[i].remove();
+					}
 				}
 			}
 		}
@@ -599,7 +601,7 @@ export function unmount(vnode, parentVNode, skipRemove) {
 		}
 	}
 
-	if (!skipRemove && vnode._dom != null) {
+	if (!skipRemove && vnode._dom != null && typeof vnode.type != 'function') {
 		vnode._dom.remove();
 	}
 

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -94,6 +94,7 @@ declare global {
 		readonly attributes?: Element['attributes'];
 		setAttribute?: Element['setAttribute'];
 		removeAttribute?: Element['removeAttribute'];
+		remove?: Element['remove'];
 
 		// Event listeners
 		addEventListener?: Element['addEventListener'];

--- a/src/util.js
+++ b/src/util.js
@@ -15,15 +15,4 @@ export function assign(obj, props) {
 	return /** @type {O & P} */ (obj);
 }
 
-/**
- * Remove a child node from its parent if attached. This is a workaround for
- * IE11 which doesn't support `Element.prototype.remove()`. Using this function
- * is smaller than including a dedicated polyfill.
- * @param {preact.ContainerNode} node The node to remove
- */
-export function removeNode(node) {
-	let parentNode = node.parentNode;
-	if (parentNode) parentNode.removeChild(node);
-}
-
 export const slice = EMPTY_ARR.slice;

--- a/test/_util/logCall.js
+++ b/test/_util/logCall.js
@@ -31,10 +31,6 @@ export function logCall(obj, method) {
 
 		let operation;
 		switch (method) {
-			case 'removeChild': {
-				operation = `${serialize(c)}.remove()`;
-				break;
-			}
 			case 'insertBefore': {
 				if (args[1] === null && args.length === 2) {
 					operation = `${serialize(this)}.appendChild(${serialize(args[0])})`;

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -31,12 +31,14 @@ describe('Fragment', () => {
 
 	let resetInsertBefore;
 	let resetAppendChild;
-	let resetRemoveChild;
+	let resetRemove;
+	let resetRemoveText;
 
 	before(() => {
 		resetInsertBefore = logCall(Element.prototype, 'insertBefore');
 		resetAppendChild = logCall(Element.prototype, 'appendChild');
-		resetRemoveChild = logCall(Element.prototype, 'removeChild');
+		resetRemove = logCall(Element.prototype, 'remove');
+		resetRemoveText = logCall(Text.prototype, 'remove');
 		// logCall(CharacterData.prototype, 'remove');
 		// TODO: Consider logging setting set data
 		// ```
@@ -52,7 +54,8 @@ describe('Fragment', () => {
 	after(() => {
 		resetInsertBefore();
 		resetAppendChild();
-		resetRemoveChild();
+		resetRemove();
+		resetRemoveText();
 	});
 
 	beforeEach(() => {

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -24,16 +24,18 @@ describe('hydrate()', () => {
 
 	let resetAppendChild;
 	let resetInsertBefore;
-	let resetRemoveChild;
+	let resetRemoveTextnode;
 	let resetRemove;
+	let resetRemoveComment;
 	let resetSetAttribute;
 	let resetRemoveAttribute;
 
 	before(() => {
 		resetAppendChild = logCall(Element.prototype, 'appendChild');
 		resetInsertBefore = logCall(Element.prototype, 'insertBefore');
-		resetRemoveChild = logCall(Element.prototype, 'removeChild');
+		resetRemoveTextnode = logCall(Text.prototype, 'remove');
 		resetRemove = logCall(Element.prototype, 'remove');
+		resetRemoveComment = logCall(Comment.prototype, 'remove');
 		resetSetAttribute = logCall(Element.prototype, 'setAttribute');
 		resetRemoveAttribute = logCall(Element.prototype, 'removeAttribute');
 	});
@@ -41,8 +43,9 @@ describe('hydrate()', () => {
 	after(() => {
 		resetAppendChild();
 		resetInsertBefore();
-		resetRemoveChild();
+		resetRemoveTextnode();
 		resetRemove();
+		resetRemoveComment();
 		resetSetAttribute();
 		resetRemoveAttribute();
 	});

--- a/test/browser/keys.test.js
+++ b/test/browser/keys.test.js
@@ -57,12 +57,14 @@ describe('keys', () => {
 	let resetInsertBefore;
 	let resetRemoveChild;
 	let resetRemove;
+	let resetRemoveText;
 
 	before(() => {
 		resetAppendChild = logCall(Element.prototype, 'appendChild');
 		resetInsertBefore = logCall(Element.prototype, 'insertBefore');
 		resetRemoveChild = logCall(Element.prototype, 'removeChild');
 		resetRemove = logCall(Element.prototype, 'remove');
+		resetRemoveText = logCall(Text.prototype, 'remove');
 	});
 
 	after(() => {
@@ -70,6 +72,7 @@ describe('keys', () => {
 		resetInsertBefore();
 		resetRemoveChild();
 		resetRemove();
+		resetRemoveText();
 	});
 
 	beforeEach(() => {

--- a/test/browser/placeholders.test.js
+++ b/test/browser/placeholders.test.js
@@ -56,21 +56,21 @@ describe('null placeholders', () => {
 
 	let resetAppendChild;
 	let resetInsertBefore;
-	let resetRemoveChild;
 	let resetRemove;
+	//let resetRemoveText;
 
 	before(() => {
 		resetAppendChild = logCall(Element.prototype, 'appendChild');
 		resetInsertBefore = logCall(Element.prototype, 'insertBefore');
-		resetRemoveChild = logCall(Element.prototype, 'removeChild');
 		resetRemove = logCall(Element.prototype, 'remove');
+		//resetRemoveText = logCall(Text.prototype, 'remove');
 	});
 
 	after(() => {
 		resetAppendChild();
 		resetInsertBefore();
-		resetRemoveChild();
 		resetRemove();
+		//resetRemoveText();
 	});
 
 	beforeEach(() => {

--- a/test/browser/placeholders.test.js
+++ b/test/browser/placeholders.test.js
@@ -57,20 +57,20 @@ describe('null placeholders', () => {
 	let resetAppendChild;
 	let resetInsertBefore;
 	let resetRemove;
-	//let resetRemoveText;
+	let resetRemoveText;
 
 	before(() => {
 		resetAppendChild = logCall(Element.prototype, 'appendChild');
 		resetInsertBefore = logCall(Element.prototype, 'insertBefore');
 		resetRemove = logCall(Element.prototype, 'remove');
-		//resetRemoveText = logCall(Text.prototype, 'remove');
+		resetRemoveText = logCall(Text.prototype, 'remove');
 	});
 
 	after(() => {
 		resetAppendChild();
 		resetInsertBefore();
 		resetRemove();
-		//resetRemoveText();
+		resetRemoveText();
 	});
 
 	beforeEach(() => {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -31,7 +31,6 @@ describe('render()', () => {
 
 	let resetAppendChild;
 	let resetInsertBefore;
-	let resetRemoveChild;
 	let resetRemove;
 
 	beforeEach(() => {
@@ -46,14 +45,12 @@ describe('render()', () => {
 	before(() => {
 		resetAppendChild = logCall(Element.prototype, 'appendChild');
 		resetInsertBefore = logCall(Element.prototype, 'insertBefore');
-		resetRemoveChild = logCall(Element.prototype, 'removeChild');
 		resetRemove = logCall(Element.prototype, 'remove');
 	});
 
 	after(() => {
 		resetAppendChild();
 		resetInsertBefore();
-		resetRemoveChild();
 		resetRemove();
 	});
 


### PR DESCRIPTION
This removes our `removeNode` helper which was used to remove a specific DOM Node, this was only needed for IE11 which doesn't support [`Element.remove()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/remove)

It looks like text-nodes aren't properly recongised when calling `.remove()`