### PR TITLE
10.21.0

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -2,7 +2,7 @@ import { options, Fragment, Component } from 'preact';
 
 export function initDevTools() {
 	if (typeof window != 'undefined' && window.__PREACT_DEVTOOLS__) {
-		window.__PREACT_DEVTOOLS__.attachPreact('10.20.2', options, {
+		window.__PREACT_DEVTOOLS__.attachPreact('10.21.0', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "10.20.2",
+  "version": "10.21.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "10.20.2",
+      "version": "10.21.0",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.20.2",
+  "version": "10.21.0",
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
## Features

- Debug throw on too many rerenders (#4349, thanks @rschristian)
- Add compat/client types (#4345, thanks @rschristian)

## Fixes

- Expose hooks through compat's `ReactCurrentDispatcher` (#4342, thanks @rschristian)
- Respect default value (#4341, thanks @JoviDeCroock)
- Incorrect "missing transform-jsx-source" warning (#4350, thanks @rschristian)

## Types

- Support ComponentChild(ren) in compat render/hydrate/createPortal (#4346, thanks @rschristian)
- Import and re-export PreactElement (#3228, thanks @henryqdineen)

## Maintenance

- Add zustand and redux-toolkit to the demo. (#3523, thanks @MortezaMirjavadi)
- Optimise jsx runtime (#4337, thanks @JoviDeCroock)