### PR TITLE
ci: Bump compressed-size-action

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -17,6 +17,6 @@ jobs:
           node-version-file: 'package.json'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
-      - uses: preactjs/compressed-size-action@v1
+      - uses: preactjs/compressed-size-action@v2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
v2 came out 4-ish years ago, guess we forgot to bump it here.