### PR TITLE
fix: Syntax in `compat/client` for IE11 support

### DIFF
--- a/compat/client.js
+++ b/compat/client.js
@@ -2,10 +2,10 @@ const { render, hydrate, unmountComponentAtNode } = require('preact/compat');
 
 function createRoot(container) {
 	return {
-		render(children) {
+		render: function (children) {
 			render(children, container);
 		},
-		unmount() {
+		unmount: function () {
 			unmountComponentAtNode(container);
 		}
 	};

--- a/compat/client.js
+++ b/compat/client.js
@@ -2,9 +2,11 @@ const { render, hydrate, unmountComponentAtNode } = require('preact/compat');
 
 function createRoot(container) {
 	return {
+		// eslint-disable-next-line
 		render: function (children) {
 			render(children, container);
 		},
+		// eslint-disable-next-line
 		unmount: function () {
 			unmountComponentAtNode(container);
 		}

--- a/compat/client.mjs
+++ b/compat/client.mjs
@@ -2,10 +2,10 @@ import { render, hydrate, unmountComponentAtNode } from 'preact/compat';
 
 export function createRoot(container) {
 	return {
-		render(children) {
+		render: function (children) {
 			render(children, container);
 		},
-		unmount() {
+		unmount: function () {
 			unmountComponentAtNode(container);
 		}
 	};

--- a/compat/client.mjs
+++ b/compat/client.mjs
@@ -2,9 +2,11 @@ import { render, hydrate, unmountComponentAtNode } from 'preact/compat';
 
 export function createRoot(container) {
 	return {
+		// eslint-disable-next-line
 		render: function (children) {
 			render(children, container);
 		},
+		// eslint-disable-next-line
 		unmount: function () {
 			unmountComponentAtNode(container);
 		}


### PR DESCRIPTION
Closes #4371

Not that this case is problematic, but might be worth considering passing all package exports through Microbundle in the future to catch this sort of thing.