### PR TITLE
debug: Provide error for illegal nesting of <button> and <a>

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -428,7 +428,7 @@ export function initDebug() {
 					);
 				}
 			} else if (type === 'a' || type === 'button') {
-				if (getDomChildren(vnode).find(childType => childType === type)) {
+				if (getDomChildren(vnode).indexOf(type) !== -1) {
 					console.error(
 						`Improper nesting of interactive content. Your <${type}>` +
 							` should not have other ${type === 'a' ? 'anchor' : 'button'}` +

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -353,7 +353,13 @@ export function initDebug() {
 			});
 		}
 
-		if (typeof type === 'string' && (isTableElement(type) || type === 'p')) {
+		if (
+			typeof type === 'string' &&
+			(isTableElement(type) ||
+				type === 'p' ||
+				type === 'a' ||
+				type === 'button')
+		) {
 			// Avoid false positives when Preact only partially rendered the
 			// HTML tree. Whilst we attempt to include the outer DOM in our
 			// validation, this wouldn't work on the server for
@@ -417,6 +423,19 @@ export function initDebug() {
 						'Improper nesting of paragraph. Your <p> should not have ' +
 							illegalDomChildrenTypes.join(', ') +
 							'as child-elements.' +
+							serializeVNode(vnode) +
+							`\n\n${getOwnerStack(vnode)}`
+					);
+				}
+			} else if (type === 'a' || type === 'button') {
+				if (getDomChildren(vnode).find(childType => childType === type)) {
+					console.error(
+						'Improper nesting of interactive content. Your <' +
+							type +
+							'> should not have ' +
+							'other ' +
+							(type === 'a' ? 'anchor' : 'button') +
+							' tags as child-elements.' +
 							serializeVNode(vnode) +
 							`\n\n${getOwnerStack(vnode)}`
 					);

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -430,11 +430,8 @@ export function initDebug() {
 			} else if (type === 'a' || type === 'button') {
 				if (getDomChildren(vnode).find(childType => childType === type)) {
 					console.error(
-						'Improper nesting of interactive content. Your <' +
-							type +
-							'> should not have ' +
-							'other ' +
-							(type === 'a' ? 'anchor' : 'button') +
+						`Improper nesting of interactive content. Your <${type}>` +
+							` should not have other ${type === 'a' ? 'anchor' : 'button'}` +
 							' tags as child-elements.' +
 							serializeVNode(vnode) +
 							`\n\n${getOwnerStack(vnode)}`

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -661,6 +661,94 @@ describe('debug', () => {
 		});
 	});
 
+	describe('button nesting', () => {
+		it('should not warn on a regular button', () => {
+			const Button = () => <button>Hello world</button>;
+
+			render(<Button />, scratch);
+			expect(console.error).to.not.be.called;
+		});
+
+		it('should warn for nesting illegal dom-nodes under a button', () => {
+			const Button = () => (
+				<button>
+					<button>Hello world</button>
+				</button>
+			);
+
+			render(<Button />, scratch);
+			expect(console.error).to.be.calledOnce;
+		});
+
+		it('should warn for nesting illegal dom-nodes under a button as func', () => {
+			const ButtonChild = ({ children }) => <button>{children}</button>;
+			const Button = () => (
+				<button>
+					<ButtonChild>Hello world</ButtonChild>
+				</button>
+			);
+
+			render(<Button />, scratch);
+			expect(console.error).to.be.calledOnce;
+		});
+
+		it('should not warn for nesting non-interactive content under a button', () => {
+			const Button = () => (
+				<button>
+					<span>Hello </span>
+					<a>World</a>
+				</button>
+			);
+
+			render(<Button />, scratch);
+			expect(console.error).to.not.be.called;
+		});
+	});
+
+	describe('anchor nesting', () => {
+		it('should not warn a regular anchor', () => {
+			const Anchor = () => <a>Hello world</a>;
+
+			render(<Anchor />, scratch);
+			expect(console.error).to.not.be.called;
+		});
+
+		it('should warn for nesting illegal dom-nodes under an anchor', () => {
+			const Anchor = () => (
+				<a>
+					<a>Hello world</a>
+				</a>
+			);
+
+			render(<Anchor />, scratch);
+			expect(console.error).to.be.calledOnce;
+		});
+
+		it('should warn for nesting illegal dom-nodes under an anchor as func', () => {
+			const AnchorChild = ({ children }) => <a>{children}</a>;
+			const Anchor = () => (
+				<a>
+					<AnchorChild>Hello world</AnchorChild>
+				</a>
+			);
+
+			render(<Anchor />, scratch);
+			expect(console.error).to.be.calledOnce;
+		});
+
+		it('should not warn for nesting non-interactive content under an anchor', () => {
+			const Anchor = () => (
+				<a>
+					<span>Hello </span>
+					<button>World</button>
+				</a>
+			);
+
+			render(<Anchor />, scratch);
+			expect(console.error).to.not.be.called;
+		});
+	});
+
 	describe('PropTypes', () => {
 		beforeEach(() => {
 			resetPropWarnings();


### PR DESCRIPTION
Technically any [Interactive Content](https://html.spec.whatwg.org/multipage/dom.html#interactive-content) is disallowed from being a child of `<a>` & `<button>`, but self nesting (`<a>` within `<a>`, `<button>` within `<button>`) seems to be the only case that actually results in a parser mismatch, hence this limited implementation.