### PR TITLE
ci: Skip running compressed-size builds twice

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -20,3 +20,6 @@ jobs:
       - uses: preactjs/compressed-size-action@v2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          # Our `prepare` script already builds the app post-install,
+          # building it again would be redundant
+          build-script: 'npm run --if-present noop'


### PR DESCRIPTION
Because we have a `prepare` script that builds the app, our compressed size action was building the apps once post-install, then again as our build script, resulting in 2 wasted builds per CI run.

You can easily see Microbundle's output [here](https://github.com/preactjs/preact/actions/runs/9010627319/job/24756985853) in both the 'Install Dependencies' and 'Build using npm' steps.