### PR TITLE
feat: Add popover types

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -2333,6 +2333,27 @@ export namespace JSXInternal {
 		placeholder?: string | undefined | SignalLike<string | undefined>;
 		playsInline?: boolean | undefined | SignalLike<boolean | undefined>;
 		playsinline?: boolean | undefined | SignalLike<boolean | undefined>;
+		popover?:
+			| 'auto'
+			| 'hint'
+			| 'manual'
+			| boolean
+			| undefined
+			| SignalLike<'auto' | 'hint' | 'manual' | boolean | undefined>;
+		popovertarget?: string | undefined | SignalLike<string | undefined>;
+		popoverTarget?: string | undefined | SignalLike<string | undefined>;
+		popovertargetaction?:
+			| 'hide'
+			| 'show'
+			| 'toggle'
+			| undefined
+			| SignalLike<'hide' | 'show' | 'toggle' | undefined>;
+		popoverTargetAction?:
+			| 'hide'
+			| 'show'
+			| 'toggle'
+			| undefined
+			| SignalLike<'hide' | 'show' | 'toggle' | undefined>;
 		poster?: string | undefined | SignalLike<string | undefined>;
 		preload?: string | undefined | SignalLike<string | undefined>;
 		radioGroup?: string | undefined | SignalLike<string | undefined>;


### PR DESCRIPTION
Reference:

* [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover)
* [popovertarget](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#popovertarget)
* [popovertargetaction](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#popovertargetaction)

---

`popover="hint"` hasn't yet [landed in the spec](https://github.com/whatwg/html/pull/9778) and as such is perhaps questionable. It seems likely that it will and I figure jumping the gun on implementation might be slightly better than needing to be pinged to add it later (as it's not a spec I'm watching), but happy to remove it if it's undesirable.