### PR TITLE
fix isolated rerenders

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -353,6 +353,10 @@ export function initDebug() {
 			});
 		}
 
+		if (vnode._component === currentComponent) {
+			renderCount = 0;
+		}
+
 		if (
 			typeof type === 'string' &&
 			(isTableElement(type) ||


### PR DESCRIPTION
Fixes #4381 

When an isolated leaf component kept re-rendering we'd throw an error, to counter-act this we check in `diffed` whether we have finished diffing this component