### PR TITLE
fix(core): support popover boolean attribute

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -116,6 +116,7 @@ export function setProperty(dom, name, value, oldValue, namespace) {
 			name != 'rowSpan' &&
 			name != 'colSpan' &&
 			name != 'role' &&
+			name != 'popover' &&
 			name in dom
 		) {
 			try {
@@ -135,7 +136,7 @@ export function setProperty(dom, name, value, oldValue, namespace) {
 		if (typeof value == 'function') {
 			// never serialize functions as attribute values
 		} else if (value != null && (value !== false || name[4] === '-')) {
-			dom.setAttribute(name, value);
+			dom.setAttribute(name, name === 'popover' && value === true ? '' : value);
 		} else {
 			dom.removeAttribute(name);
 		}

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -136,7 +136,7 @@ export function setProperty(dom, name, value, oldValue, namespace) {
 		if (typeof value == 'function') {
 			// never serialize functions as attribute values
 		} else if (value != null && (value !== false || name[4] === '-')) {
-			dom.setAttribute(name, name === 'popover' && value === true ? '' : value);
+			dom.setAttribute(name, name == 'popover' && value == true ? '' : value);
 		} else {
 			dom.removeAttribute(name);
 		}

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -472,6 +472,21 @@ describe('render()', () => {
 		expect(scratch.firstChild.spellcheck).to.equal(false);
 	});
 
+	it('should support popover auto', () => {
+		render(<div popover="auto" />, scratch);
+		expect(scratch.innerHTML).to.equal("<div popover=\"auto\"></div>");
+	});
+
+	it('should support popover true boolean', () => {
+		render(<div popover />, scratch);
+		expect(scratch.innerHTML).to.equal("<div popover=\"\"></div>");
+	});
+
+	it('should support popover true boolean', () => {
+		render(<div popover={false} />, scratch);
+		expect(scratch.innerHTML).to.equal("<div></div>");
+	});
+
 	// Test for preactjs/preact#4340
 	it('should respect defaultValue in render', () => {
 		scratch.innerHTML = '<input value="foo">';

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -482,7 +482,7 @@ describe('render()', () => {
 		expect(scratch.innerHTML).to.equal("<div popover=\"\"></div>");
 	});
 
-	it('should support popover true boolean', () => {
+	it('should support popover false boolean', () => {
 		render(<div popover={false} />, scratch);
 		expect(scratch.innerHTML).to.equal("<div></div>");
 	});


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/4391

When doing tests it looks like `setAttribute('popover', '')` is the only one that results in proper behavior here. We should double check what we do in RTS for this as well