### PR TITLE
only check is connected for dom nodes

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -116,8 +116,12 @@ export function diffChildren(
 			childVNode._flags & INSERT_VNODE ||
 			oldVNode._children === childVNode._children
 		) {
-			// @ts-expect-error olDom should be present on a DOM node
-			if (oldDom && oldDom.nodeType === 1 && !parentDom.contains(oldDom)) {
+			if (
+				oldDom &&
+				typeof childVNode.type == 'string' &&
+				// @ts-expect-error olDom should be present on a DOM node
+				!parentDom.contains(oldDom)
+			) {
 				oldDom = getDomSibling(oldVNode);
 			}
 			oldDom = insert(childVNode, oldDom, parentDom);

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -117,7 +117,7 @@ export function diffChildren(
 			oldVNode._children === childVNode._children
 		) {
 			// @ts-expect-error olDom should be present on a DOM node
-			if (oldDom && !parentDom.contains(oldDom)) {
+			if (oldDom && oldDom.nodeType === 1 && !parentDom.contains(oldDom)) {
 				oldDom = getDomSibling(oldVNode);
 			}
 			oldDom = insert(childVNode, oldDom, parentDom);


### PR DESCRIPTION
`isConnected` is not present on text nodes, this prevents us from crashing due to calling `getDomSibling` for a text node. This does highlight that Google Translate leads to a bug, in the example given in https://github.com/preactjs/preact/pull/4318#issuecomment-2168889078 we get the following as output

This is translated to Dutch, as you can see the `h1` and the first `hello` reconcile correctly, however everything after the interpolated `{label}` does not.

<img width="320" alt="Screenshot 2024-06-15 at 13 05 59" src="https://github.com/preactjs/preact/assets/17125876/9282ebc1-fdfc-411b-a123-60fdaf25e376">

When I replace `{props.label}` with a normal string or with `<span>{props.label}</span>` it does work correctly.

This does however not solve the other issue mentioned on this PR, which does not have a way to reproduce. I reckon that one could be related to the dom-sibling of `oldVNode` also not being `connected` due to removing a lot of fragment-like wrapped children and `oldDom` being captured to the first of said list.