### PR TITLE
replace isConnected with parentDom.contains

### DIFF
--- a/compat/src/portals.js
+++ b/compat/src/portals.js
@@ -39,6 +39,7 @@ function Portal(props) {
 			nodeType: 1,
 			parentNode: container,
 			childNodes: [],
+			contains: () => true,
 			appendChild(child) {
 				this.childNodes.push(child);
 				_this._container.appendChild(child);

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -117,7 +117,7 @@ export function diffChildren(
 			oldVNode._children === childVNode._children
 		) {
 			// @ts-expect-error olDom should be present on a DOM node
-			if (oldDom && !oldDom.isConnected) {
+			if (oldDom && !parentDom.contains(oldDom)) {
 				oldDom = getDomSibling(oldVNode);
 			}
 			oldDom = insert(childVNode, oldDom, parentDom);


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/4415

https://github.com/preactjs/preact/issues/4194 still works correctly and this solves the IE11 not having isConected