### PR TITLE
fix(hooks): memo being too lazy with repeated renders

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -15,8 +15,6 @@ let currentHook = 0;
 /** @type {Array<import('./internal').Component>} */
 let afterPaintEffects = [];
 
-let EMPTY = [];
-
 // Cast to use internal Options type
 const options = /** @type {import('./internal').Options} */ (_options);
 
@@ -60,7 +58,6 @@ options._render = vnode => {
 				if (hookItem._nextValue) {
 					hookItem._value = hookItem._nextValue;
 				}
-				hookItem._pendingValue = EMPTY;
 				hookItem._pendingArgs = hookItem._nextValue = undefined;
 			});
 		} else {
@@ -84,11 +81,7 @@ options.diffed = vnode => {
 			if (hookItem._pendingArgs) {
 				hookItem._args = hookItem._pendingArgs;
 			}
-			if (hookItem._pendingValue !== EMPTY) {
-				hookItem._value = hookItem._pendingValue;
-			}
 			hookItem._pendingArgs = undefined;
-			hookItem._pendingValue = EMPTY;
 		});
 	}
 	previousComponent = currentComponent = null;
@@ -159,7 +152,7 @@ function getHookState(index, type) {
 		});
 
 	if (index >= hooks._list.length) {
-		hooks._list.push({ _pendingValue: EMPTY });
+		hooks._list.push({});
 	}
 
 	return hooks._list[index];

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -61,7 +61,7 @@ options._render = vnode => {
 					hookItem._value = hookItem._nextValue;
 				}
 				hookItem._pendingValue = EMPTY;
-				hookItem._nextValue = hookItem._pendingArgs = undefined;
+				hookItem._pendingArgs = hookItem._nextValue = undefined;
 			});
 		} else {
 			hooks._pendingEffects.forEach(invokeCleanup);
@@ -350,10 +350,9 @@ export function useMemo(factory, args) {
 	/** @type {import('./internal').MemoHookState<T>} */
 	const state = getHookState(currentIndex++, 7);
 	if (argsChanged(state._args, args)) {
-		state._pendingValue = factory();
-		state._pendingArgs = args;
+		state._value = factory();
+		state._args = args;
 		state._factory = factory;
-		return state._pendingValue;
 	}
 
 	return state._value;

--- a/hooks/test/browser/useMemo.test.js
+++ b/hooks/test/browser/useMemo.test.js
@@ -151,12 +151,13 @@ describe('useMemo', () => {
 		act(() => {
 			set('bye');
 		});
-		expect(calls.length).to.equal(5);
+		expect(calls.length).to.equal(6);
 		expect(calls).to.deep.equal([
 			'doing memo',
 			'render hi',
 			'doing memo',
-			'render bye', // We expect a missing "doing memo"  here because we return to the previous args value
+			'render bye',
+			'doing memo',
 			'render hi'
 		]);
 	});

--- a/mangle.json
+++ b/mangle.json
@@ -31,7 +31,6 @@
       "$_list": "__",
       "$_pendingEffects": "__h",
       "$_value": "__",
-      "$_pendingValue": "__V",
       "$_nextValue": "__N",
       "$_original": "__v",
       "$_args": "__H",


### PR DESCRIPTION
This now equalises our behavior with React, we need to ensure that when we repeat a render we throwaway queued effects, this is done in `_render`. We however want to maintain achieved hook-states for i.e. `useMemo` as they are synchronous anyway, React seems to achieve this by disposing the WIP but retaining hooks-state. This PR makes us behave similarly.

- [Test case](https://codesandbox.io/p/sandbox/boring-wilson-9p6hyj?file=%2Fsrc%2Findex.js%3A12%2C16)
- [Repeated renders](https://stackblitz.com/edit/vitejs-vite-tylqxa?file=src%2FApp.tsx,src%2Fmain.tsx,src%2FMemo.tsx&terminal=dev)

Fixes #4422 