### PR TITLE
10.22.1

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -13,7 +13,7 @@ export function initDevTools() {
 		globalVar !== undefined &&
 		globalVar.__PREACT_DEVTOOLS__
 	) {
-		globalVar.__PREACT_DEVTOOLS__.attachPreact('10.22.0', options, {
+		globalVar.__PREACT_DEVTOOLS__.attachPreact('10.22.1', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "10.22.0",
+  "version": "10.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "10.22.0",
+      "version": "10.22.1",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.22.0",
+  "version": "10.22.1",
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
## Fixes

- Only check is connected for dom nodes (#4409, thanks @JoviDeCroock)
- Prevent useMemo from being too lazy with repeated renders (#4426, thanks @JoviDeCroock)
- Replace isConnected with parentDom.contains (#4421, thanks @JoviDeCroock)
- Graciously handle array shuffling (#4413, thanks @JoviDeCroock)
- Support popover boolean attribute (#4393, thanks @JoviDeCroock)

## Types

- Improve React compatibility for `Ref` type. (#4403, thanks @maxbrieiev)
- Expose stream render from `preact-render-to-string` (#4395, thanks @Austaras)

## Maintenance

- Prefer `globalThis` over `window` if available (#4401, thanks @marvinhagemeister)
- Bump lockfile version to v3 (#4398, thanks @rschristian)

## Performance

- Improve perf by skipping some lifecycle hooks for perf (#4366, thanks @JoviDeCroock)
- Create hot path for unmounting a tree of context (#4396, thanks @JoviDeCroock)
- Migrate husky v9 (#4390, thanks @castrogarciajs)
- Migrate to oxlint (#4387, thanks @JoviDeCroock)
- Migrate to biome (#4386, thanks @JoviDeCroock)