### PR TITLE
Update ComponentChild types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -49,7 +49,8 @@ export type ComponentChild =
 	| bigint
 	| boolean
 	| null
-	| undefined;
+	| undefined
+	| Function;
 export type ComponentChildren = ComponentChild[] | ComponentChild;
 
 export interface Attributes {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -45,7 +45,7 @@ export type ComponentChild =
 	| VNode<any>
 	| string
 	| number
-	| Iterable<ComponentChild>
+	| Array<ComponentChild>
 	| bigint
 	| boolean
 	| null

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -43,9 +43,9 @@ export type Ref<T> = RefObject<T> | RefCallback<T> | null;
 
 export type ComponentChild =
 	| VNode<any>
-	| object
 	| string
 	| number
+	| Iterable<ComponentChild>
 	| bigint
 	| boolean
 	| null


### PR DESCRIPTION
The `object` type is pretty wide and does not follow ReactNode types, so this change is to reflect the type from React.

Follows https://github.com/preactjs/preact/pull/1116