### PR TITLE
Add missing types ElementType and ComponentPropsWithoutRef

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -725,6 +725,13 @@ declare namespace React {
 		| MutableRefObject<T | null>
 		| null;
 
+	export type ElementType<P = any, Tag extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements> =
+                | { [K in Tag]: P extends JSX.IntrinsicElements[K] ? K : never }[Tag]
+                | ComponentType<P>;
+
+        export type ComponentPropsWithoutRef<T extends ElementType> = PropsWithoutRef<ComponentProps<T>>;
+
+
 	export type ComponentPropsWithRef<
 		C extends ComponentType<any> | keyof JSXInternal.IntrinsicElements
 	> = C extends new (

--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -726,11 +726,10 @@ declare namespace React {
 		| null;
 
 	export type ElementType<P = any, Tag extends keyof JSX.IntrinsicElements = keyof JSX.IntrinsicElements> =
-                | { [K in Tag]: P extends JSX.IntrinsicElements[K] ? K : never }[Tag]
-                | ComponentType<P>;
+		| { [K in Tag]: P extends JSX.IntrinsicElements[K] ? K : never }[Tag]
+		| ComponentType<P>;
 
-        export type ComponentPropsWithoutRef<T extends ElementType> = PropsWithoutRef<ComponentProps<T>>;
-
+	export type ComponentPropsWithoutRef<T extends ElementType> = PropsWithoutRef<ComponentProps<T>>;
 
 	export type ComponentPropsWithRef<
 		C extends ComponentType<any> | keyof JSXInternal.IntrinsicElements


### PR DESCRIPTION
This PR adds missing types in compat:
* ElementType
* ComponentPropsWithoutRef

The implementation is taken directly from [react's types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/ts5.0/index.d.ts).

This change is needed to get correct types when using Radix UI with react