### PR TITLE
fix(hydration): address hydration bug for fragment with missmatched dom-nodes

### DIFF
--- a/compat/test/browser/suspense-hydration.test.js
+++ b/compat/test/browser/suspense-hydration.test.js
@@ -97,7 +97,7 @@ describe('suspense hydration', () => {
 		});
 	});
 
-	it.only('should leave DOM untouched when suspending while hydrating', () => {
+	it('should replace a missmatched element during hydration', () => {
 		scratch.innerHTML = '<p>loading...</p>';
 		clearLog();
 
@@ -116,7 +116,6 @@ describe('suspense hydration', () => {
 		return resolve(() => <div>Hello</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.equal('<div>Hello</div>');
-			expect(getLog()).to.deep.equal([]);
 			clearLog();
 		});
 	});

--- a/compat/test/browser/suspense-hydration.test.js
+++ b/compat/test/browser/suspense-hydration.test.js
@@ -120,6 +120,29 @@ describe('suspense hydration', () => {
 		});
 	});
 
+	it('should replace a missmatched text-node', () => {
+		scratch.innerHTML = 'loading...';
+		clearLog();
+
+		const [Lazy, resolve] = createLazy();
+		hydrate(
+			<Suspense fallback="loading...">
+				<Lazy />
+			</Suspense>,
+			scratch
+		);
+		rerender(); // Flush rerender queue to mimic what preact will really do
+		expect(scratch.innerHTML).to.equal('loading...');
+		expect(getLog()).to.deep.equal([]);
+		clearLog();
+
+		return resolve(() => <div>Hello</div>).then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.equal('<div>Hello</div>');
+			clearLog();
+		});
+	});
+
 	it('should properly attach event listeners when suspending while hydrating', () => {
 		scratch.innerHTML = '<div>Hello</div><div>World</div>';
 		clearLog();

--- a/compat/test/browser/suspense-hydration.test.js
+++ b/compat/test/browser/suspense-hydration.test.js
@@ -97,6 +97,30 @@ describe('suspense hydration', () => {
 		});
 	});
 
+	it.only('should leave DOM untouched when suspending while hydrating', () => {
+		scratch.innerHTML = '<p>loading...</p>';
+		clearLog();
+
+		const [Lazy, resolve] = createLazy();
+		hydrate(
+			<Suspense fallback={<p>loading...</p>}>
+				<Lazy />
+			</Suspense>,
+			scratch
+		);
+		rerender(); // Flush rerender queue to mimic what preact will really do
+		expect(scratch.innerHTML).to.equal('<p>loading...</p>');
+		expect(getLog()).to.deep.equal([]);
+		clearLog();
+
+		return resolve(() => <div>Hello</div>).then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.equal('<div>Hello</div>');
+			expect(getLog()).to.deep.equal([]);
+			clearLog();
+		});
+	});
+
 	it('should properly attach event listeners when suspending while hydrating', () => {
 		scratch.innerHTML = '<div>Hello</div><div>World</div>';
 		clearLog();

--- a/src/component.js
+++ b/src/component.js
@@ -141,7 +141,8 @@ function renderComponent(component) {
 			commitQueue,
 			oldDom == null ? getDomSibling(oldVNode) : oldDom,
 			!!(oldVNode._flags & MODE_HYDRATE),
-			refQueue
+			refQueue,
+			false
 		);
 
 		newVNode._original = oldVNode._original;

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -25,6 +25,8 @@ import { getDomSibling } from '../component';
  * siblings. In most cases, it starts out as `oldChildren[0]._dom`.
  * @param {boolean} isHydrating Whether or not we are in hydration
  * @param {any[]} refQueue an array of elements needed to invoke refs
+ * @param {boolean} isResumedHydration Whether we are resuming hydration after
+ * a suspenseful resolve.
  */
 export function diffChildren(
 	parentDom,
@@ -37,7 +39,8 @@ export function diffChildren(
 	commitQueue,
 	oldDom,
 	isHydrating,
-	refQueue
+	refQueue,
+	isResumedHydration
 ) {
 	let i,
 		/** @type {VNode} */
@@ -92,7 +95,8 @@ export function diffChildren(
 			commitQueue,
 			oldDom,
 			isHydrating,
-			refQueue
+			refQueue,
+			isResumedHydration
 		);
 
 		// Adjust DOM nodes

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -402,6 +402,14 @@ function diffElementNodes(
 				break;
 			}
 		}
+
+		if (
+			dom == null &&
+			excessDomChildren.length == 1 &&
+			excessDomChildren[0] != null
+		) {
+			removeNode(excessDomChildren[0]);
+		}
 	}
 
 	if (dom == null) {
@@ -416,9 +424,6 @@ function diffElementNodes(
 		);
 
 		// we created a new parent, so none of the previously attached children can be reused:
-		// TODO: this here is problematic because we could be missmatching a fragment with a node
-		// this happens a lot in Suspense with a fallback where after hydration completes we are hydrating
-		// the content and not the fallback.
 		excessDomChildren = null;
 
 		// we are creating a new node, so we can assume this is a new subtree (in

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -403,12 +403,14 @@ function diffElementNodes(
 			}
 		}
 
-		if (
-			dom == null &&
-			excessDomChildren.length == 1 &&
-			excessDomChildren[0] != null
-		) {
-			removeNode(excessDomChildren[0]);
+		if (dom == null && nodeType !== null) {
+			for (i = 0; i < excessDomChildren.length; i++) {
+				value = excessDomChildren[i];
+				if (value) {
+					removeNode(value);
+					excessDomChildren[i] = null;
+				}
+			}
 		}
 	}
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -28,6 +28,8 @@ import options from '../options';
  * siblings. In most cases, it starts out as `oldChildren[0]._dom`.
  * @param {boolean} isHydrating Whether or not we are in hydration
  * @param {any[]} refQueue an array of elements needed to invoke refs
+ * @param {boolean} isResumedHydration Whether we are resuming hydration after
+ * a suspenseful resolve.
  */
 export function diff(
 	parentDom,
@@ -39,7 +41,8 @@ export function diff(
 	commitQueue,
 	oldDom,
 	isHydrating,
-	refQueue
+	refQueue,
+	isResumedHydration
 ) {
 	/** @type {any} */
 	let tmp,
@@ -51,7 +54,7 @@ export function diff(
 
 	// If the previous diff bailed out, resume creating/hydrating.
 	if (oldVNode._flags & MODE_SUSPENDED) {
-		isHydrating = !!(oldVNode._flags & MODE_HYDRATE);
+		isResumedHydration = isHydrating = !!(oldVNode._flags & MODE_HYDRATE);
 		oldDom = newVNode._dom = oldVNode._dom;
 		excessDomChildren = [oldDom];
 	}
@@ -254,7 +257,8 @@ export function diff(
 				commitQueue,
 				oldDom,
 				isHydrating,
-				refQueue
+				refQueue,
+				isResumedHydration
 			);
 
 			c.base = newVNode._dom;
@@ -302,7 +306,8 @@ export function diff(
 			excessDomChildren,
 			commitQueue,
 			isHydrating,
-			refQueue
+			refQueue,
+			isResumedHydration
 		);
 	}
 
@@ -351,6 +356,8 @@ export function commitRoot(commitQueue, root, refQueue) {
  * to invoke in commitRoot
  * @param {boolean} isHydrating Whether or not we are in hydration
  * @param {any[]} refQueue an array of elements needed to invoke refs
+ * @param {boolean} isResumedHydration Whether we are resuming hydration after
+ * a suspenseful resolve.
  * @returns {PreactElement}
  */
 function diffElementNodes(
@@ -362,7 +369,8 @@ function diffElementNodes(
 	excessDomChildren,
 	commitQueue,
 	isHydrating,
-	refQueue
+	refQueue,
+	isResumedHydration
 ) {
 	let oldProps = oldVNode.props;
 	let newProps = newVNode.props;
@@ -403,7 +411,7 @@ function diffElementNodes(
 			}
 		}
 
-		if (dom == null && nodeType !== null) {
+		if (isResumedHydration && dom == null && nodeType !== null) {
 			for (i = 0; i < excessDomChildren.length; i++) {
 				value = excessDomChildren[i];
 				if (value) {
@@ -523,7 +531,8 @@ function diffElementNodes(
 					? excessDomChildren[0]
 					: oldVNode._children && getDomSibling(oldVNode, 0),
 				isHydrating,
-				refQueue
+				refQueue,
+				isResumedHydration
 			);
 
 			// Remove children that are not part of any vnode.

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -416,7 +416,11 @@ function diffElementNodes(
 		);
 
 		// we created a new parent, so none of the previously attached children can be reused:
+		// TODO: this here is problematic because we could be missmatching a fragment with a node
+		// this happens a lot in Suspense with a fallback where after hydration completes we are hydrating
+		// the content and not the fallback.
 		excessDomChildren = null;
+
 		// we are creating a new node, so we can assume this is a new subtree (in
 		// case we are hydrating), this deopts the hydrate
 		isHydrating = false;

--- a/src/render.js
+++ b/src/render.js
@@ -56,7 +56,8 @@ export function render(vnode, parentDom, replaceNode) {
 				? oldVNode._dom
 				: parentDom.firstChild,
 		isHydrating,
-		refQueue
+		refQueue,
+		false
 	);
 
 	// Flush all queued effects


### PR DESCRIPTION
At the moment mainly looking for input here, the issue being that for non-fragment-like diffing this could be problematic, in theory we would have to unmount the missmatched DOM-node but we aren't sure what position we are in... This is also a problem pretty exclusive to Fragment like returns because if I'd wrap the Suspense boundary in a DOM tag this would be a non-issue.

The current solution will unmount all excessDomChildren once we have a missmatched DOM-node type.