### PR TITLE
fix: import renderToPipeableStream in server.mjs for re-exporting

### DIFF
--- a/compat/server.mjs
+++ b/compat/server.mjs
@@ -1,4 +1,5 @@
 import { renderToString } from 'preact-render-to-string';
+import { renderToPipeableStream } from 'preact-render-to-string/stream-node';
 
 export {
 	renderToString,


### PR DESCRIPTION
## Describe the bug

In Preact v10.22.1, renderToPipeableStream is re-exported from server.mjs.

However, the `export { ... } from '...' ;` syntax does not define a `renderToPipeableStream` variable, so the `export default { renderToPipeableStream }` part will cause an error.

This PR solves the above problem by explicitly importing `renderToPipeableStream`.

## Code that reproduces the bug

https://gist.github.com/3846masa/bb3ade18b8a16d947f85920640ab35a2
