### PR TITLE
fix(hydration): streaming renders

### DIFF
--- a/compat/test/browser/suspense-hydration.test.js
+++ b/compat/test/browser/suspense-hydration.test.js
@@ -97,6 +97,30 @@ describe('suspense hydration', () => {
 		});
 	});
 
+	it('should leave DOM untouched when suspending while hydrating', () => {
+		scratch.innerHTML = '<!-- test --><div>Hello</div>';
+		clearLog();
+
+		const [Lazy, resolve] = createLazy();
+		hydrate(
+			<Suspense>
+				<Lazy />
+			</Suspense>,
+			scratch
+		);
+		rerender(); // Flush rerender queue to mimic what preact will really do
+		expect(scratch.innerHTML).to.equal('<!-- test --><div>Hello</div>');
+		expect(getLog()).to.deep.equal([]);
+		clearLog();
+
+		return resolve(() => <div>Hello</div>).then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.equal('<!-- test --><div>Hello</div>');
+			expect(getLog()).to.deep.equal([]);
+			clearLog();
+		});
+	});
+
 	it('should properly attach event listeners when suspending while hydrating', () => {
 		scratch.innerHTML = '<div>Hello</div><div>World</div>';
 		clearLog();

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -273,13 +273,15 @@ export function diff(
 			newVNode._original = null;
 			// if hydrating or creating initial tree, bailout preserves DOM:
 			if (isHydrating || excessDomChildren != null) {
-				newVNode._dom = oldDom;
 				newVNode._flags |= isHydrating
 					? MODE_HYDRATE | MODE_SUSPENDED
 					: MODE_HYDRATE;
+
+				while (oldDom && oldDom.nodeType === 8 && oldDom.nextSibling) {
+					oldDom = oldDom.nextSibling;
+				}
 				excessDomChildren[excessDomChildren.indexOf(oldDom)] = null;
-				// ^ could possibly be simplified to:
-				// excessDomChildren.length = 0;
+				newVNode._dom = oldDom;
 			} else {
 				newVNode._dom = oldVNode._dom;
 				newVNode._children = oldVNode._children;


### PR DESCRIPTION
Discovered in https://github.com/jacob-ebey/preact-ooo-issues CC @jacob-ebey

What happened is that we'd use the `<!-- preact-island` indicator as our `oldDom` which made it so that we'd fail our hydration resumption when there was a fallback in Suspense. This because during hydration resumption we only reserve 1 DOM-child for the resume, this fixes it holistically where we exclude comments from being used as our resumption point.

There's an artefact here https://github.com/preactjs/preact/actions/runs/9959423157

There are still existing issues with returning multiple DOM-nodes/... in resumed hydration however that is tackled in #4442 where we'll most likely introduce a second RFC for streaming in particular