### PR TITLE
fix(debug): check not firing when p/a/button has a parent

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -370,7 +370,7 @@ export function initDebug() {
 			// `preact-render-to-string`. There we'd otherwise flood the terminal
 			// with false positives, which we'd like to avoid.
 			let domParentName = getClosestDomNodeParentName(parent);
-			if (domParentName !== '') {
+			if (domParentName !== '' && isTableElement(type)) {
 				if (
 					type === 'table' &&
 					// Tables can be nested inside each other if it's inside a cell.

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -662,6 +662,19 @@ describe('debug', () => {
 			expect(console.error).to.be.calledOnce;
 		});
 
+		it('should warn for nesting illegal dom-nodes under a paragraph with a parent', () => {
+			const Paragraph = () => (
+				<div>
+					<p>
+						<div>Hello world</div>
+					</p>
+				</div>
+			);
+
+			render(<Paragraph />, scratch);
+			expect(console.error).to.be.calledOnce;
+		});
+
 		it('should warn for nesting illegal dom-nodes under a paragraph as func', () => {
 			const Title = ({ children }) => <h1>{children}</h1>;
 			const Paragraph = () => (


### PR DESCRIPTION
The dom-parent name check is only relevant for table elements, for p/a/button this would stop us from running our checks.