### PR TITLE
DRAFT: breaking changes

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - main
+      - breaking-changes
       - v11
     paths:
       - '**/src/**.js'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ on:
   push:
     branches:
       - main
+      - breaking-changes
       - restructure
 
 jobs:


### PR DESCRIPTION
A branch to collect breaking changes on so we can verify size and performance offset.

## Breaking changes

> Byte offsets are calculated on the module build.

- [Remove hack for `.remove()` in IE11](https://github.com/preactjs/preact/pull/4452) -18b
- [Remove IE11 select fix](https://github.com/preactjs/preact/pull/4357) -13b
- [Remove `.base`](https://github.com/preactjs/preact/pull/4453) -13b
- [Switch to `queueMicrotask`](https://github.com/preactjs/preact/pull/4370) -30b
- [Remove `replaceNode`](https://github.com/preactjs/preact/pull/4359) -24b (could be more depending on what we decide to do with mutative renders)
- [Move defaultProps to compat](https://github.com/preactjs/preact/pull/4361) -75b (+50 compat)
- [Remove automatic px suffixing](https://github.com/preactjs/preact/pull/4358) -77b (+109 compat)
- [Forward ref by default](https://github.com/preactjs/preact/pull/4362) +14b (-50 compat)

Subtotal -240b

## Experiments we could run

- Splitting up mount/update - This wouldn't be breaking but could generally speed up mounting and create hot-paths/less confusion.
- Backing nodes - the biggest breakage here would be ecosystem packages and consumers relying on our options API. We could make an effort for compatibility with our VNode structure here.
- Working on streaming/async rendering/hydration