### PR TITLE
Fix issue in testing libraries where there might not be a DOM node

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -42,8 +42,8 @@ function getDomChildren(vnode) {
 function getClosestDomNodeParentName(parent) {
 	if (!parent) return '';
 	if (typeof parent.type == 'function') {
-		if (parent._parent === null) {
-			if (parent._dom !== null && parent._dom.parentNode !== null) {
+		if (parent._parent == null) {
+			if (parent._dom != null && parent._dom.parentNode !== null) {
 				return parent._dom.parentNode.localName;
 			}
 			return '';


### PR DESCRIPTION
Some hooks based testing libraries work without a DOM node so it will be undefined all the time, this loosens the check