### PR TITLE
fix: prepare for no-unused-vars

### DIFF
--- a/oxlint.json
+++ b/oxlint.json
@@ -10,7 +10,8 @@
       2,
       {
         "args": "none",
-        "varsIgnorePattern": "^h|React$"
+        "caughtErrors": "none",
+        "varsIgnorePattern": "^h|React|createElement|Fragment$"
       }
     ],
     "typescript/no-namespace": 0,


### PR DESCRIPTION
Oxlint's [no-unused-vars](https://github.com/oxc-project/oxc/pull/4445) PR will be merged soon. This PR updates `oxlint.json` to support some limitations of its implementation.

- `@jsx` pragmas are not currently recognized as a usage, so `createElement` has been added to `varsIgnorePattern`
- `Fragment` imports used via `<></>` syntax is not recognized as a usage, so `Fragment` has been added to `varsIgnorePattern`

Note that there are still some unused variables and catch parameters that, when `no-unused-vars` gets merged, will cause lint CI to fail.