### PR TITLE
fix: `_listeners` mangle to reduce collisions

### DIFF
--- a/mangle.json
+++ b/mangle.json
@@ -26,7 +26,7 @@
     "cname": 6,
     "props": {
       "$_hasScuFromHooks": "__f",
-      "$_listeners": "l",
+      "$_listeners": "__l",
       "$_cleanup": "__c",
       "$__hooks": "__H",
       "$_hydrationMismatch": "__m",


### PR DESCRIPTION
Closes #4461, unless anyone thinks we can get away with this in a minor?

Somewhat related: looks like `10.11` was skipped in the "backport" to v11 hence why we're missing `$_listeners` in `mangle.json` (and a few other things, such as `useId`)