### PR TITLE
Fix typings for HTML translate attribute

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -2485,7 +2485,7 @@ export namespace JSXInternal {
 			| undefined
 			| SignalLike<boolean | undefined>;
 		results?: number | undefined | SignalLike<number | undefined>;
-		translate?: boolean | undefined | SignalLike<boolean | undefined>;
+		translate?: 'yes' | 'no' | boolean | undefined | SignalLike<'yes' | 'no' | boolean | undefined>;
 
 		// RDFa Attributes
 		about?: string | undefined | SignalLike<string | undefined>;


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/4464

Wasn't sure if `boolean` is better removed or left in (I think "empty string" part from the specs would be same as `translate={true}`)?