### PR TITLE
chore: oxlint v0.7.0

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,2 @@
-test/fixtures
-test/ts/
-*.ts
 dist
 benchmarks

--- a/compat/test/browser/memo.test.js
+++ b/compat/test/browser/memo.test.js
@@ -11,7 +11,6 @@ import React, {
 	memo,
 	useState
 } from 'preact/compat';
-import { li, ol } from '../../../test/_util/dom';
 
 const h = React.createElement;
 

--- a/compat/test/ts/suspense.tsx
+++ b/compat/test/ts/suspense.tsx
@@ -27,7 +27,7 @@ const componentPromise = new Promise<{ default: typeof IsLazyFunctional }>(
 const IsLazyFunc = React.lazy(() => componentPromise);
 
 // Suspense using lazy component
-class SuspensefulFunc extends React.Component {
+class ReactSuspensefulFunc extends React.Component {
 	render() {
 		return (
 			<React.Suspense fallback={<FallBack />}>
@@ -38,7 +38,7 @@ class SuspensefulFunc extends React.Component {
 }
 
 //SuspenseList using lazy components
-function SuspenseListTester(props: any) {
+function ReactSuspenseListTester(_props: any) {
 	return (
 		<React.SuspenseList revealOrder="together">
 			<React.Suspense fallback={<FallBack />}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "mocha": "^9.0.0",
         "npm-merge-driver-install": "^3.0.0",
         "npm-run-all": "^4.1.5",
-        "oxlint": "^0.5.2",
+        "oxlint": "^0.7.0",
         "preact-render-to-string": "^6.5.0",
         "prop-types": "^15.8.1",
         "sade": "^1.8.1",
@@ -2836,9 +2836,9 @@
       }
     },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-0.5.2.tgz",
-      "integrity": "sha512-NVUH1ZQYP1opS7LPd8xzmha9HrEDu+TpGSxM+dq9SS34FrsaYUEE4gue2OKo8Pgplu/oTKT7mUdTR4YDDBu5xA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-0.7.0.tgz",
+      "integrity": "sha512-BlKKozOOJb5q37mqAyTQhFHMEh8KBUsQvynrO0aBKOzHqkhVQ62eTtd064XsDym+qZCNlKeNR4363wBPRZWgZw==",
       "cpu": [
         "arm64"
       ],
@@ -2849,9 +2849,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-0.5.2.tgz",
-      "integrity": "sha512-jtaKcGhFC4frGzKVN2ieGQ0h960C1E1jQrTjMjNAvGfjRUpO9nDpNMD9BpsAbC0/GULEirtIg+5pW7G8gDQPTQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-0.7.0.tgz",
+      "integrity": "sha512-GSBgglTBEecG0ri9YbQcxxu62/FxnhFScbbx6tgT9qjzKNAtpogrgx5uvi22yq0XjyD8XT3SY7oVOz8wg6GZxQ==",
       "cpu": [
         "x64"
       ],
@@ -2862,9 +2862,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-0.5.2.tgz",
-      "integrity": "sha512-B1HPicpi37lXBdSJOenSjI2sf4C/75iP+AcRHI8GPlrimm/RFvcMdV5F5k5KIVf+v7fKFiWXA/LY3SkjLkbmxw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-0.7.0.tgz",
+      "integrity": "sha512-xrX1qpnQvFbCnyfD0OvapoqR3S7kWHbCUb7PfGI8q2n5lB1CBf55FcFapcqwbxBzzC7/JaafRJu8qEiEdRH8oA==",
       "cpu": [
         "arm64"
       ],
@@ -2875,9 +2875,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-0.5.2.tgz",
-      "integrity": "sha512-8JAWyrIJd5iSnikuCrHrvLpsJoFSeqhWGz3OIb2Xp0eLOT48G5oek/yASCd0IHTOL/fGUexarTqNG8tcX/qesg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-0.7.0.tgz",
+      "integrity": "sha512-W3NBZiJ50Y+pPeB/qFTsspjvlRrzbq+ZiwWmNJfIDJD3eJWjICS4ehUm9qd+ZNUOtgakcG8xa69xoOg9NFE3Lg==",
       "cpu": [
         "arm64"
       ],
@@ -2888,9 +2888,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-0.5.2.tgz",
-      "integrity": "sha512-qBcEN1evZxF9SQi7DegeIcnHhv88v73y2nkm9dqZ3wIflusvV5nxFkLAfh3df5K38mKo1/FxSnOvxN7E6aFjdg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-0.7.0.tgz",
+      "integrity": "sha512-gHQusonVYFwlhgWKgismXRGlAVynDIk4G2lNRKXt+sQOauIEDJTH/Kgk7xlKJmu8J1Ztrb4xjR5meDeeIgyxRg==",
       "cpu": [
         "x64"
       ],
@@ -2901,9 +2901,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-0.5.2.tgz",
-      "integrity": "sha512-6DOkaRkKx6ix9hliWG51cZvXSjwlDWhOPDibJJOg0nIpxpUbtAnEEVBwK3CoGrgRsuWH7wgu/kf1gkSyyePSVQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-0.7.0.tgz",
+      "integrity": "sha512-tT5VivFnhDS2vov8h1Hmn+Rv4vWoIQuS3I+HMaQbItMkDeh6mLanE7faeg+h9p5RqV2KLjRRDm49sdRvF05s4Q==",
       "cpu": [
         "x64"
       ],
@@ -2914,9 +2914,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-0.5.2.tgz",
-      "integrity": "sha512-XBl1QQ+db0fVb/KnGLmjM6r2S3xkI770Z/u5jIvQxxj8M6FFdHdJozf55FnCRGap3H3kMpB56SVEAexB7Z29wA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-0.7.0.tgz",
+      "integrity": "sha512-Bt6D5eOC0Gb6TB4USXIAgZKXwuA1RVv96Und6z7GGryfDM53KpLrgAaeNXytx+u2yq74QuAtkkdsHh9wRosFFA==",
       "cpu": [
         "arm64"
       ],
@@ -2927,9 +2927,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-0.5.2.tgz",
-      "integrity": "sha512-qP7JL8d7y7W91BpgyA8J3BmIGBl7E2rfZH4e7PX9hJ2o+W3pHBRpPxoFFqLx+zBMMkSHdv2h2FLVfvObbI58kQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-0.7.0.tgz",
+      "integrity": "sha512-Mjmw9fTpuW1iBFt1BxacM1WK4CVzHY15esx8RKOGCJD09kcxMpMvYE0ILtlXEQkTB62iJegtHav2uwkZoazkmg==",
       "cpu": [
         "x64"
       ],
@@ -10722,9 +10722,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-0.5.2.tgz",
-      "integrity": "sha512-nEoadC0Pk3tgv41fIRwA1HiJJ45QIMj3NHkEGW89PSr5aqr7EzT0wcdhRTY1m+BFSVIoukJ26OqQABaAEG3jOQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-0.7.0.tgz",
+      "integrity": "sha512-oZI76dyBPW+cETjci4Rm56nfumbNsUcjJoPXomaC+FBzCi2fB5gV6ibnwRnVilt9yJXWGNvloB7c8/Mmmc9B5w==",
       "dev": true,
       "bin": {
         "oxlint": "bin/oxlint"
@@ -10736,14 +10736,14 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "0.5.2",
-        "@oxlint/darwin-x64": "0.5.2",
-        "@oxlint/linux-arm64-gnu": "0.5.2",
-        "@oxlint/linux-arm64-musl": "0.5.2",
-        "@oxlint/linux-x64-gnu": "0.5.2",
-        "@oxlint/linux-x64-musl": "0.5.2",
-        "@oxlint/win32-arm64": "0.5.2",
-        "@oxlint/win32-x64": "0.5.2"
+        "@oxlint/darwin-arm64": "0.7.0",
+        "@oxlint/darwin-x64": "0.7.0",
+        "@oxlint/linux-arm64-gnu": "0.7.0",
+        "@oxlint/linux-arm64-musl": "0.7.0",
+        "@oxlint/linux-x64-gnu": "0.7.0",
+        "@oxlint/linux-x64-musl": "0.7.0",
+        "@oxlint/win32-arm64": "0.7.0",
+        "@oxlint/win32-x64": "0.7.0"
       }
     },
     "node_modules/p-cancelable": {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "benchmark": "npm run test:karma:bench -- no-single-run",
     "lint": "run-s oxlint tsc",
     "tsc": "tsc -p jsconfig-lint.json",
-    "oxlint": "oxlint src test debug compat hooks test-utils -c oxlint.json",
+    "oxlint": "oxlint -c oxlint.json src test/browser test/node test/shared debug compat hooks test-utils",
     "format": "biome format --write .",
     "format:check": "biome format ."
   },
@@ -240,7 +240,7 @@
     "mocha": "^9.0.0",
     "npm-merge-driver-install": "^3.0.0",
     "npm-run-all": "^4.1.5",
-    "oxlint": "^0.5.2",
+    "oxlint": "^0.7.0",
     "preact-render-to-string": "^6.5.0",
     "prop-types": "^15.8.1",
     "sade": "^1.8.1",

--- a/test/browser/components.test.js
+++ b/test/browser/components.test.js
@@ -1231,7 +1231,7 @@ describe('Components', () => {
 
 			let j = 0;
 			class Inner extends Component {
-				constructor(...args) {
+				constructor() {
 					super();
 				}
 				componentWillMount() {}


### PR DESCRIPTION
* Fixed some `no-unused-vars` in test directories
* Removed confusing ignore directories in `.eslintignore`

---

Thank you for using `oxlint`.

This is an effort of keeping our [`ecosystem CI`](https://github.com/oxc-project/oxlint-ecosystem-ci) green.