### PR TITLE
Add TypeScript support for Container.contains

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -373,7 +373,6 @@ function insert(parentVNode, oldDom, parentDom) {
 		if (
 			oldDom &&
 			parentVNode.type &&
-			// @ts-expect-error olDom should be present on a DOM node
 			!parentDom.contains(oldDom)
 		) {
 			oldDom = getDomSibling(parentVNode);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -293,6 +293,7 @@ interface ContainerNode {
 	readonly firstChild: ContainerNode | null;
 	readonly childNodes: ArrayLike<ContainerNode>;
 
+	contains(other: ContainerNode | null): boolean;
 	insertBefore(node: ContainerNode, child: ContainerNode | null): ContainerNode;
 	appendChild(node: ContainerNode): ContainerNode;
 	removeChild(child: ContainerNode): ContainerNode;

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -97,7 +97,7 @@ function createRootFragment(parent: Element, replaceNode: Element | Element[]) {
 		parentNode: parent,
 		firstChild: replaceNodes[0],
 		childNodes: replaceNodes,
-		contains: (c) => parent.contains(c),
+		contains: (c: Node) => parent.contains(c),
 		insertBefore: insert,
 		appendChild: (c: Node) => insert(c, null),
 		removeChild: function (c: Node) {

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -97,6 +97,7 @@ function createRootFragment(parent: Element, replaceNode: Element | Element[]) {
 		parentNode: parent,
 		firstChild: replaceNodes[0],
 		childNodes: replaceNodes,
+		contains: (c) => parent.contains(c),
 		insertBefore: insert,
 		appendChild: (c: Node) => insert(c, null),
 		removeChild: function (c: Node) {


### PR DESCRIPTION
Recently the code started using the `contains` method on the Node interface but this is not exposed in the types causing a runtime crash when implementing your own `ContainerNode `