### PR TITLE
fix: `AnyComponent` type to support classes

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -110,7 +110,7 @@ export interface ComponentConstructor<P = {}, S = {}>
 // Type alias for a component instance considered generally, whether stateless or stateful.
 export type AnyComponent<P = {}, S = {}> =
 	| FunctionComponent<P>
-	| Component<P, S>;
+	| ComponentConstructor<P, S>;
 
 export interface Component<P = {}, S = {}> {
 	componentWillMount?(): void;


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact-iso/issues/35

`preact-router` similarly provided [its own implementation of `AnyComponent`]( https://github.com/preactjs/preact-router/blob/ee0ba49b0d1544aaa2f898218321a7f515605164/index.d.ts#L60-L62) to work around this.