### PR TITLE
Fix skewedIndex becoming outrageously big and document tradeoffs of our decisions

### DIFF
--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1680,12 +1680,10 @@ describe('render()', () => {
 			'<div>11.remove()',
 			'<div>9.remove()',
 			'<div>10.remove()',
-			'<div>3146250.appendChild(<div>1)',
-			'<div>3462501.appendChild(<div>2)',
-			'<div>3465012.appendChild(<div>3)',
-			'<div>4650123.appendChild(<div>4)',
-			'<div>6501234.appendChild(<div>5)',
-			'<div>6012345.appendChild(<div>6)'
+			'<div>3146250.insertBefore(<div>0, <div>3)',
+			'<div>0314625.insertBefore(<div>1, <div>3)',
+			'<div>0134625.insertBefore(<div>2, <div>3)',
+			'<div>0123465.insertBefore(<div>5, <div>6)'
 		]);
 		clearLog();
 	});


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/4482

When we move elements around i.e. [0, 1, 2] --> [1, 0, 2]

```
--> we diff 1, we find it at position 1 while our skewed index is 0 and our skew is 0
    we set the skew to 1 as we found an offset.
--> we diff 0, we find it at position 0 while our skewed index is at 2 and our skew is 1
    this makes us increase the skew again.
--> we diff 2, we find it at position 2 while our skewed index is at 4 and our skew is 2
```

This becomes an optimization question where currently we see a 1 element offset as an insertion or deletion i.e. we optimize for [0, 1, 2] --> [9, 0, 1, 2]
while a more than 1 offset we see as a swap.
We could probably build heuristics for having an optimized course of action here as well, but
might go at the cost of some bytes.

If we wanted to optimize for i.e. only swaps we'd just do the last two code-branches and have
only the first item be a re-scouting and all the others fall in their skewed counter-part.
We could also further optimize for swaps.

There are possible tweaks in how we mark a node for insertion, however I don't think it's in scope for this PR and prefer addressing the performance downgrade. Heck we could even remove the optimization for inserts/deletions and save 20-30 more bytes by only relying on `>|<`.

<details>
<summary>A more elaborate example</summary

Basically for the case of:

```js
const a = ['a', 'b', 'c', 'd', 'e'];
const b = ['a', 'd', 'b', 'c', 'e'];
```

When we follow the new-old algorithm  we have now, we know that

- a is at the same position, no operation required
- d is moved from position 3 to position 1
   - This makes our skew go to -1 because everything that was before d moves to the left
- b is moved from position 1 to 2
   - Skew -1, no action
- c is moved from position 2 to 3
  - Skew -1, no action
- e has stayed static at position 4
  - Skew -1, but we correct after the fact by seeing that we have an offset of 1

This is no bug because the placeChild algorithm but feels like we could do a lot better in this algorithm by seeing that the length has stayed the same and comparing old to new instead :sweat_smile:

Ideally we reset the skew again after diffing c
</details>