### PR TITLE
Avoid setting value for progress with nullish value

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -532,7 +532,9 @@ function diffElementNodes(
 		// As above, don't diff props during hydration
 		if (!isHydrating) {
 			i = 'value';
-			if (
+			if (nodeType === 'progress' && inputValue == null) {
+				dom.removeAttribute('value');
+			} else if (
 				inputValue !== undefined &&
 				// #2756 For the <progress>-element the initial value is 0,
 				// despite the attribute not being present. When the attribute

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -919,6 +919,20 @@ describe('render()', () => {
 		expect(scratch.firstChild.getAttribute('value')).to.equal('0');
 	});
 
+	// #4487
+	it('should not set value for undefined/null on a progress element', () => {
+		render(<progress value={undefined} />, scratch);
+		expect(scratch.firstChild.getAttribute('value')).to.equal(null);
+		render(<progress value={null} />, scratch);
+		expect(scratch.firstChild.getAttribute('value')).to.equal(null);
+		render(<progress value={0} />, scratch);
+		expect(scratch.firstChild.getAttribute('value')).to.equal('0');
+		render(<progress value={50} />, scratch);
+		expect(scratch.firstChild.getAttribute('value')).to.equal('50');
+		render(<progress value={null} />, scratch);
+		expect(scratch.firstChild.getAttribute('value')).to.equal(null);
+	});
+
 	it('should always diff `checked` and `value` properties against the DOM', () => {
 		// See https://github.com/preactjs/preact/issues/1324
 


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/4487

I opted to add an alternative branch here which does a DOM-operation as special-casing `progress/value` in the `setProperty` would be a lot of work