### PR TITLE
fix: react props with children didn't allow for multiple children

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -748,7 +748,7 @@ declare namespace React {
 	): void;
 
 	export type PropsWithChildren<P = unknown> = P & {
-		children?: preact.ComponentChild | undefined;
+		children?: preact.ComponentChildren | undefined;
 	};
 
 	export const Children: {


### PR DESCRIPTION
in some weird cases this led to wrong errors being displayed. Sadly I don't fully understand why, but defining a component (e.g. a CE) with React.PropsWithChildren _and_ providing multiple children as well as non-existent props led to typescript complaining about `Element is not assignable to string`.

So e.g.

```tsx
function Comp(_: React.PropsWithChildren) {
  return <></>;
}

const x = (
  <Comp foo="bar">
    <div />
    <div />
  </Comp>
);
```
is invalid.

```tsx
const x = (
  <Comp foo="bar">
    <div />
  </Comp>
)
```
however yields the expected error that `foo` is not a prop on `Comp`.

While I _do_ think that this is not preacts error I don't see why intrinsic elements should be able to receive multiple children while explicitly typed components should not?