### PR TITLE
ci: Bump upload/download-artifact action versions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,12 +26,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Download locally built preact package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: npm-package
       - run: mv preact.tgz preact-local.tgz
       - name: Upload locally built preact package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bench-environment
           path: preact-local.tgz
@@ -43,7 +43,7 @@ jobs:
           required: false
       - run: mv preact.tgz preact-main.tgz
       - name: Upload base preact package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bench-environment
           path: preact-main.tgz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           npm pack --ignore-scripts
           mv preact-*.tgz preact.tgz
       - name: Upload npm package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact_name || 'npm-package' }}
           path: preact.tgz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: npm-package
       - name: Create draft release

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -59,7 +59,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       # Install benchmark dependencies
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: bench-environment
       - name: Move tarballs from env to correct location
@@ -109,12 +109,12 @@ jobs:
           NAME=$(echo "${{ inputs.benchmark }}" | sed -r 's/[\/]+/_/g')
           echo "artifact_name=logs_$NAME" >> $GITHUB_OUTPUT
       - name: Upload results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: results
           path: benchmarks/out/results/${{ inputs.benchmark }}.json
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.log-artifact-name.outputs.artifact_name }}
           path: benchmarks/out/${{ inputs.benchmark }}_logs.tgz

--- a/.github/workflows/single-bench.yml
+++ b/.github/workflows/single-bench.yml
@@ -57,12 +57,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Download locally built preact package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: npm-package
       - run: mv preact.tgz preact-local.tgz
       - name: Upload locally built preact package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bench-environment
           path: preact-local.tgz
@@ -73,12 +73,12 @@ jobs:
           echo "===================="
           ls -al
       - name: Download base package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: base-npm-package
       - run: mv preact.tgz preact-main.tgz
       - name: Upload base preact package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bench-environment
           path: preact-main.tgz


### PR DESCRIPTION
Closes #4496

~~Seeing if this works for a start, though we have a few other actions that may need bumps too~~

Edit: Looks like it's indeed [clear of warnings](https://github.com/preactjs/preact/actions/runs/11061914254) now