### PR TITLE
ci: Switch to regexp for download-artifact action

### DIFF
--- a/.github/workflows/pr-reporter.yml
+++ b/.github/workflows/pr-reporter.yml
@@ -38,7 +38,8 @@ jobs:
         with:
           workflow: ${{ github.event.workflow.id }}
           run_id: ${{ github.event.workflow_run.id }}
-          name: results
+          name_is_regexp: true
+          name: /results/
           path: results
 
       # Create/update the comment with the latest results


### PR DESCRIPTION
Set up for #4515, as it uses the pr-reporter from the target branch (`main`), so updating it on that branch has 0 effect.