### PR TITLE
ci: Fix download artifact regexp

### DIFF
--- a/.github/workflows/pr-reporter.yml
+++ b/.github/workflows/pr-reporter.yml
@@ -39,7 +39,7 @@ jobs:
           workflow: ${{ github.event.workflow.id }}
           run_id: ${{ github.event.workflow_run.id }}
           name_is_regexp: true
-          name: /results/
+          name: results-*
           path: results
 
       # Create/update the comment with the latest results


### PR DESCRIPTION
Fixes #4516, again, sets up for #4515 as this action runs from how it is on `main`

Docs weren't great, I (wrongly) assumed it wanted the previous regex form. Ended up taking to a separate repo and figuring it out there. This will work for us.

Extra `-*` is just for future safety, in case we do add something. [Here's the current set of assets](https://github.com/preactjs/preact/actions/runs/11095106661).