### PR TITLE
ci: Update Tachometer reporter glob to support subdirs

### DIFF
--- a/.github/workflows/pr-reporter.yml
+++ b/.github/workflows/pr-reporter.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Report Tachometer Results
         uses: andrewiggins/tachometer-reporter-action@v2
         with:
-          path: results/*.json
+          path: results/**/*.json
           base-bench-name: preact-main
           pr-bench-name: preact-local
           summarize: 'duration, usedJSHeapSize'


### PR DESCRIPTION
This should then be the last piece for #4515

```
==> Downloading: results-todo_todo.zip (1.84 kB)
==> Extracting: results-todo_todo.zip
    inflating: results/results-todo_todo/todo.json
==> Artifact: 1993869934
==> Downloading: results-text-update_text-update.zip (2.58 kB)
==> Extracting: results-text-update_text-update.zip
    inflating: results/results-text-update_text-update/text-update.json
```

etc. Extra nest as we're now downloading results separately instead of as one.