### PR TITLE
Improve performance and reduce memory allocation

### DIFF
--- a/compat/src/forwardRef.js
+++ b/compat/src/forwardRef.js
@@ -1,5 +1,4 @@
 import { options } from 'preact';
-import { assign } from './util';
 
 let oldDiffHook = options._diff;
 options._diff = vnode => {
@@ -25,9 +24,13 @@ export const REACT_FORWARD_SYMBOL =
  */
 export function forwardRef(fn) {
 	function Forwarded(props) {
-		let clone = assign({}, props);
-		delete clone.ref;
-		return fn(clone, props.ref || null);
+		if (!('ref' in props)) return fn(props, null);
+
+		let ref = props.ref;
+		delete props.ref;
+		const result = fn(props, ref);
+		props.ref = ref;
+		return result;
 	}
 
 	// mobx-react checks for this being present

--- a/jsx-runtime/src/index.js
+++ b/jsx-runtime/src/index.js
@@ -35,15 +35,9 @@ function createVNode(type, props, key, isStaticChildren, __source, __self) {
 		ref,
 		i;
 
-	if ('ref' in normalizedProps) {
-		normalizedProps = {};
-		for (i in props) {
-			if (i == 'ref') {
-				ref = props[i];
-			} else {
-				normalizedProps[i] = props[i];
-			}
-		}
+	if ('ref' in props) {
+		ref = props.ref;
+		delete props.ref;
 	}
 
 	/** @type {VNode & { __source: any; __self: any }} */

--- a/jsx-runtime/test/browser/jsx-runtime.test.js
+++ b/jsx-runtime/test/browser/jsx-runtime.test.js
@@ -37,7 +37,8 @@ describe('Babel jsx/jsxDEV', () => {
 		const props = { ref };
 		const vnode = jsx('div', props);
 		expect(vnode.ref).to.equal(ref);
-		expect(vnode.props).to.not.equal(props);
+		expect(vnode.props).to.equal(props);
+		expect(vnode.props.ref).to.equal(undefined);
 	});
 
 	it('should not copy props wen there is no ref in props', () => {


### PR DESCRIPTION
As @developit found out, `delete x` is much faster nowadays.

- in `jsx` we delete the ref and always keep the props object, no cloning
  - Can leave this one out if we feel skeptical, would love to go for the forwardRef changes though
- in `forwardRef` we delete and re-apply the `ref` to the props object to avoid cloning
- in `forwardRef` we add a bail case where we keep props when no `ref` is passed to us