### PR TITLE
refactor: Warn on NaN in dep arrays instead of throwing

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -19,7 +19,7 @@ jobs:
         uses: andrewiggins/download-base-artifact@v3
         with:
           artifact: npm-package
-          workflow: build-test.yml
+          workflow: ci.yml
           required: true
       - run: mv preact.tgz preact-main.tgz
       - name: Upload locally build & base preact package

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -483,7 +483,7 @@ export function initDebug() {
 							const arg = hook._args[j];
 							if (isNaN(arg)) {
 								const componentName = getDisplayName(vnode);
-								throw new Error(
+								console.warn(
 									`Invalid argument passed to hook. Hooks should not be called with NaN in the dependency array. Hook index ${i} in component ${componentName} was called with NaN.`
 								);
 							}

--- a/debug/test/browser/validateHookArgs.test.js
+++ b/debug/test/browser/validateHookArgs.test.js
@@ -31,18 +31,21 @@ describe('Hook argument validation', () => {
 		};
 
 		it(`should error if ${name} is mounted with NaN as an argument`, async () => {
-			expect(() =>
-				render(<TestComponent initialValue={NaN} />, scratch)
-			).to.throw(/Hooks should not be called with NaN in the dependency array/);
+			render(<TestComponent initialValue={NaN} />, scratch);
+			expect(console.warn).to.be.calledOnce;
+			expect(console.warn.args[0]).to.match(
+				/Hooks should not be called with NaN in the dependency array/
+			);
 		});
 
 		it(`should error if ${name} is updated with NaN as an argument`, async () => {
 			render(<TestComponent initialValue={0} />, scratch);
 
-			expect(() => {
-				scratch.querySelector('button').click();
-				rerender();
-			}).to.throw(
+			scratch.querySelector('button').click();
+			rerender();
+
+			expect(console.warn).to.be.calledOnce;
+			expect(console.warn.args[0]).to.match(
 				/Hooks should not be called with NaN in the dependency array/
 			);
 		});
@@ -52,14 +55,18 @@ describe('Hook argument validation', () => {
 	let scratch;
 	/** @type {() => void} */
 	let rerender;
+	let warnings = [];
 
 	beforeEach(() => {
 		scratch = setupScratch();
 		rerender = setupRerender();
+		warnings = [];
+		sinon.stub(console, 'warn').callsFake(w => warnings.push(w));
 	});
 
 	afterEach(() => {
 		teardown(scratch);
+		console.warn.restore();
 	});
 
 	validateHook('useEffect', arg => useEffect(() => {}, [arg]));


### PR DESCRIPTION
Closes: #4344

It'll fix the issue of debug throwing & killing the app, but whether or not this works correctly is still very usage-dependent.

Will depend on #4528, as our benchmarks require a successful asset upload from `main` to be able to run, and its CI currently fails.