### PR TITLE
ci: Ensure paths-filter action works on push events

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           artifact: npm-package
           workflow: build-test.yml
-          required: false
+          required: true
       - run: mv preact.tgz preact-main.tgz
       - name: Upload locally build & base preact package
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     outputs:
       jsChanged: ${{ steps.filter.outputs.jsChanged }}
     steps:
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:


### PR DESCRIPTION
It seems `dorny/paths-filter` (which we use for the `CI` workflow) specifically fails on `push` events, [unable to find the Git repo](https://github.com/preactjs/preact/actions/runs/11210372482/job/31439621624). Adding [an explicit checkout stage seems to be the fix](https://github.com/dorny/paths-filter/issues/212#issuecomment-1960976719).