### PR TITLE
We should not always set to hydration

### DIFF
--- a/compat/test/browser/suspense-hydration.test.js
+++ b/compat/test/browser/suspense-hydration.test.js
@@ -15,6 +15,7 @@ import {
 } from '../../../test/_util/helpers';
 import { ul, li, div } from '../../../test/_util/dom';
 import { createLazy, createSuspenseLoader } from './suspense-utils';
+import { render } from 'preact';
 
 /* eslint-env browser, mocha */
 describe('suspense hydration', () => {

--- a/compat/test/browser/suspense-hydration.test.js
+++ b/compat/test/browser/suspense-hydration.test.js
@@ -15,7 +15,6 @@ import {
 } from '../../../test/_util/helpers';
 import { ul, li, div } from '../../../test/_util/dom';
 import { createLazy, createSuspenseLoader } from './suspense-utils';
-import { render } from 'preact';
 
 /* eslint-env browser, mocha */
 describe('suspense hydration', () => {

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -299,6 +299,25 @@ describe('suspense', () => {
 		});
 	});
 
+	it('should not duplicate DOM when suspending while rendering', () => {
+		scratch.innerHTML = '<div>Hello</div>';
+
+		const [Lazy, resolve] = createLazy();
+		render(
+			<Suspense>
+				<Lazy />
+			</Suspense>,
+			scratch
+		);
+		rerender(); // Flush rerender queue to mimic what preact will really do
+		expect(scratch.innerHTML).to.equal('');
+
+		return resolve(() => <div>Hello</div>).then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.equal('<div>Hello</div>');
+		});
+	});
+
 	it('should suspend when a promise is thrown', () => {
 		class ClassWrapper extends Component {
 			render(props) {

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -275,7 +275,7 @@ export function diff(
 			if (isHydrating || excessDomChildren != null) {
 				newVNode._flags |= isHydrating
 					? MODE_HYDRATE | MODE_SUSPENDED
-					: MODE_HYDRATE;
+					: MODE_SUSPENDED;
 
 				while (oldDom && oldDom.nodeType === 8 && oldDom.nextSibling) {
 					oldDom = oldDom.nextSibling;


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/4439

Currently we try to set everything to `hydrate` mode which feels like a mistake, we should only set the hydration flag when we are hydrating. I feel like we intended to set the SUSPENDED flag. This will make it so that we try to render the fallback rather than falling back to a non-suspended hydration mode, falling back to non-suspended hydration will clobber the DOM as we fall back to no excessDomChildren which is an inherent hydration mismatch.

This is so because we skip [this condition](https://github.com/preactjs/preact/blob/main/src/diff/index.js#L53)