### PR TITLE
ci: Fix PR reporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,9 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          # Should be kept in sync with the filter in the PR Reporter workflow
           filters: |
-            jsChanged: '**/src/**.js'
+            jsChanged: '**/src/**/*.js'
 
   compressed_size:
     name: Compressed Size

--- a/.github/workflows/pr-reporter.yml
+++ b/.github/workflows/pr-reporter.yml
@@ -4,19 +4,37 @@ on:
   # The pull_request event can't write comments for PRs from forks so using this
   # workflow_run workflow as a workaround
   workflow_run:
-    workflows: ['Benchmarks']
+    workflows: ['CI']
     branches: ['**']
     types:
       - completed
       - requested
 
 jobs:
+  filter_jobs:
+    name: Filter jobs
+    runs-on: ubuntu-latest
+    outputs:
+      jsChanged: ${{ steps.filter.outputs.jsChanged }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          # Should be kept in sync with the filter in the CI workflow
+          filters: |
+            jsChanged: '**/src/**/*.js'
+
   report_running:
     name: Report benchmarks are in-progress
+    needs: filter_jobs
     runs-on: ubuntu-latest
     # Only add the "benchmarks are running" text when a workflow_run is
     # requested (a.k.a starting)
-    if: ${{ github.event.action == 'requested' }}
+    if: |
+      needs.filter_jobs.outputs.jsChanged == 'true' &&
+      github.event.action == 'requested'
     steps:
       - name: Report Tachometer Running
         uses: andrewiggins/tachometer-reporter-action@v2
@@ -27,10 +45,14 @@ jobs:
 
   report_results:
     name: Report benchmark results
+    needs: filter_jobs
     runs-on: ubuntu-latest
     # Only run this job if the event action was "completed" and the triggering
     # workflow_run was successful
-    if: ${{ github.event.action == 'completed' && github.event.workflow_run.conclusion == 'success' }}
+    if: |
+      needs.filter_jobs.outputs.jsChanged == 'true' &&
+      github.event.action == 'completed' &&
+      github.event.workflow_run.conclusion == 'success'
     steps:
       # Download the artifact from the triggering workflow that contains the
       # Tachometer results to report


### PR DESCRIPTION
This should correct the PR reporter

There's no elegant way to watch jobs within a workflow, so we'll have to settle for mirroring CI's filter here to ensure we're only running the PR reporter when the benchmarks will be ran (`**/src/**/*.js`)