### PR TITLE
fix: oxlint violation of `react/iframe-missing-sandbox`

### DIFF
--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1132,6 +1132,7 @@ describe('render()', () => {
 	it('should not remove iframe', () => {
 		let setState;
 		const Iframe = () => {
+			// oxlint-disable-next-line iframe-missing-sandbox
 			return <iframe src="https://codesandbox.io/s/runtime-silence-no4zx" />;
 		};
 


### PR DESCRIPTION
## What This PR Does

Fixes a violation of `react/iframe-missing-sandbox`, a recently-added rule that will be available in the next release.

This is part of an ongoing effort to keep our ecosystem CI green. Thank you for using oxlint ⚓ 