### PR TITLE
Fix error message when nesting invalid elements within <p> tags

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -425,7 +425,7 @@ export function initDebug() {
 					console.error(
 						'Improper nesting of paragraph. Your <p> should not have ' +
 							illegalDomChildrenTypes.join(', ') +
-							'as child-elements.' +
+							' as child-elements.' +
 							serializeVNode(vnode) +
 							`\n\n${getOwnerStack(vnode)}`
 					);


### PR DESCRIPTION
Error message shows up when nesting invalid elements within `<p>` tags

<img width="626" alt="Screenshot 2024-10-15 at 11 13 10 AM" src="https://github.com/user-attachments/assets/f0f1c8e1-0037-486b-b587-9432af1f3e98">