### PR TITLE
ci: Skip PR reporter action on non-pull request triggers

### DIFF
--- a/.github/workflows/pr-reporter.yml
+++ b/.github/workflows/pr-reporter.yml
@@ -14,6 +14,8 @@ jobs:
   filter_jobs:
     name: Filter jobs
     runs-on: ubuntu-latest
+    if: |
+      github.event.workflow_run.event == 'pull_request'
     outputs:
       jsChanged: ${{ steps.filter.outputs.jsChanged }}
     steps:


### PR DESCRIPTION
Ensures the PR reporter doesn't error out when the CI workflow is ran on push to `main`.

The PR reporter workflow will still trigger, but immediately cancel with this.