### PR TITLE
Support `{ handleEvent() {} }` object interface as a listener

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -166,7 +166,7 @@ function createEventProxy(useCapture) {
 			} else if (e._dispatched < eventHandler._attached) {
 				return;
 			}
-			return eventHandler(options.event ? options.event(e) : e);
+			return ("handleEvent" in eventHandler ? eventHandler.handleEvent : eventHandler)(options.event ? options.event(e) : e);
 		}
 	};
 }

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -166,7 +166,8 @@ function createEventProxy(useCapture) {
 			} else if (e._dispatched < eventHandler._attached) {
 				return;
 			}
-			return ("handleEvent" in eventHandler ? eventHandler.handleEvent : eventHandler)(options.event ? options.event(e) : e);
+			if (options.event) e = options.event(e);
+			return "handleEvent" in eventHandler ? eventHandler.handleEvent(e) : eventHandler(e);
 		}
 	};
 }

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1480,9 +1480,13 @@ export namespace JSXInternal {
 	export type TargetedPictureInPictureEvent<Target extends EventTarget> =
 		TargetedEvent<Target, PictureInPictureEvent>;
 
+	export type EventHandlerObject<E extends TargetedEvent> = {
+		handleEvent(e: E): unknown
+	}
+
 	export type EventHandler<E extends TargetedEvent> = {
 		bivarianceHack(event: E): void;
-	}['bivarianceHack'];
+	}['bivarianceHack']  | EventHandlerObject<E>;
 
 	export type AnimationEventHandler<Target extends EventTarget> = EventHandler<
 		TargetedAnimationEvent<Target>

--- a/test/browser/events.test.js
+++ b/test/browser/events.test.js
@@ -235,4 +235,52 @@ describe('event handling', () => {
 			.to.have.been.calledTwice.and.to.have.been.calledWith('focusin')
 			.and.calledWith('focusout');
 	});
+
+	it('should register EventListenerObject as handler', () => {
+		let handler = { handleEvent() {} }
+
+		render(<div onClick={handler} />, scratch);
+
+		expect(scratch.childNodes[0].attributes.length).to.equal(0);
+
+		expect(proto.addEventListener).to.have.been.calledOnce;
+	});
+
+	it('should call registered EventListenerObject through the .handleEvent() method', () => {
+		let onclick = sinon.spy();
+
+		let handler = {
+			onclick,
+			handleEvent() {
+				this.onclick()
+			}
+		}
+
+		render(<div onClick={handler} />, scratch);
+
+		fireEvent(scratch.childNodes[0], 'click');
+
+		expect(onclick).to.have.been.calledOnce;
+	});
+
+	it('should keep the registered EventListenerObject referentially identical when calling', () => {
+		let onclick = sinon.spy();
+
+		// if the handler object was destructured or otherwise copied, this will fail
+		let handler = new class {
+			onclick = onclick
+			#onClick() {
+				this.onclick()
+			}
+			handleEvent() {
+				this.#onClick()
+			}
+		}
+
+		render(<div onClick={handler} />, scratch);
+
+		fireEvent(scratch.childNodes[0], 'click');
+
+		expect(onclick).to.have.been.calledOnce;
+	});
 });


### PR DESCRIPTION
- Implements and closes #2382
- ~~Currently a draft because I couldn't get tests to run.~~
- Introduces a 13 byte increase in brotli'd bundle size (4247b -> 4260b)
- [x] Update typescript declarations
- [x] Tests for new behavior