### PR TITLE
Fork types for TS 5.1 and beyond

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "sade": "^1.8.1",
         "sinon": "^9.2.3",
         "sinon-chai": "^3.7.0",
-        "typescript": "^4.9.5",
+        "typescript": "^5.6.3",
         "undici": "^4.12.0"
       },
       "funding": {
@@ -7328,6 +7328,19 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
+    "node_modules/microbundle/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -10556,16 +10569,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/ua-parser-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "sade": "^1.8.1",
         "sinon": "^9.2.3",
         "sinon-chai": "^3.7.0",
-        "typescript": "^5.6.3",
+        "typescript": "5.1.6",
         "undici": "^4.12.0"
       },
       "funding": {
@@ -10569,9 +10569,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "sade": "^1.8.1",
         "sinon": "^9.2.3",
         "sinon-chai": "^3.7.0",
-        "typescript": "^5.6.3",
+        "typescript": "^4.9.5",
         "undici": "^4.12.0"
       },
       "funding": {
@@ -7328,19 +7328,6 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
-    "node_modules/microbundle/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -10569,16 +10556,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "sade": "^1.8.1",
     "sinon": "^9.2.3",
     "sinon-chai": "^3.7.0",
-    "typescript": "^4.9.5",
+    "typescript": "^5.6.3",
     "undici": "^4.12.0"
   },
   "volta": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,16 @@
   "umd:main": "dist/preact.umd.js",
   "unpkg": "dist/preact.min.js",
   "source": "src/index.js",
+  "typesVersions": {
+    "<=5.0": {
+      ".": ["./src/index-5.d.ts"]
+    }
+  },
   "exports": {
     ".": {
-      "types@<=5.0": { "default": "./src/index-5.d.ts" },
+      "types@<=5.0": {
+        "types": "./src/index-5.d.ts"
+      },
       "types": "./src/index.d.ts",
       "browser": "./dist/preact.module.js",
       "umd": "./dist/preact.umd.js",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   },
   "types": "src/index.d.ts",
   "scripts": {
-    "prepare": "husky && run-s build && check-export-map && npm-merge-driver-install",
+    "prepare": "husky && run-s build && npm-merge-driver-install",
     "build": "npm-run-all --parallel build:*",
     "build:core": "microbundle build --raw --no-generateTypes -f cjs,esm,umd",
     "build:core-min": "microbundle build --raw --no-generateTypes -f cjs,esm,umd,iife src/cjs.js -o dist/preact.min.js",
@@ -247,7 +247,7 @@
     "sade": "^1.8.1",
     "sinon": "^9.2.3",
     "sinon-chai": "^3.7.0",
-    "typescript": "^5.6.3",
+    "typescript": "^4.9.5",
     "undici": "^4.12.0"
   },
   "volta": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "source": "src/index.js",
   "exports": {
     ".": {
+      "types@<=5.0": { "default": "./src/index-5.d.ts" },
       "types": "./src/index.d.ts",
       "browser": "./dist/preact.module.js",
       "umd": "./dist/preact.umd.js",
@@ -246,7 +247,7 @@
     "sade": "^1.8.1",
     "sinon": "^9.2.3",
     "sinon-chai": "^3.7.0",
-    "typescript": "^4.9.5",
+    "typescript": "^5.6.3",
     "undici": "^4.12.0"
   },
   "volta": {

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "sade": "^1.8.1",
     "sinon": "^9.2.3",
     "sinon-chai": "^3.7.0",
-    "typescript": "^5.6.3",
+    "typescript": "5.1.6",
     "undici": "^4.12.0"
   },
   "volta": {

--- a/src/index-5.d.ts
+++ b/src/index-5.d.ts
@@ -87,7 +87,7 @@ export type ComponentProps<
 		: never;
 
 export interface FunctionComponent<P = {}> {
-	(props: RenderableProps<P>, context?: any): ComponentChild;
+	(props: RenderableProps<P>, context?: any): VNode | null;
 	displayName?: string;
 	defaultProps?: Partial<P> | undefined;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -87,7 +87,7 @@ export type ComponentProps<
 		: never;
 
 export interface FunctionComponent<P = {}> {
-	(props: RenderableProps<P>, context?: any): ComponentChild;
+	(props: RenderableProps<P>, context?: any): ComponentChildren;
 	displayName?: string;
 	defaultProps?: Partial<P> | undefined;
 }
@@ -180,7 +180,7 @@ export abstract class Component<P, S> {
 		props?: RenderableProps<P>,
 		state?: Readonly<S>,
 		context?: any
-	): ComponentChild;
+	): ComponentChildren;
 }
 
 //

--- a/test/ts/VNode-test.tsx
+++ b/test/ts/VNode-test.tsx
@@ -9,7 +9,8 @@ import {
 	ComponentFactory,
 	VNode,
 	ComponentChildren,
-	cloneElement
+	cloneElement,
+	ComponentChild
 } from '../../';
 
 function getDisplayType(vnode: VNode | string | number) {
@@ -195,3 +196,11 @@ class ComponentWithNumberChildren extends Component<{ children: number[] }> {
 	{1}
 	{2}
 </ComponentWithNumberChildren>;
+
+const ComponentReturningComponentChildren = ({
+	children
+}: {
+	children: ComponentChild;
+}) => children;
+
+<ComponentReturningComponentChildren>123</ComponentReturningComponentChildren>;

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -138,22 +138,21 @@ const UseOfComponentWithChildren = () => {
 	);
 };
 
-// TODO: make this work
-// const DummyChildren: FunctionalComponent = ({ children }) => {
-// 	return children;
-// };
+const DummyChildren: FunctionalComponent = ({ children }) => {
+	return children;
+};
 
-// function ReturnChildren(props: { children: preact.ComponentChildren }) {
-// 	return props.children;
-// }
+function ReturnChildren(props: { children: preact.ComponentChildren }) {
+	return props.children;
+}
 
-// function TestUndefinedChildren() {
-// 	return (
-// 		<ReturnChildren>
-// 			<ReturnChildren>Hello</ReturnChildren>
-// 		</ReturnChildren>
-// 	);
-// }
+function TestUndefinedChildren() {
+	return (
+		<ReturnChildren>
+			<ReturnChildren>Hello</ReturnChildren>
+		</ReturnChildren>
+	);
+}
 
 // using ref and or jsx
 class ComponentUsingRef extends Component<any, any> {


### PR DESCRIPTION
In TypeScript 5.1 there was a change to the JSX types, to support this properly we'll need to fork our types in pre and post this minor version.

I'm pretty unsure whether we can add tests for this in our repository 😅 

Resolves https://github.com/preactjs/preact/issues/4113
Resolves https://github.com/preactjs/preact/issues/4425
Resolves https://github.com/preactjs/preact/issues/3611
Resolves https://github.com/preactjs/preact/issues/3815
Enables https://github.com/preactjs/preact/issues/4481
Supersedes https://github.com/preactjs/preact/pull/3482