### PR TITLE
fix: Ensure SVGAttributes includes height & width

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -227,6 +227,7 @@ export namespace JSXInternal {
 		gradientTransform?: Signalish<string | undefined>;
 		gradientUnits?: Signalish<string | undefined>;
 		hanging?: Signalish<number | string | undefined>;
+		height?: Signalish<number | string | undefined>;
 		horizAdvX?: Signalish<number | string | undefined>;
 		'horiz-adv-x'?: Signalish<number | string | undefined>;
 		horizOriginX?: Signalish<number | string | undefined>;
@@ -413,7 +414,7 @@ export namespace JSXInternal {
 		visibility?: Signalish<number | string | undefined>;
 		vMathematical?: Signalish<number | string | undefined>;
 		'v-mathematical'?: Signalish<number | string | undefined>;
-		widths?: Signalish<number | string | undefined>;
+		width?: Signalish<number | string | undefined>;
 		wordSpacing?: Signalish<number | string | undefined>;
 		'word-spacing'?: Signalish<number | string | undefined>;
 		writingMode?: Signalish<number | string | undefined>;


### PR DESCRIPTION
I'm innocent on this one! Or at least more so.

Picked up by the ecosystem-ci: https://github.com/preactjs/ecosystem-ci/actions/runs/11782934145

As `SVGAttributes` extended the mega `HTMLAttributes`, it always had access to `height` & `width` through that. However, with slimming down of `HTMLAttributes` to just the global attributes a few days ago, this is no longer the case. Need to be re-added to the SVG interface.

`widths` looks a bit odd and it was created when types were originally provided. I can't think of anything that'd call for `widths`, nor have I been able to find any reference to it, so I took a guess that it was a typo? Let me know if I'm missing something!