### PR TITLE
feat: Add `ElementRef` type to compat

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -286,13 +286,25 @@ declare namespace React {
 		ComponentProps<T>
 	>;
 
-	export type ComponentPropsWithRef<
-		C extends ComponentType<any> | keyof JSXInternal.IntrinsicElements
-	> = C extends new (
+	export type ComponentPropsWithRef<C extends ElementType> = C extends new (
 		props: infer P
 	) => Component<any, any>
 		? PropsWithoutRef<P> & RefAttributes<InstanceType<C>>
 		: ComponentProps<C>;
+
+	export type ElementRef<
+		C extends
+			| ForwardRefExoticComponent<any>
+			| { new (props: any): Component<any, any> }
+			| ((props: any) => ReactNode)
+			| keyof JSXInternal.IntrinsicElements
+	> = 'ref' extends keyof ComponentPropsWithRef<C>
+		? NonNullable<ComponentPropsWithRef<C>['ref']> extends RefAttributes<
+				infer Instance
+			>['ref']
+			? Instance
+			: never
+		: never;
 
 	export function flushSync<R>(fn: () => R): R;
 	export function flushSync<A, R>(fn: (a: A) => R, a: A): R;


### PR DESCRIPTION
Closes #4481

For comparison: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b5dc32740d9b45d11cff9b025896dd333c795b39/types/react/index.d.ts#L221-L235

Can confirm #4548 cleared the way for this -- like a total doofus I created a new vite project and was wildy confused to see the same old error re: can't assign `null | undefined` to `VNode<any>` as I had only copied over this particular change. Eventually the issue dawned on me, copied over the new types, and it worked like a treat!