### PR TITLE
10.25.0

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -13,7 +13,7 @@ export function initDevTools() {
 		globalVar !== undefined &&
 		globalVar.__PREACT_DEVTOOLS__
 	) {
-		globalVar.__PREACT_DEVTOOLS__.attachPreact('10.24.3', options, {
+		globalVar.__PREACT_DEVTOOLS__.attachPreact('10.25.0', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "10.24.3",
+  "version": "10.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "10.24.3",
+      "version": "10.25.0",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.24.3",
+  "version": "10.25.0",
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
## Features

### Move per-element type interfaces into core and more strictly type IntrinsicElements (#4546, thanks @rschristian)

This adds per-element typings for every DOM-node type, this means that our types might become slightly stricter when you are using DOM attributes/properties where they are not allowed, an example of this might be `<div src="x" />`.

If you notice any issues when upgrading tell us about them, we can evaluate whether we have missed a case.

### Recreate unkeyed functional components when they change position. (#4550, thanks @JoviDeCroock)

This is a long time bugfix, when we have elements that look like

```js
return (
	{condition ? <Element /> : null}
	{condition ? null : <Element />
)
```

We would reuse the state of the first VNode to render the second one when the condition switches. When you are using `key`, this issue was not present.

### Support `{ handleEvent() {} }` object interface as a listener (#4538, thanks @lilnasy)

We've added support for attaching object/class event-handlers

```js
let handler = {
	onclick,
	handleEvent() {
		this.onclick()
	}
}

<div onClick={handler} />
```

## Fixes

- Ensure state updates work in signals (#4560, thanks @JoviDeCroock)
- Ensure SVGAttributes includes height & width (#4556, thanks @rschristian)
- Fork types for TS 5.1 and beyond (#4548, thanks @JoviDeCroock)
- Re-add missing properties & property casings (#4554, thanks @rschristian)
- Ensure we unwrap custom .then() (#4547, thanks @JoviDeCroock)
- Fix error message when nesting invalid elements within <p> tags (#4534, thanks @jubalm)

## Maintenance

- Try constant for undefined (#4552, thanks @JoviDeCroock)
- Fix demo (#4551, thanks @JoviDeCroock)
- Use `Signalish` helper to reduce verbosity (#4545, thanks @rschristian)
- Re-export ErrorInfo type (#4541, thanks @jose-torres-marin)
- Skip PR reporter action on non-pull request triggers (#4536, thanks @rschristian)
- upgrade biome to 1.9.4 (#4535, thanks @unvalley)
- oxlint violation of `react/iframe-missing-sandbox` (#4533, thanks @DonIsaac)