### PR TITLE
Allow rendering in document

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -12,6 +12,11 @@ import { slice } from './util';
  * existing DOM tree rooted at `replaceNode`
  */
 export function render(vnode, parentDom, replaceNode) {
+	// https://github.com/preactjs/preact/issues/3794
+	if (parentDom === document) {
+		parentDom = document.documentElement;
+	}
+
 	if (options._root) options._root(vnode, parentDom);
 
 	// We abuse the `replaceNode` parameter in `hydrate()` to signal if we are in

--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -208,6 +208,8 @@ export function clearOptions() {
  * @param {HTMLElement} scratch
  */
 export function teardown(scratch) {
+	if (!document.contains(scratch)) return;
+
 	if (
 		scratch &&
 		('__k' in scratch || '_children' in scratch) &&

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1,5 +1,5 @@
 import { setupRerender } from 'preact/test-utils';
-import { createElement, render, Component, options } from 'preact';
+import { createElement, render, Component, options, Fragment } from 'preact';
 import {
 	setupScratch,
 	teardown,
@@ -1883,5 +1883,23 @@ describe('render()', () => {
 				`<div>${aa.map(n => `<div>${n}</div>`).join('')}</div>`
 			);
 		}
+	});
+
+	it('should work with document', () => {
+		document.textContent = '';
+		const App = () => (
+			<Fragment>
+				<head>
+					<title>Test</title>
+				</head>
+				<body>
+					<p>Test</p>
+				</body>
+			</Fragment>
+		);
+		render(<App />, document);
+		expect(document.documentElement.innerHTML).to.equal(
+			'<head><title>Test</title></head><body><p>Test</p></body>\n'
+		);
 	});
 });


### PR DESCRIPTION
Resolves #3794 

When we want to render straight into `document` we have to alias it to `.documentElement` as this is used in Remix we could consider supporting it, or moving it to compat.