### PR TITLE
fix: `max` and `min` input element types

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1781,10 +1781,10 @@ export namespace JSXInternal {
 		height?: Signalish<number | string | undefined>;
 		indeterminate?: Signalish<boolean | undefined>;
 		list?: Signalish<string | undefined>;
-		max?: Signalish<string | undefined>;
+		max?: Signalish<number | string | undefined>;
 		maxlength?: Signalish<number | undefined>;
 		maxLength?: Signalish<number | undefined>;
-		min?: Signalish<string | undefined>;
+		min?: Signalish<number | string | undefined>;
 		minlength?: Signalish<number | undefined>;
 		minLength?: Signalish<number | undefined>;
 		multiple?: Signalish<boolean | undefined>;


### PR DESCRIPTION
Fixes #4566

We had the correct types in the old `HTMLAttributes` (now `AllHTMLAttributes`) but in the per-element types I copied from compat seemed to be incorrect.

Will try to write up a script to compare all of our old props to the new, spotting any other discrepancies.