### PR TITLE
fix(types): mark `datetime` on `<del>` as optional

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1624,7 +1624,7 @@ export namespace JSXInternal {
 
 	interface DelHTMLAttributes<T extends EventTarget> extends HTMLAttributes<T> {
 		cite?: Signalish<string | undefined>;
-		datetime: Signalish<string | undefined>;
+		datetime?: Signalish<string | undefined>;
 		dateTime?: Signalish<string | undefined>;
 	}
 


### PR DESCRIPTION
In https://github.com/preactjs/preact/pull/4554 the `datetime` attribute of `<del>` was accidentally marked as required. This PR fixes that.