### PR TITLE
fix: Ensure resolution of core types goes through typesVersions resolution

### DIFF
--- a/compat/client.d.ts
+++ b/compat/client.d.ts
@@ -1,4 +1,6 @@
-import * as preact from '../src';
+// Intentionally not using a relative path to take advantage of
+// the TS version resolution mechanism
+import * as preact from 'preact';
 
 export function createRoot(container: preact.ContainerNode): {
 	render(children: preact.ComponentChild): void;

--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -1,5 +1,7 @@
 import * as _hooks from '../../hooks';
-import * as preact from '../../src';
+// Intentionally not using a relative path to take advantage of
+// the TS version resolution mechanism
+import * as preact from 'preact';
 import { JSXInternal } from '../../src/jsx';
 import * as _Suspense from './suspense';
 import * as _SuspenseList from './suspense-list';

--- a/compat/src/suspense-list.d.ts
+++ b/compat/src/suspense-list.d.ts
@@ -1,4 +1,6 @@
-import { Component, ComponentChild, ComponentChildren } from '../../src';
+// Intentionally not using a relative path to take advantage of
+// the TS version resolution mechanism
+import { Component, ComponentChild, ComponentChildren } from 'preact';
 
 //
 // SuspenseList

--- a/compat/src/suspense.d.ts
+++ b/compat/src/suspense.d.ts
@@ -1,4 +1,6 @@
-import { Component, ComponentChild, ComponentChildren } from '../../src';
+// Intentionally not using a relative path to take advantage of
+// the TS version resolution mechanism
+import { Component, ComponentChild, ComponentChildren } from 'preact';
 
 //
 // Suspense/lazy

--- a/compat/test/ts/tsconfig.json
+++ b/compat/test/ts/tsconfig.json
@@ -8,7 +8,10 @@
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",
     "noEmit": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "paths": {
+      "preact": ["../../../src/index.d.ts"]
+    }
   },
   "include": ["./**/*.ts", "./**/*.tsx"]
 }

--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -1,4 +1,6 @@
-import { ErrorInfo, PreactContext, Ref, RefObject } from '../..';
+// Intentionally not using a relative path to take advantage of
+// the TS version resolution mechanism
+import { ErrorInfo, PreactContext, Ref, RefObject } from 'preact';
 
 type Inputs = ReadonlyArray<unknown>;
 

--- a/jsx-runtime/src/index.d.ts
+++ b/jsx-runtime/src/index.d.ts
@@ -1,11 +1,13 @@
-export { Fragment } from '../../';
+// Intentionally not using a relative path to take advantage of
+// the TS version resolution mechanism
+export { Fragment } from 'preact';
 import {
 	ComponentType,
 	ComponentChild,
 	ComponentChildren,
 	VNode,
 	Attributes
-} from '../../';
+} from 'preact';
 import { JSXInternal } from '../../src/jsx';
 
 export function jsx(

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -1,4 +1,6 @@
-import * as preact from './index';
+// Intentionally not using a relative path to take advantage of
+// the TS version resolution mechanism
+import * as preact from 'preact';
 
 export enum HookType {
 	useState = 1,

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -9,7 +9,7 @@ import {
 	FunctionComponent,
 	PreactDOMAttributes,
 	VNode
-} from './index';
+} from 'preact';
 
 type Defaultize<Props, Defaults> =
 	// Distribute over unions


### PR DESCRIPTION
Hopefully fixes the DefinitelyTyped issues & sets us up to land #4557 w/out issue. Looks correct now that I've replaced the relative path with `preact` everywhere.