### PR TITLE
Move some frequently used things to constants

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -10,6 +10,9 @@ export const MATCHED = 1 << 17;
 /** Reset all mode flags */
 export const RESET_MODE = ~(MODE_HYDRATE | MODE_SUSPENDED);
 
+export const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
+export const XHTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
+
 export const UNDEFINED = undefined;
 export const EMPTY_OBJ = /** @type {any} */ ({});
 export const EMPTY_ARR = [];

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,6 +12,7 @@ export const RESET_MODE = ~(MODE_HYDRATE | MODE_SUSPENDED);
 
 export const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
 export const XHTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
+export const MATH_NAMESPACE = 'http://www.w3.org/1998/Math/MathML';
 
 export const UNDEFINED = undefined;
 export const EMPTY_OBJ = /** @type {any} */ ({});

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -3,7 +3,9 @@ import {
 	MODE_HYDRATE,
 	MODE_SUSPENDED,
 	RESET_MODE,
-	UNDEFINED
+	SVG_NAMESPACE,
+	UNDEFINED,
+	XHTML_NAMESPACE
 } from '../constants';
 import { BaseComponent, getDomSibling } from '../component';
 import { Fragment } from '../create-element';
@@ -390,10 +392,10 @@ function diffElementNodes(
 	let checked;
 
 	// Tracks entering and exiting namespaces when descending through the tree.
-	if (nodeType === 'svg') namespace = 'http://www.w3.org/2000/svg';
+	if (nodeType === 'svg') namespace = SVG_NAMESPACE;
 	else if (nodeType === 'math')
 		namespace = 'http://www.w3.org/1998/Math/MathML';
-	else if (!namespace) namespace = 'http://www.w3.org/1999/xhtml';
+	else if (!namespace) namespace = XHTML_NAMESPACE;
 
 	if (excessDomChildren != null) {
 		for (i = 0; i < excessDomChildren.length; i++) {
@@ -516,9 +518,7 @@ function diffElementNodes(
 				newVNode,
 				oldVNode,
 				globalContext,
-				nodeType === 'foreignObject'
-					? 'http://www.w3.org/1999/xhtml'
-					: namespace,
+				nodeType === 'foreignObject' ? XHTML_NAMESPACE : namespace,
 				excessDomChildren,
 				commitQueue,
 				excessDomChildren

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -1,5 +1,6 @@
 import {
 	EMPTY_OBJ,
+	MATH_NAMESPACE,
 	MODE_HYDRATE,
 	MODE_SUSPENDED,
 	RESET_MODE,
@@ -393,8 +394,7 @@ function diffElementNodes(
 
 	// Tracks entering and exiting namespaces when descending through the tree.
 	if (nodeType === 'svg') namespace = SVG_NAMESPACE;
-	else if (nodeType === 'math')
-		namespace = 'http://www.w3.org/1998/Math/MathML';
+	else if (nodeType === 'math') namespace = MATH_NAMESPACE;
 	else if (!namespace) namespace = XHTML_NAMESPACE;
 
 	if (excessDomChildren != null) {

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -1,4 +1,4 @@
-import { IS_NON_DIMENSIONAL } from '../constants';
+import { IS_NON_DIMENSIONAL, SVG_NAMESPACE } from '../constants';
 import options from '../options';
 
 function setStyle(style, key, value) {
@@ -12,6 +12,8 @@ function setStyle(style, key, value) {
 		style[key] = value + 'px';
 	}
 }
+
+const CAPTURE_REGEX = /(PointerCapture)$|Capture$/i;
 
 // A logical clock to solve issues like https://github.com/preactjs/preact/issues/3927.
 // When the DOM performs an event it leaves micro-ticks in between bubbling up which means that
@@ -64,8 +66,7 @@ export function setProperty(dom, name, value, oldValue, namespace) {
 	}
 	// Benchmark for comparison: https://esbench.com/bench/574c954bdb965b9a00965ac6
 	else if (name[0] === 'o' && name[1] === 'n') {
-		useCapture =
-			name !== (name = name.replace(/(PointerCapture)$|Capture$/i, '$1'));
+		useCapture = name !== (name = name.replace(CAPTURE_REGEX, '$1'));
 
 		// Infer correct casing for DOM built-in events:
 		if (
@@ -98,7 +99,7 @@ export function setProperty(dom, name, value, oldValue, namespace) {
 			);
 		}
 	} else {
-		if (namespace == 'http://www.w3.org/2000/svg') {
+		if (namespace == SVG_NAMESPACE) {
 			// Normalize incorrect prop usage for SVG:
 			// - xlink:href / xlinkHref --> href (xlink:href was removed from SVG and isn't needed)
 			// - className --> class
@@ -167,7 +168,9 @@ function createEventProxy(useCapture) {
 				return;
 			}
 			if (options.event) e = options.event(e);
-			return "handleEvent" in eventHandler ? eventHandler.handleEvent(e) : eventHandler(e);
+			return 'handleEvent' in eventHandler
+				? eventHandler.handleEvent(e)
+				: eventHandler(e);
 		}
 	};
 }


### PR DESCRIPTION
This checks the performance of moving some longer strings to constants to avoid re-allocating in the critical path. Some of these could also optimise easier as the function gets shorter