### PR TITLE
fix: Add missing SVG `type` attribute

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -383,6 +383,7 @@ export namespace JSXInternal {
 		transform?: Signalish<string | undefined>;
 		transformOrigin?: Signalish<string | undefined>;
 		'transform-origin'?: Signalish<string | undefined>;
+		type?: Signalish<string | undefined>;
 		u1?: Signalish<number | string | undefined>;
 		u2?: Signalish<number | string | undefined>;
 		underlinePosition?: Signalish<number | string | undefined>;


### PR DESCRIPTION
Another SVG type that was inherited from `HTMLAttributes` in the past.

[MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/type)
[Ref](https://github.com/hypothesis/frontend-shared/pull/1803)