### PR TITLE
Look for an alternative to .contains

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -79,6 +79,10 @@ function removeOriginal(vnode, detachedParent, originalParent) {
 				removeOriginal(child, detachedParent, originalParent)
 			);
 
+		if (vnode._dom && vnode._dom._unmounted) {
+			vnode._dom._unmounted = false;
+		}
+
 		if (vnode._component) {
 			if (vnode._component._parentDom === detachedParent) {
 				if (vnode._dom) {

--- a/mangle.json
+++ b/mangle.json
@@ -40,6 +40,7 @@
       "$_nextDom": "__d",
       "$_dirty": "__d",
       "$_mask": "__m",
+      "$_unmounted": "__u",
       "$_detachOnNextRender": "__b",
       "$_force": "__e",
       "$_nextState": "__s",

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -338,7 +338,7 @@ function insert(parentVNode, oldDom, parentDom) {
 
 		return oldDom;
 	} else if (parentVNode._dom != oldDom) {
-		if (oldDom && parentVNode.type && !parentDom.contains(oldDom)) {
+		if (oldDom && parentVNode.type && oldDom._unmounted) {
 			oldDom = getDomSibling(parentVNode);
 		}
 		parentDom.insertBefore(parentVNode._dom, oldDom || null);

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -647,6 +647,7 @@ export function unmount(vnode, parentVNode, skipRemove) {
 		}
 	}
 
+	if (vnode._dom) vnode._dom._unmounted = true;
 	if (!skipRemove) {
 		removeNode(vnode._dom);
 	}

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -60,8 +60,7 @@ export type ComponentChild =
 	| undefined;
 export type ComponentChildren = ComponentChild[] | ComponentChild;
 
-export interface FunctionComponent<P = {}>
-	extends preact.FunctionComponent<P> {
+export interface FunctionComponent<P = {}> extends preact.FunctionComponent<P> {
 	// Internally, createContext uses `contextType` on a Function component to
 	// implement the Consumer component
 	contextType?: PreactContext;
@@ -121,6 +120,8 @@ export interface PreactElement extends preact.ContainerNode {
 	_children?: VNode<any> | null;
 	/** Event listeners to support event delegation */
 	_listeners?: Record<string, (e: Event) => void>;
+	/** A flag to indicate oldDOm searching when Fragment wrapped elements get unmounted. */
+	_unmounted?: boolean;
 }
 
 export interface PreactEvent extends Event {


### PR DESCRIPTION
I've considered `isConnected` however that isn't available in all browsers, the next big thing was to manage a flag ourselves. My main fear here becomes improv Suspense implementations that might do something similar to us where the DOM tree is stored but unmounted virtually.

We've long had issues with DOM-elements that are deeply wrapped with Fragments, when these are both reordered and unmounted we fail to bubble up this behaviour. We resorted to doing `parentDom.contains` to counter-act this. `parentDom.contains` is an expensive operation as it searches the DOM tree.

This PR explores a different approach where we store our own marker. Odd to see that this actually performs worse 😅 might be de-opting V8 due to that property not always being there.