### PR TITLE
chore: Correct some internal test types

### DIFF
--- a/compat/test/browser/PureComponent.test.js
+++ b/compat/test/browser/PureComponent.test.js
@@ -72,6 +72,7 @@ describe('PureComponent', () => {
 	it('should ignore the __source variable', () => {
 		const pureSpy = sinon.spy();
 		const appSpy = sinon.spy();
+		/** @type {(v) => void} */
 		let set;
 		class Pure extends React.PureComponent {
 			render() {

--- a/compat/test/browser/cloneElement.test.js
+++ b/compat/test/browser/cloneElement.test.js
@@ -80,6 +80,7 @@ describe('compat cloneElement', () => {
 
 	it('should skip cloning on invalid element', () => {
 		let element = { foo: 42 };
+		// @ts-expect-error
 		let clone = cloneElement(element);
 		expect(clone).to.eql(element);
 	});
@@ -89,7 +90,7 @@ describe('compat cloneElement', () => {
 			return <div>{props.value}</div>;
 		}
 
-		let clone = cloneElement(preactH(Foo), { value: 'foo' });
+		let clone = cloneElement(preactH(Foo, {}), { value: 'foo' });
 		render(clone, scratch);
 		expect(scratch.textContent).to.equal('foo');
 	});

--- a/compat/test/browser/componentDidCatch.test.js
+++ b/compat/test/browser/componentDidCatch.test.js
@@ -28,6 +28,7 @@ describe('componentDidCatch', () => {
 			}
 			render() {
 				if (this.state.error) return <div />;
+				// @ts-expect-error
 				if (this.state.i === 0) return <ThrowErr />;
 				return null;
 			}

--- a/compat/test/browser/createElement.test.js
+++ b/compat/test/browser/createElement.test.js
@@ -33,6 +33,7 @@ describe('compat createElement()', () => {
 	});
 
 	it('should not normalize text nodes', () => {
+		// @ts-expect-error
 		String.prototype.capFLetter = function () {
 			return this.charAt(0).toUpperCase() + this.slice(1);
 		};

--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -178,6 +178,7 @@ describe('forwardRef', () => {
 	});
 
 	it('should support useImperativeHandle', () => {
+		/** @type {(v) => void} */
 		let setValue;
 		const Foo = forwardRef((props, ref) => {
 			const result = useState('');

--- a/compat/test/browser/hooks.test.js
+++ b/compat/test/browser/hooks.test.js
@@ -62,6 +62,7 @@ describe('React-18-hooks', () => {
 		it('runs transitions', () => {
 			const spy = sinon.spy();
 
+			/** @type {(v) => void} */
 			let go;
 			const App = () => {
 				const [isPending, start] = useTransition();

--- a/compat/test/browser/isValidElement.test.js
+++ b/compat/test/browser/isValidElement.test.js
@@ -13,10 +13,10 @@ describe('isValidElement', () => {
 	});
 
 	it('should detect a preact vnode', () => {
-		expect(isValidElement(preactCreateElement('div'))).to.equal(true);
+		expect(isValidElement(preactCreateElement('div', {}))).to.equal(true);
 	});
 
 	it('should detect a compat vnode', () => {
-		expect(isValidElement(React.createElement('div'))).to.equal(true);
+		expect(isValidElement(React.createElement('div', {}))).to.equal(true);
 	});
 });

--- a/compat/test/browser/memo.test.js
+++ b/compat/test/browser/memo.test.js
@@ -46,6 +46,7 @@ describe('memo()', () => {
 
 		let Memoized = memo(Foo);
 
+		/** @type {() => void} */
 		let update;
 		class App extends Component {
 			constructor() {
@@ -78,6 +79,7 @@ describe('memo()', () => {
 
 		let Memoized = memo(Foo);
 
+		/** @type {(v) => void} */
 		let update;
 		class App extends Component {
 			constructor() {
@@ -111,6 +113,7 @@ describe('memo()', () => {
 		let spy = sinon.spy(() => true);
 		let Memoized = memo(Foo, spy);
 
+		/** @type {(v) => void} */
 		let update;
 		class App extends Component {
 			constructor() {

--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -46,6 +46,7 @@ describe('Portal', () => {
 	});
 
 	it('should insert the portal', () => {
+		/** @type {() => void} */
 		let setFalse;
 		function Foo(props) {
 			const [mounted, setMounted] = useState(true);
@@ -66,6 +67,7 @@ describe('Portal', () => {
 	});
 
 	it('should order portal children well', () => {
+		/** @type {() => void} */
 		let bump;
 
 		function Modal() {
@@ -95,6 +97,7 @@ describe('Portal', () => {
 	});
 
 	it('should toggle the portal', () => {
+		/** @type {() => void} */
 		let toggle;
 
 		function Foo(props) {
@@ -130,6 +133,7 @@ describe('Portal', () => {
 	});
 
 	it('should notice prop changes on the portal', () => {
+		/** @type {(c) => void} */
 		let set;
 
 		function Foo(props) {
@@ -155,6 +159,7 @@ describe('Portal', () => {
 
 	it('should not unmount the portal component', () => {
 		let spy = sinon.spy();
+		/** @type {(c) => void} */
 		let set;
 		class Child extends Component {
 			componentWillUnmount() {
@@ -230,7 +235,10 @@ describe('Portal', () => {
 	});
 
 	it('should leave a working root after the portal', () => {
-		let toggle, toggle2;
+		/** @type {() => void} */
+		let toggle,
+		/** @type {() => void} */
+		toggle2;
 
 		function Foo(props) {
 			const [mounted, setMounted] = useState(false);
@@ -279,7 +287,10 @@ describe('Portal', () => {
 	});
 
 	it('should work with stacking portals', () => {
-		let toggle, toggle2;
+		/** @type {() => void} */
+		let toggle,
+		/** @type {() => void} */
+		toggle2;
 
 		function Foo(props) {
 			const [mounted, setMounted] = useState(false);
@@ -327,6 +338,7 @@ describe('Portal', () => {
 	});
 
 	it('should work with changing the container', () => {
+		/** @type {(c) => void} */
 		let set, ref;
 
 		function Foo(props) {
@@ -363,7 +375,10 @@ describe('Portal', () => {
 	});
 
 	it('should work with replacing placeholder portals', () => {
-		let toggle, toggle2;
+		/** @type {() => void} */
+		let toggle,
+		/** @type {() => void} */
+		toggle2;
 
 		function Foo(props) {
 			const [mounted, setMounted] = useState(false);
@@ -409,6 +424,7 @@ describe('Portal', () => {
 	});
 
 	it('should work with removing an element from stacked container to new one', () => {
+		/** @type {() => void} */
 		let toggle, root2;
 
 		function Foo(props) {
@@ -445,7 +461,10 @@ describe('Portal', () => {
 	});
 
 	it('should support nested portals', () => {
-		let toggle, toggle2, inner;
+		/** @type {() => void} */
+		let toggle,
+		/** @type {() => void} */
+		toggle2, inner;
 
 		function Bar() {
 			const [mounted, setMounted] = useState(false);
@@ -598,6 +617,7 @@ describe('Portal', () => {
 	});
 
 	it('should switch between non portal and portal node (Modal as lastChild)', () => {
+		/** @type {() => void} */
 		let toggle;
 		const Modal = ({ children, open }) =>
 			open ? createPortal(<div>{children}</div>, scratch) : <div>Closed</div>;
@@ -627,6 +647,7 @@ describe('Portal', () => {
 	});
 
 	it('should switch between non portal and portal node (Modal as firstChild)', () => {
+		/** @type {() => void} */
 		let toggle;
 		const Modal = ({ children, open }) =>
 			open ? createPortal(<div>{children}</div>, scratch) : <div>Closed</div>;

--- a/compat/test/browser/suspense-list.test.js
+++ b/compat/test/browser/suspense-list.test.js
@@ -546,6 +546,7 @@ describe('suspense-list', () => {
 		const ComponentA = getSuspendableComponent('A');
 		const ComponentB = getSuspendableComponent('B');
 
+		/** @type {(v) => void} */
 		let showB;
 		function Container() {
 			const [showHidden, setShowHidden] = useState(false);

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -105,6 +105,7 @@ describe('suspense', () => {
 	});
 
 	it('should reset hooks of components', () => {
+		/** @type {(v) => void} */
 		let set;
 		const LazyComp = ({ name }) => <div>Hello from {name}</div>;
 
@@ -155,6 +156,7 @@ describe('suspense', () => {
 	});
 
 	it('should call effect cleanups', () => {
+		/** @type {(v) => void} */
 		let set;
 		const effectSpy = sinon.spy();
 		const layoutEffectSpy = sinon.spy();
@@ -1374,6 +1376,7 @@ describe('suspense', () => {
 	it('should un-suspend when suspender unmounts', () => {
 		const [Suspender, suspend] = createSuspender(() => <div>Suspender</div>);
 
+		/** @type {() => void} */
 		let hide;
 
 		class Conditional extends Component {
@@ -1427,6 +1430,7 @@ describe('suspense', () => {
 			<div>Suspender 2</div>
 		));
 
+		/** @type {() => void} */
 		let hide, resolve;
 
 		class Conditional extends Component {
@@ -1495,7 +1499,10 @@ describe('suspense', () => {
 			return <div>{`Lazy ${value}`}</div>;
 		}
 
-		let hide, setValue;
+		/** @type {() => void} */
+		let hide,
+		/** @type {(v) => void} */
+		setValue;
 
 		class Conditional extends Component {
 			constructor(props) {
@@ -1560,6 +1567,7 @@ describe('suspense', () => {
 	it('should allow resolve suspense promise after unmounts', async () => {
 		const [Suspender, suspend] = createSuspender(() => <div>Suspender</div>);
 
+		/** @type {() => void} */
 		let hide, resolve;
 
 		class Conditional extends Component {
@@ -1607,6 +1615,7 @@ describe('suspense', () => {
 	it('should support updating state while suspended', async () => {
 		const [Suspender, suspend] = createSuspender(() => <div>Suspender</div>);
 
+		/** @type {() => void} */
 		let increment;
 
 		class Updater extends Component {
@@ -1672,6 +1681,7 @@ describe('suspense', () => {
 
 		Suspender.prototype.componentWillUnmount = cWUSpy;
 
+		/** @type {() => void} */
 		let hide;
 
 		let suspender = null;
@@ -1767,6 +1777,7 @@ describe('suspense', () => {
 			}
 		}
 
+		/** @type {Suspender} */
 		let suspender;
 		class Suspender extends Component {
 			constructor(props) {
@@ -1893,6 +1904,7 @@ describe('suspense', () => {
 			return content;
 		}
 
+		/** @type {Component} */
 		let parent;
 		class Parent extends Component {
 			constructor(props) {

--- a/compat/test/browser/unstable_batchedUpdates.test.js
+++ b/compat/test/browser/unstable_batchedUpdates.test.js
@@ -9,6 +9,7 @@ describe('unstable_batchedUpdates', () => {
 
 	it('should call callback with only one arg', () => {
 		const spy = sinon.spy();
+		// @ts-expect-error
 		unstable_batchedUpdates(spy, 'foo', 'bar');
 		expect(spy).to.be.calledWithExactly('foo');
 	});

--- a/mangle.json
+++ b/mangle.json
@@ -37,7 +37,6 @@
       "$_args": "__H",
       "$_factory": "__h",
       "$_depth": "__b",
-      "$_nextDom": "__d",
       "$_dirty": "__d",
       "$_mask": "__m",
       "$_detachOnNextRender": "__b",

--- a/test/_util/helpers.js
+++ b/test/_util/helpers.js
@@ -210,14 +210,6 @@ export function clearOptions() {
 export function teardown(scratch) {
 	if (!document.contains(scratch)) return;
 
-	if (
-		scratch &&
-		('__k' in scratch || '_children' in scratch) &&
-		scratch._children
-	) {
-		verifyVNodeTree(scratch._children);
-	}
-
 	if (scratch) {
 		scratch.parentNode.removeChild(scratch);
 	}
@@ -234,21 +226,6 @@ export function teardown(scratch) {
 	}
 
 	restoreElementAttributes();
-}
-
-/** @type {(vnode: import('../../src/internal').VNode) => void} */
-function verifyVNodeTree(vnode) {
-	if (vnode._nextDom) {
-		expect.fail('vnode should not have _nextDom:' + vnode._nextDom);
-	}
-
-	if (vnode._children) {
-		for (let child of vnode._children) {
-			if (child) {
-				verifyVNodeTree(child);
-			}
-		}
-	}
 }
 
 const Foo = () => 'd';

--- a/test/_util/logCall.js
+++ b/test/_util/logCall.js
@@ -39,12 +39,12 @@ export function logCall(obj, method) {
 				if (args[1] === null && args.length === 2) {
 					operation = `${serialize(this)}.appendChild(${serialize(args[0])})`;
 				} else {
-					operation = `${serialize(this)}.${method}(${c})`;
+					operation = `${serialize(this)}.${String(method)}(${c})`;
 				}
 				break;
 			}
 			default: {
-				operation = `${serialize(this)}.${method}(${c})`;
+				operation = `${serialize(this)}.${String(method)}(${c})`;
 				break;
 			}
 		}

--- a/test/browser/createContext.test.js
+++ b/test/browser/createContext.test.js
@@ -24,7 +24,7 @@ describe('createContext', () => {
 	});
 
 	it('should pass context to a consumer', () => {
-		const { Provider, Consumer } = createContext();
+		const { Provider, Consumer } = createContext(null);
 		const CONTEXT = { a: 'a' };
 
 		let receivedContext;
@@ -62,7 +62,7 @@ describe('createContext', () => {
 	// we only propagate to children.
 	// Strict equal vnode optimization
 	it('skips referentially equal children to Provider', () => {
-		const { Provider, Consumer } = createContext();
+		const { Provider, Consumer } = createContext(null);
 		let set,
 			renders = 0;
 		const Layout = ({ children }) => {
@@ -95,7 +95,7 @@ describe('createContext', () => {
 	});
 
 	it('should preserve provider context through nesting providers', done => {
-		const { Provider, Consumer } = createContext();
+		const { Provider, Consumer } = createContext(null);
 		const CONTEXT = { a: 'a' };
 		const CHILD_CONTEXT = { b: 'b' };
 
@@ -151,8 +151,8 @@ describe('createContext', () => {
 
 	it('should preserve provider context between different providers', () => {
 		const { Provider: ThemeProvider, Consumer: ThemeConsumer } =
-			createContext();
-		const { Provider: DataProvider, Consumer: DataConsumer } = createContext();
+			createContext(null);
+		const { Provider: DataProvider, Consumer: DataConsumer } = createContext(null);
 		const THEME_CONTEXT = { theme: 'black' };
 		const DATA_CONTEXT = { global: 'a' };
 
@@ -203,7 +203,7 @@ describe('createContext', () => {
 	});
 
 	it('should preserve provider context through nesting consumers', () => {
-		const { Provider, Consumer } = createContext();
+		const { Provider, Consumer } = createContext(null);
 		const CONTEXT = { a: 'a' };
 
 		let receivedData;
@@ -244,7 +244,7 @@ describe('createContext', () => {
 	});
 
 	it('should not emit when value does not update', () => {
-		const { Provider, Consumer } = createContext();
+		const { Provider, Consumer } = createContext(null);
 		const CONTEXT = { a: 'a' };
 
 		class NoUpdate extends Component {
@@ -293,7 +293,7 @@ describe('createContext', () => {
 	});
 
 	it('should preserve provider context through nested components', () => {
-		const { Provider, Consumer } = createContext();
+		const { Provider, Consumer } = createContext(null);
 		const CONTEXT = { a: 'a' };
 
 		let receivedContext;
@@ -359,7 +359,7 @@ describe('createContext', () => {
 	});
 
 	it('should propagates through shouldComponentUpdate false', done => {
-		const { Provider, Consumer } = createContext();
+		const { Provider, Consumer } = createContext(null);
 		const CONTEXT = { a: 'a' };
 		const UPDATED_CONTEXT = { a: 'b' };
 
@@ -438,7 +438,7 @@ describe('createContext', () => {
 	});
 
 	it('should keep the right context at the right "depth"', () => {
-		const { Provider, Consumer } = createContext();
+		const { Provider, Consumer } = createContext(null);
 		const CONTEXT = { theme: 'a', global: 1 };
 		const NESTED_CONTEXT = { theme: 'b', global: 1 };
 
@@ -499,7 +499,7 @@ describe('createContext', () => {
 	});
 
 	it("should not re-render the consumer if the context doesn't change", () => {
-		const { Provider, Consumer } = createContext();
+		const { Provider, Consumer } = createContext(null);
 		const CONTEXT = { i: 1 };
 
 		class NoUpdate extends Component {
@@ -564,7 +564,7 @@ describe('createContext', () => {
 
 	it('should allow for updates of props', () => {
 		let app;
-		const { Provider, Consumer } = createContext();
+		const { Provider, Consumer } = createContext(null);
 		class App extends Component {
 			constructor(props) {
 				super(props);
@@ -609,7 +609,7 @@ describe('createContext', () => {
 	});
 
 	it('should re-render the consumer if the children change', () => {
-		const { Provider, Consumer } = createContext();
+		const { Provider, Consumer } = createContext(null);
 		const CONTEXT = { i: 1 };
 
 		class Inner extends Component {
@@ -814,7 +814,7 @@ describe('createContext', () => {
 		it('should order updates correctly', () => {
 			const events = [];
 			let update;
-			const Store = createContext();
+			const Store = createContext(null);
 
 			class Root extends Component {
 				constructor(props) {

--- a/test/browser/refs.test.js
+++ b/test/browser/refs.test.js
@@ -130,7 +130,9 @@ describe('refs', () => {
 		let outer = spy('outer'),
 			inner = spy('inner'),
 			InnermostComponent = 'span',
+			/** @type {() => void} */
 			update,
+			/** @type {Inner} */
 			inst;
 		class Outer extends Component {
 			constructor() {
@@ -194,6 +196,7 @@ describe('refs', () => {
 			innermost = spy('innermost'),
 			InnermostComponent = 'span',
 			outerInst,
+			/** @type {Inner} */
 			innerInst;
 		class Outer extends Component {
 			constructor() {
@@ -335,6 +338,7 @@ describe('refs', () => {
 	});
 
 	it('should null and re-invoke refs when swapping component root element type', () => {
+		/** @type {Child} */
 		let inst;
 
 		class App extends Component {
@@ -417,6 +421,7 @@ describe('refs', () => {
 
 	// Test for #1177
 	it('should call ref after children are rendered', done => {
+		/** @type {HTMLInputElement} */
 		let input;
 		function autoFocus(el) {
 			if (el) {
@@ -545,6 +550,7 @@ describe('refs', () => {
 	// Test for #4049
 	it('should first clean-up refs and after apply them', () => {
 		let calls = [];
+		/** @type {() => void} */
 		let set;
 		class App extends Component {
 			constructor(props) {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -426,6 +426,7 @@ describe('render()', () => {
 
 	// Test for #3969
 	it('should clear rowspan and colspan', () => {
+		/** @type {(v) => void} */
 		let update;
 		class App extends Component {
 			constructor(props) {
@@ -658,6 +659,7 @@ describe('render()', () => {
 		});
 
 		it('should apply proper mutation for VNodes with dangerouslySetInnerHTML attr', () => {
+			/** @type {Component} */
 			let thing;
 			class Thing extends Component {
 				constructor(props, context) {
@@ -709,6 +711,7 @@ describe('render()', () => {
 				}
 			}
 
+			/** @type {Component} */
 			let thing;
 			render(<Thing ref={r => (thing = r)} />, scratch);
 
@@ -721,6 +724,7 @@ describe('render()', () => {
 		});
 
 		it('should unmount dangerouslySetInnerHTML', () => {
+			/** @type {(v) => void} */
 			let set;
 
 			const TextDiv = () => (
@@ -831,7 +835,9 @@ describe('render()', () => {
 
 		let todoText = 'new todo that I should complete';
 		let input;
+		/** @type {(v) => void} */
 		let setText;
+		/** @type {(v) => void} */
 		let addTodo;
 
 		const ENTER = 13;
@@ -1013,6 +1019,7 @@ describe('render()', () => {
 
 	it('should not re-render when a component returns undefined', () => {
 		let Dialog = () => undefined;
+		/** @type {() => void} */
 		let updateState;
 		class App extends Component {
 			constructor(props) {
@@ -1043,6 +1050,7 @@ describe('render()', () => {
 
 	it('should not lead to stale DOM nodes', () => {
 		let i = 0;
+		/** @type {() => void} */
 		let updateApp;
 		class App extends Component {
 			render() {
@@ -1051,6 +1059,7 @@ describe('render()', () => {
 			}
 		}
 
+		/** @type {() => void} */
 		let updateParent;
 		function Parent() {
 			updateParent = () => this.forceUpdate();
@@ -1097,6 +1106,7 @@ describe('render()', () => {
 		}
 
 		let ref;
+		/** @type {() => void} */
 		let updateApp;
 		class App extends Component {
 			constructor() {
@@ -1130,6 +1140,7 @@ describe('render()', () => {
 	});
 
 	it('should not remove iframe', () => {
+		/** @type {(v) => void} */
 		let setState;
 		const Iframe = () => {
 			// oxlint-disable-next-line iframe-missing-sandbox
@@ -1199,6 +1210,7 @@ describe('render()', () => {
 	});
 
 	it('should not call options.debounceRendering unnecessarily', () => {
+		/** @type {A} */
 		let comp;
 
 		class A extends Component {
@@ -1371,6 +1383,7 @@ describe('render()', () => {
 	it('should not crash or repeatedly add the same child when replacing a matched vnode with null', () => {
 		const B = () => <div>B</div>;
 
+		/** @type {() => void} */
 		let update;
 		class App extends Component {
 			constructor(props) {

--- a/test/browser/spec.test.js
+++ b/test/browser/spec.test.js
@@ -37,6 +37,7 @@ describe('Component spec', () => {
 		});
 
 		it('should apply default props on rerender', () => {
+			/** @type {() => void} */
 			let doRender;
 			class Outer extends Component {
 				constructor() {
@@ -100,6 +101,7 @@ describe('Component spec', () => {
 
 	describe('forceUpdate', () => {
 		it('should force a rerender', () => {
+			/** @type {() => void} */
 			let forceUpdate;
 			class ForceUpdateComponent extends Component {
 				componentWillUpdate() {}
@@ -125,6 +127,7 @@ describe('Component spec', () => {
 		});
 
 		it('should add callback to renderCallbacks', () => {
+			/** @type {() => void} */
 			let forceUpdate;
 			let callback = sinon.spy();
 			class ForceUpdateComponent extends Component {

--- a/test/extensions.d.ts
+++ b/test/extensions.d.ts
@@ -2,11 +2,17 @@ declare global {
 	namespace Chai {
 		interface Assertion {
 			equalNode(node: Node | null, message?: string): void;
+			callCount(count: number): Assertion;
 			called: Assertion;
 			calledOnce: Assertion;
+			calledOnceWith(...args: any[]): Assertion;
 			calledTwice: Assertion;
+			calledThrice: Assertion;
 			calledWith(...args: any[]): Assertion;
+			calledWithExactly(...args: any[]): Assertion;
 			calledWithMatch(...args: Record<string, unknown>[]): Assertion;
+			calledBefore(spy: Sinon.SinonSpy): Assertion;
+			returned(value: any): Assertion;
 		}
 	}
 	var expect: Chai.ExpectStatic;

--- a/test/shared/createElement.test.js
+++ b/test/shared/createElement.test.js
@@ -15,7 +15,7 @@ const h = createElement;
 describe('createElement(jsx)', () => {
 	it('should return a VNode', () => {
 		let r;
-		expect(() => (r = h('foo'))).not.to.throw();
+		expect(() => (r = h('foo', null))).not.to.throw();
 		expect(r).to.be.an('object');
 		// expect(r).to.be.an.instanceof(VNode);
 		expect(r).to.have.property('type', 'foo');
@@ -83,8 +83,8 @@ describe('createElement(jsx)', () => {
 	});
 
 	it('should support element children', () => {
-		let kid1 = h('bar');
-		let kid2 = h('baz');
+		let kid1 = h('bar', null);
+		let kid2 = h('baz', null);
 		let r = h('foo', null, kid1, kid2);
 
 		expect(r)
@@ -93,8 +93,8 @@ describe('createElement(jsx)', () => {
 	});
 
 	it('should support multiple element children, given as arg list', () => {
-		let kid1 = h('bar');
-		let kid3 = h('test');
+		let kid1 = h('bar', null);
+		let kid3 = h('test', null);
 		let kid2 = h('baz', null, kid3);
 
 		let r = h('foo', null, kid1, kid2);
@@ -105,8 +105,8 @@ describe('createElement(jsx)', () => {
 	});
 
 	it('should handle multiple element children, given as an array', () => {
-		let kid1 = h('bar');
-		let kid3 = h('test');
+		let kid1 = h('bar', null);
+		let kid3 = h('test', null);
 		let kid2 = h('baz', null, kid3);
 
 		let r = h('foo', null, [kid1, kid2]);
@@ -118,7 +118,7 @@ describe('createElement(jsx)', () => {
 
 	it('should support nested children', () => {
 		const m = x => {
-			const result = h(x);
+			const result = h(x, null);
 			delete result._original;
 			return result;
 		};
@@ -175,12 +175,12 @@ describe('createElement(jsx)', () => {
 	});
 
 	it('should NOT merge adjacent text children', () => {
-		const bar = h('bar');
-		const barClone = h('bar');
-		const baz = h('baz');
-		const bazClone = h('baz');
-		const baz2 = h('baz');
-		const baz2Clone = h('baz');
+		const bar = h('bar', null);
+		const barClone = h('bar', null);
+		const baz = h('baz', null);
+		const bazClone = h('baz', null);
+		const baz2 = h('baz', null);
+		const baz2Clone = h('baz', null);
 
 		delete bar._original;
 		delete barClone._original;
@@ -268,7 +268,7 @@ describe('createElement(jsx)', () => {
 	it('should respect defaultProps', () => {
 		const Component = ({ children }) => children;
 		Component.defaultProps = { foo: 'bar' };
-		expect(h(Component).props).to.deep.equal({ foo: 'bar' });
+		expect(h(Component, null).props).to.deep.equal({ foo: 'bar' });
 	});
 
 	it('should override defaultProps', () => {


### PR DESCRIPTION
In a (perhaps futile) desire to reduce the number of files that light up my editor like a Christmas tree, this PR tries to correct a couple hundred or so of our type errors. Switching [this line](https://github.com/preactjs/preact/blob/42524db0382b398da63a22c8a07ed487f9ca3137/package.json#L145) over to just `jsconfig.json` produces 1501 TS errors, which this PR brings down to 1292. Only corrects a small fraction of the type errors, and mostly the quick ones at that, but it's a chunk I suppose.

The only non-comment/type changes should be in adding an initial param to `createContext()` calls & passing `{}`/`null` to `h()`/`createElement()`.