### PR TITLE
Add missing space in hydration mismatch message

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -589,6 +589,6 @@ options._hydrationMismatch = (newVNode, excessDomChildren) => {
 		.map(child => child && child.localName)
 		.filter(Boolean);
 	console.error(
-		`Expected a DOM node of type ${type} but found ${availableTypes.join(', ')}as available DOM-node(s), this is caused by the SSR'd HTML containing different DOM-nodes compared to the hydrated one.\n\n${getOwnerStack(newVNode)}`
+		`Expected a DOM node of type ${type} but found ${availableTypes.join(', ')} as available DOM-node(s), this is caused by the SSR'd HTML containing different DOM-nodes compared to the hydrated one.\n\n${getOwnerStack(newVNode)}`
 	);
 };


### PR DESCRIPTION
The message reads something like this:

> Expected a DOM node of type p but found templateas available DOM-node(s), this is caused by the SSR'd HTML containing different DOM-nodes compared to the hydrated one.

It should read

> Expected a DOM node of type p but found template as available DOM-node(s), this is caused by the SSR'd HTML containing different DOM-nodes compared to the hydrated one.

"templateas" should be "template as"

```diff
-Expected a DOM node of type p but found templateas available DOM-node(s), this is caused by the SSR'd HTML containing different DOM-nodes compared to the hydrated one.
+Expected a DOM node of type p but found template as available DOM-node(s), this is caused by the SSR'd HTML containing different DOM-nodes compared to the hydrated one.
```