### PR TITLE
fix: Wrap hydration debug message node types in quotes

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -589,6 +589,6 @@ options._hydrationMismatch = (newVNode, excessDomChildren) => {
 		.map(child => child && child.localName)
 		.filter(Boolean);
 	console.error(
-		`Expected a DOM node of type ${type} but found ${availableTypes.join(', ')} as available DOM-node(s), this is caused by the SSR'd HTML containing different DOM-nodes compared to the hydrated one.\n\n${getOwnerStack(newVNode)}`
+		`Expected a DOM node of type "${type}" but found "${availableTypes.join(', ')}" as available DOM-node(s), this is caused by the SSR'd HTML containing different DOM-nodes compared to the hydrated one.\n\n${getOwnerStack(newVNode)}`
 	);
 };

--- a/debug/test/browser/debug.test.js
+++ b/debug/test/browser/debug.test.js
@@ -889,7 +889,7 @@ describe('debug', () => {
 			hydrate(<App />, scratch);
 			expect(console.error).to.be.calledOnce;
 			expect(console.error).to.be.calledOnceWith(
-				sinon.match(/Expected a DOM node of type p but found span/)
+				sinon.match(/Expected a DOM node of type "p" but found "span"/)
 			);
 		});
 


### PR DESCRIPTION
Re: https://github.com/preactjs/preact/issues/4065#issuecomment-2543047077

> Expected a DOM node of type color-mixer but found as available DOM-node(s)

This is a pretty rough error message to decipher, some wrapping quotes should help.

---

Doing away with empty text nodes by default (as mentioned on slack) would certainly help too, but I do think the quotes are always useful for determining exactly what is being referred to. For example, if an `<a>` is replaced by a `<p>`:

> Expected a DOM node of type p but found a as available DOM-node(s)

My first instinct would be a word is missing there, not that it's referring to an anchor tag, personally.

> Expected a DOM node of type "p" but found "a" as available DOM-node(s)

Much better, IMO