### PR TITLE
refactor: Remove `generic` aria role from types

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1067,7 +1067,6 @@ export namespace JSXInternal {
 		| 'feed'
 		| 'figure'
 		| 'form'
-		| 'generic'
 		| 'grid'
 		| 'gridcell'
 		| 'group'

--- a/test/ts/dom-attributes-test.tsx
+++ b/test/ts/dom-attributes-test.tsx
@@ -34,6 +34,10 @@ const signalValidAriaValues2 = (
 );
 
 const validRole = <div role="button" />;
+// @ts-expect-error We should correctly type aria roles
+const invalidRole = <div role="invalid-role" />;
+// @ts-expect-error We should disallow `generic` as it should not ever be explicitly set
+const invalidRole2 = <div role="generic" />;
 const fallbackRole = <div role="none presentation" />;
 
 const booleanishTest = (


### PR DESCRIPTION
[Spec](https://www.w3.org/TR/html-aria/#adhere-to-the-rules-of-aria)

> ARIA also defines a [generic role](https://www.w3.org/TR/wai-aria-1.2/#generic) which is meant to provide feature parity with a number of HTML elements that do not have more specific ARIA semantics of their own. For instance, HTML's [div](https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element) and [span](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element) elements, among others. ARIA discourages authors from using the generic role as its intended purpose is for use by implementors of user agents.
>
> In the following example, rather than using a generic role, authors are advised to use a div in place of the article element. If changing the HTML element is not possible, specifying a role of presentation or none would be acceptable alternaties to remove the implicit role of the article.
> 
>[Example 9](https://www.w3.org/TR/html-aria/#example-do-not-specify-elements-as-generic): Do not specify elements as generic
>
> ```html
> <!-- Avoid doing this! -->
> <article role="generic" ...>...</article>
> ```

The language used is pretty weak, ("SHOULD NOT" rather than "MUST NOT"), but the intention is clearly that the `generic` role is only meant for implicit use by user agents, not end users.

I've been searching over the past few days and have yet to find a single situation in which `role="generic"` adds any improvement and is recommended over the alternatives (like `'presentation'`) but haven't come up with anything. Therefore, I think removal is correct & an improvement to our types. Technically a valid string value but there's no reason why someone should ever set it.