### PR TITLE
fix: support multiple synchronous timings for act

### DIFF
--- a/test-utils/src/index.js
+++ b/test-utils/src/index.js
@@ -57,19 +57,19 @@ export function act(cb) {
 	const rerender = setupRerender();
 
 	/** @type {() => void} */
-	let flush, toFlush;
+	let flushes = [], toFlush;
 
 	// Override requestAnimationFrame so we can flush pending hooks.
-	options.requestAnimationFrame = fc => (flush = fc);
+	options.requestAnimationFrame = fc => flushes.push(fc);
 
 	const finish = () => {
 		try {
 			rerender();
-			while (flush) {
-				toFlush = flush;
-				flush = null;
+			while (flushes.length) {
+				toFlush = flushes;
+				flushes = [];
 
-				toFlush();
+				toFlush.forEach(x => x());
 				rerender();
 			}
 		} catch (e) {

--- a/test-utils/test/shared/act.test.js
+++ b/test-utils/test/shared/act.test.js
@@ -518,9 +518,7 @@ describe('act', () => {
 	});
 
 	describe('act function with finish implementations', () => {
-		let actDepth = 0;
 		beforeEach(function () {
-			actDepth = 0;
 			options.requestAnimationFrame = null;
 		});
 

--- a/test-utils/test/shared/act.test.js
+++ b/test-utils/test/shared/act.test.js
@@ -517,26 +517,26 @@ describe('act', () => {
 		});
 	});
 
-	describe('act function with finish implementations', function () {
+	describe('act function with finish implementations', () => {
 		let actDepth = 0;
 		beforeEach(function () {
-			actDepth = 0; // Reset actDepth before each test
-			options.requestAnimationFrame = null; // Reset before each test
+			actDepth = 0;
+			options.requestAnimationFrame = null;
 		});
 
-		it('should execute the flush callback using single flush', function () {
+		it('should execute the flush callback using single flush', () => {
 			let called = false;
 
 			act(() => {
 				options.requestAnimationFrame(() => {
-					called = true; // This should be called
+					called = true;
 				});
 			});
 
-			expect(called).to.be.true; // Verify the callback was executed
+			expect(called).to.be.true;
 		});
 
-		it.only('should execute all callbacks using array flush', function () {
+		it.only('should execute all callbacks using array flush', () => {
 			let callCount = 0;
 
 			act(() => {
@@ -545,10 +545,10 @@ describe('act', () => {
 				options.requestAnimationFrame(() => callCount++);
 			});
 
-			expect(callCount).to.equal(3); // Verify all callbacks were executed
+			expect(callCount).to.equal(3);
 		});
 
-		it('should handle errors in single flush', function () {
+		it('should handle errors in single flush', () => {
 			expect(() => {
 				act(() => {
 					options.requestAnimationFrame(() => {
@@ -558,7 +558,7 @@ describe('act', () => {
 			}).to.throw('Single flush error');
 		});
 
-		it('should handle errors in array flush', function () {
+		it('should handle errors in array flush', () => {
 			expect(() => {
 				act(() => {
 					options.requestAnimationFrame(() => {

--- a/test-utils/test/shared/act.test.js
+++ b/test-utils/test/shared/act.test.js
@@ -536,7 +536,7 @@ describe('act', () => {
 			expect(called).to.be.true;
 		});
 
-		it.only('should execute all callbacks using array flush', () => {
+		it('should execute all callbacks using array flush', () => {
 			let callCount = 0;
 
 			act(() => {

--- a/test-utils/test/shared/act.test.js
+++ b/test-utils/test/shared/act.test.js
@@ -516,4 +516,56 @@ describe('act', () => {
 			});
 		});
 	});
+
+	describe('act function with finish implementations', function () {
+		let actDepth = 0;
+		beforeEach(function () {
+			actDepth = 0; // Reset actDepth before each test
+			options.requestAnimationFrame = null; // Reset before each test
+		});
+
+		it('should execute the flush callback using single flush', function () {
+			let called = false;
+
+			act(() => {
+				options.requestAnimationFrame(() => {
+					called = true; // This should be called
+				});
+			});
+
+			expect(called).to.be.true; // Verify the callback was executed
+		});
+
+		it.only('should execute all callbacks using array flush', function () {
+			let callCount = 0;
+
+			act(() => {
+				options.requestAnimationFrame(() => callCount++);
+				options.requestAnimationFrame(() => callCount++);
+				options.requestAnimationFrame(() => callCount++);
+			});
+
+			expect(callCount).to.equal(3); // Verify all callbacks were executed
+		});
+
+		it('should handle errors in single flush', function () {
+			expect(() => {
+				act(() => {
+					options.requestAnimationFrame(() => {
+						throw new Error('Single flush error');
+					});
+				});
+			}).to.throw('Single flush error');
+		});
+
+		it('should handle errors in array flush', function () {
+			expect(() => {
+				act(() => {
+					options.requestAnimationFrame(() => {
+						throw new Error('Array flush error');
+					});
+				});
+			}).to.throw('Array flush error');
+		});
+	});
 });


### PR DESCRIPTION
### What this PR do?

As we talked [here](https://github.com/preactjs/signals/issues/633#issuecomment-2561724827)
There is a issue:
it just looks like the signal-effect update never gets flushed when there's a child depending on the signal, this might be because we first initiate a [rerender in act](https://github.com/preactjs/preact/blob/main/test-utils/src/index.js#L67) which will queue up the useEffect and potentially override the scheduled one from the signal-effect. 