### PR TITLE
Adds support for react 19

### DIFF
--- a/compat/package.json
+++ b/compat/package.json
@@ -34,6 +34,10 @@
       "import": "./server.mjs",
       "require": "./server.js"
     },
+    "./react-19": {
+      "import": "./react-19.mjs",
+      "require": "./react-19.js"
+    },
     "./jsx-runtime": {
       "import": "./jsx-runtime.mjs",
       "require": "./jsx-runtime.js"

--- a/compat/react-19.js
+++ b/compat/react-19.js
@@ -1,0 +1,12 @@
+require('preact/compat');
+
+const { options } = require('preact');
+
+const oldVNode = options.vnode;
+options.vnode = vnode => {
+	if (typeof vnode.type === 'function') {
+		vnode.type._forwarded = true;
+	}
+
+	if (oldVNode) oldVNode(vnode);
+};

--- a/compat/react-19.mjs
+++ b/compat/react-19.mjs
@@ -1,0 +1,12 @@
+import 'preact/compat';
+
+import { options } from 'preact';
+
+const oldVNode = options.vnode;
+options.vnode = vnode => {
+	if (typeof vnode.type === 'function') {
+		vnode.type._forwarded = true;
+	}
+
+	if (oldVNode) oldVNode(vnode);
+};

--- a/package.json
+++ b/package.json
@@ -171,6 +171,8 @@
     "compat/test-utils.js",
     "compat/jsx-runtime.js",
     "compat/jsx-runtime.mjs",
+    "compat/react-19.js",
+    "compat/react-19.mjs",
     "compat/jsx-dev-runtime.js",
     "compat/jsx-dev-runtime.mjs",
     "compat/package.json",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,11 @@
       "import": "./compat/jsx-runtime.mjs",
       "require": "./compat/jsx-runtime.js"
     },
+    "./compat/react-19": {
+      "types": "./compat/src/index.d.ts",
+      "import": "./compat/react-19.mjs",
+      "require": "./compat/react-19.js"
+    },
     "./compat/jsx-dev-runtime": {
       "types": "./jsx-runtime/src/index.d.ts",
       "import": "./compat/jsx-dev-runtime.mjs",


### PR DESCRIPTION
Forwarding refs by default would be a breaking change so I've opted to add an additional entrypoint where we can export relevant pieces. This uses the existing `_forwarded` property to move the ref from the `vnode` back to `props`, if the user opts to leverage `forwardRef` all we'll do is move it to the second argument.

Alongside [Context as component](https://github.com/preactjs/preact/pull/4618) and our existing ref cleanup functions. We are only missing the newly added `use` and `useActionState` hooks for React 19 support, which could be exported from the new entrypoint without causing inflated bundles. In a future major version we can cut back on exports though, `SuspenseList` and others are basically scrapped from React.

Relates to https://github.com/preactjs/preact/issues/4613
Relates to https://github.com/preactjs/preact/pull/4618