### PR TITLE
Add hasScuFromHooks to mangle

### DIFF
--- a/mangle.json
+++ b/mangle.json
@@ -25,6 +25,7 @@
   "props": {
     "cname": 6,
     "props": {
+      "$__hasScuFromHooks": "__f",
       "$_listeners": "l",
       "$_cleanup": "__c",
       "$__hooks": "__H",


### PR DESCRIPTION
I've been hammering on a good way to allow for us to check the version of Preact in signals, however there hasn't really been a good one. I've come to terms with just checking whether we have `_scuFromHooks` so we can ship https://github.com/preactjs/signals/pull/630.

The main reason why checking this is enough is that 10.12 - 10.24 would not benefit from sCU in signals being wiser either way. This because we weren't calling it either way, that got fixed in 10.25.0 by https://github.com/preactjs/preact/pull/4560.

This PR will allow us to check `this.__f` and when it's present in the sCU we know that we are dealing with a state settled update so we can avoid use the check introduced in https://github.com/preactjs/signals/pull/630 and when we don't have this we'll leverage the old code path.