### PR TITLE
chore: Fix mocha in Node v22+

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "10.26.0",
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
+  "type": "commonjs",
   "main": "dist/preact.js",
   "module": "dist/preact.module.js",
   "umd:main": "dist/preact.umd.js",


### PR DESCRIPTION
Just quick fix (that we don't need quite yet) as I noticed it.

[Mocha seemingly requires an explicit `"type": "commonjs"` as of Node 22+](https://github.com/mochajs/mocha-examples/issues/103), perhaps because of the new `require(esm)` that landed? Not quite sure.

This fixes it, in lieu of Mocha fixing something upstream (which they very well might do yet).