### PR TITLE
fix: `ComponentProps` type

### DIFF
--- a/src/index-5.d.ts
+++ b/src/index-5.d.ts
@@ -84,7 +84,7 @@ export type ComponentProps<
 	? P
 	: C extends keyof JSXInternal.IntrinsicElements
 		? JSXInternal.IntrinsicElements[C]
-		: never;
+		: {};
 
 export interface FunctionComponent<P = {}> {
 	(props: RenderableProps<P>, context?: any): VNode | null;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -84,7 +84,7 @@ export type ComponentProps<
 	? P
 	: C extends keyof JSXInternal.IntrinsicElements
 		? JSXInternal.IntrinsicElements[C]
-		: never;
+		: {};
 
 export interface FunctionComponent<P = {}> {
 	(props: RenderableProps<P>, context?: any): ComponentChildren;


### PR DESCRIPTION
Closes #4633

Looks like this was a mistake in #2461, React's types have always used `{}` here: [v19](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/42bb005b680604130d4ae72b949d9fdbe8935fe1/types/react/index.d.ts#L1426) & [v16](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/42bb005b680604130d4ae72b949d9fdbe8935fe1/types/react/v16/index.d.ts#L839).

The related issue isn't quite correct, this isn't a regression in 10.19.4; instead, prior to that release, we were missing types that meant `@react-spring/web` couldn't form a correct type. `"skipLibCheck"` hides this well of course.