### PR TITLE
Comment denoted hydration

### DIFF
--- a/compat/test/browser/component.test.js
+++ b/compat/test/browser/component.test.js
@@ -1,6 +1,6 @@
 import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import React, { createElement, Component } from 'preact/compat';
+import React, { createElement } from 'preact/compat';
 
 describe('components', () => {
 	/** @type {HTMLDivElement} */

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -130,15 +130,6 @@ export function diffChildren(
 			oldDom = insert(childVNode, oldDom, parentDom);
 		} else if (typeof childVNode.type == 'function' && result !== UNDEFINED) {
 			oldDom = result;
-			let toResolve = 0;
-			while ((oldDom && oldDom.nodeType == 8) || toResolve > 0) {
-				if (oldDom && oldDom.nodeType == 8 && oldDom.data == '$s') {
-					toResolve++;
-				} else if (oldDom && oldDom.nodeType == 8 && oldDom.data == '/$s') {
-					toResolve--;
-				}
-				oldDom = oldDom.nextSibling;
-			}
 		} else if (newDom) {
 			oldDom = newDom.nextSibling;
 		}

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -130,6 +130,15 @@ export function diffChildren(
 			oldDom = insert(childVNode, oldDom, parentDom);
 		} else if (typeof childVNode.type == 'function' && result !== UNDEFINED) {
 			oldDom = result;
+			let toResolve = 0;
+			while ((oldDom && oldDom.nodeType == 8) || toResolve > 0) {
+				if (oldDom && oldDom.nodeType == 8 && oldDom.data == '$s') {
+					toResolve++;
+				} else if (oldDom && oldDom.nodeType == 8 && oldDom.data == '/$s') {
+					toResolve--;
+				}
+				oldDom = oldDom.nextSibling;
+			}
 		} else if (newDom) {
 			oldDom = newDom.nextSibling;
 		}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -321,6 +321,7 @@ export function diff(
 								newVNode._component._excess.push(child);
 							}
 							done = commentMarkersToFind === 0;
+							oldDom = excessDomChildren[i];
 							excessDomChildren[i] = null;
 						} else if (commentMarkersToFind > 0) {
 							newVNode._component._excess.push(child);

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -68,8 +68,8 @@ export function diff(
 	// If the previous diff bailed out, resume creating/hydrating.
 	if (oldVNode._flags & MODE_SUSPENDED) {
 		isHydrating = !!(oldVNode._flags & MODE_HYDRATE);
-		oldDom = newVNode._dom = oldVNode._dom;
-		excessDomChildren = [oldDom];
+		excessDomChildren = oldVNode._component._excess;
+		oldDom = newVNode._dom = oldVNode._dom = excessDomChildren[0];
 	}
 
 	if ((tmp = options._diff)) tmp(newVNode);
@@ -288,15 +288,55 @@ export function diff(
 			// if hydrating or creating initial tree, bailout preserves DOM:
 			if (isHydrating || excessDomChildren != null) {
 				if (e.then) {
+					let shouldFallback = true,
+						commentMarkersToFind = 0,
+						done = false;
+
 					newVNode._flags |= isHydrating
 						? MODE_HYDRATE | MODE_SUSPENDED
 						: MODE_SUSPENDED;
 
-					while (oldDom && oldDom.nodeType == 8 && oldDom.nextSibling) {
-						oldDom = oldDom.nextSibling;
+					newVNode._component._excess = [];
+					for (let i = 0; i < excessDomChildren.length; i++) {
+						let child = excessDomChildren[i];
+						if (child == null || done) continue;
+
+						// When we encounter a boundary with $s we are opening
+						// a boundary, this implies that we need to bump
+						// the amount of markers we need to find before closing
+						// the outer boundary.
+						// We exclude the open and closing marker from
+						// the future excessDomChildren but any nested one
+						// needs to be included for future suspensions.
+						if (child.nodeType == 8 && child.data == '$s') {
+							if (commentMarkersToFind > 0) {
+								newVNode._component._excess.push(child);
+							}
+							commentMarkersToFind++;
+							shouldFallback = false;
+							excessDomChildren[i] = null;
+						} else if (child.nodeType == 8 && child.data == '/$s') {
+							commentMarkersToFind--;
+							if (commentMarkersToFind > 0) {
+								newVNode._component._excess.push(child);
+							}
+							done = commentMarkersToFind === 0;
+							excessDomChildren[i] = null;
+						} else if (commentMarkersToFind > 0) {
+							newVNode._component._excess.push(child);
+							excessDomChildren[i] = null;
+						}
 					}
 
-					excessDomChildren[excessDomChildren.indexOf(oldDom)] = null;
+					if (shouldFallback) {
+						while (oldDom && oldDom.nodeType == 8 && oldDom.nextSibling) {
+							oldDom = oldDom.nextSibling;
+						}
+
+						excessDomChildren[excessDomChildren.indexOf(oldDom)] = null;
+						newVNode._component._excess.push(oldDom);
+					}
+
 					newVNode._dom = oldDom;
 				} else {
 					for (let i = excessDomChildren.length; i--; ) {

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -162,6 +162,7 @@ export interface Component<P = {}, S = {}> extends preact.Component<P, S> {
 	constructor: ComponentType<P>;
 	state: S; // Override Component["state"] to not be readonly for internal use, specifically Hooks
 
+	_excess?: PreactElement[];
 	_dirty: boolean;
 	_force?: boolean;
 	_renderCallbacks: Array<() => void>; // Only class components


### PR DESCRIPTION
Relates to https://github.com/preactjs/preact/issues/4442
Implementation from https://github.com/preactjs/preact-render-to-string/pull/376
Supersedes https://github.com/preactjs/preact/pull/4444

This implements a hydration approach with the comment markers, one thing that's noteworthy is that `oldDom` in our `diffChildren` algorithm becomes stale.

We diff the wrapping element of the Suspense and non-suspenseful child, we get to an oldDom which is the first child-node of said series. When we suspend we don't move oldDom, we can try and move it inside of `diff` but this won't affect the continued `diffChildren` so we are stuck inserting that node in front of our oldDom.

This has been solved in https://github.com/preactjs/preact/pull/4444/commits/647d13865b3c9730f17f8ce68644145925a226d7 through correctly skipping comment nodes while placing children.

I think the last part of this research would be to set up a comprehensive test suite for both `renderToStringAsync` as well as `renderToStream` so we can have fixtures for this behaviour, what do you all think?