### PR TITLE
docs: Update http:// links to https://

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@
 <tr>
 <td>
 
-[![npm](https://img.shields.io/npm/v/preact.svg)](http://npm.im/preact)
+[![npm](https://img.shields.io/npm/v/preact.svg)](https://www.npmjs.com/package/preact)
 [![Preact Slack Community](https://img.shields.io/badge/Slack%20Community-preact.slack.com-blue)](https://chat.preactjs.com)
 [![OpenCollective Backers](https://opencollective.com/preact/backers/badge.svg)](#backers)
 [![OpenCollective Sponsors](https://opencollective.com/preact/sponsors/badge.svg)](#sponsors)
 
 [![coveralls](https://img.shields.io/coveralls/preactjs/preact/main.svg)](https://coveralls.io/github/preactjs/preact)
-[![gzip size](http://img.badgesize.io/https://unpkg.com/preact/dist/preact.min.js?compression=gzip&label=gzip)](https://unpkg.com/preact/dist/preact.min.js)
-[![brotli size](http://img.badgesize.io/https://unpkg.com/preact/dist/preact.min.js?compression=brotli&label=brotli)](https://unpkg.com/preact/dist/preact.min.js)
+[![gzip size](https://img.badgesize.io/https://unpkg.com/preact/dist/preact.min.js?compression=gzip&label=gzip)](https://unpkg.com/preact/dist/preact.min.js)
+[![brotli size](https://img.badgesize.io/https://unpkg.com/preact/dist/preact.min.js?compression=brotli&label=brotli)](https://unpkg.com/preact/dist/preact.min.js)
 
 </td>
 </tr>

--- a/src/component.js
+++ b/src/component.js
@@ -74,7 +74,7 @@ BaseComponent.prototype.forceUpdate = function (callback) {
 
 /**
  * Accepts `props` and `state`, and returns a new Virtual DOM tree to build.
- * Virtual DOM is generally constructed via [JSX](http://jasonformat.com/wtf-is-jsx).
+ * Virtual DOM is generally constructed via [JSX](https://jasonformat.com/wtf-is-jsx).
  * @param {object} props Props (eg: JSX attributes) received from parent
  * element/component
  * @param {object} state The component's current state


### PR DESCRIPTION
This pull request updates http:// links in the README.md and component.js to point to their https:// counterparts. The npm badge link from README.md now points directly to npmjs.com.