### PR TITLE
Support the template tag

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -525,7 +525,7 @@ function diffElementNodes(
 			if (oldHtml) dom.innerHTML = '';
 
 			diffChildren(
-				dom,
+				newVNode.type === 'template' && dom.content ? dom.content : dom,
 				isArray(newChildren) ? newChildren : [newChildren],
 				newVNode,
 				oldVNode,

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -525,7 +525,8 @@ function diffElementNodes(
 			if (oldHtml) dom.innerHTML = '';
 
 			diffChildren(
-				newVNode.type === 'template' && dom.content ? dom.content : dom,
+				// @ts-expect-error
+				newVNode.type === 'template' && 'content' in dom ? dom.content : dom,
 				isArray(newChildren) ? newChildren : [newChildren],
 				newVNode,
 				oldVNode,

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -526,7 +526,7 @@ function diffElementNodes(
 
 			diffChildren(
 				// @ts-expect-error
-				newVNode.type === 'template' && 'content' in dom ? dom.content : dom,
+				newVNode.type === 'template' ? dom.content : dom,
 				isArray(newChildren) ? newChildren : [newChildren],
 				newVNode,
 				oldVNode,

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -95,18 +95,15 @@ describe('render()', () => {
 	it('should support the <template> tag', () => {
 		function App() {
 			return (
-				<div>
-					<template>
-						<h2>this should show up</h2>
-					</template>
-				</div>
+				<template>
+					<h1>it works</h1>
+				</template>
 			);
 		}
 
 		render(<App />, scratch);
-		expect(scratch.firstChild.firstChild.content.firstChild.outerHTML).to.eql(
-			`<h2>this should show up</h2>`
-		);
+		const clone = scratch.firstChild.content.cloneNode(true);
+		expect(clone.firstChild.outerHTML).to.eql('<h1>it works</h1>');
 	});
 
 	it('should not render when detecting JSON-injection', () => {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -92,7 +92,7 @@ describe('render()', () => {
 		});
 	}
 
-	it('should support the <template> tag', () => {
+	it.only('should support the <template> tag', () => {
 		function App() {
 			return (
 				<div>
@@ -104,7 +104,9 @@ describe('render()', () => {
 		}
 
 		render(<App />, scratch);
-		console.log(scratch.firstChild.firstChild.content.innerHTML);
+		expect(scratch.firstChild.firstChild.content.firstChild.outerHTML).to.eql(
+			`<h2>this should show up</h2>`
+		);
 	});
 
 	it('should not render when detecting JSON-injection', () => {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -92,6 +92,21 @@ describe('render()', () => {
 		});
 	}
 
+	it('should support the <template> tag', () => {
+		function App() {
+			return (
+				<div>
+					<template>
+						<h2>this should show up</h2>
+					</template>
+				</div>
+			);
+		}
+
+		render(<App />, scratch);
+		console.log(scratch.firstChild.firstChild.content.innerHTML);
+	});
+
 	it('should not render when detecting JSON-injection', () => {
 		const vnode = JSON.parse('{"type":"span","children":"Malicious"}');
 		render(vnode, scratch);

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -92,7 +92,7 @@ describe('render()', () => {
 		});
 	}
 
-	it.only('should support the <template> tag', () => {
+	it('should support the <template> tag', () => {
 		function App() {
 			return (
 				<div>


### PR DESCRIPTION
Resolves #4635 

This builds out support for the template tag, the test asserts that the document fragment contains the tags we've rendered into it.