### PR TITLE
ci: Run PR Reporter even against PRs from forks

### DIFF
--- a/.github/workflows/pr-reporter.yml
+++ b/.github/workflows/pr-reporter.yml
@@ -5,7 +5,6 @@ on:
   # workflow_run workflow as a workaround
   workflow_run:
     workflows: ['CI']
-    branches: ['**']
     types:
       - completed
       - requested


### PR DESCRIPTION
For a while now we haven't been getting benchmark comments on PRs from forks (e.g., #4642), only realized once @jviide brought it up last week.

As best as I can tell, GitHub itself changed behavior here in how it handles the `branches` limit; it's a big time range, but as of #4325 it was working, and by #4471 it was not, and we didn't have any alterations to our config during that time.

Did some debugging in [another repo](https://github.com/rschristian/debug__workflow_run-fork) and it seems like it's the `branches` config itself that is the issue, as without it, the reporter does seem to run just fine. This config should be unnecessary anyhow, as the default behavior is to track everything, so removal seems correct.