### PR TITLE
ci: Fix path filter in PR Reporter action

### DIFF
--- a/.github/workflows/pr-reporter.yml
+++ b/.github/workflows/pr-reporter.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           # Should be kept in sync with the filter in the CI workflow
           filters: |
             jsChanged: '**/src/**/*.js'


### PR DESCRIPTION
Follow up to #4643

[The action is running again](https://github.com/preactjs/preact/actions/runs/12963641125) but it falls over as it cannot use the branch name from the fork as a reference to compare against -- that'll only work for local branches. To fix this, we simply switch over to the SHA, should do the trick for both forks & local branches all the same.

[Tests here](https://github.com/rschristian/debug__workflow_run-fork/actions), if anyone cares to take a look. Top 3 are a local branch (real workflow + 2 `workflow_run`-triggered events), 3 after that are from a fork.