### PR TITLE
IE11: Fix incorrect node order with conditionals and text nodes

### DIFF
--- a/compat/src/portals.js
+++ b/compat/src/portals.js
@@ -39,7 +39,7 @@ function Portal(props) {
 			nodeType: 1,
 			parentNode: container,
 			childNodes: [],
-			contains: () => true,
+			isPortal: true,
 			// Technically this isn't needed
 			appendChild(child) {
 				this.childNodes.push(child);

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -7,7 +7,7 @@ import {
 	MATCHED,
 	UNDEFINED
 } from '../constants';
-import { isArray } from '../util';
+import { isArray, contains } from '../util';
 import { getDomSibling } from '../component';
 
 /**
@@ -339,7 +339,7 @@ function insert(parentVNode, oldDom, parentDom) {
 
 		return oldDom;
 	} else if (parentVNode._dom != oldDom) {
-		if (oldDom && parentVNode.type && !parentDom.contains(oldDom)) {
+		if (oldDom && parentVNode.type && !contains(parentDom, oldDom)) {
 			oldDom = getDomSibling(parentVNode);
 		}
 		parentDom.insertBefore(parentVNode._dom, oldDom || null);

--- a/src/util.js
+++ b/src/util.js
@@ -35,6 +35,8 @@ export function removeNode(node) {
  * @param {import('./index').ContainerNode} node - The node to check for containment within the `parent` subtree.
  */
 export function contains(parent, node) {
+	if ('isPortal' in parent) return true;
+
 	while (node) {
 		if (node === parent) return true;
 		node = node.parentNode;

--- a/src/util.js
+++ b/src/util.js
@@ -25,4 +25,21 @@ export function removeNode(node) {
 	if (node && node.parentNode) node.parentNode.removeChild(node);
 }
 
+/**
+ * Checks whether a given node is contained within a specified parent node's subtree.
+ * This function is a workaround for Internet Explorer 11's limited support for
+ * `Element.prototype.contains()`, which works only for DOM elements and does not
+ * support text nodes.
+ *
+ * @param {import('./internal').PreactElement} parent - The parent node within which to search for the `node`.
+ * @param {import('./index').ContainerNode} node - The node to check for containment within the `parent` subtree.
+ */
+export function contains(parent, node) {
+	while (node) {
+		if (node === parent) return true;
+		node = node.parentNode;
+	}
+	return false;
+}
+
 export const slice = EMPTY_ARR.slice;


### PR DESCRIPTION
There is an issue with using Element.contains in IE11. IE11 only partially supports contains: it works for Element nodes but does not support Text nodes. This can cause incorrect node ordering when conditionally rendering elements that include text nodes.

Minimal Repro:

```js
import { render } from 'preact';
import { useEffect, useState } from 'preact/hooks';

export function App() {
  const [ showFirst, setShowFirst ] = useState(false);

  useEffect(function() {
    setTimeout(() => setShowFirst(true), 100);
  }, []);

  return (
    <div>
      {showFirst && <div>FIRST LINE</div>}
      plain text
      <div>LAST LINE</div>
    </div>
  );
}
```

Expected output:

```
FIRST LINE
plain text
LAST LINE
```

Actual output in IE11:

```
LAST LINE
FIRST LINE
plain text
```