### PR TITLE
types: Correct `HTMLProps` to extend all known props

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -84,7 +84,7 @@ declare namespace React {
 	export interface HTMLAttributes<T extends EventTarget>
 		extends JSXInternal.HTMLAttributes<T> {}
 	export interface HTMLProps<T extends EventTarget>
-		extends JSXInternal.HTMLAttributes<T>,
+		extends JSXInternal.AllHTMLAttributes<T>,
 			preact.ClassAttributes<T> {}
 	export interface AllHTMLAttributes<T extends EventTarget>
 		extends JSXInternal.AllHTMLAttributes<T> {}


### PR DESCRIPTION
`HTMLAttributes` used to contain everything, #4546 cut it down to only the truly global properties though. `AllHTMLAttributes` is what we want, mirroring [React](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/36f851c86a080a406b8d5dc8e95880363d16083b/types/react/index.d.ts#L2143C36-L2143C53)