### PR TITLE
ci: Fix path filter in reporter workflow

### DIFF
--- a/.github/workflows/pr-reporter.yml
+++ b/.github/workflows/pr-reporter.yml
@@ -22,7 +22,11 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          # As this Workflow is triggered by a `workflow_run` event, the filter action
+          # can't automatically assume we're working with PR data. As such, we need to
+          # wire it up manually with a base (merge target) and ref (source branch).
+          base: ${{ github.event.workflow_run.pull_requests[0].base.sha }}
+          ref: ${{ github.event.workflow_run.pull_requests[0].head.sha }}
           # Should be kept in sync with the filter in the CI workflow
           filters: |
             jsChanged: '**/src/**/*.js'


### PR DESCRIPTION
Tiny bug in our reporter action.

When not triggered by a `pull_request` event, the path filter defaults to always comparing against the main branch (`main` for us). We needed to manually hook up the base reference else, as #4653 shows, it'll compare the head commit against `main` and therefore start to report when it shouldn't.

`ref` is changed just to keep it aligned format-wise, `.head_sha` is the same whether you grab it as we were or pulling it out of the PR data.