### PR TITLE
test: Silence Karma warning over node:stream from RTS

### DIFF
--- a/compat/test/browser/textarea.test.js
+++ b/compat/test/browser/textarea.test.js
@@ -1,5 +1,5 @@
 import React, { render, hydrate, useState } from 'preact/compat';
-import ReactDOMServer from 'preact/compat/server';
+import ReactDOMServer from 'preact/compat/server.browser.js';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { act } from 'preact/test-utils';
 


### PR DESCRIPTION
We've had this noisy warning since we landed pipeable streams in RTS:

```
Error: R] Could not resolve "node:stream"

    node_modules/preact-render-to-string/dist/stream-node.module.js:1:28:
      1 │ import { PassThrough } from 'node:stream';
        ╵                             ~~~~~~~~~~~~~

  The package "node:stream" wasn't found on the file system but is built into node. Are you trying to bundle for node? You can use "platform: 'node'" to do that, which will remove this error.
```

Our tests don't actually use the `package.json` for module resolution, so `preact/compat/server` is assumed to be `preact/compat/server.js`, rather resolving to `preact/compat/server.browser.js` which removes the Node-only pipeable stream stuff. Explicitly referencing it here seems fine for the moment, it's the only place we test it and we're very explicitly in a browser test.