### PR TITLE
Remove contains with a simple parentNode check

### DIFF
--- a/compat/src/portals.js
+++ b/compat/src/portals.js
@@ -39,7 +39,6 @@ function Portal(props) {
 			nodeType: 1,
 			parentNode: container,
 			childNodes: [],
-			contains: () => true,
 			// Technically this isn't needed
 			appendChild(child) {
 				this.childNodes.push(child);

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -339,7 +339,7 @@ function insert(parentVNode, oldDom, parentDom) {
 
 		return oldDom;
 	} else if (parentVNode._dom != oldDom) {
-		if (oldDom && parentVNode.type && !parentDom.contains(oldDom)) {
+		if (oldDom && parentVNode.type && !oldDom.parentNode) {
 			oldDom = getDomSibling(parentVNode);
 		}
 		parentDom.insertBefore(parentVNode._dom, oldDom || null);

--- a/src/index-5.d.ts
+++ b/src/index-5.d.ts
@@ -290,7 +290,6 @@ interface ContainerNode {
 	readonly firstChild: ContainerNode | null;
 	readonly childNodes: ArrayLike<ContainerNode>;
 
-	contains(other: ContainerNode | null): boolean;
 	insertBefore(node: ContainerNode, child: ContainerNode | null): ContainerNode;
 	appendChild(node: ContainerNode): ContainerNode;
 	removeChild(child: ContainerNode): ContainerNode;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -289,7 +289,6 @@ interface ContainerNode {
 	readonly firstChild: ContainerNode | null;
 	readonly childNodes: ArrayLike<ContainerNode>;
 
-	contains(other: ContainerNode | null): boolean;
 	insertBefore(node: ContainerNode, child: ContainerNode | null): ContainerNode;
 	appendChild(node: ContainerNode): ContainerNode;
 	removeChild(child: ContainerNode): ContainerNode;


### PR DESCRIPTION
We basically want to check whether the following node is unmounted, which can also be done by checking for the presence of `parentNode`