### PR TITLE
Prune portals

### DIFF
--- a/compat/src/portals.js
+++ b/compat/src/portals.js
@@ -39,18 +39,9 @@ function Portal(props) {
 			nodeType: 1,
 			parentNode: container,
 			childNodes: [],
-			// Technically this isn't needed
-			appendChild(child) {
-				this.childNodes.push(child);
-				_this._container.appendChild(child);
-			},
 			insertBefore(child, before) {
 				this.childNodes.push(child);
 				_this._container.insertBefore(child, before);
-			},
-			removeChild(child) {
-				this.childNodes.splice(this.childNodes.indexOf(child) >>> 1, 1);
-				_this._container.removeChild(child);
 			}
 		};
 	}


### PR DESCRIPTION
We've stopped using `appendChild` and `removeChild`