### PR TITLE
Split vnode types

### DIFF
--- a/jsx-runtime/src/index.js
+++ b/jsx-runtime/src/index.js
@@ -45,12 +45,29 @@ function createVNode(type, props, key, isStaticChildren, __source, __self) {
 		}
 	}
 
-	/** @type {import('../../src/internal').VNode & { __source: any; __self: any }} */
+	return typeof type === 'function'
+		? createComponentVNode(type, normalizedProps, key, __source, __self)
+		: createDomVNode(type, normalizedProps, key, ref, __source, __self);
+}
+
+/**
+ * Create a VNode (used internally by Preact)
+ * @param {import('../../src/internal').VNode["type"]} type The node name or Component
+ * Constructor for this virtual node
+ * @param {object | string | number | null} props The properties of this virtual node.
+ * If this virtual node represents a text node, this is the text of the node (string or number).
+ * @param {string | number | null} key The key for this virtual node, used when
+ * diffing it against its children
+ * @returns {import('../../src/internal').VNode}
+ */
+export function createComponentVNode(type, props, key, __source, __self) {
+	// V8 seems to be better at detecting type shapes if the object is allocated from the same call site
+	// Do not inline into createElement and coerceToVNode!
+	/** @type {import('../../src/internal').VNode} */
 	const vnode = {
 		type,
-		props: normalizedProps,
+		props,
 		key,
-		ref,
 		_children: null,
 		_parent: null,
 		_depth: 0,
@@ -64,7 +81,46 @@ function createVNode(type, props, key, isStaticChildren, __source, __self) {
 		__self
 	};
 
-	if (options.vnode) options.vnode(vnode);
+	// Only invoke the vnode hook if this was *not* a direct copy:
+	if (options.vnode != null) options.vnode(vnode);
+
+	return vnode;
+}
+
+/**
+ * Create a VNode (used internally by Preact)
+ * @param {import('../../src/internal').VNode["type"]} type The node name or Component
+ * Constructor for this virtual node
+ * @param {object | string | number | null} props The properties of this virtual node.
+ * If this virtual node represents a text node, this is the text of the node (string or number).
+ * @param {string | number | null} key The key for this virtual node, used when
+ * diffing it against its children
+ * @param {import('../../src/internal').VNode["ref"]} ref The ref property that will
+ * receive a reference to its created child
+ * @returns {import('../../src/internal').VNode}
+ */
+export function createDomVNode(type, props, key, ref, __source, __self) {
+	// V8 seems to be better at detecting type shapes if the object is allocated from the same call site
+	// Do not inline into createElement and coerceToVNode!
+	/** @type {import('../../src/internal').VNode} */
+	const vnode = {
+		type,
+		props,
+		key,
+		ref,
+		_children: null,
+		_parent: null,
+		_depth: 0,
+		_dom: null,
+		constructor: undefined,
+		_index: -1,
+		__source,
+		__self
+	};
+
+	// Only invoke the vnode hook if this was *not* a direct copy:
+	if (options.vnode != null) options.vnode(vnode);
+
 	return vnode;
 }
 

--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -1,5 +1,5 @@
 import { assign, slice } from './util';
-import { createVNode } from './create-element';
+import { createComponentVNode, createDomVNode } from './create-element';
 
 /**
  * Clones the given VNode, optionally adding attributes/props and replacing its
@@ -27,11 +27,13 @@ export function cloneElement(vnode, props, children) {
 			arguments.length > 3 ? slice.call(arguments, 2) : children;
 	}
 
-	return createVNode(
-		vnode.type,
-		normalizedProps,
-		key || vnode.key,
-		ref || vnode.ref,
-		null
-	);
+	return typeof vnode.type === 'function'
+		? createComponentVNode(vnode.type, normalizedProps, key || vnode.key, null)
+		: createDomVNode(
+				vnode.type,
+				normalizedProps,
+				key || vnode.key,
+				ref || vnode.ref,
+				null
+			);
 }

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -1,5 +1,9 @@
 import { diff, unmount, applyRef } from './index';
-import { createVNode, Fragment } from '../create-element';
+import {
+	createDomVNode,
+	createComponentVNode,
+	Fragment
+} from '../create-element';
 import {
 	EMPTY_OBJ,
 	EMPTY_ARR,
@@ -191,7 +195,7 @@ function constructNewChildrenArray(
 			typeof childVNode == 'bigint' ||
 			childVNode.constructor == String
 		) {
-			childVNode = newParentVNode._children[i] = createVNode(
+			childVNode = newParentVNode._children[i] = createDomVNode(
 				null,
 				childVNode,
 				null,
@@ -199,10 +203,9 @@ function constructNewChildrenArray(
 				null
 			);
 		} else if (isArray(childVNode)) {
-			childVNode = newParentVNode._children[i] = createVNode(
+			childVNode = newParentVNode._children[i] = createComponentVNode(
 				Fragment,
 				{ children: childVNode },
-				null,
 				null,
 				null
 			);
@@ -211,13 +214,21 @@ function constructNewChildrenArray(
 			// scenario:
 			//   const reuse = <div />
 			//   <div>{reuse}<span />{reuse}</div>
-			childVNode = newParentVNode._children[i] = createVNode(
-				childVNode.type,
-				childVNode.props,
-				childVNode.key,
-				childVNode.ref ? childVNode.ref : null,
-				childVNode._original
-			);
+			childVNode = newParentVNode._children[i] =
+				typeof childVNode.type === 'function'
+					? createComponentVNode(
+							childVNode.type,
+							childVNode.props,
+							childVNode.key,
+							childVNode._original
+						)
+					: createDomVNode(
+							childVNode.type,
+							childVNode.props,
+							childVNode.key,
+							childVNode.ref ? childVNode.ref : null,
+							childVNode._original
+						);
 		} else {
 			childVNode = newParentVNode._children[i] = childVNode;
 		}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -348,12 +348,6 @@ export function diff(
 			}
 			options._catchError(e, newVNode, oldVNode);
 		}
-	} else if (
-		excessDomChildren == null &&
-		newVNode._original == oldVNode._original
-	) {
-		newVNode._children = oldVNode._children;
-		newVNode._dom = oldVNode._dom;
 	} else {
 		oldDom = newVNode._dom = diffElementNodes(
 			oldVNode._dom,


### PR DESCRIPTION
This splits the vnode types into a component and dom specific one, this should reduce the amount of properties on the vnode shape.

One thing that I currently removed is our static node optimisation, where `_original` can be used on a DOM node to bail out of renders.

Think about

```
const x = (<div />)
```

This would bail if used in a component and never rerender. I think that is such a rare optimisation and probably doesn't warrant the byte cost over the other type of strict equality bailout.

If we choose to take this, we'll need to update the typings to reflect the new shapes.