### PR TITLE
Remove static dom bail

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -348,12 +348,6 @@ export function diff(
 			}
 			options._catchError(e, newVNode, oldVNode);
 		}
-	} else if (
-		excessDomChildren == null &&
-		newVNode._original == oldVNode._original
-	) {
-		newVNode._children = oldVNode._children;
-		newVNode._dom = oldVNode._dom;
 	} else {
 		oldDom = newVNode._dom = diffElementNodes(
 			oldVNode._dom,


### PR DESCRIPTION
This is a highly unusual thing for people to use and when they do it will be very cheap either way. This removes the bail for `const x = (<div />`