### PR TITLE
types: Add auxClick event types

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -787,6 +787,8 @@ export namespace JSXInternal {
 		onGotPointerCaptureCapture?: PointerEventHandler<Target> | undefined;
 		onLostPointerCapture?: PointerEventHandler<Target> | undefined;
 		onLostPointerCaptureCapture?: PointerEventHandler<Target> | undefined;
+		onAuxClick?: PointerEventHandler<Target> | undefined;
+		onAuxClickCapture?: PointerEventHandler<Target> | undefined;
 
 		// UI Events
 		onScroll?: UIEventHandler<Target> | undefined;

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -751,6 +751,11 @@ export namespace JSXInternal {
 		onMouseOverCapture?: MouseEventHandler<Target> | undefined;
 		onMouseUp?: MouseEventHandler<Target> | undefined;
 		onMouseUpCapture?: MouseEventHandler<Target> | undefined;
+		// TODO: Spec for `auxclick` events was changed to make it a PointerEvent but only
+		// Chrome has support for it yet. When more browsers align we should change this.
+		// https://developer.mozilla.org/en-US/docs/Web/API/Element/auxclick_event#browser_compatibility
+		onAuxClick?: MouseEventHandler<Target> | undefined;
+		onAuxClickCapture?: MouseEventHandler<Target> | undefined;
 
 		// Selection Events
 		onSelect?: GenericEventHandler<Target> | undefined;
@@ -787,8 +792,6 @@ export namespace JSXInternal {
 		onGotPointerCaptureCapture?: PointerEventHandler<Target> | undefined;
 		onLostPointerCapture?: PointerEventHandler<Target> | undefined;
 		onLostPointerCaptureCapture?: PointerEventHandler<Target> | undefined;
-		onAuxClick?: PointerEventHandler<Target> | undefined;
-		onAuxClickCapture?: PointerEventHandler<Target> | undefined;
 
 		// UI Events
 		onScroll?: UIEventHandler<Target> | undefined;


### PR DESCRIPTION
From the project referenced here: https://github.com/preactjs/preact-www/issues/1240#issuecomment-2661172956

One thing worth calling out here is that the spec recently (-ish, 4 years ago) changed this event from extending a `MouseEvent` to a `PointerEvent` and [only Chrome/Chromium-based browsers support this](https://developer.mozilla.org/en-US/docs/Web/API/Element/auxclick_event#browser_compatibility) yet. Do we want to make this a `MouseEvent` with a note to change this in the future, or use `PointerEvent` now (as this PR does)? I have no opinions one way or the other.