### PR TITLE
types: Add `FowardRefRenderFunction` type to compat

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -253,7 +253,15 @@ declare namespace React {
 		ref?: preact.Ref<R> | undefined;
 	}
 
+	/**
+	 * @deprecated Please use `ForwardRefRenderFunction` instead.
+	 */
 	export interface ForwardFn<P = {}, T = any> {
+		(props: P, ref: ForwardedRef<T>): preact.ComponentChild;
+		displayName?: string;
+	}
+
+	export interface ForwardRefRenderFunction<T = any, P = {}> {
 		(props: P, ref: ForwardedRef<T>): preact.ComponentChild;
 		displayName?: string;
 	}


### PR DESCRIPTION
Unfortunately someone in the past added this under the wrong name (there's never been a `ForwardFn` in React as far as I can see) and with the generics reversed so best we can do is mark it as deprecated & add the correct type.

[React for reference](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b4a1c7594dedbcadfd67858a5fcf996d1c22e6ad/types/react/index.d.ts#L1088-L1106)