### PR TITLE
chore: Simplify compat build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "build:devtools": "microbundle build --raw --no-generateTypes -f cjs,esm,umd --cwd devtools",
     "build:hooks": "microbundle build --raw --no-generateTypes -f cjs,esm,umd --cwd hooks",
     "build:test-utils": "microbundle build --raw --no-generateTypes -f cjs,esm,umd --cwd test-utils",
-    "build:compat": "microbundle build src/index.js src/scheduler.js --raw --no-generateTypes -f cjs,esm,umd --cwd compat --globals 'preact/hooks=preactHooks'",
+    "build:compat": "microbundle build --raw --no-generateTypes -f cjs,esm,umd --cwd compat --globals 'preact/hooks=preactHooks'",
     "build:jsx": "microbundle build --raw --no-generateTypes -f cjs,esm,umd --cwd jsx-runtime",
     "postbuild": "node ./config/node-13-exports.js && node ./config/compat-entries.js",
     "dev": "microbundle watch --raw --no-generateTypes --format cjs",


### PR DESCRIPTION
Working on some changes to build output in v11, came across this and figured it was worth addressing separately.

Whilst Microbundle does support multi-entries, it does so incorrectly when combined with the `--cwd` flag in that the cwd isn't passed to [`tiny-glob`](https://github.com/developit/microbundle/blob/aae1611ef4f95f17332057018b595ef7b2794b2d/src/index.js#L221). This has `tiny-glob` resolving from the original cwd (so root of our repo) which `src/scheduler.js` fails. `src/index.js` works only as this happens to match core. As such, the `src/scheduler.js` input is stripped out & not built as an additional entry.

Bundling it separately isn't necessary though, this script has no imports so all microbundle does is minify the ~10loc. None of the other compat entries are bundled either & I think we're pretty happy with how that works?