### PR TITLE
Fix memory leak

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -259,6 +259,11 @@ export function diff(
 				tmp != null && tmp.type === Fragment && tmp.key == null;
 			let renderResult = isTopLevelFragment ? tmp.props.children : tmp;
 
+			if (isTopLevelFragment) {
+				tmp.props.children = null;
+				console.log('isTopLevelFragment', tmp);
+			}
+
 			oldDom = diffChildren(
 				parentDom,
 				isArray(renderResult) ? renderResult : [renderResult],

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -261,7 +261,6 @@ export function diff(
 
 			if (isTopLevelFragment) {
 				tmp.props.children = null;
-				console.log('isTopLevelFragment', tmp);
 			}
 
 			oldDom = diffChildren(


### PR DESCRIPTION
Fixes #4679 

Basically what happens is that when we encounter a fragment we unwrap it to return is children, this way when elements get wrapped with fragments we don't risk losing state. This has a consequence when it is used in hooks environments.

As can be seen in the reproduction, if an effect closure takes a snapshot of the outer closure it will take the `Fragment` we unwrap into memory, this means that we'll effectively start mutating its children.

Every time we rerender we'll take a new snapshot of the closure which retains a copy of `Fragment` with pointers to all of its populated children.

With this measure we counter-act this by removing the reference to `children` which removes the risk of tracking this.

Fun fact, when we implement #4679's replay with class components there is no memory leak.