### PR TITLE
types: Require initial value in `useRef`

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -117,7 +117,6 @@ declare namespace React {
 	export import CreateHandle = _hooks.CreateHandle;
 	export import EffectCallback = _hooks.EffectCallback;
 	export import Inputs = _hooks.Inputs;
-	export import PropRef = _hooks.PropRef;
 	export import Reducer = _hooks.Reducer;
 	export import Dispatch = _hooks.Dispatch;
 	export import SetStateAction = _hooks.StateUpdater;

--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -52,13 +52,6 @@ export function useReducer<S, A, I>(
 	init: (arg: I) => S
 ): [S, Dispatch<A>];
 
-/** @deprecated Use the `Ref` type instead. */
-type PropRef<T> = MutableRef<T>;
-
-interface MutableRef<T> {
-	current: T;
-}
-
 /**
  * `useRef` returns a mutable ref object whose `.current` property is initialized to the passed argument
  * (`initialValue`). The returned object will persist for the full lifetime of the component.
@@ -68,9 +61,9 @@ interface MutableRef<T> {
  *
  * @param initialValue the initial value to store in the ref object
  */
-export function useRef<T>(initialValue: T): MutableRef<T>;
-export function useRef<T>(initialValue: T | null): RefObject<T>;
-export function useRef<T = undefined>(): MutableRef<T | undefined>;
+export function useRef<T>(initialValue: T): RefObject<T>;
+export function useRef<T>(initialValue: T | null): RefObject<T | null>;
+export function useRef<T>(initialValue: T | undefined): RefObject<T | undefined>;
 
 type EffectCallback = () => void | (() => void);
 /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -37,9 +37,9 @@ export interface VNode<P = {}> {
 
 export type Key = string | number | any;
 
-export type RefObject<T> = { current: T | null };
+export type RefObject<T> = { current: T };
 export type RefCallback<T> = (instance: T | null) => void;
-export type Ref<T> = RefObject<T> | RefCallback<T> | null;
+export type Ref<T> = RefCallback<T> | RefObject<T | null> | null;
 
 export type ComponentChild =
 	| VNode<any>


### PR DESCRIPTION
I quite like the [change React made to their types in v19](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#useref-requires-argument) to require an initial argument be passed to `useRef`, it fixes some of the fiddly details of `useRef` that are really easy to stumble into. This is a breaking type change so v11 it goes.

