### PR TITLE
ci: Skip benches during release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,11 @@ jobs:
         id: filter
         with:
           # Should be kept in sync with the filter in the PR Reporter workflow
+          predicate-quantifier: 'every'
           filters: |
-            jsChanged: '**/src/**/*.js'
+            jsChanged:
+              - '**/src/**/*.js'
+              - '!devtools/src/devtools.js'
 
   compressed_size:
     name: Compressed Size

--- a/.github/workflows/pr-reporter.yml
+++ b/.github/workflows/pr-reporter.yml
@@ -28,8 +28,11 @@ jobs:
           base: ${{ github.event.workflow_run.pull_requests[0].base.sha }}
           ref: ${{ github.event.workflow_run.pull_requests[0].head.sha }}
           # Should be kept in sync with the filter in the CI workflow
+          predicate-quantifier: 'every'
           filters: |
-            jsChanged: '**/src/**/*.js'
+            jsChanged:
+              - '**/src/**/*.js'
+              - '!devtools/src/devtools.js'
 
   report_running:
     name: Report benchmarks are in-progress


### PR DESCRIPTION
Our filter pattern is a bit broad, it picks up changes to `devtools/src/devtools.js` which gets altered on every release: https://github.com/preactjs/preact/pull/4684#issuecomment-2664709989

Should be fine to exclude it specifically, none of our benchmarks depend on it anyhow.

Edit: The PR Reporter action is expected to run on this PR as the running version is that on `main`, not this PR. The benches, however, should be skipped as a result. [Workflow showing this](https://github.com/preactjs/preact/actions/runs/13384669087).
