### PR TITLE
feat: Add command invoker types

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1623,8 +1623,8 @@ export namespace JSXInternal {
 	interface ButtonHTMLAttributes<T extends EventTarget = HTMLButtonElement>
 		extends HTMLAttributes<T> {
 		command?: Signalish<string | undefined>;
-		commandfor?: Signalist<string | undefined>;
-		commandFor?: Signalist<string | undefined>;
+		commandfor?: Signalish<string | undefined>;
+		commandFor?: Signalish<string | undefined>;
 		disabled?: Signalish<boolean | undefined>;
 		form?: Signalish<string | undefined>;
 		formaction?: Signalish<string | undefined>;

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -42,6 +42,24 @@ interface ToggleEventInit extends EventInit {
 
 // End TS >5.2
 
+/** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/CommandEvent) */
+interface CommandEvent extends Event {
+	/** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/CommandEvent/source) */
+	readonly source: Element | null;
+	/** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/CommandEvent/command) */
+	readonly command: string;
+}
+
+declare var CommandEvent: {
+	prototype: CommandEvent;
+	new(type: string, eventInitDict?: CommandEventInit): CommandEvent;
+};
+
+interface CommandEventInit extends EventInit {
+	source: Element | null;
+	command: string;
+}
+
 export namespace JSXInternal {
 	export type LibraryManagedAttributes<Component, Props> = Component extends {
 		defaultProps: infer Defaults;
@@ -496,6 +514,8 @@ export namespace JSXInternal {
 		TargetedEvent<Target, AnimationEvent>;
 	export type TargetedClipboardEvent<Target extends EventTarget> =
 		TargetedEvent<Target, ClipboardEvent>;
+	export type TargetedCommandEvent<Target extends EventTarget> =
+		TargetedEvent<Target, CommandEvent>;
 	export type TargetedCompositionEvent<Target extends EventTarget> =
 		TargetedEvent<Target, CompositionEvent>;
 	export type TargetedDragEvent<Target extends EventTarget> = TargetedEvent<
@@ -557,6 +577,8 @@ export namespace JSXInternal {
 	export type ClipboardEventHandler<Target extends EventTarget> = EventHandler<
 		TargetedClipboardEvent<Target>
 	>;
+	export type CommandEventHandler<Target extends EventTarget> =
+		TargetedCommandEvent<Target>
 	export type CompositionEventHandler<Target extends EventTarget> =
 		EventHandler<TargetedCompositionEvent<Target>>;
 	export type DragEventHandler<Target extends EventTarget> = EventHandler<
@@ -828,6 +850,8 @@ export namespace JSXInternal {
 		onLeavePictureInPictureCapture?: PictureInPictureEventHandler<Target>;
 		onResize?: PictureInPictureEventHandler<Target>;
 		onResizeCapture?: PictureInPictureEventHandler<Target>;
+
+		onCommand?: CommandEventHandler<Target>
 	}
 
 	// All the WAI-ARIA 1.1 attributes from https://www.w3.org/TR/wai-aria-1.1/

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1622,6 +1622,9 @@ export namespace JSXInternal {
 
 	interface ButtonHTMLAttributes<T extends EventTarget = HTMLButtonElement>
 		extends HTMLAttributes<T> {
+		command?: Signalish<string | undefined>;
+		commandfor?: Signalist<string | undefined>;
+		commandFor?: Signalist<string | undefined>;
 		disabled?: Signalish<boolean | undefined>;
 		form?: Signalish<string | undefined>;
 		formaction?: Signalish<string | undefined>;


### PR DESCRIPTION
Reference:

- [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command)
- [commandfor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor)


------------------------------------

See chrome [Intent to ship](https://groups.google.com/a/chromium.org/g/blink-dev/c/ctNbl4gWLuk)

Leaving as Draft till the spec is merged / Chrome i2S is approved.