### PR TITLE
feat: Add onBeforeToggle event handler type

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -625,7 +625,8 @@ export namespace JSXInternal {
 		onCompositionUpdate?: CompositionEventHandler<Target> | undefined;
 		onCompositionUpdateCapture?: CompositionEventHandler<Target> | undefined;
 
-		// Details Events
+		// Popover Events
+		onBeforeToggle?: ToggleEventHandler<Target> | undefined;
 		onToggle?: ToggleEventHandler<Target> | undefined;
 
 		// Dialog Events


### PR DESCRIPTION
This is slightly complicated, basically Details has had an ontoggle for a long time but historically it was just an Event. More recently Popovers were added and they had a beforetoggle and a toggle event but used a new ToggleEvent type. Details was subsequently updated to use this type for it's toggle event too (but it doesn't have a beforetoggle event itself).

Dialogs also more recently have had a toggle and beforetoggle event added to them.