### PR TITLE
chore: Fix TS lang server support in our `.d.ts` files

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -6,14 +6,6 @@ import { JSXInternal } from '../../src/jsx';
 import * as _Suspense from './suspense';
 import * as _SuspenseList from './suspense-list';
 
-interface SignalLike<T> {
-	value: T;
-	peek(): T;
-	subscribe(fn: (value: T) => void): () => void;
-}
-
-type Signalish<T> = T | SignalLike<T>;
-
 // export default React;
 export = React;
 export as namespace React;
@@ -272,7 +264,7 @@ declare namespace React {
 	}
 
 	export function forwardRef<R, P = {}>(
-		fn: ForwardFn<P, R>
+		fn: ForwardRefRenderFunction<R, P>
 	): preact.FunctionalComponent<PropsWithoutRef<P> & { ref?: preact.Ref<R> }>;
 
 	export type PropsWithoutRef<P> = Omit<P, 'ref'>;

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -2,7 +2,9 @@ import {
 	Options as PreactOptions,
 	Component as PreactComponent,
 	VNode as PreactVNode,
-	Context as PreactContext,
+	PreactContext,
+	HookType,
+	ErrorInfo,
 } from '../../src/internal';
 import { Reducer, StateUpdater } from '.';
 
@@ -30,14 +32,14 @@ export interface ComponentHooks {
 	_pendingEffects: EffectHookState[];
 }
 
-export interface Component extends PreactComponent<any, any> {
+export interface Component extends Omit<PreactComponent<any, any>, '_renderCallbacks'> {
 	__hooks?: ComponentHooks;
 	// Extend to include HookStates
 	_renderCallbacks?: Array<HookState | (() => void)>;
 	_hasScuFromHooks?: boolean;
 }
 
-export interface VNode extends PreactVNode {
+export interface VNode extends Omit<PreactVNode, '_component'> {
 	_mask?: [number, number];
 	_component?: Component; // Override with our specific Component type
 }
@@ -52,12 +54,12 @@ export type HookState =
 
 interface BaseHookState {
 	_value?: unknown;
-	_nextValue?: undefined;
-	_pendingValue?: undefined;
-	_args?: undefined;
-	_pendingArgs?: undefined;
-	_component?: undefined;
-	_cleanup?: undefined;
+	_nextValue?: unknown;
+	_pendingValue?: unknown;
+	_args?: unknown;
+	_pendingArgs?: unknown;
+	_component?: unknown;
+	_cleanup?: unknown;
 }
 
 export type Effect = () => void | Cleanup;

--- a/jsconfig-lint.json
+++ b/jsconfig-lint.json
@@ -1,4 +1,9 @@
 {
   "extends": "./jsconfig.json",
-  "include": ["src/**/*", "hooks/src/**/*"]
+  "include": [
+    "src/**/*",
+    "hooks/src/**/*",
+    "compat/**/*.d.ts",
+    "jsx-runtime/**/*.d.ts"
+  ]
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -13,7 +13,8 @@
       "preact/*": ["./*"]
     },
     "target": "es5",
-    "noEmit": true
+    "noEmit": true,
+    "skipLibCheck": false
   },
   "exclude": ["**/node_modules/**", "**/dist/**", "coverage", "demo"]
 }

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -109,7 +109,7 @@ export interface PreactElement extends preact.ContainerNode {
 	readonly style?: CSSStyleDeclaration;
 
 	// nextSibling required for inserting nodes
-	readonly nextSibling: ContainerNode | null;
+	readonly nextSibling: PreactElement | null;
 
 	// Used to match DOM nodes to VNodes during hydration. Note: doesn't exist
 	// on Text nodes
@@ -158,7 +158,7 @@ export interface VNode<P = {}> extends preact.VNode<P> {
 	_flags: number;
 }
 
-export interface Component<P = {}, S = {}> extends preact.Component<P, S> {
+export interface Component<P = {}, S = {}> extends Omit<preact.Component<P, S>, 'base'> {
 	// When component is functional component, this is reset to functional component
 	constructor: ComponentType<P>;
 	state: S; // Override Component["state"] to not be readonly for internal use, specifically Hooks


### PR DESCRIPTION
Long been a bit of a headache, we don't get an TS support in our `.d.ts` files which allows typos, usused values, etc. to run a bit rampant. Turns out it's a simple issue: `jsconfig.json` has `skipLibCheck` set to `false` by default, and this is seemingly undocumented.

Easy fix and has surfaced a few (internal) errors already.