### PR TITLE
Keyed nullish placeholders cause re-mounts

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -253,6 +253,20 @@ function constructNewChildrenArray(
 
 		if (isMounting) {
 			if (matchingIndex == -1) {
+				// When the array of children is growing we need to decrease the skew
+				// as we are adding a new element to the array.
+				// Example:
+				// [1, 2, 3] --> [0, 1, 2, 3]
+				// oldChildren   newChildren
+				//
+				// The new element is at index 0, so our skew is 0,
+				// we need to decrease the skew as we are adding a new element.
+				// The decrease will cause us to compare the element at position 1
+				// with value 1 with the element at position 0 with value 0.
+				//
+				// A linear concept is applied when the array is shrinking,
+				// if the length is unchanged we can assume that no skew
+				// changes are needed.
 				if (newChildrenLength > oldChildrenLength) {
 					skew--;
 				} else if (newChildrenLength < oldChildrenLength) {

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -252,8 +252,12 @@ function constructNewChildrenArray(
 		const isMounting = oldVNode == NULL || oldVNode._original === NULL;
 
 		if (isMounting) {
-			if (matchingIndex == -1 && oldChildrenLength !== newChildrenLength) {
-				skew--;
+			if (matchingIndex == -1) {
+				if (newChildrenLength > oldChildrenLength) {
+					skew--;
+				} else if (newChildrenLength < oldChildrenLength) {
+					skew++;
+				}
 			}
 
 			// If we are mounting a DOM VNode, mark it for insertion

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -253,6 +253,7 @@ function constructNewChildrenArray(
 
 		if (isMounting) {
 			if (matchingIndex == -1) {
+				//skew--;
 				if (newChildrenLength > oldChildrenLength) {
 					skew--;
 				} else if (newChildrenLength < oldChildrenLength) {
@@ -411,7 +412,7 @@ function findMatchingIndex(
 		(oldVNode != NULL && (oldVNode._flags & MATCHED) == 0 ? 1 : 0);
 
 	if (
-		oldVNode === NULL ||
+		(oldVNode === NULL && !childVNode.key) ||
 		(oldVNode &&
 			key == oldVNode.key &&
 			type === oldVNode.type &&

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -252,7 +252,7 @@ function constructNewChildrenArray(
 		const isMounting = oldVNode == NULL || oldVNode._original === NULL;
 
 		if (isMounting) {
-			if (matchingIndex == -1) {
+			if (matchingIndex == -1 && oldChildrenLength !== newChildrenLength) {
 				skew--;
 			}
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -253,7 +253,6 @@ function constructNewChildrenArray(
 
 		if (isMounting) {
 			if (matchingIndex == -1) {
-				//skew--;
 				if (newChildrenLength > oldChildrenLength) {
 					skew--;
 				} else if (newChildrenLength < oldChildrenLength) {
@@ -412,7 +411,7 @@ function findMatchingIndex(
 		(oldVNode != NULL && (oldVNode._flags & MATCHED) == 0 ? 1 : 0);
 
 	if (
-		(oldVNode === NULL && !childVNode.key) ||
+		(oldVNode === NULL && childVNode.key == null) ||
 		(oldVNode &&
 			key == oldVNode.key &&
 			type === oldVNode.type &&

--- a/test/browser/keys.test.js
+++ b/test/browser/keys.test.js
@@ -977,4 +977,151 @@ describe('keys', () => {
 			'mounted 1'
 		]);
 	});
+
+	it('should handle hole prepend', () => {
+		const actions = [];
+		class Comp extends Component {
+			componentDidMount() {
+				actions.push('mounted ' + this.props.i);
+			}
+			render() {
+				return <div>Hello</div>;
+			}
+		}
+
+		const App = props => {
+			return props.y === '2' ? (
+				<div>
+					<Comp key={1} i={1} />
+					<Comp key={2} i={2} />
+					<Comp key={3} i={3} />
+				</div>
+			) : (
+				<div>
+					{null}
+					<Comp key={1} i={1} />
+					<Comp key={2} i={2} />
+					<Comp key={3} i={3} />
+				</div>
+			);
+		};
+
+		render(<App y="1" />, scratch);
+		expect(actions).to.deep.equal(['mounted 1', 'mounted 2', 'mounted 3']);
+
+		render(<App y="2" />, scratch);
+		expect(actions).to.deep.equal(['mounted 1', 'mounted 2', 'mounted 3']);
+	});
+
+	it('should handle hole replace', () => {
+		const actions = [];
+		class Comp extends Component {
+			componentDidMount() {
+				actions.push('mounted ' + this.props.i);
+			}
+			render() {
+				return <div>Hello</div>;
+			}
+		}
+
+		const App = props => {
+			return props.y === '1' ? (
+				<div>
+					<Comp key={1} i={1} />
+					<Comp key={2} i={2} />
+					<Comp key={3} i={3} />
+				</div>
+			) : (
+				<div>
+					<Comp key={1} i={1} />
+					{null}
+					<Comp key={3} i={3} />
+				</div>
+			);
+		};
+
+		render(<App y="1" />, scratch);
+		expect(actions).to.deep.equal(['mounted 1', 'mounted 2', 'mounted 3']);
+
+		render(<App y="2" />, scratch);
+		expect(actions).to.deep.equal(['mounted 1', 'mounted 2', 'mounted 3']);
+
+		render(<App y="1" />, scratch);
+		expect(actions).to.deep.equal([
+			'mounted 1',
+			'mounted 2',
+			'mounted 3',
+			'mounted 2'
+		]);
+	});
+
+	it('should handle hole insert', () => {
+		const actions = [];
+		class Comp extends Component {
+			componentDidMount() {
+				actions.push('mounted ' + this.props.i);
+			}
+			render() {
+				return <div>Hello</div>;
+			}
+		}
+
+		const App = props => {
+			return props.y === '2' ? (
+				<div>
+					<Comp key={1} i={1} />
+					<Comp key={2} i={2} />
+					<Comp key={3} i={3} />
+				</div>
+			) : (
+				<div>
+					<Comp key={1} i={1} />
+					<Comp key={2} i={2} />
+					{null}
+					<Comp key={3} i={3} />
+				</div>
+			);
+		};
+
+		render(<App y="1" />, scratch);
+		expect(actions).to.deep.equal(['mounted 1', 'mounted 2', 'mounted 3']);
+
+		render(<App y="2" />, scratch);
+		expect(actions).to.deep.equal(['mounted 1', 'mounted 2', 'mounted 3']);
+	});
+
+	it('should handle hole apppend', () => {
+		const actions = [];
+		class Comp extends Component {
+			componentDidMount() {
+				actions.push('mounted ' + this.props.i);
+			}
+			render() {
+				return <div>Hello</div>;
+			}
+		}
+
+		const App = props => {
+			return props.y === '2' ? (
+				<div>
+					<Comp key={1} i={1} />
+					<Comp key={2} i={2} />
+					<Comp key={3} i={3} />
+				</div>
+			) : (
+				<div>
+					<Comp key={1} i={1} />
+					<Comp key={2} i={2} />
+					<Comp key={3} i={3} />
+					{null}
+				</div>
+			);
+		};
+
+		render(<App y="1" />, scratch);
+		expect(actions).to.deep.equal(['mounted 1', 'mounted 2', 'mounted 3']);
+
+		render(<App y="2" />, scratch);
+		expect(actions).to.deep.equal(['mounted 1', 'mounted 2', 'mounted 3']);
+	});
 });

--- a/test/browser/keys.test.js
+++ b/test/browser/keys.test.js
@@ -943,4 +943,38 @@ describe('keys', () => {
 
 		expect(scratch.innerHTML).to.eq(`<div>${expected(sorted)}</div>`);
 	});
+
+	it('should handle keyed replacements', () => {
+		const actions = [];
+		class Comp extends Component {
+			componentDidMount() {
+				actions.push('mounted ' + this.props.i);
+			}
+			render() {
+				return <div>Hello</div>;
+			}
+		}
+
+		const App = props => {
+			return (
+				<div>
+					<Comp key={props.y} i={1} />
+					{false}
+					<Comp i={2} />
+					<Comp i={3} />
+				</div>
+			);
+		};
+
+		render(<App y="1" />, scratch);
+		expect(actions).to.deep.equal(['mounted 1', 'mounted 2', 'mounted 3']);
+
+		render(<App y="2" />, scratch);
+		expect(actions).to.deep.equal([
+			'mounted 1',
+			'mounted 2',
+			'mounted 3',
+			'mounted 1'
+		]);
+	});
 });

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1967,4 +1967,33 @@ describe('render()', () => {
 			'<head><title>Test</title></head><body><p>Test</p></body>\n'
 		);
 	});
+
+	it('should not remount components when replacing a component with a falsy value in-between', () => {
+		const actions = [];
+		class Comp extends Component {
+			componentDidMount() {
+				actions.push('mounted ' + this.props.i);
+			}
+			render() {
+				return <div>Hello</div>;
+			}
+		}
+
+		const App = props => {
+			return (
+				<div>
+					{props.y === '1' ? <Comp i={1} /> : <div />}
+					{false}
+					<Comp i={2} />
+					<Comp i={3} />
+				</div>
+			);
+		};
+
+		render(<App y="1" />, scratch);
+		expect(actions).to.deep.equal(['mounted 1', 'mounted 2', 'mounted 3']);
+
+		render(<App y="2" />, scratch);
+		expect(actions).to.deep.equal(['mounted 1', 'mounted 2', 'mounted 3']);
+	});
 });


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/4699 and a whole lot more

There's a few cases that get solved in this PR, let's go over them!

First and foremost, the issue points us at an issue where having a null'ish middle node can lead to false positives. In the example we have one keyed node like the following

```
<CompA key=1 />
null
<CompB />
<CompB />
```

When we create this initially we'll see 3 creations for A, B and B. This is expected, when we swap out CompA by changing its key to i.e. 2 we expect that the only new creation we'll see is from `<CompA />`, however this is not the case we'll also remount one of the two `<CompB />` nodes and reset their state if they are using state which is unexpected.

This is caused by the following:

- We can't find a matching vnode because the key changed
- We decrement the skew to deal with offsets, we assume that the amount of children grew in the new variant hence we increment skew. (when we increment skew we'll look at a smaller index in the oldChildren i.e. [1, 2, 3] becomes [0, 1, 2, 3] --> when we diff 0 that's technically -1 in oldChildren and we want to compare 1 with 1)
- When we get to the next skew in newChildren we'll compare `<CompB />` with `null`, this means that we'll erroneously assume we swapped out `<CompB />` with null which makes us unmount it.

We fix the above by adding a check in the mount case that does the following

- Decrement the skew if the list of newChildren is larger than the list of oldChildren (we added a node 0 becomes -1)
- Increment the skew if the list of newChildren is smaller than the list of oldChildren (we removed a node 0 becomes 1)
- If the list stays the same, like our issue case, we don't do anything!

This made me start looking into non-keyed cases and indeed, this issue existed in the unkeyed case as well which luckily is also fixed with the above measure. I've added tests for all of these cases. When digging even deeper I found some [general issues](https://github.com/preactjs/preact/pull/4700/files#diff-bbe8c651c89dccfac2b57fc4ac13928d4bef226b6163dd6975ee6caf53797c41R1016-R1126) with how we handle placeholders (aka holes in our array). Generally when we replace a keyed node, append or prepend with a placeholder we see re-mounting issues. I've counter-acted that by replacing our `null` case in the child-matching with a `&& !key` condition, this means that for keyed nodes we'll always search the children as this is kind of the goal of keys, we can move them around without fear.