### PR TITLE
Prevent memo'd components that unsuspend from bailing

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -57,6 +57,9 @@ function detachedClone(vnode, detachedParent, parentDom) {
 			if (vnode._component._parentDom === parentDom) {
 				vnode._component._parentDom = detachedParent;
 			}
+
+			vnode._component._force = true;
+
 			vnode._component = null;
 		}
 


### PR DESCRIPTION
Set `Memo` Component to when unsuspending `_force` so when the subsequent render arrives there is no possibility of bailing out of the render pass.

fixes #4631