### PR TITLE
Address context fragments issue

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -261,13 +261,7 @@ export function diff(
 			let renderResult = tmp;
 
 			if (isTopLevelFragment) {
-				renderResult = isArray(tmp.props.children)
-					? tmp.props.children.map(v =>
-							isArray(v) ? v : v != NULL && typeof v === 'object' ? { ...v } : v
-						)
-					: tmp.props.children != NULL && typeof tmp.props.children === 'object'
-						? { ...tmp.props.children }
-						: tmp.props.children;
+				renderResult = cloneNode(tmp.props.children);
 			}
 
 			oldDom = diffChildren(
@@ -372,6 +366,18 @@ export function commitRoot(commitQueue, root, refQueue) {
 			options._catchError(e, c._vnode);
 		}
 	});
+}
+
+function cloneNode(node) {
+	if (typeof node !== 'object' || node == NULL) {
+		return node;
+	}
+
+	if (isArray(node)) {
+		return node.map(cloneNode);
+	}
+
+	return assign({}, node);
 }
 
 /**

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -258,10 +258,16 @@ export function diff(
 
 			let isTopLevelFragment =
 				tmp != NULL && tmp.type === Fragment && tmp.key == NULL;
-			let renderResult = isTopLevelFragment ? tmp.props.children : tmp;
+			let renderResult = tmp;
 
 			if (isTopLevelFragment) {
-				tmp.props.children = NULL;
+				renderResult = isArray(tmp.props.children)
+					? tmp.props.children.map(v =>
+							isArray(v) ? v : v != NULL && typeof v === 'object' ? { ...v } : v
+						)
+					: tmp.props.children != NULL && typeof tmp.props.children === 'object'
+						? { ...tmp.props.children }
+						: tmp.props.children;
 			}
 
 			oldDom = diffChildren(

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -1,5 +1,11 @@
 import { setupRerender } from 'preact/test-utils';
-import { createElement, render, Component, Fragment } from 'preact';
+import {
+	createElement,
+	render,
+	Component,
+	Fragment,
+	createContext
+} from 'preact';
 import { setupScratch, teardown } from '../_util/helpers';
 import { span, div, ul, ol, li, section } from '../_util/dom';
 import { logCall, clearLog, getLog } from '../_util/logCall';
@@ -3149,5 +3155,118 @@ describe('Fragment', () => {
 
 		expect(scratch.innerHTML).to.equal([div('A'), div(1), div(2)].join(''));
 		expectDomLogToBe(['<div>B.remove()', '<div>2A1.appendChild(<div>2)']);
+	});
+
+	it('Should retain content when parent rerenders', () => {
+		let toggle;
+		const ctx = createContext(null);
+
+		class Provider extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { value: props.value };
+				toggle = () => this.setState({ value: props.value + 1 });
+			}
+
+			render(props) {
+				return (
+					<ctx.Provider value={this.state.value}>{props.children}</ctx.Provider>
+				);
+			}
+		}
+
+		class App extends Component {
+			render() {
+				return (
+					<Provider value={1}>
+						<Fragment>
+							<p>Hello world</p>
+						</Fragment>
+					</Provider>
+				);
+			}
+		}
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal('<p>Hello world</p>');
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<p>Hello world</p>');
+	});
+
+	it('Should retain content when parent rerenders w/ multiple children', () => {
+		let toggle;
+		const ctx = createContext(null);
+
+		class Provider extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { value: props.value };
+				toggle = () => this.setState({ value: props.value + 1 });
+			}
+
+			render(props) {
+				return (
+					<ctx.Provider value={this.state.value}>{props.children}</ctx.Provider>
+				);
+			}
+		}
+
+		class App extends Component {
+			render() {
+				return (
+					<Provider value={1}>
+						<Fragment>
+							<p>Hello</p>
+							<p>World</p>
+						</Fragment>
+					</Provider>
+				);
+			}
+		}
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal('<p>Hello</p><p>World</p>');
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<p>Hello</p><p>World</p>');
+	});
+
+	it('Should retain content when parent rerenders w/ text children', () => {
+		let toggle;
+		const ctx = createContext(null);
+
+		class Provider extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { value: props.value };
+				toggle = () => this.setState({ value: props.value + 1 });
+			}
+
+			render(props) {
+				return (
+					<ctx.Provider value={this.state.value}>{props.children}</ctx.Provider>
+				);
+			}
+		}
+
+		class App extends Component {
+			render() {
+				return (
+					<Provider value={1}>
+						<Fragment>Hello world</Fragment>
+					</Provider>
+				);
+			}
+		}
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal('Hello world');
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal('Hello world');
 	});
 });

--- a/test/browser/fragments.test.js
+++ b/test/browser/fragments.test.js
@@ -3269,4 +3269,44 @@ describe('Fragment', () => {
 		rerender();
 		expect(scratch.innerHTML).to.equal('Hello world');
 	});
+
+	it('Should retain content when parent rerenders when deeper children are subscribed', () => {
+		let toggle;
+		const ctx = createContext(null);
+
+		class Provider extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { value: props.value };
+				toggle = () => this.setState({ value: props.value + 1 });
+			}
+
+			render(props) {
+				return (
+					<ctx.Provider value={this.state.value}>{props.children}</ctx.Provider>
+				);
+			}
+		}
+
+		class App extends Component {
+			render() {
+				return (
+					<Provider value={1}>
+						<Fragment>
+							<ctx.Consumer>
+								{value => <p>I can count to {value}</p>}
+							</ctx.Consumer>
+						</Fragment>
+					</Provider>
+				);
+			}
+		}
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal('<p>I can count to 1</p>');
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<p>I can count to 2</p>');
+	});
 });


### PR DESCRIPTION
Fixes #4716 

When we do strict equality bailouts we rely on `props.children` as we aren't invoking render, this rather than setting the top-level fragment children to null clones them.

I've confirmed that the memory leak of https://github.com/preactjs/preact/issues/4679 is still addressed 