### PR TITLE
refactor: Skip dom check for inferring lower-cased event names

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -66,13 +66,8 @@ export function setProperty(dom, name, value, oldValue, namespace) {
 	else if (name[0] == 'o' && name[1] == 'n') {
 		useCapture = name != (name = name.replace(CAPTURE_REGEX, '$1'));
 
-		// Infer correct casing for DOM built-in events:
-		if (
-			name.toLowerCase() in dom ||
-			name == 'onFocusOut' ||
-			name == 'onFocusIn'
-		)
-			name = name.toLowerCase().slice(2);
+		// Infer correct casing for events:
+		if (name[2].toLowerCase() != name[2]) name = name.toLowerCase().slice(2);
 		else name = name.slice(2);
 
 		if (!dom._listeners) dom._listeners = {};

--- a/test/browser/events.test.js
+++ b/test/browser/events.test.js
@@ -58,7 +58,7 @@ describe('event handling', () => {
 		expect(
 			proto.addEventListener
 		).to.have.been.calledOnce.and.to.have.been.calledWithExactly(
-			'OtherClick',
+			'otherclick',
 			sinon.match.func,
 			false
 		);


### PR DESCRIPTION
To my knowledge, all event types are lower cased with the possible exception of user-created events, as they can be any arbitrary name. We could simplify our check here & reduce a few bytes with the assumption that any user-created event will match the platform in naming/casing which, to me, sounds pretty reasonable? Using any other form of naming would be quite odd & something we could reasonably discourage, IMO.

Breaking change though as `onMyClickEvent` will now listen for `myclickevent` instead of `MyClickEvent`.

~~Need to fiddle with the check yet, though I think that's the smallest & fastest form. Beats regex or charCodeAt for sure.~~ Think this is the best option, lmk if anyone has other ideas!