### PR TITLE
revert: Bring back strict-equality bailout for children even w/ context updates

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -165,14 +165,14 @@ export function diff(
 				}
 
 				if (
-					!c._force &&
-					((c.shouldComponentUpdate != NULL &&
+					(!c._force &&
+						c.shouldComponentUpdate != NULL &&
 						c.shouldComponentUpdate(
 							newProps,
 							c._nextState,
 							componentContext
 						) === false) ||
-						newVNode._original == oldVNode._original)
+						newVNode._original == oldVNode._original
 				) {
 					// More info about this here: https://gist.github.com/JoviDeCroock/bec5f2ce93544d2e6070ef8e0036e4e8
 					if (newVNode._original != oldVNode._original) {


### PR DESCRIPTION
Reverts a portion of #4048

This has been a bit of an annoyance in `preact-iso` for a while; essentially, when navigating between async routes, our router will render both children (outgoing & incoming) once before swapping over to just the incoming. Because of #4048, which altered this conditional from `(!c._force && c.sCU() == false) || new._orig == old._orig` to `!c._force && (c.sCU() === false || new orig == old.orig)`, the outgoing route would now be rerendered with the new context value. Rerenders aren't great but this was specifically problematic as it was rerendering with location data that component should never see in the first place which can result in a few weird surprises for users.

Jovi & I had originally talked a bit about this prior to https://github.com/preactjs/preact-iso/pull/37, but we decided to just comment out the failing tests with a note as we only caught it long after the fact. It seems part of the prior PR can be safely reverted though, keeping the tests the user added.