### PR TITLE
Object.is fn for dependency comparison

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -537,7 +537,7 @@ function argsChanged(oldArgs, newArgs) {
 	return (
 		!oldArgs ||
 		oldArgs.length !== newArgs.length ||
-		newArgs.some((arg, index) => arg !== oldArgs[index])
+		newArgs.some((arg, index) => !Object.is(arg, oldArgs[index]))
 	);
 }
 


### PR DESCRIPTION
To match the dependency comparison behaviour with React.

**Preact:** runs on every re-render
`useEffect(() => {
  console.log("deps changed");
 },  [NaN]);`
Example - https://codepen.io/dsr/pen/RNwZqKP
 
**React:** only once
`useEffect(() => {
  console.log("deps changed");
 },  [NaN]);`
 Example - https://codepen.io/dsr/pen/MWMWEbG
 
 Similar for: useLayoutEffect, useMemo.
  