### PR TITLE
Avoid cloning reused nodes

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -172,7 +172,7 @@ export function diff(
 							c._nextState,
 							componentContext
 						) === false) ||
-						newVNode._original == oldVNode._original
+					newVNode._original == oldVNode._original
 				) {
 					// More info about this here: https://gist.github.com/JoviDeCroock/bec5f2ce93544d2e6070ef8e0036e4e8
 					if (newVNode._original != oldVNode._original) {
@@ -369,7 +369,11 @@ export function commitRoot(commitQueue, root, refQueue) {
 }
 
 function cloneNode(node) {
-	if (typeof node != 'object' || node == NULL) {
+	if (
+		typeof node != 'object' ||
+		node == NULL ||
+		(node._depth && node._depth > 1)
+	) {
 		return node;
 	}
 
@@ -531,8 +535,7 @@ function diffElementNodes(
 			if (
 				!isHydrating &&
 				(!oldHtml ||
-					(newHtml.__html != oldHtml.__html &&
-						newHtml.__html != dom.innerHTML))
+					(newHtml.__html != oldHtml.__html && newHtml.__html != dom.innerHTML))
 			) {
 				dom.innerHTML = newHtml.__html;
 			}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -372,7 +372,7 @@ function cloneNode(node) {
 	if (
 		typeof node != 'object' ||
 		node == NULL ||
-		(node._depth && node._depth > 1)
+		(node._depth && node._depth > 0)
 	) {
 		return node;
 	}

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1996,4 +1996,35 @@ describe('render()', () => {
 		render(<App y="2" />, scratch);
 		expect(actions).to.deep.equal(['mounted 1', 'mounted 2', 'mounted 3']);
 	});
+
+	it('Should render intercepted component', () => {
+		class Test {
+			constructor(text) {
+				this.text = text;
+			}
+		}
+
+		const TestValue = props => {
+			return props.text;
+		};
+
+		Object.defineProperties(Test.prototype, {
+			constructor: { configurable: true, value: undefined },
+			type: { configurable: true, value: TestValue },
+			props: {
+				configurable: true,
+				get() {
+					return { text: this.text };
+				}
+			},
+			_depth: { configurable: true, value: 1 }
+		});
+
+		const test = new Test('hello world');
+
+		const App = () => <Fragment>{test}</Fragment>;
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal('hello world');
+	});
 });


### PR DESCRIPTION
Fixes https://github.com/preactjs/signals/issues/659

Avoid cloning nodes that we are re-using, the diffChildren algorithm will already ensure we clone these and we do it in a more correct way there https://github.com/preactjs/preact/blob/main/src/diff/children.js#L210. In signals we rely on this cloning with https://github.com/preactjs/signals/blob/main/packages/preact/src/index.ts#L164

I have yet to test this fix, but this looks like the right approach 😅 

EDIT: does seem to work https://stackblitz.com/edit/vitejs-vite-jdff8rn3?file=src%2Fsignals.js,src%2Fapp.tsx,src%2Fpreact.js,src%2Fhooks.js,src%2Fmain.tsx