### PR TITLE
10.26.5

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -13,7 +13,7 @@ export function initDevTools() {
 		globalVar !== undefined &&
 		globalVar.__PREACT_DEVTOOLS__
 	) {
-		globalVar.__PREACT_DEVTOOLS__.attachPreact('10.26.4', options, {
+		globalVar.__PREACT_DEVTOOLS__.attachPreact('10.26.5', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "10.26.4",
+  "version": "10.26.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "10.26.4",
+      "version": "10.26.5",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.26.4",
+  "version": "10.26.5",
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
## Types

- Return 'AllHTMLAttributes' to manually including all attrs (#4728, thanks @rschristian)

## Fixes

- Avoid cloning reused nodes (#4733, thanks @JoviDeCroock)
- Bring back strict-equality bailout for children even w/ context updates (#4724, thanks @rschristian)
- Effect in memoed boundary should be re-executed when the lazy boundary resolves (#4711, thanks @CaptainWang98)

## Maintenance

- Add case for context w/ strictly-equal children (#4725, thanks @rschristian)
- Golf down unnecessary strict equality checks (#4723, thanks @rschristian)