### PR TITLE
Bugfix: Change `HTMLMediaElement.controlslist` type to string (DOMTokenList)

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1289,12 +1289,8 @@ export namespace JSXInternal {
 		/** @deprecated See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contextmenu */
 		contextmenu?: Signalish<string | undefined>;
 		controls?: Signalish<boolean | undefined>;
-		controlslist?: Signalish<
-			'nodownload' | 'nofullscreen' | 'noremoteplayback' | undefined
-		>;
-		controlsList?: Signalish<
-			'nodownload' | 'nofullscreen' | 'noremoteplayback' | undefined
-		>;
+		controlslist?: Signalish<string | undefined>;
+		controlsList?: Signalish<string | undefined>;
 		coords?: Signalish<string | undefined>;
 		crossOrigin?: Signalish<string | undefined>;
 		crossorigin?: Signalish<string | undefined>;
@@ -1960,12 +1956,8 @@ export namespace JSXInternal {
 		autoplay?: Signalish<boolean | undefined>;
 		autoPlay?: Signalish<boolean | undefined>;
 		controls?: Signalish<boolean | undefined>;
-		controlslist?: Signalish<
-			'nodownload' | 'nofullscreen' | 'noremoteplayback' | undefined
-		>;
-		controlsList?: Signalish<
-			'nodownload' | 'nofullscreen' | 'noremoteplayback' | undefined
-		>;
+		controlslist?: Signalish<string | undefined>;
+		controlsList?: Signalish<string | undefined>;
 		crossorigin?: Signalish<HTMLAttributeCrossOrigin>;
 		crossOrigin?: Signalish<HTMLAttributeCrossOrigin>;
 		currentTime?: Signalish<number | undefined>;


### PR DESCRIPTION
This partially reverts #4705 which incorrectly narrowed down types for [HTMLMediaElement.controlsList](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList) attribute.

The `controlsList` attribute is a `DOMTokenList` (space separated list of recommended keywords, like Element.classList), not a single keyword.

Reproduction:

```tsx
function video() {
  return (
    <video controlsList="nodownload nofullscreen noremoteplayback noplaybackrate" />
  )
}

// error TS2322: Type '"nodownload nofullscreen noremoteplayback noplaybackrate"' is not assignable to type 'Signalish<"nodownload" | "nofullscreen" | "noremoteplayback" | undefined>'.
```

References:
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/controlsList
- https://wicg.github.io/controls-list/explainer.html
- https://googlechrome.github.io/samples/media/controlslist.html