### PR TITLE
10.26.6

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -13,7 +13,7 @@ export function initDevTools() {
 		globalVar !== undefined &&
 		globalVar.__PREACT_DEVTOOLS__
 	) {
-		globalVar.__PREACT_DEVTOOLS__.attachPreact('10.26.5', options, {
+		globalVar.__PREACT_DEVTOOLS__.attachPreact('10.26.6', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "10.26.5",
+  "version": "10.26.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "10.26.5",
+      "version": "10.26.6",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.26.5",
+  "version": "10.26.6",
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
## Fixes

- Ensure useId works in portals (#4752, thanks @JoviDeCroock)

## Types

- Change `HTMLMediaElement.controlsList` type to string (DOMTokenList) (#4744, thanks @piotr-cz)

## Maintenance
- Switch testing from karma to vitest (#4687, thanks @JoviDeCroock)
- Dedupe preact in vitest setup (#4702, thanks @sheremet-va)