### PR TITLE
Golf some portal bytes

### DIFF
--- a/compat/src/portals.js
+++ b/compat/src/portals.js
@@ -47,11 +47,6 @@ function Portal(props) {
 			childNodes: [],
 			_children: { _mask: root._mask },
 			contains: () => true,
-			// Technically this isn't needed
-			appendChild(child) {
-				this.childNodes.push(child);
-				_this._container.appendChild(child);
-			},
 			insertBefore(child, before) {
 				this.childNodes.push(child);
 				_this._container.insertBefore(child, before);

--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -246,6 +246,44 @@ describe('Portal', () => {
 		);
 	});
 
+	it('should have unique ids for each portal, even when a new one shows up', () => {
+		let root = document.createElement('div');
+		let dialog = document.createElement('div');
+		dialog.id = 'container';
+
+		scratch.appendChild(root);
+		scratch.appendChild(dialog);
+
+		function Id() {
+			const id = useId();
+			return id;
+		}
+
+		function Dialog(props) {
+			return <Id />;
+		}
+
+		function App(props) {
+			return (
+				<div>
+					<Id />
+					{createPortal(<Dialog />, dialog)}
+					{props.renderPortal && createPortal(<Dialog />, dialog)}
+				</div>
+			);
+		}
+
+		render(<App />, root);
+		expect(scratch.innerHTML).to.equal(
+			'<div><div>P0-0</div></div><div id="container">P0-1</div>'
+		);
+
+		render(<App renderPortal={true} />, root);
+		expect(scratch.innerHTML).to.equal(
+			'<div><div>P0-0</div></div><div id="container">P0-1P0-2</div>'
+		);
+	});
+
 	it('should unmount Portal', () => {
 		let root = document.createElement('div');
 		let dialog = document.createElement('div');

--- a/test/shared/createContext.test.js
+++ b/test/shared/createContext.test.js
@@ -1,4 +1,4 @@
-import { createElement, createContext } from '../../';
+import { createElement, createContext } from '../../src/index';
 import { expect } from 'chai';
 
 /** @jsx createElement */

--- a/test/shared/createElement.test.js
+++ b/test/shared/createElement.test.js
@@ -1,4 +1,4 @@
-import { createElement } from '../../';
+import { createElement } from '../../src/index';
 import { expect } from 'chai';
 
 const h = createElement;

--- a/test/shared/exports.test.js
+++ b/test/shared/exports.test.js
@@ -11,7 +11,7 @@ import {
 	createRef,
 	toChildArray,
 	isValidElement
-} from '../../';
+} from '../../src/index';
 import { expect } from 'chai';
 
 describe('preact', () => {

--- a/test/shared/isValidElement.test.js
+++ b/test/shared/isValidElement.test.js
@@ -1,4 +1,4 @@
-import { createElement, isValidElement, Component } from '../../';
+import { createElement, isValidElement, Component } from '../../src/index';
 import { expect } from 'chai';
 import { isValidElementTests } from './isValidElementTests';
 


### PR DESCRIPTION
This golfs some bytes from the portal implementation as well as changing the `_mask` thing. ~~I ended up feeling a bit uncomfortable while thinking about testing solutions and this being on `_children`~~ Shook it off as this is not a VNode but a FAUX dom node