### PR TITLE
fix(types): add `name` to `<details>`

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1703,6 +1703,7 @@ export namespace JSXInternal {
 
 	interface DetailsHTMLAttributes<T extends EventTarget = HTMLDetailsElement>
 		extends HTMLAttributes<T> {
+		name?: Signalish<string | undefined>;
 		open?: Signalish<boolean | undefined>;
 	}
 


### PR DESCRIPTION
We were missing types for the `name` attribute for `<detail>`-elements, see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/details#name