### PR TITLE
chore: Specify target browsers

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -24,7 +24,13 @@ module.exports = function (api) {
 					modules: noModules ? false : 'auto',
 					exclude: ['@babel/plugin-transform-typeof-symbol'],
 					targets: {
-						browsers: ['last 2 versions', 'IE >= 9']
+						browsers: [
+							'chrome >= 40',
+							'safari >= 9',
+							'firefox >= 36',
+							'edge >= 12',
+							'not dead'
+						]
 					}
 				}
 			]


### PR DESCRIPTION
Shouldn't have any effect at the moment but it is used by Microbundle and so should be adjusted to make sure we're not getting any silly transpiling changes in the future.

[As mentioned](https://github.com/preactjs/preact/pull/4549#discussion_r2105749158), these are the browsers that support `Symbol.for` which is our new absolute floor (can be increased yet of course).