### PR TITLE
Fix nullish default props

### DIFF
--- a/jsx-runtime/src/index.js
+++ b/jsx-runtime/src/index.js
@@ -69,7 +69,7 @@ function createVNode(type, props, key, isStaticChildren, __source, __self) {
 	// Note: `type` is often a String, and can be `undefined` in development.
 	if (typeof type === 'function' && (ref = type.defaultProps)) {
 		for (i in ref)
-			if (typeof normalizedProps[i] === 'undefined') {
+			if (normalizedProps[i] === undefined) {
 				normalizedProps[i] = ref[i];
 			}
 	}

--- a/jsx-runtime/test/browser/jsx-runtime.test.js
+++ b/jsx-runtime/test/browser/jsx-runtime.test.js
@@ -68,6 +68,12 @@ describe('Babel jsx/jsxDEV', () => {
 		});
 	});
 
+	it('should respect defaultProps when props are null', () => {
+		const Component = ({ children }) => children;
+		Component.defaultProps = { foo: 'bar' };
+		expect(jsx(Component, { foo: null }).props).to.deep.equal({ foo: null });
+	});
+
 	it('should keep props over defaultProps', () => {
 		class Foo extends Component {
 			render() {

--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -26,7 +26,7 @@ export function cloneElement(vnode, props, children) {
 	for (i in props) {
 		if (i == 'key') key = props[i];
 		else if (i == 'ref') ref = props[i];
-		else if (props[i] == UNDEFINED && defaultProps != UNDEFINED) {
+		else if (props[i] === UNDEFINED && defaultProps != UNDEFINED) {
 			normalizedProps[i] = defaultProps[i];
 		} else {
 			normalizedProps[i] = props[i];

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -33,7 +33,7 @@ export function createElement(type, props, children) {
 	// Note: type may be undefined in development, must never error here.
 	if (typeof type == 'function' && type.defaultProps != NULL) {
 		for (i in type.defaultProps) {
-			if (normalizedProps[i] == UNDEFINED) {
+			if (normalizedProps[i] === UNDEFINED) {
 				normalizedProps[i] = type.defaultProps[i];
 			}
 		}

--- a/test/browser/cloneElement.test.js
+++ b/test/browser/cloneElement.test.js
@@ -97,4 +97,17 @@ describe('cloneElement', () => {
 		const clone = cloneElement(element, { color: undefined });
 		expect(clone.props.color).to.equal('blue');
 	});
+
+	it('should prevent undefined properties from overriding default props', () => {
+		class Example extends Component {
+			render(props) {
+				return <div style={{ color: props.color }}>thing</div>;
+			}
+		}
+		Example.defaultProps = { color: 'blue' };
+
+		const element = <Example color="red" />;
+		const clone = cloneElement(element, { color: null });
+		expect(clone.props.color).to.equal(null);
+	});
 });

--- a/test/shared/createElement.test.js
+++ b/test/shared/createElement.test.js
@@ -271,6 +271,12 @@ describe('createElement(jsx)', () => {
 		expect(h(Component, null).props).to.deep.equal({ foo: 'bar' });
 	});
 
+	it('should respect defaultProps when props are null', () => {
+		const Component = ({ children }) => children;
+		Component.defaultProps = { foo: 'bar' };
+		expect(h(Component, { foo: null }).props).to.deep.equal({ foo: null });
+	});
+
 	it('should override defaultProps', () => {
 		const Component = ({ children }) => children;
 		Component.defaultProps = { foo: 'default' };


### PR DESCRIPTION
Fixes https://github.com/preactjs/preact/issues/4774

This PR fixes an issue with the handling of null values in component props when default props are set. Previously, the loose equality check (==) would treat null values the same as undefined, causing default props to override explicitly passed null values. The fix changes these checks to strict equality (===), ensuring that null values are preserved as intended.

The change applies to:

- createElement
- cloneElement
- jsx-runtime

Test cases were added to verify proper handling of null prop values with defaultProps in all affected locations.