### PR TITLE
refactor (v11): Remove deprecated 'ForwardFn' type from compat

### DIFF
--- a/compat/src/forwardRef.js
+++ b/compat/src/forwardRef.js
@@ -6,7 +6,7 @@ export const REACT_FORWARD_SYMBOL = Symbol.for('react.forward_ref');
  * Pass ref down to a child. This is mainly used in libraries with HOCs that
  * wrap components. Using `forwardRef` there is an easy way to get a reference
  * of the wrapped component instead of one of the wrapper itself.
- * @param {import('./index').ForwardFn} fn
+ * @param {import('./index').ForwardRefRenderFunction} fn
  * @returns {import('./internal').FunctionComponent}
  */
 export function forwardRef(fn) {

--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -335,14 +335,6 @@ declare namespace React {
 		ref?: preact1.Ref<R> | undefined;
 	}
 
-	/**
-	 * @deprecated Please use `ForwardRefRenderFunction` instead.
-	 */
-	export interface ForwardFn<P = {}, T = any> {
-		(props: P, ref: ForwardedRef<T>): preact1.ComponentChild;
-		displayName?: string;
-	}
-
 	export interface ForwardRefRenderFunction<T = any, P = {}> {
 		(props: P, ref: ForwardedRef<T>): preact1.ComponentChild;
 		displayName?: string;

--- a/compat/test/ts/forward-ref.tsx
+++ b/compat/test/ts/forward-ref.tsx
@@ -1,9 +1,9 @@
 import React from '../../src';
 
-const MyInput: React.ForwardFn<{ id: string }, { focus(): void }> = (
-	props,
-	ref
-) => {
+const MyInput: React.ForwardRefRenderFunction<
+	{ focus(): void },
+	{ id: string }
+> = (props, ref) => {
 	const inputRef = React.useRef<HTMLInputElement>(null);
 
 	React.useImperativeHandle(ref, () => ({


### PR DESCRIPTION
`ForwardFn` is a Preact-only type, created for internal use originally. This however doesn't match the React name (`ForwardRefRenderFunction`) and also reverses the order of the generics. #4675 added the React-compatible type, deprecating `ForwardFn`, and I think it's safe to remove for v11. I can see no usage of it in the wild from a code search here and it'll be pretty quick to correct for any users who do rely on it.