### PR TITLE
Export test-utils from compat

### DIFF
--- a/compat/package.json
+++ b/compat/package.json
@@ -46,6 +46,10 @@
       "import": "./scheduler.mjs",
       "require": "./scheduler.js"
     },
+    "./test-utils": {
+      "import": "./test-utils.mjs",
+      "require": "./test-utils.js"
+    },
     "./package.json": "./package.json"
   }
 }

--- a/compat/test-utils.mjs
+++ b/compat/test-utils.mjs
@@ -1,0 +1,1 @@
+export * from 'preact/test-utils';

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "compat/scheduler.js",
     "compat/scheduler.mjs",
     "compat/test-utils.js",
+    "compat/test-utils.mjs",
     "compat/jsx-runtime.js",
     "compat/jsx-runtime.mjs",
     "compat/jsx-dev-runtime.js",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,13 @@
       "import": "./test-utils/dist/testUtils.mjs",
       "require": "./test-utils/dist/testUtils.js"
     },
+    "./compat/test-utils": {
+      "types": "./test-utils/src/index.d.ts",
+      "browser": "./test-utils/dist/testUtils.module.js",
+      "umd": "./test-utils/dist/testUtils.umd.js",
+      "import": "./test-utils/dist/testUtils.mjs",
+      "require": "./test-utils/dist/testUtils.js"
+    },
     "./jsx-runtime": {
       "types": "./jsx-runtime/src/index.d.ts",
       "browser": "./jsx-runtime/dist/jsxRuntime.module.js",


### PR DESCRIPTION
Hello!

`react-dom` exports test-utils as `react-dom/test-utils` (https://github.com/facebook/react/blob/d742611ce40545127032f4e221c78bf9f70eb437/packages/react-dom/package.json#L113C5-L113C39)

since it is very common to resolve `react` and `react-dom` to `preact/compat` the fact that `preact/compat/test-utils` isn't a valid export can break some things.

I noticed this trying to run storybook preact. Storybook Vite lists `'react-dom/test-utils'` as an `optimizeDependency` candidate. Since this ultimately tries to get resolved as `preact/compat/test-utils` it breaks.