### PR TITLE
refactor (v11): Remove all export maps in nested pkg.json files

### DIFF
--- a/compat/package.json
+++ b/compat/package.json
@@ -1,7 +1,6 @@
 {
   "name": "preact-compat",
   "amdName": "preactCompat",
-  "version": "4.0.0",
   "private": true,
   "description": "A React compatibility layer for Preact",
   "main": "dist/compat.js",
@@ -15,41 +14,5 @@
   },
   "peerDependencies": {
     "preact": "^10.0.0"
-  },
-  "exports": {
-    ".": {
-      "types": "./src/index.d.ts",
-      "module": "./dist/compat.mjs",
-      "umd": "./dist/compat.umd.js",
-      "import": "./dist/compat.mjs",
-      "require": "./dist/compat.js"
-    },
-    "./client": {
-      "types": "./client.d.ts",
-      "import": "./client.mjs",
-      "require": "./client.js"
-    },
-    "./server": {
-      "browser": "./server.browser.js",
-      "import": "./server.mjs",
-      "require": "./server.js"
-    },
-    "./jsx-runtime": {
-      "import": "./jsx-runtime.mjs",
-      "require": "./jsx-runtime.js"
-    },
-    "./jsx-dev-runtime": {
-      "import": "./jsx-dev-runtime.mjs",
-      "require": "./jsx-dev-runtime.js"
-    },
-    "./scheduler": {
-      "import": "./scheduler.mjs",
-      "require": "./scheduler.js"
-    },
-    "./test-utils": {
-      "import": "./test-utils.mjs",
-      "require": "./test-utils.js"
-    },
-    "./package.json": "./package.json"
   }
 }

--- a/debug/package.json
+++ b/debug/package.json
@@ -1,27 +1,18 @@
 {
   "name": "preact-debug",
   "amdName": "preactDebug",
-  "version": "1.0.0",
   "private": true,
   "description": "Preact extensions for development",
   "main": "dist/debug.js",
   "module": "dist/debug.mjs",
   "umd:main": "dist/debug.umd.js",
   "source": "src/index.js",
+  "types": "src/index.d.ts",
   "license": "MIT",
   "mangle": {
     "regex": "^(?!_renderer)^_"
   },
   "peerDependencies": {
     "preact": "^10.0.0"
-  },
-  "exports": {
-    ".": {
-      "types": "./src/index.d.ts",
-      "module": "./dist/debug.mjs",
-      "umd": "./dist/debug.umd.js",
-      "import": "./dist/debug.mjs",
-      "require": "./dist/debug.js"
-    }
   }
 }

--- a/devtools/package.json
+++ b/devtools/package.json
@@ -1,25 +1,15 @@
 {
   "name": "preact-devtools",
   "amdName": "preactDevtools",
-  "version": "1.0.0",
   "private": true,
   "description": "Preact bridge for Preact devtools",
   "main": "dist/devtools.js",
   "module": "dist/devtools.mjs",
   "umd:main": "dist/devtools.umd.js",
   "source": "src/index.js",
-  "license": "MIT",
   "types": "src/index.d.ts",
+  "license": "MIT",
   "peerDependencies": {
     "preact": "^10.0.0"
-  },
-  "exports": {
-    ".": {
-      "types": "./src/index.d.ts",
-      "module": "./dist/devtools.mjs",
-      "umd": "./dist/devtools.umd.js",
-      "import": "./dist/devtools.mjs",
-      "require": "./dist/devtools.js"
-    }
   }
 }

--- a/hooks/package.json
+++ b/hooks/package.json
@@ -1,35 +1,18 @@
 {
   "name": "preact-hooks",
   "amdName": "preactHooks",
-  "version": "0.1.0",
   "private": true,
   "description": "Hook addon for Preact",
   "main": "dist/hooks.js",
   "module": "dist/hooks.mjs",
   "umd:main": "dist/hooks.umd.js",
   "source": "src/index.js",
-  "license": "MIT",
   "types": "src/index.d.ts",
-  "scripts": {
-    "build": "microbundle build --raw",
-    "dev": "microbundle watch --raw --format cjs",
-    "test": "npm-run-all build --parallel test:karma",
-    "test:karma": "karma start test/karma.conf.js --single-run",
-    "test:karma:watch": "karma start test/karma.conf.js --no-single-run"
-  },
-  "peerDependencies": {
-    "preact": "^10.0.0"
-  },
+  "license": "MIT",
   "mangle": {
     "regex": "^_"
   },
-  "exports": {
-    ".": {
-      "types": "./src/index.d.ts",
-      "module": "./dist/hooks.mjs",
-      "umd": "./dist/hooks.umd.js",
-      "import": "./dist/hooks.mjs",
-      "require": "./dist/hooks.js"
-    }
+  "peerDependencies": {
+    "preact": "^10.0.0"
   }
 }

--- a/jsx-runtime/package.json
+++ b/jsx-runtime/package.json
@@ -1,7 +1,6 @@
 {
   "name": "jsx-runtime",
   "amdName": "jsxRuntime",
-  "version": "1.0.0",
   "private": true,
   "description": "Preact JSX runtime",
   "main": "dist/jsxRuntime.js",
@@ -10,19 +9,10 @@
   "source": "src/index.js",
   "types": "src/index.d.ts",
   "license": "MIT",
-  "peerDependencies": {
-    "preact": "^10.0.0"
-  },
   "mangle": {
     "regex": "^_"
   },
-  "exports": {
-    ".": {
-      "types": "./src/index.d.ts",
-      "module": "./dist/jsxRuntime.mjs",
-      "umd": "./dist/jsxRuntime.umd.js",
-      "import": "./dist/jsxRuntime.mjs",
-      "require": "./dist/jsxRuntime.js"
-    }
+  "peerDependencies": {
+    "preact": "^10.0.0"
   }
 }

--- a/test-utils/package.json
+++ b/test-utils/package.json
@@ -1,28 +1,18 @@
 {
   "name": "test-utils",
   "amdName": "preactTestUtils",
-  "version": "0.1.0",
   "private": true,
   "description": "Test-utils for Preact",
   "main": "dist/testUtils.js",
   "module": "dist/testUtils.mjs",
   "umd:main": "dist/testUtils.umd.js",
   "source": "src/index.js",
-  "license": "MIT",
   "types": "src/index.d.ts",
-  "peerDependencies": {
-    "preact": "^10.0.0"
-  },
+  "license": "MIT",
   "mangle": {
     "regex": "^_"
   },
-  "exports": {
-    ".": {
-      "types": "./src/index.d.ts",
-      "module": "./dist/testUtils.mjs",
-      "umd": "./dist/testUtils.umd.js",
-      "import": "./dist/testUtils.mjs",
-      "require": "./dist/testUtils.js"
-    }
+  "peerDependencies": {
+    "preact": "^10.0.0"
   }
 }


### PR DESCRIPTION
These were originally added in #3565 to support our use of `.module.js` as ESM in tools like Vite & Vitest (which incorrectly implement the top-level `"module"` spec) as they use a non-standard resolution mechanism which allows this to be a viable hack.

This has become unnecessary in v11 though, we're exclusively using `.mjs` for ESM and so these serve no real purpose anymore. We could get rid of the nested `package.json` files altogether and move the Microbundle config into the root `package.json` too if we wanted at some point, but I'll leave that for now.

While I was at it I removed left-over `"script"` & `"version"` entries (AFAICT `"version"` was never requested/needed by anyone, might've been copy/pasted in without much thought?) and re-ordered the keys to make the files consistent. Sorry for the OCD 😅