### PR TITLE
Avoid caching so file-saves work first try

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,8 @@
         "@types/mocha": "^10.0.0",
         "@types/node": "^18.19.87",
         "@types/sinon": "^17.0.3",
-        "@vitest/browser": "^3.1.2",
-        "@vitest/coverage-istanbul": "^3.1.2",
+        "@vitest/browser": "^3.2.1",
+        "@vitest/coverage-istanbul": "^3.2.1",
         "babel-plugin-transform-rename-properties": "0.1.0",
         "chai": "^5.2.0",
         "coveralls": "^3.1.1",
@@ -44,8 +44,8 @@
         "typescript": "5.1.6",
         "undici": "^4.12.0",
         "vite": "^6.2.0",
-        "vitest": "^3.1.2",
-        "webdriverio": "^9.11.0"
+        "vitest": "^3.2.1",
+        "webdriverio": "^9.15.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3434,9 +3434,9 @@
       "dev": true
     },
     "node_modules/@types/chai": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.1.tgz",
-      "integrity": "sha512-iu1JLYmGmITRzUgNiLMZD3WCoFzpYtueuyAgHTXqgwSRAMIlFTnZqG6/xenkpUGRJEzSfklUTI4GNSzks/dc0w==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
       "dev": true,
       "dependencies": {
         "@types/deep-eql": "*"
@@ -3525,26 +3525,26 @@
       }
     },
     "node_modules/@vitest/browser": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-3.1.2.tgz",
-      "integrity": "sha512-dwL6hQg3NSDP3Z4xzIZL0xHq/AkQAPQ4StFpWVlY2zbRJtK3Y2YqdFZ7YmZjszTETN1BDQZRn/QOrcP+c8ATgg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-3.2.1.tgz",
+      "integrity": "sha512-7GKkf05uoFN1WLsLWIEOkKq61dcfErwHXh20pJN7YYUzkRrrfvMTnB3aTYxi3syWQ95jeUs9asanoZNTpS42GQ==",
       "dev": true,
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
-        "@vitest/mocker": "3.1.2",
-        "@vitest/utils": "3.1.2",
+        "@vitest/mocker": "3.2.1",
+        "@vitest/utils": "3.2.1",
         "magic-string": "^0.30.17",
         "sirv": "^3.0.1",
         "tinyrainbow": "^2.0.0",
-        "ws": "^8.18.1"
+        "ws": "^8.18.2"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "playwright": "*",
-        "vitest": "3.1.2",
+        "vitest": "3.2.1",
         "webdriverio": "^7.0.0 || ^8.0.0 || ^9.0.0"
       },
       "peerDependenciesMeta": {
@@ -3559,47 +3559,6 @@
         }
       }
     },
-    "node_modules/@vitest/browser/node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-      "dev": true
-    },
-    "node_modules/@vitest/browser/node_modules/@vitest/mocker": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.2.tgz",
-      "integrity": "sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==",
-      "dev": true,
-      "dependencies": {
-        "@vitest/spy": "3.1.2",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitest/browser/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/@vitest/browser/node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -3610,13 +3569,13 @@
       }
     },
     "node_modules/@vitest/coverage-istanbul": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-3.1.2.tgz",
-      "integrity": "sha512-PXjSd4g7SxlC9WJ00jbMMFJob+LcjXUYow5vpXuZe/acjhlEQgCaf6npm+W9Mg/ahiFKtIAHI+P8A9n2JfZilg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-3.2.1.tgz",
+      "integrity": "sha512-GLNByl+nFP1GPAhmlL7iFVonVKk/GuZcCfNSXX6uPuH30X62jmQy3ZkzxTZoHLkTQwTONM/JY9sxVjQyuL6koQ==",
       "dev": true,
       "dependencies": {
         "@istanbuljs/schema": "^0.1.3",
-        "debug": "^4.4.0",
+        "debug": "^4.4.1",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-instrument": "^6.0.3",
         "istanbul-lib-report": "^3.0.1",
@@ -3630,7 +3589,7 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "3.1.2"
+        "vitest": "3.2.1"
       }
     },
     "node_modules/@vitest/coverage-istanbul/node_modules/brace-expansion": {
@@ -3692,13 +3651,14 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.2.tgz",
-      "integrity": "sha512-O8hJgr+zREopCAqWl3uCVaOdqJwZ9qaDwUP7vy3Xigad0phZe9APxKhPcDNqYYi0rX5oMvwJMSCAXY2afqeTSA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.1.tgz",
+      "integrity": "sha512-FqS/BnDOzV6+IpxrTg5GQRyLOCtcJqkwMwcS8qGCI2IyRVDwPAtutztaf1CjtPHlZlWtl1yUPCd7HM0cNiDOYw==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "3.1.2",
-        "@vitest/utils": "3.1.2",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.1",
+        "@vitest/utils": "3.2.1",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -3706,10 +3666,60 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.1.tgz",
+      "integrity": "sha512-OXxMJnx1lkB+Vl65Re5BrsZEHc90s5NMjD23ZQ9NlU7f7nZiETGoX4NeKZSmsKjseuMq2uOYXdLOeoM0pJU+qw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.1",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/@types/estree": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "dev": true
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
-      "integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.1.tgz",
+      "integrity": "sha512-xBh1X2GPlOGBupp6E1RcUQWIxw0w/hRLd3XyBS6H+dMdKTAqHDNsIR2AnJwPA3yYe9DFy3VUKTe3VRTrAiQ01g==",
       "dev": true,
       "dependencies": {
         "tinyrainbow": "^2.0.0"
@@ -3719,12 +3729,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.2.tgz",
-      "integrity": "sha512-bhLib9l4xb4sUMPXnThbnhX2Yi8OutBMA8Yahxa7yavQsFDtwY/jrUZwpKp2XH9DhRFJIeytlyGpXCqZ65nR+g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.1.tgz",
+      "integrity": "sha512-kygXhNTu/wkMYbwYpS3z/9tBe0O8qpdBuC3dD/AW9sWa0LE/DAZEjnHtWA9sIad7lpD4nFW1yQ+zN7mEKNH3yA==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "3.1.2",
+        "@vitest/utils": "3.2.1",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -3732,12 +3742,12 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.2.tgz",
-      "integrity": "sha512-Q1qkpazSF/p4ApZg1vfZSQ5Yw6OCQxVMVrLjslbLFA1hMDrT2uxtqMaw8Tc/jy5DLka1sNs1Y7rBcftMiaSH/Q==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.1.tgz",
+      "integrity": "sha512-5xko/ZpW2Yc65NVK9Gpfg2y4BFvcF+At7yRT5AHUpTg9JvZ4xZoyuRY4ASlmNcBZjMslV08VRLDrBOmUe2YX3g==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "3.1.2",
+        "@vitest/pretty-format": "3.2.1",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -3755,24 +3765,24 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.2.tgz",
-      "integrity": "sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.1.tgz",
+      "integrity": "sha512-Nbfib34Z2rfcJGSetMxjDCznn4pCYPZOtQYox2kzebIJcgH75yheIKd5QYSFmR8DIZf2M8fwOm66qSDIfRFFfQ==",
       "dev": true,
       "dependencies": {
-        "tinyspy": "^3.0.2"
+        "tinyspy": "^4.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.2.tgz",
-      "integrity": "sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.1.tgz",
+      "integrity": "sha512-KkHlGhePEKZSub5ViknBcN5KEF+u7dSUr9NW8QsVICusUojrgrOnnY3DEWWO877ax2Pyopuk2qHmt+gkNKnBVw==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "3.1.2",
+        "@vitest/pretty-format": "3.2.1",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -3781,14 +3791,14 @@
       }
     },
     "node_modules/@wdio/config": {
-      "version": "9.12.6",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.12.6.tgz",
-      "integrity": "sha512-zlOJixJUHxeoyfIN/KdM797HwJj/oNgBaEdftgJARqbXt5AVZu18vJ3zljb+wzbY2M0pl7Y4+5OFH06WlDgQ+A==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.15.0.tgz",
+      "integrity": "sha512-IQzSZx2Y0KdAVWHSdcBLkuUjCmYtOnc1oDY7Psi814wDR7dEPVOuKgMo8ZZ0P1yhioMzqvy5tBemYSzj7CrFTA==",
       "dev": true,
       "dependencies": {
-        "@wdio/logger": "9.4.4",
-        "@wdio/types": "9.12.6",
-        "@wdio/utils": "9.12.6",
+        "@wdio/logger": "9.15.0",
+        "@wdio/types": "9.15.0",
+        "@wdio/utils": "9.15.0",
         "deepmerge-ts": "^7.0.3",
         "glob": "^10.2.2",
         "import-meta-resolve": "^4.0.0"
@@ -3842,9 +3852,9 @@
       }
     },
     "node_modules/@wdio/logger": {
-      "version": "9.4.4",
-      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.4.4.tgz",
-      "integrity": "sha512-BXx8RXFUW2M4dcO6t5Le95Hi2ZkTQBRsvBQqLekT2rZ6Xmw8ZKZBPf0FptnoftFGg6dYmwnDidYv/0+4PiHjpQ==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.15.0.tgz",
+      "integrity": "sha512-3IkaissyOsUQwg8IinkVm1svsvRMGJpFyaSiEhQ0oQXD7mnWrNVFSU9kmeFvbKAtoc4j60FRjU6XqtH94xRceg==",
       "dev": true,
       "dependencies": {
         "chalk": "^5.1.2",
@@ -3857,9 +3867,9 @@
       }
     },
     "node_modules/@wdio/protocols": {
-      "version": "9.12.5",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.12.5.tgz",
-      "integrity": "sha512-i+yc0EZtZOh5fFuwHxvcnXeTXk2ZjFICRbcAxTNE0F2Jr4uOydvcAOw4EIIRmb9NWUSPf/bGZAA+4SEXmxmjUA==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.15.0.tgz",
+      "integrity": "sha512-5O7bwiG7t8nmSVOx888YryO/9AQgQ7p/Ecd9rS13UyDQL169HmVKXP0vvJKGH3X+oeE92U1wVrwrIl4Xx3BQ6Q==",
       "dev": true
     },
     "node_modules/@wdio/repl": {
@@ -3890,9 +3900,9 @@
       "dev": true
     },
     "node_modules/@wdio/types": {
-      "version": "9.12.6",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.12.6.tgz",
-      "integrity": "sha512-WzZhaN834du9wjqT/Go9qPyB7VkzV2bjr6pr06DrIzxIpJq/snWOv96C6OjJu8nmYNRjV769mAxyggBUf+sUoQ==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.15.0.tgz",
+      "integrity": "sha512-hR0Dm9TsrjtgOLWOjUMYTOB1hWIlnDzFgZt7XGOzI9Ig8Qa+TDfZSFaZukGxqLIZS/eGhxpnunSHaTAXwJIxYA==",
       "dev": true,
       "dependencies": {
         "@types/node": "^20.1.0"
@@ -3902,9 +3912,9 @@
       }
     },
     "node_modules/@wdio/types/node_modules/@types/node": {
-      "version": "20.17.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
-      "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
+      "version": "20.17.57",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.57.tgz",
+      "integrity": "sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -3917,14 +3927,14 @@
       "dev": true
     },
     "node_modules/@wdio/utils": {
-      "version": "9.12.6",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.12.6.tgz",
-      "integrity": "sha512-JfI4CxBRQCOgToJeQNaZLv+wYNIGyJG1gqrpxUOvkrJvBgdOAmIu3dzlcKP/WviXlcxvwLQF2FK8bQVTjHv0fQ==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.15.0.tgz",
+      "integrity": "sha512-XuT1PE1nh4wwJfQW6IN4UT6+iv0+Yf4zhgMh5et04OX6tfrIXkWdx2SDimghDtRukp9i85DvIGWjdPEoQFQdaA==",
       "dev": true,
       "dependencies": {
         "@puppeteer/browsers": "^2.2.0",
-        "@wdio/logger": "9.4.4",
-        "@wdio/types": "9.12.6",
+        "@wdio/logger": "9.15.0",
+        "@wdio/types": "9.15.0",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^7.0.3",
         "edgedriver": "^6.1.1",
@@ -3941,16 +3951,16 @@
       }
     },
     "node_modules/@wdio/utils/node_modules/@puppeteer/browsers": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.2.tgz",
-      "integrity": "sha512-i4Ez+s9oRWQbNjtI/3+jxr7OH508mjAKvza0ekPJem0ZtmsYHP3B5dq62+IaBHKaGCOuqJxXzvFLUhJvQ6jtsQ==",
+      "version": "2.10.5",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.5.tgz",
+      "integrity": "sha512-eifa0o+i8dERnngJwKrfp3dEq7ia5XFyoqB17S4gK8GhsQE4/P8nxOfQSE0zQHxzzLo/cmF+7+ywEQ7wK7Fb+w==",
       "dev": true,
       "dependencies": {
-        "debug": "^4.4.0",
+        "debug": "^4.4.1",
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
         "proxy-agent": "^6.5.0",
-        "semver": "^7.7.1",
+        "semver": "^7.7.2",
         "tar-fs": "^3.0.8",
         "yargs": "^17.7.2"
       },
@@ -4013,9 +4023,9 @@
       }
     },
     "node_modules/@wdio/utils/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -4037,9 +4047,9 @@
       }
     },
     "node_modules/@wdio/utils/node_modules/tar-fs": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
+      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
       "dev": true,
       "dependencies": {
         "pump": "^3.0.0",
@@ -4078,9 +4088,9 @@
       }
     },
     "node_modules/@zip.js/zip.js": {
-      "version": "2.7.60",
-      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.60.tgz",
-      "integrity": "sha512-vA3rLyqdxBrVo1FWSsbyoecaqWTV+vgPRf0QKeM7kVDG0r+lHUqd7zQDv1TO9k4BcAoNzNDSNrrel24Mk6addA==",
+      "version": "2.7.62",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.62.tgz",
+      "integrity": "sha512-OaLvZ8j4gCkLn048ypkZu29KX30r8/OfFF2w4Jo5WXFr+J04J+lzJ5TKZBVgFXhlvSkqNFQdfnY1Q8TMTCyBVA==",
       "dev": true,
       "engines": {
         "bun": ">=0.7.0",
@@ -4490,9 +4500,9 @@
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.2.tgz",
-      "integrity": "sha512-8wSeOia5B7LwD4+h465y73KOdj5QHsbbuoUfPBi+pXgFJIPuG7SsiOdJuijWMyfid49eD+WivpfY7KT8gbAzBA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.5.tgz",
+      "integrity": "sha512-1zccWBMypln0jEE05LzZt+V/8y8AQsQQqxtklqaIyg5nu6OAYFhZxPXinJTSG+kU5qyNmeLgcn9AW7eHiCHVLA==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -5551,9 +5561,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
@@ -6468,9 +6478,9 @@
       }
     },
     "node_modules/geckodriver/node_modules/tar-fs": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
+      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
       "dev": true,
       "dependencies": {
         "pump": "^3.0.0",
@@ -11564,9 +11574,9 @@
       "dev": true
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
-      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
       "dev": true,
       "dependencies": {
         "fdir": "^6.4.4",
@@ -11606,9 +11616,9 @@
       }
     },
     "node_modules/tinypool": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
-      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.0.tgz",
+      "integrity": "sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==",
       "dev": true,
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
@@ -11624,9 +11634,9 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -12023,16 +12033,16 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.2.tgz",
-      "integrity": "sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.1.tgz",
+      "integrity": "sha512-V4EyKQPxquurNJPtQJRZo8hKOoKNBRIhxcDbQFPFig0JdoWcUhwRgK8yoCXXrfYVPKS6XwirGHPszLnR8FbjCA==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.4.0",
-        "es-module-lexer": "^1.6.0",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
         "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "bin": {
         "vite-node": "vite-node.mjs"
@@ -12540,31 +12550,33 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.2.tgz",
-      "integrity": "sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.1.tgz",
+      "integrity": "sha512-VZ40MBnlE1/V5uTgdqY3DmjUgZtIzsYq758JGlyQrv5syIsaYcabkfPkEuWML49Ph0D/SoqpVFd0dyVTr551oA==",
       "dev": true,
       "dependencies": {
-        "@vitest/expect": "3.1.2",
-        "@vitest/mocker": "3.1.2",
-        "@vitest/pretty-format": "^3.1.2",
-        "@vitest/runner": "3.1.2",
-        "@vitest/snapshot": "3.1.2",
-        "@vitest/spy": "3.1.2",
-        "@vitest/utils": "3.1.2",
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.1",
+        "@vitest/mocker": "3.2.1",
+        "@vitest/pretty-format": "^3.2.1",
+        "@vitest/runner": "3.2.1",
+        "@vitest/snapshot": "3.2.1",
+        "@vitest/spy": "3.2.1",
+        "@vitest/utils": "3.2.1",
         "chai": "^5.2.0",
-        "debug": "^4.4.0",
+        "debug": "^4.4.1",
         "expect-type": "^1.2.1",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
         "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.13",
-        "tinypool": "^1.0.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.0",
         "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0",
-        "vite-node": "3.1.2",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.1",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -12580,8 +12592,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.1.2",
-        "@vitest/ui": "3.1.2",
+        "@vitest/browser": "3.2.1",
+        "@vitest/ui": "3.2.1",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -12609,47 +12621,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-      "dev": true
-    },
-    "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.2.tgz",
-      "integrity": "sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==",
-      "dev": true,
-      "dependencies": {
-        "@vitest/spy": "3.1.2",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/vitest/node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -12657,6 +12628,18 @@
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/wait-port": {
@@ -12702,18 +12685,18 @@
       }
     },
     "node_modules/webdriver": {
-      "version": "9.12.6",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.12.6.tgz",
-      "integrity": "sha512-Alz+JiaVW15b/Qy6zSmJeYXxvmtMIVpEAg7QDfCWqG9miZSKJYWwgWE3xoSrwYn5kTylUszqb17Pb5wyrj7YFw==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.15.0.tgz",
+      "integrity": "sha512-JCW5xvhZtL6kjbckdePgVYMOlvWbh22F1VFkIf9pw3prwXI2EHED5Eq/nfDnNfHiqr0AfFKWmIDPziSafrVv4Q==",
       "dev": true,
       "dependencies": {
         "@types/node": "^20.1.0",
         "@types/ws": "^8.5.3",
-        "@wdio/config": "9.12.6",
-        "@wdio/logger": "9.4.4",
-        "@wdio/protocols": "9.12.5",
-        "@wdio/types": "9.12.6",
-        "@wdio/utils": "9.12.6",
+        "@wdio/config": "9.15.0",
+        "@wdio/logger": "9.15.0",
+        "@wdio/protocols": "9.15.0",
+        "@wdio/types": "9.15.0",
+        "@wdio/utils": "9.15.0",
         "deepmerge-ts": "^7.0.3",
         "undici": "^6.20.1",
         "ws": "^8.8.0"
@@ -12723,18 +12706,18 @@
       }
     },
     "node_modules/webdriver/node_modules/@types/node": {
-      "version": "20.17.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
-      "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
+      "version": "20.17.57",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.57.tgz",
+      "integrity": "sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
     },
     "node_modules/webdriver/node_modules/undici": {
-      "version": "6.21.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
-      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
       "dev": true,
       "engines": {
         "node": ">=18.17"
@@ -12747,19 +12730,19 @@
       "dev": true
     },
     "node_modules/webdriverio": {
-      "version": "9.12.7",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.12.7.tgz",
-      "integrity": "sha512-HxpLQrFuadfE65dqh+Qc2pdvz18FbsdpdiZogy8VUBtxRanijbOsi4cV84ffGXab8Ownzu+bNBJuJjlTBDX00Q==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.15.0.tgz",
+      "integrity": "sha512-910g6ktwXdAKGyhgCPGw9BzIKOEBBYMFN1bLwC3bW/3mFlxGHO/n70c7Sg9hrsu9VWTzv6m+1Clf27B9uz4a/Q==",
       "dev": true,
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
-        "@wdio/config": "9.12.6",
-        "@wdio/logger": "9.4.4",
-        "@wdio/protocols": "9.12.5",
+        "@wdio/config": "9.15.0",
+        "@wdio/logger": "9.15.0",
+        "@wdio/protocols": "9.15.0",
         "@wdio/repl": "9.4.4",
-        "@wdio/types": "9.12.6",
-        "@wdio/utils": "9.12.6",
+        "@wdio/types": "9.15.0",
+        "@wdio/utils": "9.15.0",
         "archiver": "^7.0.1",
         "aria-query": "^5.3.0",
         "cheerio": "^1.0.0-rc.12",
@@ -12776,7 +12759,7 @@
         "rgb2hex": "0.2.5",
         "serialize-error": "^11.0.3",
         "urlpattern-polyfill": "^10.0.0",
-        "webdriver": "9.12.6"
+        "webdriver": "9.15.0"
       },
       "engines": {
         "node": ">=18.20.0"
@@ -12983,9 +12966,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -222,8 +222,8 @@
     "@types/mocha": "^10.0.0",
     "@types/node": "^18.19.87",
     "@types/sinon": "^17.0.3",
-    "@vitest/browser": "^3.1.2",
-    "@vitest/coverage-istanbul": "^3.1.2",
+    "@vitest/browser": "^3.2.1",
+    "@vitest/coverage-istanbul": "^3.2.1",
     "babel-plugin-transform-rename-properties": "0.1.0",
     "chai": "^5.2.0",
     "coveralls": "^3.1.1",
@@ -245,8 +245,8 @@
     "typescript": "5.1.6",
     "undici": "^4.12.0",
     "vite": "^6.2.0",
-    "vitest": "^3.1.2",
-    "webdriverio": "^9.11.0"
+    "vitest": "^3.2.1",
+    "webdriverio": "^9.15.0"
   },
   "volta": {
     "node": "20.19.1"

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -158,21 +158,7 @@ export default defineConfig({
 					return null;
 				}
 
-				const cached = cache.get(id);
-				if (cached && cached.input === code) {
-					return cached.result;
-				}
-
-				if (pending.has(id)) {
-					const result = await pending.get(id);
-					pending.delete(id);
-					return {
-						code: result.code,
-						map: result.map
-					};
-				}
-
-				const promise = transformAsync(code, {
+				const transformed = await transformAsync(code, {
 					filename: id,
 					configFile: false,
 					plugins: [
@@ -184,13 +170,6 @@ export default defineConfig({
 						]
 					],
 					include: ['**/src/**/*.js', '**/test/**/*.js']
-				});
-
-				pending.set(id, promise);
-				const transformed = await promise;
-				cache.set(id, {
-					input: code,
-					result: transformed
 				});
 
 				return {


### PR DESCRIPTION
This bumps vitest to 3.2 and removes the caching from the transform. It looks like vitest does a lot of internal caching and us sharing the Promise as well as caching the output works against us. This resulted in us having to save the file twice for changes to show