### PR TITLE
fix(types): ensure `forwardRef` overrides the default ref type

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -265,7 +265,7 @@ declare namespace React {
 
 	export function forwardRef<R, P = {}>(
 		fn: ForwardRefRenderFunction<R, P>
-	): preact.FunctionalComponent<PropsWithoutRef<P> & { ref?: preact.Ref<R> }>;
+	): preact.FunctionalComponent<PropsWithoutRef<P>, R>;
 
 	export type PropsWithoutRef<P> = Omit<P, 'ref'>;
 

--- a/src/index-5.d.ts
+++ b/src/index-5.d.ts
@@ -86,12 +86,12 @@ export type ComponentProps<
 		? JSXInternal.IntrinsicElements[C]
 		: {};
 
-export interface FunctionComponent<P = {}> {
-	(props: RenderableProps<P>, context?: any): VNode | null;
+export interface FunctionComponent<P = {}, RefType = any> {
+	(props: RenderableProps<P, RefType>, context?: any): VNode | null;
 	displayName?: string;
 	defaultProps?: Partial<P> | undefined;
 }
-export interface FunctionalComponent<P = {}> extends FunctionComponent<P> {}
+export interface FunctionalComponent<P = {}, RefType = any> extends FunctionComponent<P, RefType> {}
 
 export interface ComponentClass<P = {}, S = {}> {
 	new (props: P, context?: any): Component<P, S>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -86,12 +86,12 @@ export type ComponentProps<
 		? JSXInternal.IntrinsicElements[C]
 		: {};
 
-export interface FunctionComponent<P = {}> {
-	(props: RenderableProps<P>, context?: any): ComponentChildren;
+export interface FunctionComponent<P = {}, RefType = any> {
+	(props: RenderableProps<P, RefType>, context?: any): ComponentChildren;
 	displayName?: string;
 	defaultProps?: Partial<P> | undefined;
 }
-export interface FunctionalComponent<P = {}> extends FunctionComponent<P> {}
+export interface FunctionalComponent<P = {}, RefType = any> extends FunctionComponent<P, RefType> {}
 
 export interface ComponentClass<P = {}, S = {}> {
 	new (props: P, context?: any): Component<P, S>;


### PR DESCRIPTION
This fixes an issue with `forwardRef` that was leading to a type conflict, which was basically…

```ts
(Ref<HTMLDivElement> | undefined) …from forwardRef's return type
  & (Ref<any> | undefined) // …from the RenderableProps type
```