### PR TITLE
chore: Remove extraneous pkg.json key

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "main": "dist/preact.js",
   "module": "dist/preact.mjs",
   "umd:main": "dist/preact.umd.js",
-  "unpkg": "dist/preact.min.js",
   "source": "src/index.js",
   "typesVersions": {
     "<=5.0": {


### PR DESCRIPTION
Looks like I missed this in #4562 

`umd:main` & `unpkg` are keys that Microbundle uses to determine the output file name for UMD builds, with [`umd:main` taking precedence](https://github.com/developit/microbundle/blob/aae1611ef4f95f17332057018b595ef7b2794b2d/src/index.js#L317). We no longer provide the `.min` files, as they didn't really serve much of a purpose, so this entry is now referring to a file that does not exist.
