### PR TITLE
fix(compat): add .render property referencing original render function

### DIFF
--- a/compat/src/forwardRef.js
+++ b/compat/src/forwardRef.js
@@ -22,7 +22,7 @@ export function forwardRef(fn) {
 	// It expects an object here with a `render` property,
 	// and prototype.render will fail. Without this
 	// mobx-react throws.
-	Forwarded.render = Forwarded;
+	Forwarded.render = fn;
 
 	Forwarded.prototype.isReactComponent = true;
 	Forwarded.displayName = 'ForwardRef(' + (fn.displayName || fn.name) + ')';

--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -498,4 +498,15 @@ describe('forwardRef', () => {
 
 		expect(actual).to.equal(null);
 	});
+
+	// Issue #4769
+	it('should attach .render pointing to the original render function', () => {
+		function Foo(props, ref) {
+			return <div ref={ref} />;
+		}
+
+		const Forwarded = forwardRef(Foo);
+
+		expect(Forwarded.render).to.equal(Foo);
+  });
 });


### PR DESCRIPTION
Resolves https://github.com/preactjs/preact/issues/4769

This change ensures that the function returned by `forwardRef` carries over the original render callback as a `.render` property. Without this, integrations like `DevTools` and `mobx-react` which rely on calling or observing `Component.render` were unable to track or trigger updates correctly.