### PR TITLE
fix: escape style object value in precompile transform

### DIFF
--- a/jsx-runtime/src/index.js
+++ b/jsx-runtime/src/index.js
@@ -115,7 +115,7 @@ function jsxAttr(name, value) {
 				str = str + name + ':' + val + ';';
 			}
 		}
-		return name + '="' + str + '"';
+		return name + '="' + encodeEntities(str) + '"';
 	}
 
 	if (

--- a/jsx-runtime/test/browser/jsx-runtime.test.js
+++ b/jsx-runtime/test/browser/jsx-runtime.test.js
@@ -122,6 +122,9 @@ describe('precompiled JSX', () => {
 
 		it('should escape values', () => {
 			expect(jsxAttr('foo', "&<'")).to.equal('foo="&amp;&lt;\'"');
+			expect(jsxAttr('style', { foo: `"&<'"` })).to.equal(
+				'style="foo:&quot;&amp;&lt;\'&quot;;"'
+			);
 		});
 
 		it('should call options.attr()', () => {


### PR DESCRIPTION
We didn't escape the value when passing an `object` to `style` when using Deno's `precompile` transform. This does not affect other JSX transforms.