### PR TITLE
chore: point release workflow to 10.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on: create
 jobs:
   build:
     if: github.ref_type == 'tag'
-    uses: preactjs/preact/.github/workflows/build-test.yml@main
+    uses: preactjs/preact/.github/workflows/build-test.yml@v10.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The 10.x release line should use the workflow from the `v10.x` branch instead of `main`.