### PR TITLE
Fix outdated public RefCallback type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -38,7 +38,7 @@ export interface VNode<P = {}> {
 export type Key = string | number | any;
 
 export type RefObject<T> = { current: T };
-export type RefCallback<T> = (instance: T | null): void | (() => void);
+export type RefCallback<T> = (instance: T | null) => void | (() => void);
 export type Ref<T> = RefCallback<T> | RefObject<T | null> | null;
 
 export type ComponentChild =

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -38,7 +38,7 @@ export interface VNode<P = {}> {
 export type Key = string | number | any;
 
 export type RefObject<T> = { current: T };
-export type RefCallback<T> = (instance: T | null) => void;
+export type RefCallback<T> = (instance: T | null): void | (() => void);
 export type Ref<T> = RefCallback<T> | RefObject<T | null> | null;
 
 export type ComponentChild =


### PR DESCRIPTION
We updated the internal callback type to allow returning a cleanup, but not the public one.