### PR TITLE
test: migrate hooks tests to vitest spies

### DIFF
--- a/compat/test/browser/compat.options.test.js
+++ b/compat/test/browser/compat.options.test.js
@@ -29,8 +29,8 @@ describe('compat options', () => {
 		scratch = setupScratch();
 		rerender = setupRerender();
 
-		vnodeSpy.resetHistory();
-		eventSpy.resetHistory();
+		vnodeSpy.mockClear();
+		eventSpy.mockClear();
 
 		buttonRef = createRef();
 	});
@@ -61,7 +61,7 @@ describe('compat options', () => {
 	it('should call old options on mount', () => {
 		render(<ClassApp />, scratch);
 
-		expect(vnodeSpy).to.have.been.called;
+		expect(vnodeSpy).toHaveBeenCalled();
 	});
 
 	it('should call old options on event and update', () => {
@@ -72,14 +72,14 @@ describe('compat options', () => {
 		rerender();
 		expect(scratch.innerHTML).to.equal('<button>1</button>');
 
-		expect(vnodeSpy).to.have.been.called;
-		expect(eventSpy).to.have.been.called;
+		expect(vnodeSpy).toHaveBeenCalled();
+		expect(eventSpy).toHaveBeenCalled();
 	});
 
 	it('should call old options on unmount', () => {
 		render(<ClassApp />, scratch);
 		render(null, scratch);
 
-		expect(vnodeSpy).to.have.been.called;
+		expect(vnodeSpy).toHaveBeenCalled();
 	});
 });

--- a/debug/test/browser/debug.options.test.js
+++ b/debug/test/browser/debug.options.test.js
@@ -32,12 +32,12 @@ describe('debug options', () => {
 		scratch = setupScratch();
 		rerender = setupRerender();
 
-		vnodeSpy.resetHistory();
-		rootSpy.resetHistory();
-		beforeDiffSpy.resetHistory();
-		hookSpy.resetHistory();
-		afterDiffSpy.resetHistory();
-		catchErrorSpy.resetHistory();
+		vnodeSpy.mockClear();
+		rootSpy.mockClear();
+		beforeDiffSpy.mockClear();
+		hookSpy.mockClear();
+		afterDiffSpy.mockClear();
+		catchErrorSpy.mockClear();
 	});
 
 	afterEach(() => {
@@ -60,10 +60,10 @@ describe('debug options', () => {
 	it('should call old options on mount', () => {
 		render(<ClassApp />, scratch);
 
-		expect(vnodeSpy).to.have.been.called;
-		expect(rootSpy).to.have.been.called;
-		expect(beforeDiffSpy).to.have.been.called;
-		expect(afterDiffSpy).to.have.been.called;
+		expect(vnodeSpy).toHaveBeenCalled();
+		expect(rootSpy).toHaveBeenCalled();
+		expect(beforeDiffSpy).toHaveBeenCalled();
+		expect(afterDiffSpy).toHaveBeenCalled();
 	});
 
 	it('should call old options on update', () => {
@@ -72,20 +72,20 @@ describe('debug options', () => {
 		setCount(1);
 		rerender();
 
-		expect(vnodeSpy).to.have.been.called;
-		expect(rootSpy).to.have.been.called;
-		expect(beforeDiffSpy).to.have.been.called;
-		expect(afterDiffSpy).to.have.been.called;
+		expect(vnodeSpy).toHaveBeenCalled();
+		expect(rootSpy).toHaveBeenCalled();
+		expect(beforeDiffSpy).toHaveBeenCalled();
+		expect(afterDiffSpy).toHaveBeenCalled();
 	});
 
 	it('should call old options on unmount', () => {
 		render(<ClassApp />, scratch);
 		render(null, scratch);
 
-		expect(vnodeSpy).to.have.been.called;
-		expect(rootSpy).to.have.been.called;
-		expect(beforeDiffSpy).to.have.been.called;
-		expect(afterDiffSpy).to.have.been.called;
+		expect(vnodeSpy).toHaveBeenCalled();
+		expect(rootSpy).toHaveBeenCalled();
+		expect(beforeDiffSpy).toHaveBeenCalled();
+		expect(afterDiffSpy).toHaveBeenCalled();
 	});
 
 	it('should call old hook options for hook components', () => {
@@ -97,7 +97,7 @@ describe('debug options', () => {
 
 		render(<HookApp />, scratch);
 
-		expect(hookSpy).to.have.been.called;
+		expect(hookSpy).toHaveBeenCalled();
 	});
 
 	it('should call old options on error', () => {
@@ -128,7 +128,7 @@ describe('debug options', () => {
 		render(<ErrorApp />, scratch);
 		rerender();
 
-		expect(catchErrorSpy).to.have.been.called;
+		expect(catchErrorSpy).toHaveBeenCalled();
 
 		// we expect to throw after setTimeout to trigger a window.onerror
 		// this is to ensure react compat (i.e. with next.js' dev overlay)

--- a/hooks/test/browser/combinations.test.js
+++ b/hooks/test/browser/combinations.test.js
@@ -11,6 +11,7 @@ import {
 	useContext
 } from 'preact/hooks';
 import { scheduleEffectAssert } from '../_util/useEffectUtil';
+import { vi } from 'vitest';
 
 /** @jsx createElement */
 
@@ -74,7 +75,7 @@ describe('combinations', () => {
 	});
 
 	it('can rerender asynchronously from within an effect', () => {
-		const didRender = sinon.spy();
+		const didRender = vi.fn();
 
 		function Comp() {
 			const [counter, setCounter] = useState(0);
@@ -91,12 +92,13 @@ describe('combinations', () => {
 
 		return scheduleEffectAssert(() => {
 			rerender();
-			expect(didRender).to.have.been.calledTwice.and.calledWith(1);
+			expect(didRender).toHaveBeenCalledTimes(2);
+			expect(didRender).toHaveBeenCalledWith(1);
 		});
 	});
 
 	it('can rerender synchronously from within a layout effect', () => {
-		const didRender = sinon.spy();
+		const didRender = vi.fn();
 
 		function Comp() {
 			const [counter, setCounter] = useState(0);
@@ -112,7 +114,8 @@ describe('combinations', () => {
 		render(<Comp />, scratch);
 		rerender();
 
-		expect(didRender).to.have.been.calledTwice.and.calledWith(1);
+		expect(didRender).toHaveBeenCalledTimes(2);
+		expect(didRender).toHaveBeenCalledWith(1);
 	});
 
 	it('can access refs from within a layout effect callback', () => {
@@ -404,7 +407,7 @@ describe('combinations', () => {
 		const tooltipId = 'tooltip';
 		const effectLog = [];
 
-		let useRef2 = sinon.spy(init => {
+		let useRef2 = vi.fn(init => {
 			const realRef = useRef(init);
 			const ref = useRef(init);
 			Object.defineProperty(ref, 'current', {

--- a/hooks/test/browser/errorBoundary.test.js
+++ b/hooks/test/browser/errorBoundary.test.js
@@ -2,6 +2,7 @@ import { Fragment, createElement, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useErrorBoundary, useLayoutEffect, useState } from 'preact/hooks';
 import { setupRerender } from 'preact/test-utils';
+import { vi } from 'vitest';
 
 /** @jsx createElement */
 
@@ -42,7 +43,7 @@ describe('errorBoundary', () => {
 	});
 
 	it('calls the errorBoundary callback', () => {
-		const spy = sinon.spy();
+		const spy = vi.fn();
 		const error = new Error('test');
 		const Throws = () => {
 			throw error;
@@ -56,8 +57,8 @@ describe('errorBoundary', () => {
 		render(<App />, scratch);
 		rerender();
 		expect(scratch.innerHTML).to.equal('<p>Error</p>');
-		expect(spy).to.be.calledOnce;
-		expect(spy).to.be.calledWith(error, {});
+		expect(spy).toHaveBeenCalledOnce();
+		expect(spy).toHaveBeenCalledWith(error, {});
 	});
 
 	it('returns error', () => {
@@ -79,8 +80,8 @@ describe('errorBoundary', () => {
 	});
 
 	it('does not leave a stale closure', () => {
-		const spy = sinon.spy(),
-			spy2 = sinon.spy();
+		const spy = vi.fn(),
+			spy2 = vi.fn();
 		let resetErr;
 		const error = new Error('test');
 		const Throws = () => {
@@ -96,27 +97,27 @@ describe('errorBoundary', () => {
 		render(<App onError={spy} />, scratch);
 		rerender();
 		expect(scratch.innerHTML).to.equal('<p>Error</p>');
-		expect(spy).to.be.calledOnce;
-		expect(spy).to.be.calledWith(error);
+		expect(spy).toHaveBeenCalledOnce();
+		expect(spy).toHaveBeenCalledWith(error, {});
 
 		resetErr();
 		render(<App onError={spy2} />, scratch);
 		rerender();
-		expect(spy).to.be.calledOnce;
-		expect(spy2).to.be.calledOnce;
-		expect(spy2).to.be.calledWith(error);
+		expect(spy).toHaveBeenCalledOnce();
+		expect(spy2).toHaveBeenCalledOnce();
+		expect(spy2).toHaveBeenCalledWith(error, {});
 		expect(scratch.innerHTML).to.equal('<p>Error</p>');
 	});
 
 	it('does not invoke old effects when a cleanup callback throws an error and is handled', () => {
 		let throwErr = false;
-		let thrower = sinon.spy(() => {
+		let thrower = vi.fn(() => {
 			if (throwErr) {
 				throw new Error('test');
 			}
 		});
-		let badEffect = sinon.spy(() => thrower);
-		let goodEffect = sinon.spy();
+		let badEffect = vi.fn(() => thrower);
+		let goodEffect = vi.fn();
 
 		function EffectThrowsError() {
 			useLayoutEffect(badEffect);
@@ -141,16 +142,16 @@ describe('errorBoundary', () => {
 
 		render(<App />, scratch);
 		expect(scratch.innerHTML).to.equal('<span>Test</span>');
-		expect(badEffect).to.be.calledOnce;
-		expect(goodEffect).to.be.calledOnce;
+		expect(badEffect).toHaveBeenCalledOnce();
+		expect(goodEffect).toHaveBeenCalledOnce();
 
 		throwErr = true;
 		render(<App />, scratch);
 		rerender();
 		expect(scratch.innerHTML).to.equal('<p>Error</p>');
-		expect(thrower).to.be.calledOnce;
-		expect(badEffect).to.be.calledOnce;
-		expect(goodEffect).to.be.calledOnce;
+		expect(thrower).toHaveBeenCalledOnce();
+		expect(badEffect).toHaveBeenCalledOnce();
+		expect(goodEffect).toHaveBeenCalledOnce();
 	});
 
 	it('should not duplicate in lists where an item throws and the parent catches and returns a differing type', () => {

--- a/hooks/test/browser/hooks.options.test.js
+++ b/hooks/test/browser/hooks.options.test.js
@@ -20,6 +20,7 @@ import {
 	useContext,
 	useErrorBoundary
 } from 'preact/hooks';
+import { vi } from 'vitest';
 
 /** @jsx createElement */
 
@@ -37,10 +38,10 @@ describe('hook options', () => {
 		scratch = setupScratch();
 		rerender = setupRerender();
 
-		afterDiffSpy.resetHistory();
-		unmountSpy.resetHistory();
-		beforeRenderSpy.resetHistory();
-		hookSpy.resetHistory();
+		afterDiffSpy.mockClear();
+		unmountSpy.mockClear();
+		beforeRenderSpy.mockClear();
+		hookSpy.mockClear();
 	});
 
 	afterEach(() => {
@@ -56,8 +57,8 @@ describe('hook options', () => {
 	it('should call old options on mount', () => {
 		render(<App />, scratch);
 
-		expect(beforeRenderSpy).to.have.been.called;
-		expect(afterDiffSpy).to.have.been.called;
+		expect(beforeRenderSpy).toHaveBeenCalled();
+		expect(afterDiffSpy).toHaveBeenCalled();
 	});
 
 	it('should call old options.diffed on update', () => {
@@ -66,15 +67,15 @@ describe('hook options', () => {
 		increment();
 		rerender();
 
-		expect(beforeRenderSpy).to.have.been.called;
-		expect(afterDiffSpy).to.have.been.called;
+		expect(beforeRenderSpy).toHaveBeenCalled();
+		expect(afterDiffSpy).toHaveBeenCalled();
 	});
 
 	it('should call old options on unmount', () => {
 		render(<App />, scratch);
 		render(null, scratch);
 
-		expect(unmountSpy).to.have.been.called;
+		expect(unmountSpy).toHaveBeenCalled();
 	});
 
 	it('should detect hooks', () => {
@@ -111,7 +112,7 @@ describe('hook options', () => {
 			scratch
 		);
 
-		expect(hookSpy.args.map(arg => [arg[1], arg[2]])).to.deep.equal([
+		expect(hookSpy.mock.calls.map(arg => [arg[1], arg[2]])).to.deep.equal([
 			[0, USE_STATE],
 			[1, USE_REDUCER],
 			[2, USE_EFFECT],
@@ -137,7 +138,7 @@ describe('hook options', () => {
 		});
 
 		it('should skip effect hooks', () => {
-			const spy = sinon.spy();
+			const spy = vi.fn();
 			function App() {
 				useEffect(spy, []);
 				useLayoutEffect(spy, []);
@@ -148,7 +149,7 @@ describe('hook options', () => {
 				render(<App />, scratch);
 			});
 
-			expect(spy.callCount).to.equal(0);
+			expect(spy).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/hooks/test/browser/useContext.test.js
+++ b/hooks/test/browser/useContext.test.js
@@ -47,7 +47,7 @@ describe('useContext', () => {
 
 	it('should use default value', () => {
 		const Foo = createContext(42);
-		const spy = sinon.spy();
+		const spy = vi.fn();
 
 		function App() {
 			spy(useContext(Foo));
@@ -55,11 +55,11 @@ describe('useContext', () => {
 		}
 
 		render(<App />, scratch);
-		expect(spy).to.be.calledWith(42);
+		expect(spy).toHaveBeenCalledWith(42);
 	});
 
 	it('should update when value changes with nonUpdating Component on top', async () => {
-		const spy = sinon.spy();
+		const spy = vi.fn();
 		const Ctx = createContext(0);
 
 		class NoUpdate extends Component {
@@ -88,23 +88,23 @@ describe('useContext', () => {
 		}
 
 		render(<App value={0} />, scratch);
-		expect(spy).to.be.calledOnce;
-		expect(spy).to.be.calledWith(0);
+		expect(spy).toHaveBeenCalledOnce();
+		expect(spy).toHaveBeenCalledWith(0);
 		render(<App value={1} />, scratch);
 
 		return new Promise(resolve => {
 			// Wait for enqueued hook update
 			setTimeout(() => {
 				// Should not be called a third time
-				expect(spy).to.be.calledTwice;
-				expect(spy).to.be.calledWith(1);
+				expect(spy).toHaveBeenCalledTimes(2);
+				expect(spy).toHaveBeenCalledWith(1);
 				resolve();
 			}, 0);
 		});
 	});
 
 	it('should only update when value has changed', async () => {
-		const spy = sinon.spy();
+		const spy = vi.fn();
 		const Ctx = createContext(0);
 
 		function App(props) {
@@ -122,18 +122,18 @@ describe('useContext', () => {
 		}
 
 		render(<App value={0} />, scratch);
-		expect(spy).to.be.calledOnce;
-		expect(spy).to.be.calledWith(0);
+		expect(spy).toHaveBeenCalledOnce();
+		expect(spy).toHaveBeenCalledWith(0);
 		render(<App value={1} />, scratch);
 
-		expect(spy).to.be.calledTwice;
-		expect(spy).to.be.calledWith(1);
+		expect(spy).toHaveBeenCalledTimes(2);
+		expect(spy).toHaveBeenCalledWith(1);
 
 		return new Promise(resolve => {
 			// Wait for enqueued hook update
 			setTimeout(() => {
 				// Should not be called a third time
-				expect(spy).to.be.calledTwice;
+				expect(spy).toHaveBeenCalledTimes(2);
 				resolve();
 			}, 0);
 		});
@@ -142,8 +142,8 @@ describe('useContext', () => {
 	it('should allow multiple context hooks at the same time', () => {
 		const Foo = createContext(0);
 		const Bar = createContext(10);
-		const spy = sinon.spy();
-		const unmountspy = sinon.spy();
+		const spy = vi.fn();
+		const unmountspy = vi.fn();
 
 		function Comp() {
 			const foo = useContext(Foo);
@@ -163,8 +163,8 @@ describe('useContext', () => {
 			scratch
 		);
 
-		expect(spy).to.be.calledOnce;
-		expect(spy).to.be.calledWith(0, 10);
+		expect(spy).toHaveBeenCalledOnce();
+		expect(spy).toHaveBeenCalledWith(0, 10);
 
 		render(
 			<Foo.Provider value={11}>
@@ -175,8 +175,8 @@ describe('useContext', () => {
 			scratch
 		);
 
-		expect(spy).to.be.calledTwice;
-		expect(unmountspy).not.to.be.called;
+		expect(spy).toHaveBeenCalledTimes(2);
+		expect(unmountspy).not.toHaveBeenCalled();
 	});
 
 	it('should only subscribe a component once', () => {
@@ -199,7 +199,7 @@ describe('useContext', () => {
 			</Context.Provider>,
 			scratch
 		);
-		subSpy = sinon.spy(provider, 'sub');
+		subSpy = vi.spyOn(provider, 'sub');
 
 		render(
 			<Context.Provider value={69}>
@@ -207,7 +207,7 @@ describe('useContext', () => {
 			</Context.Provider>,
 			scratch
 		);
-		expect(subSpy).to.not.have.been.called;
+		expect(subSpy).not.toHaveBeenCalled();
 
 		expect(values).to.deep.equal([13, 42, 69]);
 	});
@@ -232,7 +232,7 @@ describe('useContext', () => {
 			</Context>,
 			scratch
 		);
-		subSpy = sinon.spy(provider, 'sub');
+		subSpy = vi.spyOn(provider, 'sub');
 
 		render(
 			<Context value={69}>
@@ -240,7 +240,7 @@ describe('useContext', () => {
 			</Context>,
 			scratch
 		);
-		expect(subSpy).to.not.have.been.called;
+		expect(subSpy).not.toHaveBeenCalled();
 
 		expect(values).to.deep.equal([13, 42, 69]);
 	});

--- a/hooks/test/browser/useDebugValue.test.js
+++ b/hooks/test/browser/useDebugValue.test.js
@@ -1,6 +1,7 @@
 import { createElement, render, options } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useDebugValue, useState } from 'preact/hooks';
+import { vi } from 'vitest';
 
 /** @jsx createElement */
 
@@ -32,7 +33,7 @@ describe('useDebugValue', () => {
 	});
 
 	it('should call options hook with value', () => {
-		let spy = (options.useDebugValue = sinon.spy());
+		let spy = (options.useDebugValue = vi.fn());
 
 		function useFoo() {
 			useDebugValue('foo');
@@ -46,12 +47,12 @@ describe('useDebugValue', () => {
 
 		render(<App />, scratch);
 
-		expect(spy).to.be.calledOnce;
-		expect(spy).to.be.calledWith('foo');
+		expect(spy).toHaveBeenCalledOnce();
+		expect(spy).toHaveBeenCalledWith('foo');
 	});
 
 	it('should apply optional formatter', () => {
-		let spy = (options.useDebugValue = sinon.spy());
+		let spy = (options.useDebugValue = vi.fn());
 
 		function useFoo() {
 			useDebugValue('foo', x => x + 'bar');
@@ -65,7 +66,7 @@ describe('useDebugValue', () => {
 
 		render(<App />, scratch);
 
-		expect(spy).to.be.calledOnce;
-		expect(spy).to.be.calledWith('foobar');
+		expect(spy).toHaveBeenCalledOnce();
+		expect(spy).toHaveBeenCalledWith('foobar');
 	});
 });

--- a/hooks/test/browser/useEffect.test.js
+++ b/hooks/test/browser/useEffect.test.js
@@ -4,6 +4,7 @@ import { useEffect, useState, useRef } from 'preact/hooks';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useEffectAssertions } from './useEffectAssertions';
 import { scheduleEffectAssert } from '../_util/useEffectUtil';
+import { vi } from 'vitest';
 
 /** @jsx createElement */
 
@@ -22,8 +23,8 @@ describe('useEffect', () => {
 	useEffectAssertions(useEffect, scheduleEffectAssert);
 
 	it('calls the effect immediately if another render is about to start', () => {
-		const cleanupFunction = sinon.spy();
-		const callback = sinon.spy(() => cleanupFunction);
+		const cleanupFunction = vi.fn();
+		const callback = vi.fn(() => cleanupFunction);
 
 		function Comp() {
 			useEffect(callback);
@@ -33,18 +34,18 @@ describe('useEffect', () => {
 		render(<Comp />, scratch);
 		render(<Comp />, scratch);
 
-		expect(cleanupFunction).to.be.not.called;
-		expect(callback).to.be.calledOnce;
+		expect(cleanupFunction).not.toHaveBeenCalled();
+		expect(callback).toHaveBeenCalledOnce();
 
 		render(<Comp />, scratch);
 
-		expect(cleanupFunction).to.be.calledOnce;
-		expect(callback).to.be.calledTwice;
+		expect(cleanupFunction).toHaveBeenCalledOnce();
+		expect(callback).toHaveBeenCalledTimes(2);
 	});
 
 	it('cancels the effect when the component get unmounted before it had the chance to run it', () => {
-		const cleanupFunction = sinon.spy();
-		const callback = sinon.spy(() => cleanupFunction);
+		const cleanupFunction = vi.fn();
+		const callback = vi.fn(() => cleanupFunction);
 
 		function Comp() {
 			useEffect(callback);
@@ -55,8 +56,8 @@ describe('useEffect', () => {
 		render(null, scratch);
 
 		return scheduleEffectAssert(() => {
-			expect(cleanupFunction).to.not.be.called;
-			expect(callback).to.not.be.called;
+			expect(cleanupFunction).not.toHaveBeenCalled();
+			expect(callback).not.toHaveBeenCalled();
 		});
 	});
 
@@ -133,7 +134,7 @@ describe('useEffect', () => {
 	});
 
 	it('should throw an error upwards', () => {
-		const spy = sinon.spy();
+		const spy = vi.fn();
 		let errored = false;
 
 		const Page1 = () => {
@@ -168,21 +169,21 @@ describe('useEffect', () => {
 		}
 
 		act(() => render(<App page={1} />, scratch));
-		expect(spy).to.not.be.called;
+		expect(spy).not.toHaveBeenCalled();
 		expect(scratch.innerHTML).to.equal('<p>loaded</p>');
 
 		act(() => render(<App page={2} />, scratch));
-		expect(spy).to.be.calledOnce;
+		expect(spy).toHaveBeenCalledOnce();
 		expect(scratch.innerHTML).to.equal('<p>Error</p>');
 		errored = false;
 
 		act(() => render(<App page={1} />, scratch));
-		expect(spy).to.be.calledOnce;
+		expect(spy).toHaveBeenCalledOnce();
 		expect(scratch.innerHTML).to.equal('<p>loaded</p>');
 	});
 
 	it('should throw an error upwards from return', () => {
-		const spy = sinon.spy();
+		const spy = vi.fn();
 		let errored = false;
 
 		const Page1 = () => {
@@ -222,12 +223,12 @@ describe('useEffect', () => {
 		expect(scratch.innerHTML).to.equal('<p>Load</p>');
 
 		act(() => render(<App page={1} />, scratch));
-		expect(spy).to.be.calledOnce;
+		expect(spy).toHaveBeenCalledOnce();
 		expect(scratch.innerHTML).to.equal('<p>Error</p>');
 	});
 
 	it('catches errors when error is invoked during render', () => {
-		const spy = sinon.spy();
+		const spy = vi.fn();
 		let errored;
 
 		function Comp() {
@@ -257,7 +258,7 @@ describe('useEffect', () => {
 		act(() => {
 			render(<App />, scratch);
 		});
-		expect(spy).to.be.calledOnce;
+		expect(spy).toHaveBeenCalledOnce();
 		expect(errored).to.be.an('Error').with.property('message', 'hi');
 		expect(scratch.innerHTML).to.equal('<p>Error</p>');
 	});
@@ -305,7 +306,7 @@ describe('useEffect', () => {
 	});
 
 	it('should not crash when effect returns truthy non-function value', () => {
-		const callback = sinon.spy(() => 'truthy');
+		const callback = vi.fn(() => 'truthy');
 		function Comp() {
 			useEffect(callback);
 			return null;
@@ -314,7 +315,7 @@ describe('useEffect', () => {
 		render(<Comp />, scratch);
 		render(<Comp />, scratch);
 
-		expect(callback).to.have.been.calledOnce;
+		expect(callback).toHaveBeenCalledOnce();
 
 		render(<div>Replacement</div>, scratch);
 	});
@@ -435,10 +436,10 @@ describe('useEffect', () => {
 		}
 
 		let update;
-		const firstEffectSpy = sinon.spy();
-		const firstEffectcleanup = sinon.spy();
-		const secondEffectSpy = sinon.spy();
-		const secondEffectcleanup = sinon.spy();
+		const firstEffectSpy = vi.fn();
+		const firstEffectcleanup = vi.fn();
+		const secondEffectSpy = vi.fn();
+		const secondEffectcleanup = vi.fn();
 
 		const MainContent = () => {
 			const [val, setVal] = useState(false);
@@ -471,17 +472,17 @@ describe('useEffect', () => {
 			);
 		});
 
-		expect(firstEffectSpy).to.be.calledOnce;
-		expect(secondEffectSpy).to.be.calledOnce;
+		expect(firstEffectSpy).toHaveBeenCalledOnce();
+		expect(secondEffectSpy).toHaveBeenCalledOnce();
 
 		act(() => {
 			update();
 		});
 
-		expect(firstEffectSpy).to.be.calledOnce;
-		expect(secondEffectSpy).to.be.calledOnce;
-		expect(firstEffectcleanup).to.be.calledOnce;
-		expect(secondEffectcleanup).to.be.calledOnce;
+		expect(firstEffectSpy).toHaveBeenCalledOnce();
+		expect(secondEffectSpy).toHaveBeenCalledOnce();
+		expect(firstEffectcleanup).toHaveBeenCalledOnce();
+		expect(secondEffectcleanup).toHaveBeenCalledOnce();
 	});
 
 	it('orders effects effectively', () => {

--- a/hooks/test/browser/useImperativeHandle.test.js
+++ b/hooks/test/browser/useImperativeHandle.test.js
@@ -2,6 +2,7 @@ import { createElement, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useImperativeHandle, useRef, useState } from 'preact/hooks';
 import { setupRerender } from 'preact/test-utils';
+import { vi } from 'vitest';
 
 /** @jsx createElement */
 
@@ -37,7 +38,7 @@ describe('useImperativeHandle', () => {
 
 	it('Calls ref unmounting function', () => {
 		let ref;
-		const unmount = sinon.spy();
+		const unmount = vi.fn();
 
 		function Comp() {
 			useImperativeHandle(
@@ -55,13 +56,13 @@ describe('useImperativeHandle', () => {
 		expect(ref).to.have.property('test');
 		expect(ref.test()).to.equal('test');
 		render(null, scratch);
-		expect(unmount).to.be.calledOnce;
+		expect(unmount).toHaveBeenCalledOnce();
 		expect(ref).to.equal(null);
 	});
 
 	it('calls createHandle after every render by default', () => {
 		let ref,
-			createHandleSpy = sinon.spy();
+			createHandleSpy = vi.fn();
 
 		function Comp() {
 			ref = useRef({});
@@ -70,18 +71,18 @@ describe('useImperativeHandle', () => {
 		}
 
 		render(<Comp />, scratch);
-		expect(createHandleSpy).to.have.been.calledOnce;
+		expect(createHandleSpy).toHaveBeenCalledOnce();
 
 		render(<Comp />, scratch);
-		expect(createHandleSpy).to.have.been.calledTwice;
+		expect(createHandleSpy).toHaveBeenCalledTimes(2);
 
 		render(<Comp />, scratch);
-		expect(createHandleSpy).to.have.been.calledThrice;
+		expect(createHandleSpy).toHaveBeenCalledTimes(3);
 	});
 
 	it('calls createHandle only on mount if an empty array is passed', () => {
 		let ref,
-			createHandleSpy = sinon.spy();
+			createHandleSpy = vi.fn();
 
 		function Comp() {
 			ref = useRef({});
@@ -90,15 +91,15 @@ describe('useImperativeHandle', () => {
 		}
 
 		render(<Comp />, scratch);
-		expect(createHandleSpy).to.have.been.calledOnce;
+		expect(createHandleSpy).toHaveBeenCalledOnce();
 
 		render(<Comp />, scratch);
-		expect(createHandleSpy).to.have.been.calledOnce;
+		expect(createHandleSpy).toHaveBeenCalledOnce();
 	});
 
 	it('Updates given ref when args change', () => {
 		let ref,
-			createHandleSpy = sinon.spy();
+			createHandleSpy = vi.fn();
 
 		function Comp({ a }) {
 			ref = useRef({});
@@ -114,17 +115,17 @@ describe('useImperativeHandle', () => {
 		}
 
 		render(<Comp a={0} />, scratch);
-		expect(createHandleSpy).to.have.been.calledOnce;
+		expect(createHandleSpy).toHaveBeenCalledOnce();
 		expect(ref.current).to.have.property('test');
 		expect(ref.current.test()).to.equal('test0');
 
 		render(<Comp a={1} />, scratch);
-		expect(createHandleSpy).to.have.been.calledTwice;
+		expect(createHandleSpy).toHaveBeenCalledTimes(2);
 		expect(ref.current).to.have.property('test');
 		expect(ref.current.test()).to.equal('test1');
 
 		render(<Comp a={0} />, scratch);
-		expect(createHandleSpy).to.have.been.calledThrice;
+		expect(createHandleSpy).toHaveBeenCalledTimes(3);
 		expect(ref.current).to.have.property('test');
 		expect(ref.current.test()).to.equal('test0');
 	});
@@ -138,7 +139,7 @@ describe('useImperativeHandle', () => {
 		/** @type {() => void} */
 		let updateState;
 
-		const createHandleSpy = sinon.spy(() => ({
+		const createHandleSpy = vi.fn(() => ({
 			test: () => 'test'
 		}));
 
@@ -157,28 +158,28 @@ describe('useImperativeHandle', () => {
 		}
 
 		render(<Comp a={0} />, scratch);
-		expect(createHandleSpy).to.have.been.calledOnce;
+		expect(createHandleSpy).toHaveBeenCalledOnce();
 
 		updateState();
 		rerender();
-		expect(createHandleSpy).to.have.been.calledOnce;
+		expect(createHandleSpy).toHaveBeenCalledOnce();
 
 		setRef(ref2);
 		rerender();
-		expect(createHandleSpy).to.have.been.calledTwice;
+		expect(createHandleSpy).toHaveBeenCalledTimes(2);
 
 		updateState();
 		rerender();
-		expect(createHandleSpy).to.have.been.calledTwice;
+		expect(createHandleSpy).toHaveBeenCalledTimes(2);
 
 		setRef(ref1);
 		rerender();
-		expect(createHandleSpy).to.have.been.calledThrice;
+		expect(createHandleSpy).toHaveBeenCalledTimes(3);
 	});
 
 	it('should not update ref when args have not changed', () => {
 		let ref,
-			createHandleSpy = sinon.spy(() => ({ test: () => 'test' }));
+			createHandleSpy = vi.fn(() => ({ test: () => 'test' }));
 
 		function Comp() {
 			ref = useRef({});
@@ -187,11 +188,11 @@ describe('useImperativeHandle', () => {
 		}
 
 		render(<Comp />, scratch);
-		expect(createHandleSpy).to.have.been.calledOnce;
+		expect(createHandleSpy).toHaveBeenCalledOnce();
 		expect(ref.current.test()).to.equal('test');
 
 		render(<Comp />, scratch);
-		expect(createHandleSpy).to.have.been.calledOnce;
+		expect(createHandleSpy).toHaveBeenCalledOnce();
 		expect(ref.current.test()).to.equal('test');
 	});
 
@@ -206,7 +207,7 @@ describe('useImperativeHandle', () => {
 
 	it('should reset ref object to null when the component get unmounted', () => {
 		let ref,
-			createHandleSpy = sinon.spy(() => ({ test: () => 'test' }));
+			createHandleSpy = vi.fn(() => ({ test: () => 'test' }));
 
 		function Comp() {
 			ref = useRef({});
@@ -215,18 +216,18 @@ describe('useImperativeHandle', () => {
 		}
 
 		render(<Comp />, scratch);
-		expect(createHandleSpy).to.have.been.calledOnce;
+		expect(createHandleSpy).toHaveBeenCalledOnce();
 		expect(ref.current).to.not.equal(null);
 
 		render(<div />, scratch);
-		expect(createHandleSpy).to.have.been.calledOnce;
+		expect(createHandleSpy).toHaveBeenCalledOnce();
 		expect(ref.current).to.equal(null);
 	});
 
 	it('should reset ref callback to null when the component get unmounted', () => {
-		const ref = sinon.spy();
+		const ref = vi.fn();
 		const handle = { test: () => 'test' };
-		const createHandleSpy = sinon.spy(() => handle);
+		const createHandleSpy = vi.fn(() => handle);
 
 		function Comp() {
 			useImperativeHandle(ref, createHandleSpy, [1]);
@@ -234,13 +235,13 @@ describe('useImperativeHandle', () => {
 		}
 
 		render(<Comp />, scratch);
-		expect(createHandleSpy).to.have.been.calledOnce;
-		expect(ref).to.have.been.calledWith(handle);
+		expect(createHandleSpy).toHaveBeenCalledOnce();
+		expect(ref).toHaveBeenCalledWith(handle);
 
-		ref.resetHistory();
+		ref.mockClear();
 
 		render(<div />, scratch);
-		expect(createHandleSpy).to.have.been.calledOnce;
-		expect(ref).to.have.been.calledWith(null);
+		expect(createHandleSpy).toHaveBeenCalledOnce();
+		expect(ref).toHaveBeenCalledWith(null);
 	});
 });

--- a/hooks/test/browser/useLayoutEffect.test.js
+++ b/hooks/test/browser/useLayoutEffect.test.js
@@ -7,6 +7,7 @@ import {
 } from '../../../test/_util/helpers';
 import { useEffectAssertions } from './useEffectAssertions';
 import { useLayoutEffect, useRef, useState } from 'preact/hooks';
+import { vi } from 'vitest';
 
 /** @jsx createElement */
 
@@ -32,8 +33,8 @@ describe('useLayoutEffect', () => {
 	useEffectAssertions(useLayoutEffect, scheduleEffectAssert);
 
 	it('calls the effect immediately after render', () => {
-		const cleanupFunction = sinon.spy();
-		const callback = sinon.spy(() => cleanupFunction);
+		const cleanupFunction = vi.fn();
+		const callback = vi.fn(() => cleanupFunction);
 
 		function Comp() {
 			useLayoutEffect(callback);
@@ -43,17 +44,17 @@ describe('useLayoutEffect', () => {
 		render(<Comp />, scratch);
 		render(<Comp />, scratch);
 
-		expect(cleanupFunction).to.be.calledOnce;
-		expect(callback).to.be.calledTwice;
+		expect(cleanupFunction).toHaveBeenCalledOnce();
+		expect(callback).toHaveBeenCalledTimes(2);
 
 		render(<Comp />, scratch);
 
-		expect(cleanupFunction).to.be.calledTwice;
-		expect(callback).to.be.calledThrice;
+		expect(cleanupFunction).toHaveBeenCalledTimes(2);
+		expect(callback).toHaveBeenCalledTimes(3);
 	});
 
 	it('works on a nested component', () => {
-		const callback = sinon.spy();
+		const callback = vi.fn();
 
 		function Parent() {
 			return (
@@ -70,7 +71,7 @@ describe('useLayoutEffect', () => {
 
 		render(<Parent />, scratch);
 
-		expect(callback).to.be.calledOnce;
+		expect(callback).toHaveBeenCalledOnce();
 	});
 
 	it('should execute multiple layout effects in same component in the right order', () => {
@@ -130,7 +131,7 @@ describe('useLayoutEffect', () => {
 
 	it('should invoke layout effects after subtree is fully connected', () => {
 		let ref;
-		let layoutEffect = sinon.spy(() => {
+		let layoutEffect = vi.fn(() => {
 			const isConnected = document.body.contains(ref.current);
 			expect(isConnected).to.equal(true, 'isConnected');
 		});
@@ -155,7 +156,7 @@ describe('useLayoutEffect', () => {
 		}
 
 		render(<Outer />, scratch);
-		expect(layoutEffect).to.have.been.calledOnce;
+		expect(layoutEffect).toHaveBeenCalledOnce();
 	});
 
 	// TODO: Make this test pass to resolve issue #1886
@@ -231,7 +232,7 @@ describe('useLayoutEffect', () => {
 	});
 
 	it('should throw an error upwards', () => {
-		const spy = sinon.spy();
+		const spy = vi.fn();
 		let errored = false;
 
 		const Page1 = () => {
@@ -266,21 +267,21 @@ describe('useLayoutEffect', () => {
 		}
 
 		act(() => render(<App page={1} />, scratch));
-		expect(spy).to.not.be.called;
+		expect(spy).not.toHaveBeenCalled();
 		expect(scratch.innerHTML).to.equal('<p>loaded</p>');
 
 		act(() => render(<App page={2} />, scratch));
-		expect(spy).to.be.calledOnce;
+		expect(spy).toHaveBeenCalledOnce();
 		expect(scratch.innerHTML).to.equal('<p>Error</p>');
 		errored = false;
 
 		act(() => render(<App page={1} />, scratch));
-		expect(spy).to.be.calledOnce;
+		expect(spy).toHaveBeenCalledOnce();
 		expect(scratch.innerHTML).to.equal('<p>loaded</p>');
 	});
 
 	it('should throw an error upwards from return', () => {
-		const spy = sinon.spy();
+		const spy = vi.fn();
 		let errored = false;
 
 		const Page1 = () => {
@@ -320,7 +321,7 @@ describe('useLayoutEffect', () => {
 		expect(scratch.innerHTML).to.equal('<p>Load</p>');
 
 		act(() => render(<App page={1} />, scratch));
-		expect(spy).to.be.calledOnce;
+		expect(spy).toHaveBeenCalledOnce();
 		expect(scratch.innerHTML).to.equal('<p>Error</p>');
 	});
 

--- a/hooks/test/browser/useMemo.test.js
+++ b/hooks/test/browser/useMemo.test.js
@@ -2,6 +2,7 @@ import { createElement, render } from 'preact';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useMemo, useState } from 'preact/hooks';
 import { act } from 'preact/test-utils';
+import { vi } from 'vitest';
 
 /** @jsx createElement */
 
@@ -18,7 +19,7 @@ describe('useMemo', () => {
 	});
 
 	it('only recomputes the result when inputs change', () => {
-		let memoFunction = sinon.spy((a, b) => a + b);
+		let memoFunction = vi.fn((a, b) => a + b);
 		const results = [];
 
 		function Comp({ a, b }) {
@@ -31,17 +32,17 @@ describe('useMemo', () => {
 		render(<Comp a={1} b={1} />, scratch);
 
 		expect(results).to.deep.equal([2, 2]);
-		expect(memoFunction).to.have.been.calledOnce;
+		expect(memoFunction).toHaveBeenCalledOnce();
 
 		render(<Comp a={1} b={2} />, scratch);
 		render(<Comp a={1} b={2} />, scratch);
 
 		expect(results).to.deep.equal([2, 2, 3, 3]);
-		expect(memoFunction).to.have.been.calledTwice;
+		expect(memoFunction).toHaveBeenCalledTimes(2);
 	});
 
 	it('should rerun when deps length changes', () => {
-		let memoFunction = sinon.spy(() => 1 + 2);
+		let memoFunction = vi.fn(() => 1 + 2);
 
 		function Comp({ all }) {
 			const deps = [1, all && 2].filter(Boolean);
@@ -50,14 +51,14 @@ describe('useMemo', () => {
 		}
 
 		render(<Comp all />, scratch);
-		expect(memoFunction).to.have.been.calledOnce;
+		expect(memoFunction).toHaveBeenCalledOnce();
 		render(<Comp all={false} />, scratch);
-		expect(memoFunction).to.have.been.calledTwice;
+		expect(memoFunction).toHaveBeenCalledTimes(2);
 	});
 
 	it('should rerun when first run threw an error', () => {
 		let hasThrown = false;
-		let memoFunction = sinon.spy(() => {
+		let memoFunction = vi.fn(() => {
 			if (!hasThrown) {
 				hasThrown = true;
 				throw new Error('test');
@@ -72,14 +73,14 @@ describe('useMemo', () => {
 		}
 
 		expect(() => render(<Comp />, scratch)).to.throw('test');
-		expect(memoFunction).to.have.been.calledOnce;
+		expect(memoFunction).toHaveBeenCalledOnce();
 		expect(() => render(<Comp />, scratch)).not.to.throw();
-		expect(memoFunction).to.have.been.calledTwice;
+		expect(memoFunction).toHaveBeenCalledTimes(2);
 	});
 
 	it('short circuits diffing for memoized components', () => {
-		let spy = sinon.spy();
-		let spy2 = sinon.spy();
+		let spy = vi.fn();
+		let spy2 = vi.fn();
 		const X = ({ count }) => {
 			spy();
 			return <span>{count}</span>;
@@ -101,26 +102,26 @@ describe('useMemo', () => {
 		};
 
 		render(<App x={0} />, scratch);
-		expect(spy).to.be.calledOnce;
-		expect(spy2).to.be.calledOnce;
+		expect(spy).toHaveBeenCalledOnce();
+		expect(spy2).toHaveBeenCalledOnce();
 		expect(scratch.innerHTML).to.equal('<div><span>0</span><p>0</p></div>');
 
 		render(<App x={0} />, scratch);
-		expect(spy).to.be.calledTwice;
-		expect(spy2).to.be.calledOnce;
+		expect(spy).toHaveBeenCalledTimes(2);
+		expect(spy2).toHaveBeenCalledOnce();
 		expect(scratch.innerHTML).to.equal('<div><span>0</span><p>0</p></div>');
 
 		render(<App x={1} />, scratch);
-		expect(spy).to.be.calledThrice;
-		expect(spy2).to.be.calledTwice;
+		expect(spy).toHaveBeenCalledTimes(3);
+		expect(spy2).toHaveBeenCalledTimes(2);
 		expect(scratch.innerHTML).to.equal('<div><span>1</span><p>1</p></div>');
 
 		render(<App x={1} />, scratch);
-		expect(spy2).to.be.calledTwice;
+		expect(spy2).toHaveBeenCalledTimes(2);
 		expect(scratch.innerHTML).to.equal('<div><span>1</span><p>1</p></div>');
 
 		render(<App x={2} />, scratch);
-		expect(spy2).to.be.calledThrice;
+		expect(spy2).toHaveBeenCalledTimes(3);
 		expect(scratch.innerHTML).to.equal('<div><span>2</span><p>2</p></div>');
 	});
 

--- a/hooks/test/browser/useState.test.js
+++ b/hooks/test/browser/useState.test.js
@@ -46,7 +46,7 @@ describe('useState', () => {
 	});
 
 	it('can initialize the state via a function', () => {
-		const initState = sinon.spy(() => 1);
+		const initState = vi.fn(() => 1);
 
 		function Comp() {
 			useState(initState);
@@ -56,7 +56,7 @@ describe('useState', () => {
 		render(<Comp />, scratch);
 		render(<Comp />, scratch);
 
-		expect(initState).to.be.calledOnce;
+		expect(initState).toHaveBeenCalledOnce();
 	});
 
 	it('does not rerender on equal state', () => {
@@ -163,7 +163,7 @@ describe('useState', () => {
 
 	it('should correctly re-initialize when first run threw an error', () => {
 		let hasThrown = false;
-		let setup = sinon.spy(() => {
+		let setup = vi.fn(() => {
 			if (!hasThrown) {
 				hasThrown = true;
 				throw new Error('test');
@@ -178,9 +178,9 @@ describe('useState', () => {
 		};
 
 		expect(() => render(<App />, scratch)).to.throw('test');
-		expect(setup).to.have.been.calledOnce;
+		expect(setup).toHaveBeenCalledOnce();
 		expect(() => render(<App />, scratch)).not.to.throw();
-		expect(setup).to.have.been.calledTwice;
+		expect(setup).toHaveBeenCalledTimes(2);
 		expect(scratch.innerHTML).to.equal('<p>hi</p>');
 	});
 
@@ -304,7 +304,7 @@ describe('useState', () => {
 	});
 
 	it('does not loop when states are equal after batches', () => {
-		const renderSpy = sinon.spy();
+		const renderSpy = vi.fn();
 		const Context = createContext(null);
 
 		function ModalProvider(props) {
@@ -352,13 +352,13 @@ describe('useState', () => {
 			render(<App />, scratch);
 		});
 
-		expect(renderSpy).to.be.calledThrice;
+		expect(renderSpy).toHaveBeenCalledTimes(3);
 	});
 
 	it('Cancels effect invocations correctly when bailing', () => {
-		const renderSpy = sinon.spy();
-		const cleanupSpy = sinon.spy();
-		const spy = sinon.spy();
+		const renderSpy = vi.fn();
+		const cleanupSpy = vi.fn();
+		const spy = vi.fn();
 		let set;
 
 		function App() {
@@ -379,18 +379,18 @@ describe('useState', () => {
 			render(<App />, scratch);
 		});
 
-		expect(renderSpy).to.be.calledOnce;
-		expect(spy).to.be.calledOnce;
-		expect(cleanupSpy).to.not.be.called;
+		expect(renderSpy).toHaveBeenCalledOnce();
+		expect(spy).toHaveBeenCalledOnce();
+		expect(cleanupSpy).not.toHaveBeenCalled();
 
 		act(() => {
 			set('updated');
 			set('initial');
 		});
 
-		expect(renderSpy).to.be.calledTwice;
-		expect(spy).to.be.calledOnce;
-		expect(cleanupSpy).to.not.be.called;
+		expect(renderSpy).toHaveBeenCalledTimes(2);
+		expect(spy).toHaveBeenCalledOnce();
+		expect(cleanupSpy).not.toHaveBeenCalled();
 	});
 
 	// see preactjs/preact#3731

--- a/test/_util/optionSpies.js
+++ b/test/_util/optionSpies.js
@@ -1,4 +1,5 @@
 import { options as rawOptions } from 'preact';
+import { vi } from 'vitest';
 
 /** @type {import('preact/src/internal').Options} */
 let options = rawOptions;
@@ -15,17 +16,17 @@ let oldBeforeCommit = options._commit;
 let oldHook = options._hook;
 let oldCatchError = options._catchError;
 
-export const vnodeSpy = sinon.spy(oldVNode);
-export const eventSpy = sinon.spy(oldEvent);
-export const afterDiffSpy = sinon.spy(oldAfterDiff);
-export const unmountSpy = sinon.spy(oldUnmount);
+export const vnodeSpy = vi.fn(oldVNode);
+export const eventSpy = vi.fn(oldEvent);
+export const afterDiffSpy = vi.fn(oldAfterDiff);
+export const unmountSpy = vi.fn(oldUnmount);
 
-export const rootSpy = sinon.spy(oldRoot);
-export const beforeDiffSpy = sinon.spy(oldBeforeDiff);
-export const beforeRenderSpy = sinon.spy(oldBeforeRender);
-export const beforeCommitSpy = sinon.spy(oldBeforeCommit);
-export const hookSpy = sinon.spy(oldHook);
-export const catchErrorSpy = sinon.spy(oldCatchError);
+export const rootSpy = vi.fn(oldRoot);
+export const beforeDiffSpy = vi.fn(oldBeforeDiff);
+export const beforeRenderSpy = vi.fn(oldBeforeRender);
+export const beforeCommitSpy = vi.fn(oldBeforeCommit);
+export const hookSpy = vi.fn(oldHook);
+export const catchErrorSpy = vi.fn(oldCatchError);
 
 options.vnode = vnodeSpy;
 options.event = eventSpy;


### PR DESCRIPTION
Since we change the util too, some `compat` and `debug` tests also
changed.
