### PR TITLE
test: migrate compat tests to vitest spies

### DIFF
--- a/compat/test/browser/PureComponent.test.js
+++ b/compat/test/browser/PureComponent.test.js
@@ -1,6 +1,7 @@
 import React, { createElement } from 'preact/compat';
 import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { vi } from 'vitest';
 
 describe('PureComponent', () => {
 	/** @type {HTMLDivElement} */
@@ -23,7 +24,7 @@ describe('PureComponent', () => {
 	});
 
 	it('should pass props in constructor', () => {
-		let spy = sinon.spy();
+		let spy = vi.fn();
 		class Foo extends React.PureComponent {
 			constructor(props) {
 				super(props);
@@ -34,7 +35,7 @@ describe('PureComponent', () => {
 		React.render(<Foo foo="bar" />, scratch);
 
 		let expected = { foo: 'bar' };
-		expect(spy).to.be.calledWithMatch(expected, expected);
+		expect(spy).toHaveBeenCalledWith(expected, expected);
 	});
 
 	it('should pass context in constructor', () => {
@@ -54,14 +55,14 @@ describe('PureComponent', () => {
 			}
 		}
 
-		sinon.spy(Foo.prototype, 'render');
+		vi.spyOn(Foo.prototype, 'render');
 
 		const PROPS = { foo: 'bar' };
 		React.render(<Foo {...PROPS} />, scratch);
 
-		expect(Foo.prototype.render)
-			.to.have.been.calledOnce.and.to.have.been.calledWithMatch(PROPS, {}, {})
-			.and.to.have.returned(sinon.match({ type: 'div', props: PROPS }));
+		expect(Foo.prototype.render).toHaveBeenCalledOnce();
+		expect(Foo.prototype.render).toHaveBeenCalledWith(PROPS, {}, {});
+		expect(Foo.prototype.render).toHaveReturned({ type: 'div', props: PROPS });
 		expect(instance.props).to.deep.equal(PROPS);
 		expect(instance.state).to.deep.equal({});
 		expect(instance.context).to.deep.equal({});
@@ -70,8 +71,8 @@ describe('PureComponent', () => {
 	});
 
 	it('should ignore the __source variable', () => {
-		const pureSpy = sinon.spy();
-		const appSpy = sinon.spy();
+		const pureSpy = vi.fn();
+		const appSpy = vi.fn();
 		/** @type {(v) => void} */
 		let set;
 		class Pure extends React.PureComponent {
@@ -89,13 +90,13 @@ describe('PureComponent', () => {
 		};
 
 		React.render(<App />, scratch);
-		expect(appSpy).to.be.calledOnce;
-		expect(pureSpy).to.be.calledOnce;
+		expect(appSpy).toHaveBeenCalledOnce();
+		expect(pureSpy).toHaveBeenCalledOnce();
 
 		set(1);
 		rerender();
-		expect(appSpy).to.be.calledTwice;
-		expect(pureSpy).to.be.calledOnce;
+		expect(appSpy).toHaveBeenCalledTimes(2);
+		expect(pureSpy).toHaveBeenCalledOnce();
 	});
 
 	it('should only re-render when props or state change', () => {
@@ -104,39 +105,39 @@ describe('PureComponent', () => {
 				return <div />;
 			}
 		}
-		let spy = sinon.spy(C.prototype, 'render');
+		let spy = vi.spyOn(C.prototype, 'render');
 
 		let inst = React.render(<C />, scratch);
-		expect(spy).to.have.been.calledOnce;
-		spy.resetHistory();
+		expect(spy).toHaveBeenCalledOnce();
+		spy.mockClear();
 
 		inst = React.render(<C />, scratch);
-		expect(spy).not.to.have.been.called;
+		expect(spy).not.toHaveBeenCalled();
 
 		let b = { foo: 'bar' };
 		inst = React.render(<C a="a" b={b} />, scratch);
-		expect(spy).to.have.been.calledOnce;
-		spy.resetHistory();
+		expect(spy).toHaveBeenCalledOnce();
+		spy.mockClear();
 
 		inst = React.render(<C a="a" b={b} />, scratch);
-		expect(spy).not.to.have.been.called;
+		expect(spy).not.toHaveBeenCalled();
 
 		inst.setState({});
 		rerender();
-		expect(spy).not.to.have.been.called;
+		expect(spy).not.toHaveBeenCalled();
 
 		inst.setState({ a: 'a', b });
 		rerender();
-		expect(spy).to.have.been.calledOnce;
-		spy.resetHistory();
+		expect(spy).toHaveBeenCalledOnce();
+		spy.mockClear();
 
 		inst.setState({ a: 'a', b });
 		rerender();
-		expect(spy).not.to.have.been.called;
+		expect(spy).not.toHaveBeenCalled();
 	});
 
 	it('should update when props are removed', () => {
-		let spy = sinon.spy();
+		let spy = vi.fn();
 		class App extends React.PureComponent {
 			render() {
 				spy();
@@ -146,7 +147,7 @@ describe('PureComponent', () => {
 
 		React.render(<App a="foo" />, scratch);
 		React.render(<App />, scratch);
-		expect(spy).to.be.calledTwice;
+		expect(spy).toHaveBeenCalledTimes(2);
 	});
 
 	it('should have "isPureReactComponent" property', () => {

--- a/compat/test/browser/events.test.js
+++ b/compat/test/browser/events.test.js
@@ -7,6 +7,7 @@ import {
 } from '../../../test/_util/helpers';
 
 import React, { createElement } from 'preact/compat';
+import { vi } from 'vitest';
 
 describe('preact/compat events', () => {
 	/** @type {HTMLDivElement} */
@@ -17,19 +18,19 @@ describe('preact/compat events', () => {
 		scratch = setupScratch();
 
 		proto = Element.prototype;
-		sinon.spy(proto, 'addEventListener');
-		sinon.spy(proto, 'removeEventListener');
+		vi.spyOn(proto, 'addEventListener');
+		vi.spyOn(proto, 'removeEventListener');
 	});
 
 	afterEach(() => {
 		teardown(scratch);
 
-		proto.addEventListener.restore();
-		proto.removeEventListener.restore();
+		proto.addEventListener.mockRestore();
+		proto.removeEventListener.mockRestore();
 	});
 
 	it('should patch events', () => {
-		let spy = sinon.spy(event => {
+		let spy = vi.fn(event => {
 			expect(event.isDefaultPrevented()).to.be.false;
 			event.preventDefault();
 			expect(event.isDefaultPrevented()).to.be.true;
@@ -42,8 +43,8 @@ describe('preact/compat events', () => {
 		render(<div onClick={spy} />, scratch);
 		scratch.firstChild.click();
 
-		expect(spy).to.be.calledOnce;
-		const event = spy.args[0][0];
+		expect(spy).toHaveBeenCalledOnce();
+		const event = spy.mock.calls[0][0];
 		expect(event).to.haveOwnProperty('persist');
 		expect(event).to.haveOwnProperty('nativeEvent');
 		expect(event).to.haveOwnProperty('isDefaultPrevented');
@@ -87,44 +88,42 @@ describe('preact/compat events', () => {
 
 	it('should normalize onChange for range', () => {
 		render(<input type="range" onChange={() => null} />, scratch);
-		expect(proto.addEventListener).to.have.been.calledOnce;
-		expect(proto.addEventListener).to.have.been.calledWithExactly(
+		expect(proto.addEventListener).toHaveBeenCalledOnce();
+		expect(proto.addEventListener).toHaveBeenCalledWith(
 			'input',
-			sinon.match.func,
+			expect.any(Function),
 			false
 		);
 	});
 
 	it('should support onAnimationEnd', () => {
-		const func = sinon.spy(() => {});
+		const func = vi.fn(() => {});
 		render(<div onAnimationEnd={func} />, scratch);
 
-		expect(
-			proto.addEventListener
-		).to.have.been.calledOnce.and.to.have.been.calledWithExactly(
+		expect(proto.addEventListener).toHaveBeenCalledOnce();
+		expect(proto.addEventListener).toHaveBeenCalledWith(
 			'animationend',
-			sinon.match.func,
+			expect.any(Function),
 			false
 		);
 
 		scratch.firstChild.dispatchEvent(createEvent('animationend'));
-		expect(func).to.have.been.calledOnce;
+		expect(func).toHaveBeenCalledOnce();
 
 		render(<div />, scratch);
-		expect(
-			proto.removeEventListener
-		).to.have.been.calledOnce.and.to.have.been.calledWithExactly(
+		expect(proto.removeEventListener).toHaveBeenCalledOnce();
+		expect(proto.removeEventListener).toHaveBeenCalledWith(
 			'animationend',
-			sinon.match.func,
+			expect.any(Function),
 			false
 		);
 	});
 
 	it('should support onTouch* events', () => {
-		const onTouchStart = sinon.spy();
-		const onTouchEnd = sinon.spy();
-		const onTouchMove = sinon.spy();
-		const onTouchCancel = sinon.spy();
+		const onTouchStart = vi.fn();
+		const onTouchEnd = vi.fn();
+		const onTouchMove = vi.fn();
+		const onTouchCancel = vi.fn();
 
 		render(
 			<div
@@ -136,70 +135,68 @@ describe('preact/compat events', () => {
 			scratch
 		);
 
-		expect(proto.addEventListener.args.length).to.eql(4);
-		expect(proto.addEventListener.args[0].length).to.eql(3);
-		expect(proto.addEventListener.args[0][0]).to.eql('touchstart');
-		expect(proto.addEventListener.args[0][2]).to.eql(false);
-		expect(proto.addEventListener.args[1].length).to.eql(3);
-		expect(proto.addEventListener.args[1][0]).to.eql('touchend');
-		expect(proto.addEventListener.args[1][2]).to.eql(false);
-		expect(proto.addEventListener.args[2].length).to.eql(3);
-		expect(proto.addEventListener.args[2][0]).to.eql('touchmove');
-		expect(proto.addEventListener.args[2][2]).to.eql(false);
-		expect(proto.addEventListener.args[3].length).to.eql(3);
-		expect(proto.addEventListener.args[3][0]).to.eql('touchcancel');
-		expect(proto.addEventListener.args[3][2]).to.eql(false);
+		expect(proto.addEventListener.mock.calls.length).to.eql(4);
+		expect(proto.addEventListener.mock.calls[0].length).to.eql(3);
+		expect(proto.addEventListener.mock.calls[0][0]).to.eql('touchstart');
+		expect(proto.addEventListener.mock.calls[0][2]).to.eql(false);
+		expect(proto.addEventListener.mock.calls[1].length).to.eql(3);
+		expect(proto.addEventListener.mock.calls[1][0]).to.eql('touchend');
+		expect(proto.addEventListener.mock.calls[1][2]).to.eql(false);
+		expect(proto.addEventListener.mock.calls[2].length).to.eql(3);
+		expect(proto.addEventListener.mock.calls[2][0]).to.eql('touchmove');
+		expect(proto.addEventListener.mock.calls[2][2]).to.eql(false);
+		expect(proto.addEventListener.mock.calls[3].length).to.eql(3);
+		expect(proto.addEventListener.mock.calls[3][0]).to.eql('touchcancel');
+		expect(proto.addEventListener.mock.calls[3][2]).to.eql(false);
 
 		scratch.firstChild.dispatchEvent(createEvent('touchstart'));
-		expect(onTouchStart).to.have.been.calledOnce;
+		expect(onTouchStart).toHaveBeenCalledOnce();
 
 		scratch.firstChild.dispatchEvent(createEvent('touchmove'));
-		expect(onTouchMove).to.have.been.calledOnce;
+		expect(onTouchMove).toHaveBeenCalledOnce();
 
 		scratch.firstChild.dispatchEvent(createEvent('touchend'));
-		expect(onTouchEnd).to.have.been.calledOnce;
+		expect(onTouchEnd).toHaveBeenCalledOnce();
 
 		scratch.firstChild.dispatchEvent(createEvent('touchcancel'));
-		expect(onTouchCancel).to.have.been.calledOnce;
+		expect(onTouchCancel).toHaveBeenCalledOnce();
 
 		render(<div />, scratch);
 
-		expect(proto.removeEventListener.args.length).to.eql(4);
-		expect(proto.removeEventListener.args[0].length).to.eql(3);
-		expect(proto.removeEventListener.args[0][0]).to.eql('touchstart');
-		expect(proto.removeEventListener.args[0][2]).to.eql(false);
-		expect(proto.removeEventListener.args[1].length).to.eql(3);
-		expect(proto.removeEventListener.args[1][0]).to.eql('touchend');
-		expect(proto.removeEventListener.args[1][2]).to.eql(false);
-		expect(proto.removeEventListener.args[2].length).to.eql(3);
-		expect(proto.removeEventListener.args[2][0]).to.eql('touchmove');
-		expect(proto.removeEventListener.args[2][2]).to.eql(false);
-		expect(proto.removeEventListener.args[3].length).to.eql(3);
-		expect(proto.removeEventListener.args[3][0]).to.eql('touchcancel');
-		expect(proto.removeEventListener.args[3][2]).to.eql(false);
+		expect(proto.removeEventListener.mock.calls.length).to.eql(4);
+		expect(proto.removeEventListener.mock.calls[0].length).to.eql(3);
+		expect(proto.removeEventListener.mock.calls[0][0]).to.eql('touchstart');
+		expect(proto.removeEventListener.mock.calls[0][2]).to.eql(false);
+		expect(proto.removeEventListener.mock.calls[1].length).to.eql(3);
+		expect(proto.removeEventListener.mock.calls[1][0]).to.eql('touchend');
+		expect(proto.removeEventListener.mock.calls[1][2]).to.eql(false);
+		expect(proto.removeEventListener.mock.calls[2].length).to.eql(3);
+		expect(proto.removeEventListener.mock.calls[2][0]).to.eql('touchmove');
+		expect(proto.removeEventListener.mock.calls[2][2]).to.eql(false);
+		expect(proto.removeEventListener.mock.calls[3].length).to.eql(3);
+		expect(proto.removeEventListener.mock.calls[3][0]).to.eql('touchcancel');
+		expect(proto.removeEventListener.mock.calls[3][2]).to.eql(false);
 	});
 
 	it('should support onTransitionEnd', () => {
-		const func = sinon.spy(() => {});
+		const func = vi.fn(() => {});
 		render(<div onTransitionEnd={func} />, scratch);
 
-		expect(
-			proto.addEventListener
-		).to.have.been.calledOnce.and.to.have.been.calledWithExactly(
+		expect(proto.addEventListener).toHaveBeenCalledOnce();
+		expect(proto.addEventListener).toHaveBeenCalledWith(
 			'transitionend',
-			sinon.match.func,
+			expect.any(Function),
 			false
 		);
 
 		scratch.firstChild.dispatchEvent(createEvent('transitionend'));
-		expect(func).to.have.been.calledOnce;
+		expect(func).toHaveBeenCalledOnce();
 
 		render(<div />, scratch);
-		expect(
-			proto.removeEventListener
-		).to.have.been.calledOnce.and.to.have.been.calledWithExactly(
+		expect(proto.removeEventListener).toHaveBeenCalledOnce();
+		expect(proto.removeEventListener).toHaveBeenCalledWith(
 			'transitionend',
-			sinon.match.func,
+			expect.any(Function),
 			false
 		);
 	});
@@ -247,36 +244,36 @@ describe('preact/compat events', () => {
 	});
 
 	it('should normalize beforeinput event listener', () => {
-		let spy = sinon.spy();
+		let spy = vi.fn();
 		render(<input onBeforeInput={spy} />, scratch);
 		scratch.firstChild.dispatchEvent(createEvent('beforeinput'));
-		expect(spy).to.be.calledOnce;
+		expect(spy).toHaveBeenCalledOnce();
 	});
 
 	it('should normalize compositionstart event listener', () => {
-		let spy = sinon.spy();
+		let spy = vi.fn();
 		render(<input onCompositionStart={spy} />, scratch);
 		scratch.firstChild.dispatchEvent(createEvent('compositionstart'));
-		expect(spy).to.be.calledOnce;
+		expect(spy).toHaveBeenCalledOnce();
 	});
 
 	it('should normalize onFocus to onfocusin', () => {
-		let spy = sinon.spy();
+		let spy = vi.fn();
 		render(<input onFocus={spy} />, scratch);
 		scratch.firstChild.dispatchEvent(createEvent('focusin'));
-		expect(spy).to.be.calledOnce;
+		expect(spy).toHaveBeenCalledOnce();
 	});
 
 	it('should normalize onBlur to onfocusout', () => {
-		let spy = sinon.spy();
+		let spy = vi.fn();
 		render(<input onBlur={spy} />, scratch);
 		scratch.firstChild.dispatchEvent(createEvent('focusout'));
-		expect(spy).to.be.calledOnce;
+		expect(spy).toHaveBeenCalledOnce();
 	});
 
 	if (supportsPassiveEvents()) {
 		it('should use capturing for event props ending with *Capture', () => {
-			let click = sinon.spy();
+			let click = vi.fn();
 
 			render(
 				<div onTouchMoveCapture={click}>
@@ -285,10 +282,10 @@ describe('preact/compat events', () => {
 				scratch
 			);
 
-			expect(proto.addEventListener).to.have.been.calledOnce;
-			expect(proto.addEventListener).to.have.been.calledWithExactly(
+			expect(proto.addEventListener).toHaveBeenCalledOnce();
+			expect(proto.addEventListener).toHaveBeenCalledWith(
 				'touchmove',
-				sinon.match.func,
+				expect.any(Function),
 				true
 			);
 		});

--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -14,6 +14,7 @@ import React, {
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { setupRerender, act } from 'preact/test-utils';
 import { getSymbol } from './testUtils';
+import { vi } from 'vitest';
 
 /* eslint-disable react/jsx-boolean-value, react/display-name, prefer-arrow-callback */
 
@@ -75,11 +76,11 @@ describe('forwardRef', () => {
 	});
 
 	it('should forward props', () => {
-		let spy = sinon.spy();
+		let spy = vi.fn();
 		let App = forwardRef(spy);
 		render(<App foo="bar" />, scratch);
 
-		expect(spy).to.be.calledWithMatch({ foo: 'bar' });
+		expect(spy).toHaveBeenCalledWith({ foo: 'bar' }, null);
 	});
 
 	it('should support nesting', () => {
@@ -272,26 +273,26 @@ describe('forwardRef', () => {
 			})
 		);
 
-		const ref = sinon.spy();
+		const ref = vi.fn();
 
 		render(<App ref={ref} optional="foo" />, scratch);
 		expect(renderCount).to.equal(1);
 
-		expect(ref).to.have.been.called;
+		expect(ref).toHaveBeenCalled();
 
-		ref.resetHistory();
+		ref.mockClear();
 		render(<App ref={ref} optional="foo" />, scratch);
 		expect(renderCount).to.equal(1);
 
-		const differentRef = sinon.spy();
+		const differentRef = vi.fn();
 
 		render(<App ref={differentRef} optional="foo" />, scratch);
 		expect(renderCount).to.equal(2);
 
-		expect(ref).to.have.been.calledWith(null);
-		expect(differentRef).to.have.been.called;
+		expect(ref).toHaveBeenCalledWith(null);
+		expect(differentRef).toHaveBeenCalled();
 
-		differentRef.resetHistory();
+		differentRef.mockClear();
 		render(<App ref={ref} optional="bar" />, scratch);
 		expect(renderCount).to.equal(3);
 	});
@@ -352,15 +353,15 @@ describe('forwardRef', () => {
 	});
 
 	it('calls ref when this is a function.', () => {
-		const spy = sinon.spy();
+		const spy = vi.fn();
 		const Bar = forwardRef((props, ref) => {
 			useImperativeHandle(ref, () => ({ foo: 100 }));
 			return null;
 		});
 
 		render(<Bar ref={spy} />, scratch);
-		expect(spy).to.be.calledOnce;
-		expect(spy).to.be.calledWithExactly({ foo: 100 });
+		expect(spy).toHaveBeenCalledOnce();
+		expect(spy).toHaveBeenCalledWith({ foo: 100 });
 	});
 
 	it('stale ref missing with passed useRef', () => {
@@ -508,5 +509,5 @@ describe('forwardRef', () => {
 		const Forwarded = forwardRef(Foo);
 
 		expect(Forwarded.render).to.equal(Foo);
-  });
+	});
 });

--- a/compat/test/browser/hooks.test.js
+++ b/compat/test/browser/hooks.test.js
@@ -11,6 +11,7 @@ import React, {
 } from 'preact/compat';
 import { setupRerender, act } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { vi } from 'vitest';
 
 describe('React-18-hooks', () => {
 	/** @type {HTMLDivElement} */
@@ -43,7 +44,7 @@ describe('React-18-hooks', () => {
 
 	describe('useInsertionEffect', () => {
 		it('runs the effect', () => {
-			const spy = sinon.spy();
+			const spy = vi.fn();
 			const App = () => {
 				useInsertionEffect(spy, []);
 				return <p>hello world</p>;
@@ -54,13 +55,13 @@ describe('React-18-hooks', () => {
 			});
 
 			expect(scratch.innerHTML).to.equal('<p>hello world</p>');
-			expect(spy).to.be.calledOnce;
+			expect(spy).toHaveBeenCalledOnce();
 		});
 	});
 
 	describe('useTransition', () => {
 		it('runs transitions', () => {
-			const spy = sinon.spy();
+			const spy = vi.fn();
 
 			/** @type {(v) => void} */
 			let go;
@@ -75,7 +76,7 @@ describe('React-18-hooks', () => {
 
 			go(spy);
 			rerender();
-			expect(spy).to.be.calledOnce;
+			expect(spy).toHaveBeenCalledOnce();
 			expect(scratch.innerHTML).to.equal('<p>Pending: no</p>');
 		});
 	});

--- a/compat/test/browser/hydrate.test.js
+++ b/compat/test/browser/hydrate.test.js
@@ -1,5 +1,6 @@
 import React, { hydrate } from 'preact/compat';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { vi } from 'vitest';
 
 describe('compat hydrate', () => {
 	/** @type {HTMLDivElement} */
@@ -26,9 +27,9 @@ describe('compat hydrate', () => {
 	it('should call the callback', () => {
 		scratch.innerHTML = '<div></div>';
 
-		let spy = sinon.spy();
+		let spy = vi.fn();
 		hydrate(<div />, scratch, spy);
-		expect(spy).to.be.calledOnce;
-		expect(spy).to.be.calledWithExactly();
+		expect(spy).toHaveBeenCalledOnce();
+		expect(spy).toHaveBeenCalledWith();
 	});
 });

--- a/compat/test/browser/memo.test.js
+++ b/compat/test/browser/memo.test.js
@@ -11,6 +11,7 @@ import React, {
 	memo,
 	useState
 } from 'preact/compat';
+import { vi } from 'vitest';
 
 const h = React.createElement;
 
@@ -37,7 +38,7 @@ describe('memo()', () => {
 	});
 
 	it('should work with function components', () => {
-		let spy = sinon.spy();
+		let spy = vi.fn();
 
 		function Foo() {
 			spy();
@@ -59,16 +60,16 @@ describe('memo()', () => {
 		}
 		render(<App />, scratch);
 
-		expect(spy).to.be.calledOnce;
+		expect(spy).toHaveBeenCalledOnce();
 
 		update();
 		rerender();
 
-		expect(spy).to.be.calledOnce;
+		expect(spy).toHaveBeenCalledOnce();
 	});
 
 	it('should support adding refs', () => {
-		let spy = sinon.spy();
+		let spy = vi.fn();
 
 		let ref = null;
 
@@ -92,7 +93,7 @@ describe('memo()', () => {
 		}
 		render(<App />, scratch);
 
-		expect(spy).to.be.calledOnce;
+		expect(spy).toHaveBeenCalledOnce();
 
 		ref = {};
 
@@ -101,7 +102,7 @@ describe('memo()', () => {
 
 		expect(ref.current).to.equal(scratch.firstChild);
 		// TODO: not sure whether this is in-line with react...
-		expect(spy).to.be.calledTwice;
+		expect(spy).toHaveBeenCalledTimes(2);
 	});
 
 	it('should support custom comparer functions', () => {
@@ -109,7 +110,7 @@ describe('memo()', () => {
 			return <h1>Hello World</h1>;
 		}
 
-		let spy = sinon.spy(() => true);
+		let spy = vi.fn(() => true);
 		let Memoized = memo(Foo, spy);
 
 		/** @type {(v) => void} */
@@ -128,12 +129,12 @@ describe('memo()', () => {
 		update();
 		rerender();
 
-		expect(spy).to.be.calledOnce;
-		expect(spy).to.be.calledWith({}, {});
+		expect(spy).toHaveBeenCalledOnce();
+		expect(spy).toHaveBeenCalledWith({}, {});
 	});
 
 	it('should rerender when custom comparer returns false', () => {
-		const spy = sinon.spy();
+		const spy = vi.fn();
 		function Foo() {
 			spy();
 			return <h1>Hello World</h1>;
@@ -141,14 +142,14 @@ describe('memo()', () => {
 
 		const App = memo(Foo, () => false);
 		render(<App />, scratch);
-		expect(spy).to.be.calledOnce;
+		expect(spy).toHaveBeenCalledOnce();
 
 		render(<App foo="bar" />, scratch);
-		expect(spy).to.be.calledTwice;
+		expect(spy).toHaveBeenCalledTimes(2);
 	});
 
 	it('should pass props and nextProps to comparer fn', () => {
-		const spy = sinon.spy(() => false);
+		const spy = vi.fn(() => false);
 		function Foo() {
 			return <div>foo</div>;
 		}
@@ -159,7 +160,7 @@ describe('memo()', () => {
 		render(h(App, props), scratch);
 		render(h(App, nextProps), scratch);
 
-		expect(spy).to.be.calledWith(props, nextProps);
+		expect(spy).toHaveBeenCalledWith(props, nextProps);
 	});
 
 	it('should nest without errors', () => {

--- a/compat/test/browser/portals.test.js
+++ b/compat/test/browser/portals.test.js
@@ -11,6 +11,7 @@ import React, {
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { setupRerender, act } from 'preact/test-utils';
 import { expect } from 'chai';
+import { vi } from 'vitest';
 
 /* eslint-disable react/jsx-boolean-value, react/display-name, prefer-arrow-callback */
 
@@ -160,7 +161,7 @@ describe('Portal', () => {
 	});
 
 	it('should not unmount the portal component', () => {
-		let spy = sinon.spy();
+		let spy = vi.fn();
 		/** @type {(c) => void} */
 		let set;
 		class Child extends Component {
@@ -187,11 +188,11 @@ describe('Portal', () => {
 		}
 
 		render(<Foo />, scratch);
-		expect(spy).not.to.be.called;
+		expect(spy).not.toHaveBeenCalled();
 
 		set({});
 		rerender();
-		expect(spy).not.to.be.called;
+		expect(spy).not.toHaveBeenCalled();
 	});
 
 	it('should not render <undefined> for Portal nodes', () => {
@@ -653,7 +654,7 @@ describe('Portal', () => {
 		scratch.appendChild(root);
 		scratch.appendChild(dialog);
 
-		let spy = sinon.spy();
+		let spy = vi.fn();
 		class Child extends Component {
 			componentDidMount() {
 				spy();
@@ -664,7 +665,7 @@ describe('Portal', () => {
 			}
 		}
 
-		let spyParent = sinon.spy();
+		let spyParent = vi.fn();
 		class App extends Component {
 			componentDidMount() {
 				spyParent();
@@ -676,8 +677,8 @@ describe('Portal', () => {
 
 		render(<App />, root);
 		let dom = document.getElementById('child');
-		expect(spyParent).to.be.calledOnce;
-		expect(spy).to.be.calledOnce;
+		expect(spyParent).toHaveBeenCalledOnce();
+		expect(spy).toHaveBeenCalledOnce();
 
 		// Render twice to trigger update scenario
 		render(<App />, root);
@@ -685,8 +686,8 @@ describe('Portal', () => {
 
 		let domNew = document.getElementById('child');
 		expect(dom).to.equal(domNew);
-		expect(spyParent).to.be.calledOnce;
-		expect(spy).to.be.calledOnce;
+		expect(spyParent).toHaveBeenCalledOnce();
+		expect(spy).toHaveBeenCalledOnce();
 	});
 
 	it('should switch between non portal and portal node (Modal as lastChild)', () => {

--- a/compat/test/browser/render.test.js
+++ b/compat/test/browser/render.test.js
@@ -13,6 +13,7 @@ import {
 	createEvent,
 	sortAttributes
 } from '../../../test/_util/helpers';
+import { vi } from 'vitest';
 
 describe('compat render', () => {
 	/** @type {HTMLDivElement} */
@@ -239,32 +240,32 @@ describe('compat render', () => {
 	});
 
 	it('should call onChange and onInput when input event is dispatched', () => {
-		const onChange = sinon.spy();
-		const onInput = sinon.spy();
+		const onChange = vi.fn();
+		const onInput = vi.fn();
 
 		render(<input onChange={onChange} onInput={onInput} />, scratch);
 
 		scratch.firstChild.dispatchEvent(createEvent('input'));
 
-		expect(onChange).to.be.calledOnce;
-		expect(onInput).to.be.calledOnce;
+		expect(onChange).toHaveBeenCalledOnce();
+		expect(onInput).toHaveBeenCalledOnce();
 
-		onChange.resetHistory();
-		onInput.resetHistory();
+		onChange.mockClear();
+		onInput.mockClear();
 
 		// change props order
 		render(<input onInput={onInput} onChange={onChange} />, scratch);
 
 		scratch.firstChild.dispatchEvent(createEvent('input'));
 
-		expect(onChange).to.be.calledOnce;
-		expect(onInput).to.be.calledOnce;
+		expect(onChange).toHaveBeenCalledOnce();
+		expect(onInput).toHaveBeenCalledOnce();
 	});
 
 	it('should keep value of uncontrolled inputs using defaultValue', () => {
 		// See https://github.com/preactjs/preact/issues/2391
 
-		const spy = sinon.spy();
+		const spy = vi.fn();
 
 		class Input extends Component {
 			render() {
@@ -289,14 +290,14 @@ describe('compat render', () => {
 		scratch.firstChild.dispatchEvent(createEvent('input'));
 		rerender();
 		expect(scratch.firstChild.value).to.equal('foo');
-		expect(spy).to.be.calledOnce;
+		expect(spy).toHaveBeenCalledOnce();
 	});
 
 	it('should call the callback', () => {
-		let spy = sinon.spy();
+		let spy = vi.fn();
 		render(<div />, scratch, spy);
-		expect(spy).to.be.calledOnce;
-		expect(spy).to.be.calledWithExactly();
+		expect(spy).toHaveBeenCalledOnce();
+		expect(spy).toHaveBeenCalledWith();
 	});
 
 	// Issue #1727
@@ -511,9 +512,9 @@ describe('compat render', () => {
 	});
 
 	it('should support static content', () => {
-		const updateSpy = sinon.spy();
-		const mountSpy = sinon.spy();
-		const renderSpy = sinon.spy();
+		const updateSpy = vi.fn();
+		const mountSpy = vi.fn();
+		const renderSpy = vi.fn();
 
 		function StaticContent({ children, element = 'div', staticMode }) {
 			// if we're in the server or a spa navigation, just render it
@@ -554,9 +555,9 @@ describe('compat render', () => {
 		});
 
 		expect(scratch.innerHTML).to.eq('<div><div>Staticness</div></div>');
-		expect(renderSpy).to.be.calledOnce;
-		expect(mountSpy).to.be.calledOnce;
-		expect(updateSpy).to.not.be.calledOnce;
+		expect(renderSpy).toHaveBeenCalledOnce();
+		expect(mountSpy).toHaveBeenCalledOnce();
+		expect(updateSpy).not.toHaveBeenCalled();
 
 		act(() => {
 			hydrate(
@@ -568,9 +569,9 @@ describe('compat render', () => {
 		});
 
 		expect(scratch.innerHTML).to.eq('<div><div>Staticness</div></div>');
-		expect(renderSpy).to.be.calledOnce;
-		expect(mountSpy).to.be.calledOnce;
-		expect(updateSpy).to.not.be.calledOnce;
+		expect(renderSpy).toHaveBeenCalledOnce();
+		expect(mountSpy).toHaveBeenCalledOnce();
+		expect(updateSpy).not.toHaveBeenCalled();
 	});
 
 	it('should support the translate attribute w/ yes as a string', () => {
@@ -631,7 +632,7 @@ describe('compat render', () => {
 			}
 		}
 
-		sinon.spy(Inner.prototype, 'render');
+		vi.spyOn(Inner.prototype, 'render');
 
 		render(
 			<Context value={CONTEXT}>
@@ -648,7 +649,11 @@ describe('compat render', () => {
 		);
 
 		// initial render does not invoke anything but render():
-		expect(Inner.prototype.render).to.have.been.calledWithMatch(CONTEXT);
+		expect(Inner.prototype.render).toHaveBeenCalledWith(
+			CONTEXT,
+			{},
+			expect.anything()
+		);
 		expect(receivedContext).to.equal(CONTEXT);
 		expect(scratch.innerHTML).to.equal('<div><div>a</div></div>');
 	});

--- a/compat/test/browser/scheduler.test.js
+++ b/compat/test/browser/scheduler.test.js
@@ -7,25 +7,26 @@ import {
 	unstable_ImmediatePriority,
 	unstable_now
 } from 'preact/compat/scheduler';
+import { vi } from 'vitest';
 
 describe('scheduler', () => {
 	describe('runWithPriority', () => {
 		it('should call callback ', () => {
-			const spy = sinon.spy();
+			const spy = vi.fn();
 			unstable_runWithPriority(unstable_IdlePriority, spy);
-			expect(spy.callCount).to.equal(1);
+			expect(spy).toHaveBeenCalledTimes(1);
 
 			unstable_runWithPriority(unstable_LowPriority, spy);
-			expect(spy.callCount).to.equal(2);
+			expect(spy).toHaveBeenCalledTimes(2);
 
 			unstable_runWithPriority(unstable_NormalPriority, spy);
-			expect(spy.callCount).to.equal(3);
+			expect(spy).toHaveBeenCalledTimes(3);
 
 			unstable_runWithPriority(unstable_UserBlockingPriority, spy);
-			expect(spy.callCount).to.equal(4);
+			expect(spy).toHaveBeenCalledTimes(4);
 
 			unstable_runWithPriority(unstable_ImmediatePriority, spy);
-			expect(spy.callCount).to.equal(5);
+			expect(spy).toHaveBeenCalledTimes(5);
 		});
 	});
 

--- a/compat/test/browser/suspense-hydration.test.js
+++ b/compat/test/browser/suspense-hydration.test.js
@@ -15,6 +15,7 @@ import {
 } from '../../../test/_util/helpers';
 import { ul, li, div } from '../../../test/_util/dom';
 import { createLazy, createSuspenseLoader } from './suspense-utils';
+import { vi } from 'vitest';
 
 /* eslint-env browser */
 describe('suspense hydration', () => {
@@ -125,8 +126,8 @@ describe('suspense hydration', () => {
 		scratch.innerHTML = '<div>Hello</div><div>World</div>';
 		clearLog();
 
-		const helloListener = sinon.spy();
-		const worldListener = sinon.spy();
+		const helloListener = vi.fn();
+		const worldListener = vi.fn();
 
 		const [Lazy, resolve] = createLazy();
 		hydrate(
@@ -142,7 +143,7 @@ describe('suspense hydration', () => {
 		clearLog();
 
 		scratch.querySelector('div:last-child').dispatchEvent(createEvent('click'));
-		expect(worldListener, 'worldListener 1').to.have.been.calledOnce;
+		expect(worldListener, 'worldListener 1').toHaveBeenCalledOnce();
 
 		return resolve(() => <div onClick={helloListener}>Hello</div>).then(() => {
 			rerender();
@@ -152,12 +153,12 @@ describe('suspense hydration', () => {
 			scratch
 				.querySelector('div:first-child')
 				.dispatchEvent(createEvent('click'));
-			expect(helloListener, 'helloListener').to.have.been.calledOnce;
+			expect(helloListener, 'helloListener').toHaveBeenCalledOnce();
 
 			scratch
 				.querySelector('div:last-child')
 				.dispatchEvent(createEvent('click'));
-			expect(worldListener, 'worldListener 2').to.have.been.calledTwice;
+			expect(worldListener, 'worldListener 2').toHaveBeenCalledTimes(2);
 
 			clearLog();
 		});
@@ -372,13 +373,7 @@ describe('suspense hydration', () => {
 	it('should properly hydrate suspense with Fragment siblings', () => {
 		const originalHtml = ul([li(0), li(1), li(2), li(3), li(4)]);
 
-		const listeners = [
-			sinon.spy(),
-			sinon.spy(),
-			sinon.spy(),
-			sinon.spy(),
-			sinon.spy()
-		];
+		const listeners = [vi.fn(), vi.fn(), vi.fn(), vi.fn(), vi.fn()];
 
 		scratch.innerHTML = originalHtml;
 		clearLog();
@@ -403,11 +398,11 @@ describe('suspense hydration', () => {
 		rerender(); // Flush rerender queue to mimic what preact will really do
 		expect(scratch.innerHTML).to.equal(originalHtml);
 		expect(getLog()).to.deep.equal([]);
-		expect(listeners[4]).not.to.have.been.called;
+		expect(listeners[4]).not.toHaveBeenCalled();
 
 		clearLog();
 		scratch.querySelector('li:last-child').dispatchEvent(createEvent('click'));
-		expect(listeners[4]).to.have.been.calledOnce;
+		expect(listeners[4]).toHaveBeenCalledOnce();
 
 		return resolve(() => (
 			<Fragment>
@@ -422,25 +417,19 @@ describe('suspense hydration', () => {
 			scratch
 				.querySelector('li:nth-child(3)')
 				.dispatchEvent(createEvent('click'));
-			expect(listeners[2]).to.have.been.calledOnce;
+			expect(listeners[2]).toHaveBeenCalledOnce();
 
 			scratch
 				.querySelector('li:last-child')
 				.dispatchEvent(createEvent('click'));
-			expect(listeners[4]).to.have.been.calledTwice;
+			expect(listeners[4]).toHaveBeenCalledTimes(2);
 		});
 	});
 
 	it('should properly hydrate suspense with Component & Fragment siblings', () => {
 		const originalHtml = ul([li(0), li(1), li(2), li(3), li(4)]);
 
-		const listeners = [
-			sinon.spy(),
-			sinon.spy(),
-			sinon.spy(),
-			sinon.spy(),
-			sinon.spy()
-		];
+		const listeners = [vi.fn(), vi.fn(), vi.fn(), vi.fn(), vi.fn()];
 
 		scratch.innerHTML = originalHtml;
 		clearLog();
@@ -465,11 +454,11 @@ describe('suspense hydration', () => {
 		rerender(); // Flush rerender queue to mimic what preact will really do
 		expect(scratch.innerHTML).to.equal(originalHtml);
 		expect(getLog()).to.deep.equal([]);
-		expect(listeners[4]).not.to.have.been.called;
+		expect(listeners[4]).not.toHaveBeenCalled();
 
 		clearLog();
 		scratch.querySelector('li:last-child').dispatchEvent(createEvent('click'));
-		expect(listeners[4]).to.have.been.calledOnce;
+		expect(listeners[4]).toHaveBeenCalledOnce();
 
 		return resolve(() => (
 			<Fragment>
@@ -484,12 +473,12 @@ describe('suspense hydration', () => {
 			scratch
 				.querySelector('li:nth-child(3)')
 				.dispatchEvent(createEvent('click'));
-			expect(listeners[2]).to.have.been.calledOnce;
+			expect(listeners[2]).toHaveBeenCalledOnce();
 
 			scratch
 				.querySelector('li:last-child')
 				.dispatchEvent(createEvent('click'));
-			expect(listeners[4]).to.have.been.calledTwice;
+			expect(listeners[4]).toHaveBeenCalledTimes(2);
 		});
 	});
 
@@ -530,7 +519,7 @@ describe('suspense hydration', () => {
 		expect(getLog()).to.deep.equal([]);
 		clearLog();
 
-		const lazySpy = sinon.spy();
+		const lazySpy = vi.fn();
 		return resolve(() => <div onClick={lazySpy}>Hello</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.equal(html);
@@ -539,12 +528,12 @@ describe('suspense hydration', () => {
 
 			const lazyDiv = scratch.firstChild.firstChild.nextSibling;
 			expect(lazyDiv.textContent).to.equal('Hello');
-			expect(lazySpy).not.to.have.been.called;
+			expect(lazySpy).not.toHaveBeenCalled();
 
 			lazyDiv.dispatchEvent(createEvent('click'));
 			rerender();
 
-			expect(lazySpy).to.have.been.calledOnce;
+			expect(lazySpy).toHaveBeenCalledOnce();
 		});
 	});
 
@@ -593,7 +582,7 @@ describe('suspense hydration', () => {
 		expect(getLog()).to.deep.equal([]);
 		clearLog();
 
-		const lazySpy = sinon.spy();
+		const lazySpy = vi.fn();
 		return resolve(() => <div onClick={lazySpy}>Hello</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.equal(html);
@@ -602,12 +591,12 @@ describe('suspense hydration', () => {
 
 			const lazyDiv = scratch.firstChild.nextSibling;
 			expect(lazyDiv.textContent).to.equal('Hello');
-			expect(lazySpy).not.to.have.been.called;
+			expect(lazySpy).not.toHaveBeenCalled();
 
 			lazyDiv.dispatchEvent(createEvent('click'));
 			rerender();
 
-			expect(lazySpy).to.have.been.calledOnce;
+			expect(lazySpy).toHaveBeenCalledOnce();
 		});
 	});
 
@@ -616,8 +605,8 @@ describe('suspense hydration', () => {
 		scratch.innerHTML = originalHtml;
 		clearLog();
 
-		const bOnClickSpy = sinon.spy();
-		const cOnClickSpy = sinon.spy();
+		const bOnClickSpy = vi.fn();
+		const cOnClickSpy = vi.fn();
 
 		const [Lazy, resolve] = createLazy();
 
@@ -647,7 +636,7 @@ describe('suspense hydration', () => {
 
 		scratch.lastChild.dispatchEvent(createEvent('click'));
 		rerender();
-		expect(cOnClickSpy).to.have.been.calledOnce;
+		expect(cOnClickSpy).toHaveBeenCalledOnce();
 
 		return resolve(() => <div onClick={bOnClickSpy}>b1</div>)
 			.then(() => {
@@ -658,7 +647,7 @@ describe('suspense hydration', () => {
 
 				scratch.firstChild.nextSibling.dispatchEvent(createEvent('click'));
 				rerender();
-				expect(bOnClickSpy).to.have.been.calledOnce;
+				expect(bOnClickSpy).toHaveBeenCalledOnce();
 
 				// suspend again and validate normal suspension works (fallback renders
 				// and result)
@@ -677,10 +666,10 @@ describe('suspense hydration', () => {
 				);
 
 				scratch.lastChild.dispatchEvent(createEvent('click'));
-				expect(cOnClickSpy).to.have.been.calledTwice;
+				expect(cOnClickSpy).toHaveBeenCalledTimes(2);
 
 				scratch.firstChild.nextSibling.dispatchEvent(createEvent('click'));
-				expect(bOnClickSpy).to.have.been.calledTwice;
+				expect(bOnClickSpy).toHaveBeenCalledTimes(2);
 			});
 	});
 
@@ -735,14 +724,7 @@ describe('suspense hydration', () => {
 			li(5)
 		]);
 
-		const listeners = [
-			sinon.spy(),
-			sinon.spy(),
-			sinon.spy(),
-			sinon.spy(),
-			sinon.spy(),
-			sinon.spy()
-		];
+		const listeners = [vi.fn(), vi.fn(), vi.fn(), vi.fn(), vi.fn(), vi.fn()];
 
 		scratch.innerHTML = originalHtml;
 		clearLog();
@@ -767,11 +749,11 @@ describe('suspense hydration', () => {
 		rerender(); // Flush rerender queue to mimic what preact will really do
 		expect(getLog()).to.deep.equal([]);
 		expect(scratch.innerHTML).to.equal(originalHtml);
-		expect(listeners[5]).not.to.have.been.called;
+		expect(listeners[5]).not.toHaveBeenCalled();
 
 		clearLog();
 		scratch.querySelector('li:last-child').dispatchEvent(createEvent('click'));
-		expect(listeners[5]).to.have.been.calledOnce;
+		expect(listeners[5]).toHaveBeenCalledOnce();
 
 		return resolve(() => (
 			<Fragment>
@@ -787,12 +769,12 @@ describe('suspense hydration', () => {
 			scratch
 				.querySelector('li:nth-child(4)')
 				.dispatchEvent(createEvent('click'));
-			expect(listeners[3]).to.have.been.calledOnce;
+			expect(listeners[3]).toHaveBeenCalledOnce();
 
 			scratch
 				.querySelector('li:last-child')
 				.dispatchEvent(createEvent('click'));
-			expect(listeners[5]).to.have.been.calledTwice;
+			expect(listeners[5]).toHaveBeenCalledTimes(2);
 		});
 	});
 
@@ -806,7 +788,7 @@ describe('suspense hydration', () => {
 			li(3)
 		]);
 
-		const listeners = [sinon.spy(), sinon.spy(), sinon.spy(), sinon.spy()];
+		const listeners = [vi.fn(), vi.fn(), vi.fn(), vi.fn()];
 
 		scratch.innerHTML = originalHtml;
 		clearLog();
@@ -831,11 +813,11 @@ describe('suspense hydration', () => {
 		rerender(); // Flush rerender queue to mimic what preact will really do
 		expect(getLog()).to.deep.equal([]);
 		expect(scratch.innerHTML).to.equal(originalHtml);
-		expect(listeners[3]).not.to.have.been.called;
+		expect(listeners[3]).not.toHaveBeenCalled();
 
 		clearLog();
 		scratch.querySelector('li:last-child').dispatchEvent(createEvent('click'));
-		expect(listeners[3]).to.have.been.calledOnce;
+		expect(listeners[3]).toHaveBeenCalledOnce();
 
 		return resolve(() => null).then(() => {
 			rerender();
@@ -846,12 +828,12 @@ describe('suspense hydration', () => {
 			scratch
 				.querySelector('li:nth-child(2)')
 				.dispatchEvent(createEvent('click'));
-			expect(listeners[1]).to.have.been.calledOnce;
+			expect(listeners[1]).toHaveBeenCalledOnce();
 
 			scratch
 				.querySelector('li:last-child')
 				.dispatchEvent(createEvent('click'));
-			expect(listeners[3]).to.have.been.calledTwice;
+			expect(listeners[3]).toHaveBeenCalledTimes(2);
 		});
 	});
 

--- a/compat/test/browser/suspense-utils.js
+++ b/compat/test/browser/suspense-utils.js
@@ -1,4 +1,5 @@
 import React, { Component, lazy } from 'preact/compat';
+import { vi } from 'vitest';
 
 const h = React.createElement;
 
@@ -101,7 +102,7 @@ export function createSuspender(DefaultComponent) {
 		}
 	}
 
-	sinon.spy(Suspender.prototype, 'render');
+	vi.spyOn(Suspender.prototype, 'render');
 
 	/**
 	 * @returns {Resolvers}

--- a/compat/test/browser/suspense.test.js
+++ b/compat/test/browser/suspense.test.js
@@ -14,6 +14,7 @@ import React, {
 } from 'preact/compat';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { createLazy, createSuspender } from './suspense-utils';
+import { vi } from 'vitest';
 
 const h = React.createElement;
 /* eslint-env browser */
@@ -159,8 +160,8 @@ describe('suspense', () => {
 	it('should call effect cleanups', () => {
 		/** @type {(v) => void} */
 		let set;
-		const effectSpy = sinon.spy();
-		const layoutEffectSpy = sinon.spy();
+		const effectSpy = vi.fn();
+		const layoutEffectSpy = vi.fn();
 		const LazyComp = ({ name }) => <div>Hello from {name}</div>;
 
 		/** @type {() => Promise<void>} */
@@ -212,13 +213,13 @@ describe('suspense', () => {
 		set(true);
 		rerender();
 		expect(scratch.innerHTML).to.eql('<div>Suspended...</div>');
-		expect(effectSpy).to.be.calledOnce;
-		expect(layoutEffectSpy).to.be.calledOnce;
+		expect(effectSpy).toHaveBeenCalledOnce();
+		expect(layoutEffectSpy).toHaveBeenCalledOnce();
 
 		return resolve().then(() => {
 			rerender();
-			expect(effectSpy).to.be.calledOnce;
-			expect(layoutEffectSpy).to.be.calledOnce;
+			expect(effectSpy).toHaveBeenCalledOnce();
+			expect(layoutEffectSpy).toHaveBeenCalledOnce();
 			expect(scratch.innerHTML).to.eql(`<div><p>hi</p></div>`);
 		});
 	});
@@ -388,10 +389,10 @@ describe('suspense', () => {
 		}
 
 		const lifecycles = LifecycleSuspender.prototype;
-		sinon.spy(lifecycles, 'componentWillMount');
-		sinon.spy(lifecycles, 'componentDidMount');
-		sinon.spy(lifecycles, 'componentDidUpdate');
-		sinon.spy(lifecycles, 'componentWillUnmount');
+		vi.spyOn(lifecycles, 'componentWillMount');
+		vi.spyOn(lifecycles, 'componentDidMount');
+		vi.spyOn(lifecycles, 'componentDidUpdate');
+		vi.spyOn(lifecycles, 'componentWillUnmount');
 
 		render(
 			<Suspense fallback={<div>Suspended...</div>}>
@@ -401,28 +402,28 @@ describe('suspense', () => {
 		);
 
 		expect(scratch.innerHTML).to.eql(``);
-		expect(lifecycles.componentWillMount).to.have.been.calledOnce;
-		expect(lifecycles.componentDidMount).to.not.have.been.called;
-		expect(lifecycles.componentDidUpdate).to.not.have.been.called;
-		expect(lifecycles.componentWillUnmount).to.not.have.been.called;
+		expect(lifecycles.componentWillMount).toHaveBeenCalledOnce();
+		expect(lifecycles.componentDidMount).not.toHaveBeenCalled();
+		expect(lifecycles.componentDidUpdate).not.toHaveBeenCalled();
+		expect(lifecycles.componentWillUnmount).not.toHaveBeenCalled();
 
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(`<div>Suspended...</div>`);
-		expect(lifecycles.componentWillMount).to.have.been.calledOnce;
-		expect(lifecycles.componentDidMount).to.not.have.been.called;
-		expect(lifecycles.componentDidUpdate).to.not.have.been.called;
-		expect(lifecycles.componentWillUnmount).to.not.have.been.called;
+		expect(lifecycles.componentWillMount).toHaveBeenCalledOnce();
+		expect(lifecycles.componentDidMount).not.toHaveBeenCalled();
+		expect(lifecycles.componentDidUpdate).not.toHaveBeenCalled();
+		expect(lifecycles.componentWillUnmount).not.toHaveBeenCalled();
 
 		return resolve().then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(`<div>Lifecycle</div>`);
 
-			expect(lifecycles.componentWillMount).to.have.been.calledOnce;
-			expect(lifecycles.componentDidMount).to.have.been.calledOnce;
+			expect(lifecycles.componentWillMount).toHaveBeenCalledOnce();
+			expect(lifecycles.componentDidMount).toHaveBeenCalledOnce();
 			// TODO: This is unexpected. See TODO in next test regarding this and preactjs/preact#2098
-			expect(lifecycles.componentDidUpdate).to.have.been.calledOnce;
-			expect(lifecycles.componentWillUnmount).to.not.have.been.called;
+			expect(lifecycles.componentDidUpdate).toHaveBeenCalledOnce();
+			expect(lifecycles.componentWillUnmount).not.toHaveBeenCalled();
 		});
 	});
 
@@ -466,10 +467,10 @@ describe('suspense', () => {
 		}
 
 		const lifecycles = LifecycleSuspender.prototype;
-		sinon.spy(lifecycles, 'componentWillMount');
-		sinon.spy(lifecycles, 'componentDidMount');
-		sinon.spy(lifecycles, 'componentDidUpdate');
-		sinon.spy(lifecycles, 'componentWillUnmount');
+		vi.spyOn(lifecycles, 'componentWillMount');
+		vi.spyOn(lifecycles, 'componentDidMount');
+		vi.spyOn(lifecycles, 'componentDidUpdate');
+		vi.spyOn(lifecycles, 'componentWillUnmount');
 
 		render(
 			<Suspense fallback={<div>Suspended...</div>}>
@@ -479,41 +480,41 @@ describe('suspense', () => {
 		);
 
 		expect(scratch.innerHTML).to.eql(`<p>Count: 0</p>`);
-		expect(lifecycles.componentWillMount).to.have.been.calledOnce;
-		expect(lifecycles.componentDidMount).to.have.been.calledOnce;
-		expect(lifecycles.componentDidUpdate).to.not.have.been.called;
-		expect(lifecycles.componentWillUnmount).to.not.have.been.called;
+		expect(lifecycles.componentWillMount).toHaveBeenCalledOnce();
+		expect(lifecycles.componentDidMount).toHaveBeenCalledOnce();
+		expect(lifecycles.componentDidUpdate).not.toHaveBeenCalled();
+		expect(lifecycles.componentWillUnmount).not.toHaveBeenCalled();
 
 		increment();
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(`<p>Count: 1</p>`);
-		expect(lifecycles.componentWillMount).to.have.been.calledOnce;
-		expect(lifecycles.componentDidMount).to.have.been.calledOnce;
-		expect(lifecycles.componentDidUpdate).to.have.been.calledOnce;
-		expect(lifecycles.componentWillUnmount).to.not.have.been.called;
+		expect(lifecycles.componentWillMount).toHaveBeenCalledOnce();
+		expect(lifecycles.componentDidMount).toHaveBeenCalledOnce();
+		expect(lifecycles.componentDidUpdate).toHaveBeenCalledOnce();
+		expect(lifecycles.componentWillUnmount).not.toHaveBeenCalled();
 
 		increment();
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(`<div>Suspended...</div>`);
-		expect(lifecycles.componentWillMount).to.have.been.calledOnce;
-		expect(lifecycles.componentDidMount).to.have.been.calledOnce;
-		expect(lifecycles.componentDidUpdate).to.have.been.calledOnce;
-		expect(lifecycles.componentWillUnmount).to.not.have.been.called;
+		expect(lifecycles.componentWillMount).toHaveBeenCalledOnce();
+		expect(lifecycles.componentDidMount).toHaveBeenCalledOnce();
+		expect(lifecycles.componentDidUpdate).toHaveBeenCalledOnce();
+		expect(lifecycles.componentWillUnmount).not.toHaveBeenCalled();
 
 		return resolve().then(() => {
 			rerender();
 
 			expect(scratch.innerHTML).to.eql(`<p>Count: 2</p>`);
-			expect(lifecycles.componentWillMount).to.have.been.calledOnce;
-			expect(lifecycles.componentDidMount).to.have.been.calledOnce;
+			expect(lifecycles.componentWillMount).toHaveBeenCalledOnce();
+			expect(lifecycles.componentDidMount).toHaveBeenCalledOnce();
 			// TODO: This is called thrice since the cDU queued up after the second
 			// increment is never cleared once the component suspends. So when it
 			// resumes and the component is rerendered, we queue up another cDU so
 			// cDU is called an extra time.
-			expect(lifecycles.componentDidUpdate).to.have.been.calledThrice;
-			expect(lifecycles.componentWillUnmount).to.not.have.been.called;
+			expect(lifecycles.componentDidUpdate).toHaveBeenCalledTimes(3);
+			expect(lifecycles.componentWillUnmount).not.toHaveBeenCalled();
 		});
 	});
 
@@ -529,10 +530,10 @@ describe('suspense', () => {
 		}
 
 		const lifecycles = LifecycleLogger.prototype;
-		sinon.spy(lifecycles, 'componentWillMount');
-		sinon.spy(lifecycles, 'componentDidMount');
-		sinon.spy(lifecycles, 'componentDidUpdate');
-		sinon.spy(lifecycles, 'componentWillUnmount');
+		vi.spyOn(lifecycles, 'componentWillMount');
+		vi.spyOn(lifecycles, 'componentDidMount');
+		vi.spyOn(lifecycles, 'componentDidUpdate');
+		vi.spyOn(lifecycles, 'componentWillUnmount');
 
 		const [Suspender, suspend] = createSuspender(() => <div>Suspense</div>);
 
@@ -545,20 +546,20 @@ describe('suspense', () => {
 		);
 
 		expect(scratch.innerHTML).to.eql(`<div>Suspense</div><div>Lifecycle</div>`);
-		expect(lifecycles.componentWillMount).to.have.been.calledOnce;
-		expect(lifecycles.componentDidMount).to.have.been.calledOnce;
-		expect(lifecycles.componentDidUpdate).to.not.have.been.called;
-		expect(lifecycles.componentWillUnmount).to.not.have.been.called;
+		expect(lifecycles.componentWillMount).toHaveBeenCalledOnce();
+		expect(lifecycles.componentDidMount).toHaveBeenCalledOnce();
+		expect(lifecycles.componentDidUpdate).not.toHaveBeenCalled();
+		expect(lifecycles.componentWillUnmount).not.toHaveBeenCalled();
 
 		const [resolve] = suspend();
 
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(`<div>Suspended...</div>`);
-		expect(lifecycles.componentWillMount).to.have.been.calledOnce;
-		expect(lifecycles.componentDidMount).to.have.been.calledOnce;
-		expect(lifecycles.componentDidUpdate).to.not.have.been.called;
-		expect(lifecycles.componentWillUnmount).to.not.have.been.called;
+		expect(lifecycles.componentWillMount).toHaveBeenCalledOnce();
+		expect(lifecycles.componentDidMount).toHaveBeenCalledOnce();
+		expect(lifecycles.componentDidUpdate).not.toHaveBeenCalled();
+		expect(lifecycles.componentWillUnmount).not.toHaveBeenCalled();
 
 		return resolve(() => <div>Suspense 2</div>).then(() => {
 			rerender();
@@ -566,10 +567,10 @@ describe('suspense', () => {
 				`<div>Suspense 2</div><div>Lifecycle</div>`
 			);
 
-			expect(lifecycles.componentWillMount).to.have.been.calledOnce;
-			expect(lifecycles.componentDidMount).to.have.been.calledOnce;
-			expect(lifecycles.componentDidUpdate).to.have.been.calledOnce;
-			expect(lifecycles.componentWillUnmount).to.not.have.been.called;
+			expect(lifecycles.componentWillMount).toHaveBeenCalledOnce();
+			expect(lifecycles.componentDidMount).toHaveBeenCalledOnce();
+			expect(lifecycles.componentDidUpdate).toHaveBeenCalledOnce();
+			expect(lifecycles.componentWillUnmount).not.toHaveBeenCalled();
 		});
 	});
 
@@ -584,9 +585,9 @@ describe('suspense', () => {
 		}
 
 		const lifecycles = LifecycleLogger.prototype;
-		sinon.spy(lifecycles, 'componentWillMount');
-		sinon.spy(lifecycles, 'componentDidMount');
-		sinon.spy(lifecycles, 'componentWillUnmount');
+		vi.spyOn(lifecycles, 'componentWillMount');
+		vi.spyOn(lifecycles, 'componentDidMount');
+		vi.spyOn(lifecycles, 'componentWillUnmount');
 
 		const [Suspender, suspend] = createSuspender(() => <div>Suspense</div>);
 
@@ -598,26 +599,26 @@ describe('suspense', () => {
 		);
 
 		expect(scratch.innerHTML).to.eql(`<div>Suspense</div>`);
-		expect(lifecycles.componentWillMount).to.not.have.been.called;
-		expect(lifecycles.componentDidMount).to.not.have.been.called;
-		expect(lifecycles.componentWillUnmount).to.not.have.been.called;
+		expect(lifecycles.componentWillMount).not.toHaveBeenCalled();
+		expect(lifecycles.componentDidMount).not.toHaveBeenCalled();
+		expect(lifecycles.componentWillUnmount).not.toHaveBeenCalled();
 
 		const [resolve] = suspend();
 
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(`<div>Lifecycle</div>`);
-		expect(lifecycles.componentWillMount).to.have.been.calledOnce;
-		expect(lifecycles.componentDidMount).to.have.been.calledOnce;
-		expect(lifecycles.componentWillUnmount).to.not.have.been.called;
+		expect(lifecycles.componentWillMount).toHaveBeenCalledOnce();
+		expect(lifecycles.componentDidMount).toHaveBeenCalledOnce();
+		expect(lifecycles.componentWillUnmount).not.toHaveBeenCalled();
 
 		return resolve(() => <div>Suspense 2</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(`<div>Suspense 2</div>`);
 
-			expect(lifecycles.componentWillMount).to.have.been.calledOnce;
-			expect(lifecycles.componentDidMount).to.have.been.calledOnce;
-			expect(lifecycles.componentWillUnmount).to.have.been.calledOnce;
+			expect(lifecycles.componentWillMount).toHaveBeenCalledOnce();
+			expect(lifecycles.componentDidMount).toHaveBeenCalledOnce();
+			expect(lifecycles.componentWillUnmount).toHaveBeenCalledOnce();
 		});
 	});
 
@@ -831,33 +832,33 @@ describe('suspense', () => {
 		expect(scratch.innerHTML).to.eql(
 			`<div>Hello first</div><div>Hello second</div>`
 		);
-		expect(Suspender1.prototype.render).to.have.been.calledOnce;
-		expect(Suspender2.prototype.render).to.have.been.calledOnce;
+		expect(Suspender1.prototype.render).toHaveBeenCalledOnce();
+		expect(Suspender2.prototype.render).toHaveBeenCalledOnce();
 
 		const [resolve1] = suspend1();
 		const [resolve2] = suspend2();
-		expect(Suspender1.prototype.render).to.have.been.calledOnce;
-		expect(Suspender2.prototype.render).to.have.been.calledOnce;
+		expect(Suspender1.prototype.render).toHaveBeenCalledOnce();
+		expect(Suspender2.prototype.render).toHaveBeenCalledOnce();
 
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(`<div>Suspended...</div>`);
-		expect(Suspender1.prototype.render).to.have.been.calledTwice;
-		expect(Suspender2.prototype.render).to.have.been.calledTwice;
+		expect(Suspender1.prototype.render).toHaveBeenCalledTimes(2);
+		expect(Suspender2.prototype.render).toHaveBeenCalledTimes(2);
 
 		return resolve1(() => <div>Hello first 2</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(`<div>Suspended...</div>`);
-			expect(Suspender1.prototype.render).to.have.been.calledTwice;
-			expect(Suspender2.prototype.render).to.have.been.calledTwice;
+			expect(Suspender1.prototype.render).toHaveBeenCalledTimes(2);
+			expect(Suspender2.prototype.render).toHaveBeenCalledTimes(2);
 
 			return resolve2(() => <div>Hello second 2</div>).then(() => {
 				rerender();
 				expect(scratch.innerHTML).to.eql(
 					`<div>Hello first 2</div><div>Hello second 2</div>`
 				);
-				expect(Suspender1.prototype.render).to.have.been.calledThrice;
-				expect(Suspender2.prototype.render).to.have.been.calledThrice;
+				expect(Suspender1.prototype.render).toHaveBeenCalledTimes(3);
+				expect(Suspender2.prototype.render).toHaveBeenCalledTimes(3);
 			});
 		});
 	});
@@ -885,33 +886,33 @@ describe('suspense', () => {
 		expect(scratch.innerHTML).to.eql(
 			`<div>Hello first</div><div><div>Hello second</div></div>`
 		);
-		expect(Suspender1.prototype.render).to.have.been.calledOnce;
-		expect(Suspender2.prototype.render).to.have.been.calledOnce;
+		expect(Suspender1.prototype.render).toHaveBeenCalledOnce();
+		expect(Suspender2.prototype.render).toHaveBeenCalledOnce();
 
 		const [resolve1] = suspend1();
 		const [resolve2] = suspend2();
-		expect(Suspender1.prototype.render).to.have.been.calledOnce;
-		expect(Suspender2.prototype.render).to.have.been.calledOnce;
+		expect(Suspender1.prototype.render).toHaveBeenCalledOnce();
+		expect(Suspender2.prototype.render).toHaveBeenCalledOnce();
 
 		rerender();
 
 		expect(scratch.innerHTML).to.eql(`<div>Suspended...</div>`);
-		expect(Suspender1.prototype.render).to.have.been.calledTwice;
-		expect(Suspender2.prototype.render).to.have.been.calledTwice;
+		expect(Suspender1.prototype.render).toHaveBeenCalledTimes(2);
+		expect(Suspender2.prototype.render).toHaveBeenCalledTimes(2);
 
 		return resolve1(() => <div>Hello first 2</div>).then(() => {
 			rerender();
 			expect(scratch.innerHTML).to.eql(`<div>Suspended...</div>`);
-			expect(Suspender1.prototype.render).to.have.been.calledTwice;
-			expect(Suspender2.prototype.render).to.have.been.calledTwice;
+			expect(Suspender1.prototype.render).toHaveBeenCalledTimes(2);
+			expect(Suspender2.prototype.render).toHaveBeenCalledTimes(2);
 
 			return resolve2(() => <div>Hello second 2</div>).then(() => {
 				rerender();
 				expect(scratch.innerHTML).to.eql(
 					`<div>Hello first 2</div><div><div>Hello second 2</div></div>`
 				);
-				expect(Suspender1.prototype.render).to.have.been.calledThrice;
-				expect(Suspender2.prototype.render).to.have.been.calledThrice;
+				expect(Suspender1.prototype.render).toHaveBeenCalledTimes(3);
+				expect(Suspender2.prototype.render).toHaveBeenCalledTimes(3);
 			});
 		});
 	});
@@ -1410,7 +1411,7 @@ describe('suspense', () => {
 		expect(scratch.innerHTML).to.eql(
 			`<div>conditional show<div>Suspender</div></div>`
 		);
-		expect(Suspender.prototype.render).to.have.been.calledOnce;
+		expect(Suspender.prototype.render).toHaveBeenCalledOnce();
 
 		suspend();
 		rerender();
@@ -1647,7 +1648,7 @@ describe('suspense', () => {
 		);
 
 		expect(scratch.innerHTML).to.eql(`<div>i: 0<div>Suspender</div></div>`);
-		expect(Suspender.prototype.render).to.have.been.calledOnce;
+		expect(Suspender.prototype.render).toHaveBeenCalledOnce();
 
 		const [resolve] = suspend();
 		rerender();
@@ -1671,7 +1672,7 @@ describe('suspense', () => {
 	});
 
 	it('should call componentWillUnmount on a suspended component', () => {
-		const cWUSpy = sinon.spy();
+		const cWUSpy = vi.fn();
 
 		// eslint-disable-next-line react/require-render-return
 		class Suspender extends Component {
@@ -1730,15 +1731,15 @@ describe('suspense', () => {
 		);
 
 		expect(scratch.innerHTML).to.eql(`<div>conditional show</div>`);
-		expect(cWUSpy).to.not.have.been.called;
+		expect(cWUSpy).not.toHaveBeenCalled();
 
 		hide();
 		rerender();
 
-		expect(cWUSpy).to.have.been.calledOnce;
+		expect(cWUSpy).toHaveBeenCalledOnce();
 		expect(suspender).not.to.be.undefined;
 		expect(suspender).not.to.be.null;
-		expect(cWUSpy.getCall(0).thisValue).to.eql(suspender);
+		expect(cWUSpy.mock.contexts[0]).to.eql(suspender);
 		expect(scratch.innerHTML).to.eql(`<div>conditional hide</div>`);
 	});
 

--- a/compat/test/browser/useSyncExternalStore.test.js
+++ b/compat/test/browser/useSyncExternalStore.test.js
@@ -10,6 +10,7 @@ import React, {
 } from 'preact/compat';
 import { setupRerender, act } from 'preact/test-utils';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { vi } from 'vitest';
 
 const ReactDOM = React;
 
@@ -84,8 +85,8 @@ describe('useSyncExternalStore', () => {
 	}
 
 	it('subscribes and follows effects', () => {
-		const subscribe = sinon.spy(() => () => {});
-		const getSnapshot = sinon.spy(() => 'hello world');
+		const subscribe = vi.fn(() => () => {});
+		const getSnapshot = vi.fn(() => 'hello world');
 
 		const App = () => {
 			const value = useSyncExternalStore(subscribe, getSnapshot);
@@ -96,19 +97,19 @@ describe('useSyncExternalStore', () => {
 			render(<App />, scratch);
 		});
 		expect(scratch.innerHTML).to.equal('<p>hello world</p>');
-		expect(subscribe).to.be.calledOnce;
-		expect(getSnapshot).to.be.calledThrice;
+		expect(subscribe).toHaveBeenCalledOnce();
+		expect(getSnapshot).toHaveBeenCalledTimes(3);
 	});
 
 	it('subscribes and rerenders when called', () => {
 		/** @type {() => void} */
 		let flush;
-		const subscribe = sinon.spy(cb => {
+		const subscribe = vi.fn(cb => {
 			flush = cb;
 			return () => {};
 		});
 		let called = false;
-		const getSnapshot = sinon.spy(() => {
+		const getSnapshot = vi.fn(() => {
 			if (called) {
 				return 'hello new world';
 			}
@@ -125,8 +126,8 @@ describe('useSyncExternalStore', () => {
 			render(<App />, scratch);
 		});
 		expect(scratch.innerHTML).to.equal('<p>hello world</p>');
-		expect(subscribe).to.be.calledOnce;
-		expect(getSnapshot).to.be.calledThrice;
+		expect(subscribe).toHaveBeenCalledOnce();
+		expect(getSnapshot).toHaveBeenCalledTimes(3);
 
 		called = true;
 		flush();
@@ -138,12 +139,12 @@ describe('useSyncExternalStore', () => {
 	it('getSnapshot can return NaN without causing infinite loop', () => {
 		/** @type {() => void} */
 		let flush;
-		const subscribe = sinon.spy(cb => {
+		const subscribe = vi.fn(cb => {
 			flush = cb;
 			return () => {};
 		});
 		let called = false;
-		const getSnapshot = sinon.spy(() => {
+		const getSnapshot = vi.fn(() => {
 			if (called) {
 				return NaN;
 			}
@@ -160,8 +161,8 @@ describe('useSyncExternalStore', () => {
 			render(<App />, scratch);
 		});
 		expect(scratch.innerHTML).to.equal('<p>1</p>');
-		expect(subscribe).to.be.calledOnce;
-		expect(getSnapshot).to.be.calledThrice;
+		expect(subscribe).toHaveBeenCalledOnce();
+		expect(getSnapshot).toHaveBeenCalledTimes(3);
 
 		called = true;
 		flush();
@@ -173,7 +174,7 @@ describe('useSyncExternalStore', () => {
 	it('should not call function values on subscription', () => {
 		/** @type {() => void} */
 		let flush;
-		const subscribe = sinon.spy(cb => {
+		const subscribe = vi.fn(cb => {
 			flush = cb;
 			return () => {};
 		});
@@ -181,7 +182,7 @@ describe('useSyncExternalStore', () => {
 		const func = () => 'value: ' + i++;
 
 		let i = 0;
-		const getSnapshot = sinon.spy(() => {
+		const getSnapshot = vi.fn(() => {
 			return func;
 		});
 
@@ -194,8 +195,8 @@ describe('useSyncExternalStore', () => {
 			render(<App />, scratch);
 		});
 		expect(scratch.innerHTML).to.equal('<p>value: 0</p>');
-		expect(subscribe).to.be.calledOnce;
-		expect(getSnapshot).to.be.calledThrice;
+		expect(subscribe).toHaveBeenCalledOnce();
+		expect(getSnapshot).toHaveBeenCalledTimes(3);
 
 		flush();
 		rerender();
@@ -206,7 +207,7 @@ describe('useSyncExternalStore', () => {
 	it('should work with changing getSnapshot', () => {
 		/** @type {() => void} */
 		let flush;
-		const subscribe = sinon.spy(cb => {
+		const subscribe = vi.fn(cb => {
 			flush = cb;
 			return () => {};
 		});
@@ -223,7 +224,7 @@ describe('useSyncExternalStore', () => {
 			render(<App />, scratch);
 		});
 		expect(scratch.innerHTML).to.equal('<p>value: 0</p>');
-		expect(subscribe).to.be.calledOnce;
+		expect(subscribe).toHaveBeenCalledOnce();
 
 		i++;
 		flush();


### PR DESCRIPTION
Migrates to using vitest spies (`vi.fn` etc).
