### PR TITLE
ci: Switch to fork of paths-filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       jsChanged: ${{ steps.filter.outputs.jsChanged }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: rschristian/paths-filter@v3
         id: filter
         with:
           # Should be kept in sync with the filter in the PR Reporter workflow

--- a/.github/workflows/pr-reporter.yml
+++ b/.github/workflows/pr-reporter.yml
@@ -19,7 +19,7 @@ jobs:
       jsChanged: ${{ steps.filter.outputs.jsChanged }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: rschristian/paths-filter@v3
         id: filter
         with:
           # As this Workflow is triggered by a `workflow_run` event, the filter action


### PR DESCRIPTION
Unfortunately [`dorny/paths-filter`](https://github.com/dorny/paths-filter) hasn't been maintained recently and has a few known issues, such as warning on use of the (valid & documented) `predicate-quantifier` option. I'd like to correct some of these as they're a bit frustrating and impacting us, so, I've forked it. Not planning on taking over general maintenance so much as fixing the problems we deal with here.

[Release so far](https://github.com/rschristian/paths-filter/releases/tag/v3.0.3), specifically gets rid of this message on the workflow page:

![Image shows a warning that this action does not take a 'predicate-quantifier' option, as this input is not listed as a known input](https://github.com/user-attachments/assets/bdc977da-57dc-4c6d-ad52-707da03592d0)

