### PR TITLE
ci: Correct PR reporter filter for forks

### DIFF
--- a/.github/workflows/pr-reporter.yml
+++ b/.github/workflows/pr-reporter.yml
@@ -25,8 +25,8 @@ jobs:
           # As this Workflow is triggered by a `workflow_run` event, the filter action
           # can't automatically assume we're working with PR data. As such, we need to
           # wire it up manually with a base (merge target) and ref (source branch).
-          base: ${{ github.event.workflow_run.pull_requests[0].base.sha }}
-          ref: ${{ github.event.workflow_run.pull_requests[0].head.sha }}
+          base: ${{ github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           # Should be kept in sync with the filter in the CI workflow
           predicate-quantifier: 'every'
           filters: |


### PR DESCRIPTION
The PR reporter filter hasn't been working on forks for a while (likely since I added the filter), resulting in benchmark comments being added even when they shouldn't be (see #4820 as an example).

It seems as though the `pull_request` property just isn't available on PRs originating from forks. I can't find any obvious reasoning for this but we can work around it by pulling the SHAs from elsewhere in the event payload :shrug: