### PR TITLE
fix: export helper functions from `preact/debug`

### DIFF
--- a/debug/src/index.js
+++ b/debug/src/index.js
@@ -4,3 +4,9 @@ import 'preact/devtools';
 initDebug();
 
 export { resetPropWarnings } from './check-props';
+
+export {
+	getCurrentVNode,
+	getDisplayName,
+	getOwnerStack
+} from './component-stack';


### PR DESCRIPTION
Lynx utilizes Preact as its rendering library, and we're aiming to enhance diagnostic messages by incorporating the component stack.

It would be highly beneficial if `preact/debug` could provide exports for these helper functions.

We are now forking `component-stack.js` in our codebase. See: https://github.com/lynx-family/lynx-stack/pull/1238