### PR TITLE
fix: Ensure 'compat/test-utils' exports match & are valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     },
     "./compat/test-utils": {
       "types": "./test-utils/src/index.d.ts",
-      "browser": "./test-utils/dist/testUtils.module.js",
+      "module": "./test-utils/dist/testUtils.mjs",
       "umd": "./test-utils/dist/testUtils.umd.js",
       "import": "./test-utils/dist/testUtils.mjs",
       "require": "./test-utils/dist/testUtils.js"


### PR DESCRIPTION
Added in #4783, might've been missed when rebasing v11? Or possibly I missed it when reviewing that PR. Either way, it's using `"browser"` which we've otherwise done away with and the file path won't match as we're not producing `.module.js` files anymore.