### PR TITLE
types: Add types for '/compat/server' & '/compat/scheduler'

### DIFF
--- a/compat/scheduler.d.ts
+++ b/compat/scheduler.d.ts
@@ -1,0 +1,12 @@
+export var unstable_ImmediatePriority: number;
+export var unstable_UserBlockingPriority: number;
+export var unstable_NormalPriority: number;
+export var unstable_LowPriority: number;
+export var unstable_IdlePriority: number;
+
+export function unstable_runWithPriority(
+	priority: number,
+	callback: () => void
+): void;
+
+export var unstable_now: DOMHighResTimeStamp;

--- a/compat/server.d.ts
+++ b/compat/server.d.ts
@@ -1,0 +1,17 @@
+import { renderToString } from 'preact-render-to-string';
+import { renderToPipeableStream } from 'preact-render-to-string/stream-node';
+import { renderToReadableStream } from 'preact-render-to-string/stream';
+
+export {
+	renderToString,
+	renderToString as renderToStaticMarkup
+} from 'preact-render-to-string';
+
+export { renderToPipeableStream } from 'preact-render-to-string/stream-node';
+export { renderToReadableStream } from 'preact-render-to-string/stream';
+export = {
+	renderToString: typeof renderToString,
+	renderToStaticMarkup: typeof renderToString,
+	renderToPipeableStream: typeof renderToPipeableStream,
+	renderToReadableStream: typeof renderToReadableStream
+};

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
       "require": "./compat/client.js"
     },
     "./compat/server": {
+      "types": "./compat/server.d.ts",
       "browser": "./compat/server.browser.js",
       "import": "./compat/server.mjs",
       "require": "./compat/server.js"
@@ -93,6 +94,7 @@
       "require": "./compat/jsx-dev-runtime.js"
     },
     "./compat/scheduler": {
+      "types": "./compat/scheduler.d.ts",
       "import": "./compat/scheduler.mjs",
       "require": "./compat/scheduler.js"
     },
@@ -152,9 +154,11 @@
     "compat/client.d.ts",
     "compat/client.js",
     "compat/client.mjs",
+    "compat/server.d.ts",
     "compat/server.browser.js",
     "compat/server.js",
     "compat/server.mjs",
+    "compat/scheduler.d.ts",
     "compat/scheduler.js",
     "compat/scheduler.mjs",
     "compat/test-utils.js",


### PR DESCRIPTION
Quite minor but it can't hurt & adds some more green boxes to Are The Types Wrong?