### PR TITLE
feat: add unstable batched updates to compat

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -394,6 +394,9 @@ declare namespace React {
 	export function flushSync<R>(fn: () => R): R;
 	export function flushSync<A, R>(fn: (a: A) => R, a: A): R;
 
+	export function unstable_batchedUpdates<A, R>(callback: (a: A) => R, a: A): R;
+	export function unstable_batchedUpdates<R>(callback: () => R): R;
+
 	export type PropsWithChildren<P = unknown> = P & {
 		children?: preact1.ComponentChildren | undefined;
 	};

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -134,6 +134,19 @@ function findDOMNode(component) {
 const flushSync = (callback, arg) => callback(arg);
 
 /**
+ * In React, `unstable_batchedUpdates` is a legacy feature that was made a no-op
+ * outside of legacy mode in React 18 and a no-op across the board in React 19.
+ * @template Arg
+ * @template Result
+ * @param {(arg: Arg) => Result} callback
+ * @param {Arg} [arg]
+ * @returns {Result}
+ */
+function unstable_batchedUpdates(callback, arg) {
+	return callback(arg);
+}
+
+/**
  * Strict Mode is not implemented in Preact, so we provide a stand-in for it
  * that just renders its children without imposing any restrictions.
  */
@@ -165,6 +178,7 @@ export {
 	memo,
 	forwardRef,
 	flushSync,
+	unstable_batchedUpdates,
 	useInsertionEffect,
 	startTransition,
 	useDeferredValue,
@@ -216,6 +230,7 @@ export default {
 	memo,
 	forwardRef,
 	flushSync,
+	unstable_batchedUpdates,
 	StrictMode,
 	Suspense,
 	lazy,

--- a/demo/mobx.jsx
+++ b/demo/mobx.jsx
@@ -1,7 +1,6 @@
 import React, { forwardRef, useRef, useState } from 'react';
 import { decorate, observable } from 'mobx';
 import { observer, useObserver } from 'mobx-react';
-import 'mobx-react-lite/batchingForReactDom';
 
 class Todo {
 	constructor() {


### PR DESCRIPTION
Closes #4837

IIUC, it was a made a no-op outside of legacy mode (aka, `render()`) in React 18 and is now a no-op across the board in React 19. Mobx still "relies on it" though.