### PR TITLE
chore: Update 'replaceNode' deprecation comment to point at new shim

### DIFF
--- a/src/index-5.d.ts
+++ b/src/index-5.d.ts
@@ -301,9 +301,10 @@ interface ContainerNode {
 
 export function render(vnode: ComponentChild, parent: ContainerNode): void;
 /**
- * @deprecated Will be removed in v11.
+ * @deprecated The `replaceNode` parameter will be removed in v11.
  *
- * Replacement Preact 10+ implementation can be found here: https://gist.github.com/developit/f4c67a2ede71dc2fab7f357f39cff28c
+ * Replacement Preact 10+ implementation can be found in the `preact-root-fragment` package.
+ * Docs: https://github.com/preactjs/preact-root-fragment
  */
 export function render(
 	vnode: ComponentChild,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -301,9 +301,10 @@ interface ContainerNode {
 
 export function render(vnode: ComponentChild, parent: ContainerNode): void;
 /**
- * @deprecated Will be removed in v11.
+ * @deprecated The `replaceNode` parameter will be removed in v11.
  *
- * Replacement Preact 10+ implementation can be found here: https://gist.github.com/developit/f4c67a2ede71dc2fab7f357f39cff28c
+ * Replacement Preact 10+ implementation can be found in the `preact-root-fragment` package.
+ * Docs: https://github.com/preactjs/preact-root-fragment
  */
 export function render(
 	vnode: ComponentChild,


### PR DESCRIPTION
Links to the new shim package rather than the gist.

A [comment on the gist](https://gist.github.com/developit/f4c67a2ede71dc2fab7f357f39cff28c?permalink_comment_id=4729975#gistcomment-4729975) stated they were seeing the comment on the deprecated overload even when not using the third parameter, and whilst I can't reproduce (it only pops up when I actually use the third param in my editor), I figured expanding the comment to explicitly mentioning `replaceNode` would be a good idea.