### PR TITLE
Add parameter `oldVNode` when calling `options._diff`

### DIFF
--- a/debug/src/component-stack.js
+++ b/debug/src/component-stack.js
@@ -118,11 +118,11 @@ export function setupComponentStack() {
 		if (oldDiffed) oldDiffed(vnode);
 	};
 
-	options._diff = vnode => {
+	options._diff = (vnode, oldVnode) => {
 		if (isPossibleOwner(vnode)) {
 			renderStack.push(vnode);
 		}
-		if (oldDiff) oldDiff(vnode);
+		if (oldDiff) oldDiff(vnode, oldVnode);
 	};
 
 	options._root = (vnode, parent) => {

--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -145,7 +145,7 @@ export function initDebug() {
 		if (oldRoot) oldRoot(vnode, parentNode);
 	};
 
-	options._diff = vnode => {
+	options._diff = (vnode, oldVNode) => {
 		let { type } = vnode;
 
 		hooksAllowed = true;
@@ -241,7 +241,7 @@ export function initDebug() {
 			);
 		}
 
-		if (oldBeforeDiff) oldBeforeDiff(vnode);
+		if (oldBeforeDiff) oldBeforeDiff(vnode, oldVNode);
 	};
 
 	let renderCount = 0;

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -34,9 +34,9 @@ const RAF_TIMEOUT = 35;
 let prevRaf;
 
 /** @type {(vnode: import('./internal').VNode) => void} */
-options._diff = vnode => {
+options._diff = (vnode, oldVNode) => {
 	currentComponent = null;
-	if (oldBeforeDiff) oldBeforeDiff(vnode);
+	if (oldBeforeDiff) oldBeforeDiff(vnode, oldVNode);
 };
 
 options._root = (vnode, parentDom) => {

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -12,7 +12,7 @@ export { PreactContext };
 
 export interface Options extends PreactOptions {
 	/** Attach a hook that is invoked before a vnode is diffed. */
-	_diff?(vnode: VNode): void;
+	_diff?(vnode: VNode, oldVNode: VNode): void;
 	diffed?(vnode: VNode): void;
 	/** Attach a hook that is invoked before a vnode has rendered. */
 	_render?(vnode: VNode): void;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -76,7 +76,7 @@ export function diff(
 		}
 	}
 
-	if ((tmp = options._diff)) tmp(newVNode);
+	if ((tmp = options._diff)) tmp(newVNode, oldVNode);
 
 	outer: if (typeof newType == 'function') {
 		try {

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -30,7 +30,7 @@ export interface Options extends preact.Options {
 	/** Attach a hook that is invoked before render, mainly to check the arguments. */
 	_root?(vnode: ComponentChild, parent: preact.ContainerNode): void;
 	/** Attach a hook that is invoked before a vnode is diffed. */
-	_diff?(vnode: VNode): void;
+	_diff?(vnode: VNode, oldVNode: VNode): void;
 	/** Attach a hook that is invoked after a tree was mounted or was updated. */
 	_commit?(vnode: VNode, commitQueue: Component[]): void;
 	/** Attach a hook that is invoked before a vnode has rendered. */


### PR DESCRIPTION
`oldVnode` is not exposed in `options._diff`, which makes it difficult to get the component instance in this hook (because `newVNode` usually does not have a `_component` property). This PR provides a new way to get the component instance in the update process, which can still work when, for example, parent and child components `setState` at the same time.

