### PR TITLE
fix(debug): fix memory leak in VNode owner tracking

### DIFF
--- a/debug/src/component-stack.js
+++ b/debug/src/component-stack.js
@@ -40,9 +40,11 @@ let renderStack = [];
  * ```
  *
  * Note: A `vnode` may be hoisted to the root scope due to compiler
- * optimiztions. In these cases the `_owner` will be different.
+ * optimiztions. In these cases the owner will be different.
  */
 let ownerStack = [];
+
+const ownerMap = new WeakMap();
 
 /**
  * Get the currently rendered `vnode`
@@ -76,9 +78,8 @@ function isPossibleOwner(vnode) {
 export function getOwnerStack(vnode) {
 	const stack = [vnode];
 	let next = vnode;
-	while (next._owner != null) {
-		stack.push(next._owner);
-		next = next._owner;
+	while ((next = ownerMap.get(next)) != null) {
+		stack.push(next);
 	}
 
 	return stack.reduce((acc, owner) => {
@@ -131,8 +132,7 @@ export function setupComponentStack() {
 	};
 
 	options.vnode = vnode => {
-		vnode._owner =
-			ownerStack.length > 0 ? ownerStack[ownerStack.length - 1] : null;
+		ownerMap.set(vnode, ownerStack.length > 0 ? ownerStack[ownerStack.length - 1] : null);
 		if (oldVNode) oldVNode(vnode);
 	};
 


### PR DESCRIPTION
This fixes preactjs/signals#726. The issue was that `preact/debug` calculates and assigns an `_owner` property (minified as `__o`) on every VNode that refers to its owning component, creating a cycle. Switching from a property a WeakMap is better for performance anyway, as it moves the cost into `getComponentStack()` which is a debugging helper that is only called in response to errors.