### PR TITLE
Provide solution to long standing memleak

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -1,5 +1,9 @@
 import { Component, createElement, options, Fragment } from 'preact';
-import { MODE_HYDRATE, FORCE_PROPS_REVALIDATE, COMPONENT_FORCE } from '../../src/constants';
+import {
+	MODE_HYDRATE,
+	FORCE_PROPS_REVALIDATE,
+	COMPONENT_FORCE
+} from '../../src/constants';
 import { assign } from './util';
 
 const oldCatchError = options._catchError;
@@ -139,21 +143,11 @@ Suspense.prototype._childDidSuspend = function (promise, suspendingVNode) {
 			// suspended children into the _children array
 			if (c.state._suspended) {
 				const suspendedVNode = c.state._suspended;
-				if (!c._vnode._children) {
-					c._vnode._children = [
-						removeOriginal(
-							suspendedVNode,
-							suspendedVNode._component._parentDom,
-							suspendedVNode._component._originalParentDom
-						)
-					];
-				} else {
-					c._vnode._children[0] = removeOriginal(
-						suspendedVNode,
-						suspendedVNode._component._parentDom,
-						suspendedVNode._component._originalParentDom
-					);
-				}
+				c._vnode._children[0] = removeOriginal(
+					suspendedVNode,
+					suspendedVNode._component._parentDom,
+					suspendedVNode._component._originalParentDom
+				);
 			}
 
 			c.setState({ _suspended: (c._detachOnNextRender = null) });

--- a/compat/test/browser/suspense-hydration.test.js
+++ b/compat/test/browser/suspense-hydration.test.js
@@ -656,6 +656,14 @@ describe('suspense hydration', () => {
 				rerender();
 
 				expect(scratch.innerHTML, 'second suspend').to.equal(div('fallback'));
+				expect(getLog()).to.deep.equal([
+					'<div>b1.remove()',
+					'<div>a.remove()',
+					'<div>c.remove()',
+					'<div>.appendChild(#text)',
+					'<div>.appendChild(<div>fallback)'
+				]);
+				clearLog();
 
 				return resolve2(() => <div onClick={bOnClickSpy}>b2</div>);
 			})
@@ -664,12 +672,20 @@ describe('suspense hydration', () => {
 				expect(scratch.innerHTML, 'second suspend resumes').to.equal(
 					[div('a'), div('b2'), div('c')].join('')
 				);
-
-				scratch.lastChild.dispatchEvent(createEvent('click'));
-				expect(cOnClickSpy).toHaveBeenCalledTimes(2);
+				expect(getLog()).to.deep.equal([
+					'<div>fallback.appendChild(<div>a)',
+					'<div>fallback.remove()',
+					'<div>a.appendChild(<div>a)',
+					'<div>.appendChild(#text)',
+					'<div>a.appendChild(<div>b2)',
+					'<div>ab2.appendChild(<div>c)'
+				]);
 
 				scratch.firstChild.nextSibling.dispatchEvent(createEvent('click'));
 				expect(bOnClickSpy).toHaveBeenCalledTimes(2);
+
+				scratch.lastChild.dispatchEvent(createEvent('click'));
+				expect(cOnClickSpy).toHaveBeenCalledTimes(2);
 			});
 	});
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,6 +7,8 @@ export const MODE_SUSPENDED = 1 << 7;
 export const INSERT_VNODE = 1 << 2;
 /** Indicates a VNode has been matched with another VNode in the diff */
 export const MATCHED = 1 << 1;
+/** Indicates that this vnode has been unmounted before indicating the loss of event listeners */
+export const FORCE_PROPS_REVALIDATE = 1 << 0;
 
 // component._bits
 /** Component is processing an exception */

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -721,15 +721,15 @@ export function unmount(vnode, parentVNode, skipRemove) {
 		}
 	}
 
-	if (!skipRemove) removeNode(vnode._dom);
-
-	if (vnode._component) {
-		vnode._children = vnode._dom = vnode._component = NULL;
-	} else if (vnode.type && vnode._dom) {
-		vnode._children = vnode._dom = vnode._dom._listeners = NULL;
+	if (!skipRemove) {
+		removeNode(vnode._dom);
 	}
 
-	vnode._parent = NULL;
+	if (vnode._dom && vnode._dom._listeners) {
+		vnode._dom._listeners = NULL;
+	}
+
+	vnode._dom = vnode._component = vnode._parent = NULL;
 }
 
 /** The `.render()` method for a PFC backing instance. */


### PR DESCRIPTION
We can't safely remove `_listeners` as that would mean we are risking suspense-hydration breaking 😅 basically during suspense we store the vnodes which means that old and new vnode will always be equal, if we want to remove `_listeners` as well we'll have to probably stop storing our virtual DOM tree when it's a mount and store the previous variant when it's an update. This would however mean that our mutative approach is a bad thought.

EDIT: I solved the `_listeners` issue

Resolves https://github.com/preactjs/preact/issues/3668