### PR TITLE
fix: under concurrency pressure,  oldVNode may be empty, and preact may crash. Fix for that scenario

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -191,7 +191,7 @@ export function diff(
 					}
 
 					newVNode._dom = oldVNode._dom;
-					newVNode._children = oldVNode._children;
+					newVNode._children = oldVNode._children || [];
 					newVNode._children.some(vnode => {
 						if (vnode) vnode._parent = newVNode;
 					});


### PR DESCRIPTION
This is a highly tricky concurrency issue. Under some mix of preact signals, and preact suspense, oldVNode._children can evaluate to null, leading to a full preact page crash. I have limited time in digging deeper for a repro, but attached PR fixes the issue.
