### PR TITLE
Ensure we rerender after a suspensefully hydrating boundary throws an…

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -314,7 +314,7 @@ export function diff(
 			} else {
 				newVNode._dom = oldVNode._dom;
 				newVNode._children = oldVNode._children;
-				markAsForce(newVNode);
+				if (!e.then) markAsForce(newVNode);
 			}
 			options._catchError(e, newVNode, oldVNode);
 		}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -309,10 +309,12 @@ export function diff(
 					for (let i = excessDomChildren.length; i--; ) {
 						removeNode(excessDomChildren[i]);
 					}
+					markAsForce(newVNode);
 				}
 			} else {
 				newVNode._dom = oldVNode._dom;
 				newVNode._children = oldVNode._children;
+				markAsForce(newVNode);
 			}
 			options._catchError(e, newVNode, oldVNode);
 		}
@@ -339,6 +341,11 @@ export function diff(
 	if ((tmp = options.diffed)) tmp(newVNode);
 
 	return newVNode._flags & MODE_SUSPENDED ? undefined : oldDom;
+}
+
+function markAsForce(vnode) {
+	if (vnode && vnode._component) vnode._component._force = true;
+	if (vnode && vnode._children) vnode._children.forEach(markAsForce);
 }
 
 /**


### PR DESCRIPTION
Consider the following scenario, we have an application with a shell:

```
App
  Header
  Suspense
    ErrorBoundary
      Body --> Async
  Footer
```

We server-side render the HTML, send it to the client. The client starts hydrating and we do that successfully up to the `Body`, the `Body` will throw a Promise and we'll suspend. This means that the Header/Footer will be interactive the the Body won't be, when Body loads we continue hydration _but_ there is an error in the component.

When there is an error we remove the existing DOM as hydration is considered useless and we need to render the `ErrorBoundary`. When the `ErrorBoundary` is set to `retry` immediately we'll attempt to re-render the component. With Signals (and PureComponent/...) there's a chance that we now bail out of rendering, we'd bail out of rendering while having a partially mutated oldVNode. The oldVNode would signal that it has `_component` and hence is not new while being absent from `_children` as we never reached `diffChildren`.

This PR will ensure that when we error that we _must_ consider the update as forced, this ensures that we _never_ bail out of rendering and that any erroneous state that could be in the component is reset.

Initially I had a simpler solution where I would set `vnode._component` to null but that means that we'd break components catching their own error. Hence why I got to a solution that requires a bit more bytes but solves most of the issues. In reality the `else` branch isn't really needed for the issue at hand but I'd prefer being safe.

Big thanks to @joel-solymosi for finding this issue and providing the hints we needed.

The issue was introduced in https://github.com/preactjs/preact/pull/4563

Supersedes #4854 
Supersedes https://github.com/preactjs/preact/pull/4822