### PR TITLE
fix(types) make React.SVGAttributes generic

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -87,7 +87,8 @@ declare namespace React {
 		extends JSXInternal.SVGAttributes<T>,
 			preact.ClassAttributes<T> {}
 
-	interface SVGAttributes extends JSXInternal.SVGAttributes {}
+	interface SVGAttributes<T extends EventTarget = SVGElement>
+		extends JSXInternal.SVGAttributes<T> {}
 
 	interface ReactSVG extends JSXInternal.IntrinsicSVGElements {}
 


### PR DESCRIPTION
React.SVGAttributes should be generic.

<https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7662e054f506bf695a4e352017d4dafe6926791d/types/react/index.d.ts#L3492>

React itself seems to demand the generic type argument but since I wasn't sure about the implications of adding mandatory generic type arg I made it default to the same type its was before.