### PR TITLE
feat: add .type property referencing original component

### DIFF
--- a/compat/src/memo.js
+++ b/compat/src/memo.js
@@ -29,5 +29,6 @@ export function memo(c, comparer) {
 	}
 	Memoed.displayName = 'Memo(' + (c.displayName || c.name) + ')';
 	Memoed.prototype.isReactComponent = true;
+	Memoed.type = c;
 	return Memoed;
 }

--- a/compat/test/browser/memo.test.js
+++ b/compat/test/browser/memo.test.js
@@ -229,4 +229,13 @@ describe('memo()', () => {
 			`<ol><li>A</li><li>B</li><li class="selected">C</li><li>D</li></ol>`
 		);
 	});
+
+	it('should attach .type pointing to the original component', () => {
+		function Foo() {
+			return <div />;
+		}
+		const Memoized = memo(Foo);
+
+		expect(Memoized.type).to.equal(Foo);
+	});
 });


### PR DESCRIPTION
Solves #4769 

In `why-did-you-render`, if we want to patch a memoed component, we need to use `.type` to get the original component being memoed, see:

https://github.com/welldone-software/why-did-you-render/blob/3ec3512d750c49448fe2241e26d05db9e42f0c21/src/patches/patchMemoComponent.js#L11
