### PR TITLE
feat: add .type property referencing original component

### DIFF
--- a/compat/src/memo.js
+++ b/compat/src/memo.js
@@ -30,5 +30,6 @@ export function memo(c, comparer) {
 	Memoed.displayName = 'Memo(' + (c.displayName || c.name) + ')';
 	Memoed.prototype.isReactComponent = true;
 	Memoed._forwarded = true;
+	Memoed.type = c;
 	return Memoed;
 }

--- a/compat/test/browser/memo.test.js
+++ b/compat/test/browser/memo.test.js
@@ -233,4 +233,13 @@ describe('memo()', () => {
 			`<ol><li>A</li><li>B</li><li class="selected">C</li><li>D</li></ol>`
 		);
 	});
+
+	it('should attach .type pointing to the original component', () => {
+		function Foo() {
+			return <div />;
+		}
+		const Memoized = memo(Foo);
+
+		expect(Memoized.type).to.equal(Foo);
+	});
 });


### PR DESCRIPTION
Follows #4868, port the `.type` of memoed component to preact v10.x