### PR TITLE
fix(compat): add .render property referencing original render function

### DIFF
--- a/compat/src/forwardRef.js
+++ b/compat/src/forwardRef.js
@@ -36,7 +36,7 @@ export function forwardRef(fn) {
 	// It expects an object here with a `render` property,
 	// and prototype.render will fail. Without this
 	// mobx-react throws.
-	Forwarded.render = Forwarded;
+	Forwarded.render = fn;
 
 	Forwarded.prototype.isReactComponent = Forwarded._forwarded = true;
 	Forwarded.displayName = 'ForwardRef(' + (fn.displayName || fn.name) + ')';

--- a/compat/test/browser/forwardRef.test.js
+++ b/compat/test/browser/forwardRef.test.js
@@ -499,4 +499,15 @@ describe('forwardRef', () => {
 
 		expect(actual).to.equal(null);
 	});
+
+	// Issue #4769
+	it('should attach .render pointing to the original render function', () => {
+		function Foo(props, ref) {
+			return <div ref={ref} />;
+		}
+
+		const Forwarded = forwardRef(Foo);
+
+		expect(Forwarded.render).to.equal(Foo);
+  });
 });


### PR DESCRIPTION
Follows #4793, port the `.render` of forwarded component to preact v10.x