### PR TITLE
feat(debug): add `captureOwnerStack`

### DIFF
--- a/debug/src/component-stack.js
+++ b/debug/src/component-stack.js
@@ -147,3 +147,11 @@ export function setupComponentStack() {
 		if (oldRender) oldRender(vnode);
 	};
 }
+
+/**
+ * Return the component stack that was captured up to this point.
+ * @returns {string}
+ */
+export function captureOwnerStack() {
+	return getOwnerStack(getCurrentVNode());
+}

--- a/debug/src/index.d.ts
+++ b/debug/src/index.d.ts
@@ -1,14 +1,7 @@
-import { VNode } from 'preact';
-
-/**
- * Get the currently rendered `vnode`
- */
-export function getCurrentVNode(): VNode | null;
-
 /**
  * Return the component stack that was captured up to this point.
  */
-export function getOwnerStack(vnode: VNode): string;
+export function captureOwnerStack(): string;
 
 /**
  * Setup code to capture the component trace while rendering. Note that

--- a/debug/src/index.d.ts
+++ b/debug/src/index.d.ts
@@ -1,7 +1,19 @@
+import { VNode } from 'preact';
+
 /**
  * Return the component stack that was captured up to this point.
  */
 export function captureOwnerStack(): string;
+
+/**
+ * Get the currently rendered `vnode`
+ */
+export function getCurrentVNode(): VNode | null;
+
+/**
+ * Return the component stack that was captured up to this point.
+ */
+export function getOwnerStack(vnode: VNode): string;
 
 /**
  * Setup code to capture the component trace while rendering. Note that

--- a/debug/src/index.js
+++ b/debug/src/index.js
@@ -5,8 +5,4 @@ initDebug();
 
 export { resetPropWarnings } from './check-props';
 
-export {
-	getCurrentVNode,
-	getDisplayName,
-	getOwnerStack
-} from './component-stack';
+export { captureOwnerStack } from './component-stack';

--- a/debug/src/index.js
+++ b/debug/src/index.js
@@ -5,4 +5,9 @@ initDebug();
 
 export { resetPropWarnings } from './check-props';
 
-export { captureOwnerStack } from './component-stack';
+export {
+	captureOwnerStack,
+	getCurrentVNode,
+	getDisplayName,
+	getOwnerStack
+} from './component-stack';


### PR DESCRIPTION
Export a new `captureOwnerStack` API from `preact/debug`.

> [`captureOwnerStack`](https://react.dev/reference/react/captureOwnerStack) is the new API added in React [v19.1.0](https://github.com/facebook/react/releases/tag/v19.1.0).
