### PR TITLE
Export IntrinsicHTMLElements interface

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -141,9 +141,7 @@ export namespace JSXInternal {
 		semantics: preact.SemanticsMathMLAttributes<MathMLElement>;
 	}
 
-	export interface IntrinsicElements
-		extends IntrinsicSVGElements,
-			IntrinsicMathMLElements {
+	export interface IntrinsicHTMLElements {
 		a: preact.AccessibleAnchorHTMLAttributes<HTMLAnchorElement>;
 		abbr: preact.HTMLAttributes<HTMLElement>;
 		address: preact.HTMLAttributes<HTMLElement>;
@@ -262,4 +260,9 @@ export namespace JSXInternal {
 		video: preact.VideoHTMLAttributes<HTMLVideoElement>;
 		wbr: preact.WbrHTMLAttributes<HTMLElement>;
 	}
+
+	export interface IntrinsicElements
+		extends IntrinsicSVGElements,
+			IntrinsicMathMLElements,
+			IntrinsicHTMLElements {}
 }


### PR DESCRIPTION
This PR introduces and exports the `IntrinsicHTMLElements` interface, which is extended by `IntrinsicElements`. This approach allows you to declare built-in custom elements without running into interface merging issues.

Example:
```ts
declare global {
    namespace preact.JSX {
        interface IntrinsicElements {
            'details': preact.JSX.IntrinsicHTMLElements['details'] | {
                is: 'x-details';
                customProp: boolean;
            }
        }
    }
}
```