### PR TITLE
ci: Fix benchmarks for v10.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,7 @@ on:
   push:
     branches:
       - main
-      - restructure
-      - v11
+      - v10.x
 
 jobs:
   filter_jobs:


### PR DESCRIPTION
Our [benchmarks action is failing](https://github.com/preactjs/preact/actions/runs/17023195272/job/48255153404) on PRs opened against v10.x as we're not running the "CI" workflow on push. The "CI" workflow triggers "Build & Test" which uploads assets that future commits will compare against; the merge commits we're making at the moment aren't associated with a workflow run, ergo, the action will fail to download the artifact for comparison.

Edit: Or at least that's what I think is happening. Fingers crossed?