### PR TITLE
v11.0.0-beta.0

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -13,7 +13,7 @@ export function initDevTools() {
 		globalVar !== undefined &&
 		globalVar.__PREACT_DEVTOOLS__
 	) {
-		globalVar.__PREACT_DEVTOOLS__.attachPreact('10.26.8', options, {
+		globalVar.__PREACT_DEVTOOLS__.attachPreact('11.0.0-beta.0', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "10.26.8",
+  "version": "11.0.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "10.26.8",
+      "version": "11.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.26.8",
+  "version": "11.0.0-beta.0",
   "private": false,
   "description": "Fast 4kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
## Breaking Changes

- Drop IE11 support (#4549, thanks @JoviDeCroock)
- Move `defaultProps` into `preact/compat` (#4657, thanks @JoviDeCroock)
- Remove automatic px suffix (#4665, thanks @JoviDeCroock)
- Remove contains with a simple parentNode check (#4666, thanks @JoviDeCroock)
- Remove `component.base` (#4549, thanks @JoviDeCroock)
- Remove SuspenseList (#4668, thanks @JoviDeCroock)
- Remove static dom bail (#4670, thanks @JoviDeCroock)
- Breaking changes to outputs & pkg.json (#4652, thanks @rschristian)
- Drop support for TS versions < 5.1 (#4788, thanks @rschristian)
- Remove all export maps in nested pkg.json files (#4784, thanks @rschristian)
- Remove deprecated 'ForwardFn' type from compat (#4777, thanks @rschristian)

## Features

- Comment denoted hydration (#4636, thanks @JoviDeCroock)
- Forward ref by default (#4658, thanks @JoviDeCroock)
- Add `captureOwnerStack` (#4875, thanks @colinaaa)
- Add context argument to compat/Children map api (#3855, thanks @ParSal123)
- Export helper functions from `preact/debug` (#4830, thanks @colinaaa)
- Export test-utils from compat (#4783, thanks @rawrmonstar)

## Types

- Require initial value in `useRef` (#4683, thanks @rschristian)
- Types w/ module augmentation (#4884, thanks @rschristian)
- Fix outdated public RefCallback type (#4801, thanks @developit)
- Export IntrinsicHTMLElements interface (#4885, thanks @edoardocavazza)
- Avoid breaking change for ARIA element types (#4882, thanks @rschristian)
- Move most interfaces out of the JSX namespace (#4878, thanks @rschristian)
- Make HTMLAttribute type declarations consistent (#4876, thanks @rschristian)
- Restrict aria roles by element type (#4607, thanks @rschristian)
- Add types for '/compat/server' & '/compat/scheduler' (#4835, thanks @rschristian)

## Fixes

- Ensure memoized components re-render after errors (#4880, thanks @JoviDeCroock)
- Provide solution to long standing memleak (#4853, thanks @JoviDeCroock)
- Ensure we properly re-render bailing errored children (#4857, thanks @JoviDeCroock)
- Support alternative contentDocument (#4851, thanks @JoviDeCroock)
- Fix memory leak in VNode owner tracking (#4850, thanks @developit)
- Ensure 'compat/test-utils' exports match & are valid (#4834, thanks @rschristian)
- Fix signal attribute values not working with precompile transform (#4799, thanks @marvinhagemeister)
- Fix escape style object value in precompile transform (#4794, thanks @marvinhagemeister)
- Fix `_listeners` mangle to reduce collisions (#4463, thanks @rschristian)

## Performance

- Do not re-insert memoized vnodes that keep their relative order after swap (#4888, thanks @vasylenkoval)
- Call tolowercase only when needed (#4881, thanks @JoviDeCroock)
- Reduce some repeated logic (#4814, thanks @43081j)
- Golf down suspense (#4855, thanks @JoviDeCroock)
- Add flags for component type (#4867, thanks @JoviDeCroock)

## Refactors

- DOM event name casing (#4843, thanks @rschristian)
- Improve accuracy of non-dimensional regex (#4772, thanks @rschristian)
- Skip dom check for inferring lower-cased event names (#4720, thanks @rschristian)
- Prune portal logic (#4667, thanks @JoviDeCroock)
- Switch to Object.is for hook args (#4663, thanks @rschristian)
- Remove `rerendercount` (#4877, thanks @JoviDeCroock)

## Testing & Development

- Bump testing/transpilation/formatting deps (#4858, thanks @JoviDeCroock)
- Upgrade oxlint to 1.8.0, fix errors (#4848, thanks @camc314)
- Add simple test for `unstable_batchedUpdate` to improve coverage (#4842, thanks @rschristian)
- Correct PR reporter filter for forks (#4828, thanks @rschristian)
- Remove sinon (#4820, thanks @43081j)
- Migrate compat tests to vitest spies (#4819, thanks @43081j)
- Migrate debug tests to vitest spies (#4817, thanks @43081j)
- Migrate hooks tests to vitest spies (#4816, thanks @43081j)
- Migrate lifecycle tests to use vitest spies (#4815, thanks @43081j)
- Migrate events/refs tests to vitest spies (#4813, thanks @43081j)
- Migrate more browser tests to use vitest spies (#4812, thanks @43081j)
- Migrate context tests to vitest spies (#4810, thanks @43081j)
- Migrate createContext test to use vitest spies (#4811, thanks @43081j)
- Migrate components tests to vitest spies (#4809, thanks @43081j)
- Use v8 coverage (#4807, thanks @43081j)
- Switch to playwright for browser tests (#4808, thanks @43081j)
- Migrate from mocha to vitest (#4806, thanks @43081j)
- Add test ensuring effects are cleaned up (#4792, thanks @JoviDeCroock)
- Avoid caching so file-saves work first try (#4786, thanks @JoviDeCroock)
- Bump browserslist (#4785, thanks @rschristian)
- Specify target browsers (#4773, thanks @rschristian)
- Remove extraneous pkg.json key (#4789, thanks @rschristian)
- Drop unused/broken test (#4653, thanks @rschristian)