### PR TITLE
Add TrustedHTML (from @types/trusted-types) to dangerouslySetInnerHTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@babel/register": "^7.27.1",
         "@biomejs/biome": "^2.1.2",
         "@types/node": "^18.19.87",
+        "@types/trusted-types": "^2.0.7",
         "@vitest/browser": "^3.2.4",
         "@vitest/coverage-v8": "^3.2.4",
         "babel-plugin-transform-rename-properties": "0.1.0",
@@ -3468,6 +3469,13 @@
       "dev": true,
       "optional": true,
       "peer": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -212,6 +212,7 @@
     "@babel/register": "^7.27.1",
     "@biomejs/biome": "^2.1.2",
     "@types/node": "^18.19.87",
+    "@types/trusted-types": "^2.0.7",
     "@vitest/browser": "^3.2.4",
     "@vitest/coverage-v8": "^3.2.4",
     "babel-plugin-transform-rename-properties": "0.1.0",

--- a/src/dom.d.ts
+++ b/src/dom.d.ts
@@ -2,6 +2,8 @@
 
 import { ClassAttributes, PreactDOMAttributes } from 'preact';
 
+export interface TrustedHTML {}
+
 // Implementations of some DOM events that are not available in TS 5.1
 interface ToggleEvent extends Event {
 	readonly newState: string;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -66,7 +66,7 @@ export interface ClassAttributes<T> extends Attributes {
 export interface PreactDOMAttributes {
 	children?: ComponentChildren;
 	dangerouslySetInnerHTML?: {
-		__html: string;
+		__html: string | TrustedHTML;
 	};
 }
 


### PR DESCRIPTION
If you use [DomPurify with TrustedTypes](https://github.com/cure53/DOMPurify?tab=readme-ov-file#what-about-dompurify-and-trusted-types), setting dangerouslySetInnerHTML requires faking the type:

```jsx
<div dangerouslySetInnerHTML={{
   __html: parsed as unknown as string // hacking the type since Preact innerHTML doesn't list TrustedHTML as possible type
}} />
```
