### PR TITLE
ci: Kickstart benches again in v10.x w/ successful run

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -21,14 +21,14 @@ jobs:
           artifact: npm-package
           workflow: ci.yml
           required: false
-      - run: mv preact.tgz preact-main.tgz
-      - name: Upload locally build & base preact package
-        uses: actions/upload-artifact@v4
-        with:
-          name: bench-environment
-          path: |
-            preact-local.tgz
-            preact-main.tgz
+      #- run: mv preact.tgz preact-main.tgz
+      #- name: Upload locally build & base preact package
+      #  uses: actions/upload-artifact@v4
+      #  with:
+      #    name: bench-environment
+      #    path: |
+      #      preact-local.tgz
+      #      preact-main.tgz
 
   #bench_todo:
   #  name: Bench todo

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,62 +30,62 @@ jobs:
             preact-local.tgz
             preact-main.tgz
 
-  bench_todo:
-    name: Bench todo
-    uses: ./.github/workflows/run-bench.yml
-    needs: prepare
-    with:
-      benchmark: todo/todo
-      timeout: 10
+  #bench_todo:
+  #  name: Bench todo
+  #  uses: ./.github/workflows/run-bench.yml
+  #  needs: prepare
+  #  with:
+  #    benchmark: todo/todo
+  #    timeout: 10
 
-  bench_text_update:
-    name: Bench text-update
-    uses: ./.github/workflows/run-bench.yml
-    needs: prepare
-    with:
-      benchmark: text-update/text-update
-      timeout: 10
+  #bench_text_update:
+  #  name: Bench text-update
+  #  uses: ./.github/workflows/run-bench.yml
+  #  needs: prepare
+  #  with:
+  #    benchmark: text-update/text-update
+  #    timeout: 10
 
-  bench_many_updates:
-    name: Bench many-updates
-    uses: ./.github/workflows/run-bench.yml
-    needs: prepare
-    with:
-      benchmark: many-updates/many-updates
-      timeout: 10
+  #bench_many_updates:
+  #  name: Bench many-updates
+  #  uses: ./.github/workflows/run-bench.yml
+  #  needs: prepare
+  #  with:
+  #    benchmark: many-updates/many-updates
+  #    timeout: 10
 
-  bench_replace1k:
-    name: Bench replace1k
-    uses: ./.github/workflows/run-bench.yml
-    needs: prepare
-    with:
-      benchmark: table-app/replace1k
+  #bench_replace1k:
+  #  name: Bench replace1k
+  #  uses: ./.github/workflows/run-bench.yml
+  #  needs: prepare
+  #  with:
+  #    benchmark: table-app/replace1k
 
-  bench_update10th1k:
-    name: Bench 03_update10th1k_x16
-    uses: ./.github/workflows/run-bench.yml
-    needs: prepare
-    with:
-      benchmark: table-app/update10th1k
+  #bench_update10th1k:
+  #  name: Bench 03_update10th1k_x16
+  #  uses: ./.github/workflows/run-bench.yml
+  #  needs: prepare
+  #  with:
+  #    benchmark: table-app/update10th1k
 
-  bench_create10k:
-    name: Bench create10k
-    uses: ./.github/workflows/run-bench.yml
-    needs: prepare
-    with:
-      benchmark: table-app/create10k
+  #bench_create10k:
+  #  name: Bench create10k
+  #  uses: ./.github/workflows/run-bench.yml
+  #  needs: prepare
+  #  with:
+  #    benchmark: table-app/create10k
 
-  bench_hydrate1k:
-    name: Bench hydrate1k
-    uses: ./.github/workflows/run-bench.yml
-    needs: prepare
-    with:
-      benchmark: table-app/hydrate1k
+  #bench_hydrate1k:
+  #  name: Bench hydrate1k
+  #  uses: ./.github/workflows/run-bench.yml
+  #  needs: prepare
+  #  with:
+  #    benchmark: table-app/hydrate1k
 
-  bench_filter_list:
-    name: Bench filter-list
-    uses: ./.github/workflows/run-bench.yml
-    needs: prepare
-    with:
-      benchmark: filter-list/filter-list
-      timeout: 10
+  #bench_filter_list:
+  #  name: Bench filter-list
+  #  uses: ./.github/workflows/run-bench.yml
+  #  needs: prepare
+  #  with:
+  #    benchmark: filter-list/filter-list
+  #    timeout: 10


### PR DESCRIPTION
Bit silly but I think it's necessary as a kickstart for the v10.x benches.

Specifically, the benches currently fail after trying to move the artifact that's meant to be downloaded by `andrewiggins/download-base-artifact`:

```
Trying to get workflow matching "ci.yml"...
Resolved to "CI" (id: 722041)
Base ref of pull request is v10.x
Base commit of pull request is 0be5d206ec8ac309d47b780604c3023e23dbe09b
Warning: Workflow run for 0be5d206ec8ac309d47b780604c3023e23dbe09b (CI#5117) was not successful. Conclusion was "failure". Could not find any successful workflow run for v10.x to fall back to.
Error was thrown but "required" input is set to false so ignoring it. See below for error.
Error: Could not find workflow run matching {"workflowId":722041,"baseCommit":"0be5d206ec8ac309d47b780604c3023e23dbe09b","baseRef":"v10.x","status":"success"}
```

> [Source](https://github.com/preactjs/preact/actions/runs/17356574153/job/49270441591)

I think we just need a dummy successful run here to kickstart things as there's no setting in that action to download from failed runs and we can't have a successful run without bailing out entirely.

I wasn't quite sure if `exit 0` would bail out of the benches too, or if they'd then fail as there was no artifact, so I just commented them out. Obviously we'll revert this once we have a successful run to consume in subsequent runs.