### PR TITLE
10.27.2

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -13,7 +13,7 @@ export function initDevTools() {
 		globalVar !== undefined &&
 		globalVar.__PREACT_DEVTOOLS__
 	) {
-		globalVar.__PREACT_DEVTOOLS__.attachPreact('10.27.1', options, {
+		globalVar.__PREACT_DEVTOOLS__.attachPreact('10.27.2', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "10.27.1",
+  "version": "10.27.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "10.27.1",
+      "version": "10.27.2",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.27.1",
+  "version": "10.27.2",
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
## Types

- Mirror non-JSX types to the 'preact' namespace (#4904, thanks @rschristian)

## Fixes

- Address memory leak (#4906, thanks @JoviDeCroock)