### PR TITLE
Avoid lazy components without result going in throw loop

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -243,18 +243,23 @@ export function suspended(vnode) {
 
 export function lazy(loader) {
 	let prom;
-	let component;
+	let component = null;
 	let error;
+	let resolved;
 
 	function Lazy(props) {
 		if (!prom) {
 			prom = loader();
 			prom.then(
 				exports => {
-					component = exports.default || exports;
+					if (exports) {
+						component = exports.default || exports;
+					}
+					resolved = true;
 				},
 				e => {
 					error = e;
+					resolved = true;
 				}
 			);
 		}
@@ -263,11 +268,11 @@ export function lazy(loader) {
 			throw error;
 		}
 
-		if (!component) {
+		if (!resolved) {
 			throw prom;
 		}
 
-		return createElement(component, props);
+		return component ? createElement(component, props) : null;
 	}
 
 	Lazy.displayName = 'Lazy';


### PR DESCRIPTION
Resolves #4933 

I think this is the safest solution, rendering to nothing if the error is caught and nothing is returned.