### PR TITLE
fix(compat): add `commpat/server.browser` entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,10 @@
       "import": "./compat/server.mjs",
       "require": "./compat/server.js"
     },
+    "./compat/server.browser": {
+      "types": "./compat/server.d.ts",
+      "default": "./compat/server.browser.js"
+    },
     "./compat/jsx-runtime": {
       "types": "./jsx-runtime/src/index.d.ts",
       "import": "./compat/jsx-runtime.mjs",


### PR DESCRIPTION
The `react-email/components` package needs this. See https://github.com/resend/react-email/blob/e87e6fc4d85f45b6a25df2d7bc1bd520627aaff2/packages/render/src/browser/render.tsx#L8

Fixes https://github.com/denoland/fresh/issues/3579