### PR TITLE
fix(compat): add `commpat/server.browser` entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,10 @@
       "import": "./compat/server.mjs",
       "require": "./compat/server.js"
     },
+    "./compat/server.browser": {
+      "types": "./compat/server.d.ts",
+      "default": "./compat/server.browser.js"
+    },
     "./compat/jsx-runtime": {
       "types": "./jsx-runtime/src/index.d.ts",
       "import": "./compat/jsx-runtime.mjs",


### PR DESCRIPTION
The `react-email/components` package needs this.

Backport https://github.com/preactjs/preact/pull/4940