### PR TITLE
types: Fix scroll events

### DIFF
--- a/src/dom.d.ts
+++ b/src/dom.d.ts
@@ -774,8 +774,9 @@ export interface DOMAttributes<Target extends EventTarget>
 
 	// Scroll Events
 	onScroll?: GenericEventHandler<Target> | undefined;
-	onScrollEnd?: GenericEventHandler<Target> | undefined;
 	onScrollCapture?: GenericEventHandler<Target> | undefined;
+	onScrollEnd?: GenericEventHandler<Target> | undefined;
+	onScrollEndCapture?: GenericEventHandler<Target> | undefined;
 
 	// Wheel Events
 	onWheel?: WheelEventHandler<Target> | undefined;


### PR DESCRIPTION
[`scroll`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scroll_event#event_type) and [`scrollend`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollend_event#event_type) events both are of type `Event`, not `UIEvent`. 

This has existed in the repo since types were introduced, seems like it was a copy/paste bug is all. Obviously not a big surface area for issues, but still, should be corrected.