### PR TITLE
refactor(diff): no need to reset props and context when creating component

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -132,9 +132,7 @@ export function diff(
 				}
 				if (provider) provider.sub(c);
 
-				c.props = newProps;
 				if (!c.state) c.state = {};
-				c.context = componentContext;
 				c._globalContext = globalContext;
 				c._bits |= COMPONENT_DIRTY;
 				c._renderCallbacks = [];


### PR DESCRIPTION
`props` and `context` are already being set in `BaseComponent` when creating either a class component or an FC