### PR TITLE
Fix rare scenario where an unmounted suspended tree would resolve

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -147,7 +147,7 @@ Suspense.prototype._childDidSuspend = function (promise, suspendingVNode) {
 		if (!--c._pendingSuspensionCount) {
 			// If the suspension was during hydration we don't need to restore the
 			// suspended children into the _children array
-			if (c.state._suspended) {
+			if (c.state._suspended && c.state._suspended._component) {
 				const suspendedVNode = c.state._suspended;
 				c._vnode._children[0] = removeOriginal(
 					suspendedVNode,
@@ -181,6 +181,7 @@ Suspense.prototype._childDidSuspend = function (promise, suspendingVNode) {
 
 Suspense.prototype.componentWillUnmount = function () {
 	this._suspenders = [];
+	this.state._suspended = this._detachOnNextRender = null;
 };
 
 /**
@@ -236,6 +237,7 @@ Suspense.prototype.render = function (props, state) {
  * @returns {((unsuspend: () => void) => void)?}
  */
 export function suspended(vnode) {
+	if (!vnode._parent) return null;
 	/** @type {import('./internal').Component} */
 	let component = vnode._parent._component;
 	return component && component._suspended && component._suspended(vnode);

--- a/src/component.js
+++ b/src/component.js
@@ -126,7 +126,7 @@ function renderComponent(component) {
 		commitQueue = [],
 		refQueue = [];
 
-	if (component._parentDom) {
+	if (component._parentDom && oldVNode._parent) {
 		const newVNode = assign({}, oldVNode);
 		newVNode._original = oldVNode._original + 1;
 		if (options.vnode) options.vnode(newVNode);


### PR DESCRIPTION
I've been chasing a bug where a suspended VNode would get unmounted as well as re-rendered. My assumption is that this happens as two items in the re-render queue.

- VNode suspends
- SomeNode updates and schedules an unmount
- VNode resolves and schedules an update
- Flush happens
- We handle SomeNode first
- We start handling VNode
  - Due to how suspense works this `Component` will have `_parentDom`
  - This `Component` will have `_vnode` but the `VNode` is in an unmounted state meaning it has no `_parent`
- We handle the diff and when we do `vnode._parent._children[index] = foo` we crash

We add a test that highlights this scenario as well as schedules cleanup in `unmounting` a suspense boundary as well as defensively diffs only when `_parent` is present. 