### PR TITLE
Fix cascading renders with signals

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -165,14 +165,14 @@ export function diff(
 				}
 
 				if (
+					newVNode._original == oldVNode._original ||
 					(!c._force &&
 						c.shouldComponentUpdate != NULL &&
 						c.shouldComponentUpdate(
 							newProps,
 							c._nextState,
 							componentContext
-						) === false) ||
-					newVNode._original == oldVNode._original
+						) === false)
 				) {
 					// More info about this here: https://gist.github.com/JoviDeCroock/bec5f2ce93544d2e6070ef8e0036e4e8
 					if (newVNode._original != oldVNode._original) {


### PR DESCRIPTION
We need to calculate a strict equality bailout before ever touching shouldComponentUpdate else we risk early calculating next values which bails either way.

The issue presents itself when we have two context providers nested

```
FooContext
  BarContext
    Child
```

Imagine that we queue up a render of FooContext and BarContext, the depth algorithm will make it render top-down which means that when FooContext finishes we will enter BarContext. This will bail due to the strict equality bailout, before this change we'd first run sCU which would consolidate the hooks-state due to reconciling _nextValue. When the reconciled component of BarContext would render again it would bail when signals was imported due to its sCU