### PR TITLE
Resolve some suspense crashes

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -27,6 +27,7 @@ const oldUnmount = options.unmount;
 options.unmount = function (vnode) {
 	/** @type {import('./internal').Component} */
 	const component = vnode._component;
+	if (component) component._unmounted = true;
 	if (component && component._onResolve) {
 		component._onResolve();
 	}
@@ -129,7 +130,7 @@ Suspense.prototype._childDidSuspend = function (promise, suspendingVNode) {
 
 	let resolved = false;
 	const onResolved = () => {
-		if (resolved) return;
+		if (resolved || c._unmounted) return;
 
 		resolved = true;
 		suspendingComponent._onResolve = null;

--- a/mangle.json
+++ b/mangle.json
@@ -49,6 +49,7 @@
       "$_children": "__k",
       "$_pendingSuspensionCount": "__u",
       "$_childDidSuspend": "__c",
+      "$_unmounted": "__z",
       "$_onResolve": "__R",
       "$_suspended": "__a",
       "$_dom": "__e",


### PR DESCRIPTION
In the first commit we are resolving a suspense crash that happens when we do a state update on a component that is in a suspended state which has been unmounted.

In the second commit we resolve a forced remount of an unmounted component which resolves after unmount.

RE the second commit

Before this when we unmounted a vnode which was in a suspended state it was possible to cause this to render while being unmounted.
One disturbing thing is that I wanted to check `vnode._component._onResolve` in the `options.unmount` hook, this however was not possible because somehow the reference to `_component` isn't being updated on the `vnode` (my assumption is it being related to us cloning the vnode during the suspension) that's actually unmounting. For this reason I opted to use a separate flag.
