### PR TITLE
refactor(props): call toLowerCase on name regardless of its current casing

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -67,8 +67,7 @@ export function setProperty(dom, name, value, oldValue, namespace) {
 		useCapture = name != (name = name.replace(CAPTURE_REGEX, '$1'));
 
 		// Infer correct casing for DOM built-in events:
-		name = name.slice(2);
-		if (name[0].toLowerCase() != name[0]) name = name.toLowerCase();
+		name = name.slice(2).toLowerCase();
 
 		if (!dom._listeners) dom._listeners = {};
 		dom._listeners[name + useCapture] = value;


### PR DESCRIPTION
if benchmarks don't get negatively affected, we could save some bytes and perhaps even improve performance a bit