### PR TITLE
10.28.3

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -13,7 +13,7 @@ export function initDevTools() {
 		globalVar !== undefined &&
 		globalVar.__PREACT_DEVTOOLS__
 	) {
-		globalVar.__PREACT_DEVTOOLS__.attachPreact('10.28.2', options, {
+		globalVar.__PREACT_DEVTOOLS__.attachPreact('10.28.3', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "10.28.2",
+  "version": "10.28.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "10.28.2",
+      "version": "10.28.3",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.28.2",
+  "version": "10.28.3",
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
## Fixes

- Avoid scheduling suspense state udpates (#5006, thanks @JoviDeCroock)
- Resolve some suspense crashes (#4999, thanks @JoviDeCroock)
- Support inheriting namespace through portals (#4993, thanks @JoviDeCroock)

## Maintenance

- Update test with addition of `_original` (#4989, thanks @JoviDeCroock)