### PR TITLE
Beta.1

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -13,7 +13,7 @@ export function initDevTools() {
 		globalVar !== undefined &&
 		globalVar.__PREACT_DEVTOOLS__
 	) {
-		globalVar.__PREACT_DEVTOOLS__.attachPreact('11.0.0-beta.0', options, {
+		globalVar.__PREACT_DEVTOOLS__.attachPreact('11.0.0-beta.1', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "11.0.0-beta.0",
+  "version": "11.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "11.0.0-beta.0",
+      "version": "11.0.0-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "11.0.0-beta.0",
+  "version": "11.0.0-beta.1",
   "private": false,
   "description": "Fast 4kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
## Fixes

- Forward-port fixes from v10 (#5008, thanks @JoviDeCroock)
- Avoid scheduling suspense state udpates (#5006, thanks @JoviDeCroock)
- Resolve some suspense crashes (#4999, thanks @JoviDeCroock)
- Support inheriting namespace through portals (#4993) (#4995, thanks @JoviDeCroock)
- Forward-port diffing fix (#4976, thanks @JoviDeCroock)
- Fix cascading renders with signals (#4966) (#4969, thanks @JoviDeCroock)
- Avoid lazy components without result going in throw loop (#4939, thanks @JoviDeCroock)
- Support XHTML phrasing content in MathML token elements (#4924, thanks @rschristian)
- Check excess for preact-iso (#4898, thanks @JoviDeCroock)

## Types

- Export setupComponentStack (#4974, thanks @ssssota)
- Add types for 'getDisplayName' (#4957, thanks @rschristian)
- Adds `scrollsnapchange` and `scrollsnapchanging` event support (#4946, thanks @argyleink)
- Fix scroll events (#4948, thanks @rschristian)
- Updates dangerouslySetInnerHTML type so future TS will accept Trusted… (#4930, thanks @lukewarlow)

## Performance

- Call toLowerCase on name regardless of its current casing (#5003, thanks @ali-garajian)
- Set oldProps's default value on declaration (#4959, thanks @ali-garajian)
- Prevent frequently updated components from retaining memory (#4907, thanks @JoviDeCroock)
- Golf down hooks impl (#4897, thanks @JoviDeCroock)
- Save bytes by inlining ref unmount checks (#4896, thanks @JoviDeCroock)
- Save bytes on hydration 2.0 (#4894, thanks @JoviDeCroock)

## Maintenance

- Remove leftover codemods (#5000, thanks @rschristian)
- Clean configs (#4996, thanks @rschristian)
- Force strict equality on vnode constructor (#4986, thanks @JoviDeCroock)
- types: Correct outdated imports in `jsx-runtime` (#4981, thanks @rschristian)
- Delete redundant code of conduct (#4962, thanks @JoviDeCroock)
- Update CODE_OF_CONDUCT to include LLM usage guidelines (#4961, thanks @JoviDeCroock)
- Add comments for hooks options (#4942, thanks @situ2001)
- Add `commpat/server.browser` entry (#4940, thanks @marvinhagemeister)
- Switch tests to use `.jsx` file extension (#4925, thanks @rschristian)
- Fix PR reporter for non-main branch targets (#4900, thanks @rschristian)
