### PR TITLE
refactor(diff): make oldProps diffing more compact (#5004)

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -498,16 +498,14 @@ function diffElementNodes(
 
 		for (i in oldProps) {
 			value = oldProps[i];
-			if (i == 'children') {
-			} else if (i == 'dangerouslySetInnerHTML') {
+			if (i == 'dangerouslySetInnerHTML') {
 				oldHtml = value;
-			} else if (!(i in newProps)) {
-				if (
-					(i == 'value' && 'defaultValue' in newProps) ||
-					(i == 'checked' && 'defaultChecked' in newProps)
-				) {
-					continue;
-				}
+			} else if (
+				i != 'children' &&
+				!(i in newProps) &&
+				!(i == 'value' && 'defaultValue' in newProps) &&
+				!(i == 'checked' && 'defaultChecked' in newProps)
+			) {
 				setProperty(dom, i, NULL, value, namespace);
 			}
 		}

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -533,6 +533,21 @@ describe('render()', () => {
 		expect(scratch.firstChild.checked).to.equal(false);
 	});
 
+	it('should not try to set element.children', () => {
+		render(
+			<div>
+				<span />
+			</div>,
+			scratch
+		);
+		const spy = vi.fn();
+		Object.defineProperty(scratch.firstChild, 'children', {
+			set: spy
+		});
+		render(<div />, scratch);
+		expect(spy).not.toHaveBeenCalled();
+	});
+
 	it('should render download attribute', () => {
 		render(<a download="" />, scratch);
 		expect(scratch.firstChild.getAttribute('download')).to.equal('');


### PR DESCRIPTION
* refactor(diff): make oldProps diffing more compact

* test(render): check if children is being set on rerenders

---------

Land https://github.com/preactjs/preact/pull/5004 in v10