### PR TITLE
Account for full document renders

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -14,7 +14,11 @@ import { slice } from './util';
 export function render(vnode, parentDom, replaceNode) {
 	// https://github.com/preactjs/preact/issues/3794
 	if (parentDom == document) {
-		parentDom = document.documentElement;
+		parentDom = {
+			nodeType: 1,
+			firstChild: document.documentElement,
+			childNodes: [document.documentElement]
+		};
 	}
 
 	if (options._root) options._root(vnode, parentDom);

--- a/src/render.js
+++ b/src/render.js
@@ -12,6 +12,9 @@ import { slice } from './util';
  * existing DOM tree rooted at `replaceNode`
  */
 export function render(vnode, parentDom, replaceNode) {
+	const documentElement = document.documentElement,
+		isDocumentRender = parentDom == document;
+
 	if (options._root) options._root(vnode, parentDom);
 
 	// We abuse the `replaceNode` parameter in `hydrate()` to signal if we are in
@@ -35,7 +38,7 @@ export function render(vnode, parentDom, replaceNode) {
 	let commitQueue = [],
 		refQueue = [];
 	diff(
-		parentDom,
+		isDocumentRender ? documentElement : parentDom,
 		// Determine the new vnode tree and store it on the DOM element on
 		// our custom `_children` property.
 		vnode,
@@ -47,8 +50,8 @@ export function render(vnode, parentDom, replaceNode) {
 			: oldVNode
 				? NULL
 				: parentDom.firstChild
-					? parentDom == Document
-						? [document.documentElement]
+					? isDocumentRender
+						? [documentElement]
 						: slice.call(parentDom.childNodes)
 					: NULL,
 		commitQueue,
@@ -56,8 +59,8 @@ export function render(vnode, parentDom, replaceNode) {
 			? replaceNode
 			: oldVNode
 				? oldVNode._dom
-				: parentDom == Document
-					? document.documentElement
+				: isDocumentRender
+					? documentElement
 					: parentDom.firstChild,
 		isHydrating,
 		refQueue

--- a/src/render.js
+++ b/src/render.js
@@ -12,15 +12,6 @@ import { slice } from './util';
  * existing DOM tree rooted at `replaceNode`
  */
 export function render(vnode, parentDom, replaceNode) {
-	// https://github.com/preactjs/preact/issues/3794
-	if (parentDom == document) {
-		parentDom = {
-			nodeType: 1,
-			firstChild: document.documentElement,
-			childNodes: [document.documentElement]
-		};
-	}
-
 	if (options._root) options._root(vnode, parentDom);
 
 	// We abuse the `replaceNode` parameter in `hydrate()` to signal if we are in
@@ -56,14 +47,18 @@ export function render(vnode, parentDom, replaceNode) {
 			: oldVNode
 				? NULL
 				: parentDom.firstChild
-					? slice.call(parentDom.childNodes)
+					? parentDom == Document
+						? [document.documentElement]
+						: slice.call(parentDom.childNodes)
 					: NULL,
 		commitQueue,
 		!isHydrating && replaceNode
 			? replaceNode
 			: oldVNode
 				? oldVNode._dom
-				: parentDom.firstChild,
+				: parentDom == Document
+					? document.documentElement
+					: parentDom.firstChild,
 		isHydrating,
 		refQueue
 	);

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1970,14 +1970,14 @@ describe('render()', () => {
 	it('should work with document', () => {
 		document.textContent = '';
 		const App = () => (
-			<Fragment>
+			<html>
 				<head>
 					<title>Test</title>
 				</head>
 				<body>
 					<p>Test</p>
 				</body>
-			</Fragment>
+			</html>
 		);
 		render(<App />, document);
 		expect(document.documentElement.innerHTML.trim()).to.equal(


### PR DESCRIPTION
If we see `document` as the hydration root we actually need to zoom out as the user will want to render the full document so `html` which is the firstChild and the childNodes of documentElement needs to be included