### PR TITLE
Maintain elements in head/body during hydration

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -557,7 +557,10 @@ function diffElementNodes(
 			// Remove children that are not part of any vnode.
 			if (excessDomChildren != NULL) {
 				for (i = excessDomChildren.length; i--; ) {
-					removeNode(excessDomChildren[i]);
+					const nodeName =
+						excessDomChildren[i] && excessDomChildren[i].localName;
+					if (nodeName != 'script' && nodeName != 'style' && nodeName != 'link')
+						removeNode(excessDomChildren[i]);
 				}
 			}
 		}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -558,9 +558,11 @@ function diffElementNodes(
 			if (excessDomChildren != NULL) {
 				for (i = excessDomChildren.length; i--; ) {
 					const nodeName =
-						excessDomChildren[i] && excessDomChildren[i].localName;
-					if (nodeName != 'script' && nodeName != 'style' && nodeName != 'link')
-						removeNode(excessDomChildren[i]);
+						excessDomChildren[i] &&
+						excessDomChildren[i].parentNode &&
+						excessDomChildren[i].parentNode.localName;
+
+					if (nodeName != 'head') removeNode(excessDomChildren[i]);
 				}
 			}
 		}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -555,15 +555,13 @@ function diffElementNodes(
 			);
 
 			// Remove children that are not part of any vnode.
-			if (excessDomChildren != NULL) {
+			if (
+				excessDomChildren != NULL &&
+				newVNode.type != 'body' &&
+				newVNode.type != 'head'
+			) {
 				for (i = excessDomChildren.length; i--; ) {
-					const nodeName =
-						excessDomChildren[i] &&
-						excessDomChildren[i].parentNode &&
-						excessDomChildren[i].parentNode.localName;
-
-					if (nodeName != 'head' && nodeName != 'body')
-						removeNode(excessDomChildren[i]);
+					removeNode(excessDomChildren[i]);
 				}
 			}
 		}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -562,7 +562,8 @@ function diffElementNodes(
 						excessDomChildren[i].parentNode &&
 						excessDomChildren[i].parentNode.localName;
 
-					if (nodeName != 'head') removeNode(excessDomChildren[i]);
+					if (nodeName != 'head' && nodeName != 'body')
+						removeNode(excessDomChildren[i]);
 				}
 			}
 		}

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -485,6 +485,33 @@ describe('hydrate()', () => {
 		expect(getLog()).to.deep.equal(['Comment.remove()', 'Comment.remove()']);
 	});
 
+	it('should preserve existing head children when hydrating document', () => {
+		document.textContent = '';
+		document.head.innerHTML =
+			'<title>Test</title><meta name="viewport" content="width=device-width">';
+		document.body.innerHTML = '<p>Test</p>';
+		clearLog();
+
+		const App = () => (
+			<Fragment>
+				<head>
+					<title>Test</title>
+				</head>
+				<body>
+					<p>Test</p>
+				</body>
+			</Fragment>
+		);
+
+		hydrate(<App />, document);
+
+		expect(document.head.querySelector('meta[name="viewport"]')).to.not.equal(
+			null
+		);
+		expect(document.head.querySelector('title').textContent).to.equal('Test');
+		expect(document.body.innerHTML).to.equal('<p>Test</p>');
+	});
+
 	it('should work with error boundaries', () => {
 		scratch.innerHTML = '<div>Hello, World!</div>';
 		class Root extends Component {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1980,9 +1980,8 @@ describe('render()', () => {
 			</Fragment>
 		);
 		render(<App />, document);
-		expect(document.documentElement.innerHTML.trim()).to.equal(
-			'<head><title>Test</title></head><body><p>Test</p></body>'
-		);
+		expect(document.head.querySelector('title').textContent).to.equal('Test');
+		expect(document.body.innerHTML.trim()).to.equal('<p>Test</p>');
 	});
 
 	it('should not remount components when replacing a component with a falsy value in-between', () => {

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -1969,6 +1969,7 @@ describe('render()', () => {
 
 	it('should work with document', () => {
 		document.textContent = '';
+		document.body.textContent = '';
 		const App = () => (
 			<Fragment>
 				<head>


### PR DESCRIPTION
Relates to https://github.com/preactjs/preact-render-to-string/pull/446

This is the same thing as what React 19 does to prevent browser extensions and existing styles getting clobbered by full document renders/hdyrates

https://react.dev/blog/2024/12/05/react-19

> In React 19, unexpected tags in the <head> and <body> will be skipped over, avoiding the mismatch errors. If React needs to re-render the entire document due to an unrelated hydration mismatch, it will leave in place stylesheets inserted by third-party scripts and browser extensions.

