### PR TITLE
fix(diff): handle undefined prototype in component type check

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -98,7 +98,7 @@ export function diff(
 				snapshot,
 				newProps = newVNode.props;
 			const isClassComponent =
-				'prototype' in newType && newType.prototype.render;
+				'prototype' in newType && newType.prototype?.render;
 
 			// Necessary for createContext api. Setting this property will pass
 			// the context value as `this.context` just for this component.

--- a/test/browser/components.test.jsx
+++ b/test/browser/components.test.jsx
@@ -82,6 +82,34 @@ describe('Components', () => {
 			expect(scratch.innerHTML).to.equal('<div foo="bar"></div>');
 		});
 
+		it('should render functional components wrapped with a proxy that has prototype set to undefined', () => {
+			function MyComponent(props) {
+				return <div {...props} />;
+			}
+
+			const proxy = Object.create(null, {
+				prototype: { value: undefined },
+				apply: {
+					value: function (_target, _thisArg, args) {
+						return MyComponent(...args);
+					}
+				}
+			});
+
+			const WrappedComponent = new Proxy(MyComponent, {
+				get(target, prop) {
+					if (prop === 'prototype') return undefined;
+					return Reflect.get(target, prop);
+				}
+			});
+
+			expect(() => {
+				render(<WrappedComponent foo="bar" />, scratch);
+			}).not.to.throw();
+
+			expect(scratch.innerHTML).to.equal('<div foo="bar"></div>');
+		});
+
 		it('should render components with props', () => {
 			let constructorProps;
 


### PR DESCRIPTION
## Summary

Fixes #5011

When a functional component is wrapped with a proxy or object that has `prototype` as an own property but set to `undefined`, the expression `'prototype' in newType && newType.prototype.render` throws a `TypeError: Cannot read properties of undefined (reading 'render')`.

This happens because the `in` operator returns `true` (the property exists), but the value is `undefined`, so accessing `.render` on it crashes.

## Fix

Use optional chaining on the prototype access:

```diff
- 'prototype' in newType && newType.prototype.render
+ 'prototype' in newType && newType.prototype?.render
```

This safely returns `undefined` instead of throwing when `prototype` is `undefined`.

## Reproduction

This occurs in practice when using testing libraries like Sinon that create spies/stubs wrapping functional components, where the spy object has `prototype` set to `undefined`. A test has been added that reproduces this scenario using a `Proxy` with `prototype` returning `undefined`.

## Test

Added a test in `test/browser/components.test.jsx` that creates a functional component wrapped in a Proxy where `get(target, 'prototype')` returns `undefined`, verifying it renders without throwing.

## Disclosure

This PR was co-authored with the help of Claude (LLM) for identifying the fix, writing the test, and structuring the description.