### PR TITLE
refactor(props): use startsWith instead of char check for event handler checks

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -63,7 +63,7 @@ export function setProperty(dom, name, value, oldValue, namespace) {
 		}
 	}
 	// Benchmark for comparison: https://esbench.com/bench/574c954bdb965b9a00965ac6
-	else if (name[0] == 'o' && name[1] == 'n') {
+	else if (name.startsWith('on')) {
 		useCapture = name != (name = name.replace(CAPTURE_REGEX, '$1'));
 
 		// Infer correct casing for DOM built-in events:


### PR DESCRIPTION
I ran the mentioned benchmark three times and every time `startsWith` gained a higher score than `char check`. Am I missing something?

<img width="1920" height="930" alt="Screenshot 1404-12-03 at 23 27 01" src="https://github.com/user-attachments/assets/65e7b4b0-19bb-42f0-803c-a3bc42140275" />
<img width="1920" height="1000" alt="Screenshot 1404-12-03 at 23 28 00" src="https://github.com/user-attachments/assets/69fffbe0-73b4-4d27-8c9f-ddc0b5d6c592" />
<img width="1920" height="992" alt="Screenshot 1404-12-03 at 23 30 12" src="https://github.com/user-attachments/assets/b15cdc10-69bf-4671-8743-b949906c94b0" />
