### PR TITLE
Flush subtree effects

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -64,9 +64,9 @@ options._render = vnode => {
 				hookItem._pendingArgs = hookItem._nextValue = undefined;
 			});
 		} else {
-			hooks._pendingEffects.some(invokeCleanup);
-			hooks._pendingEffects.some(invokeEffect);
-			hooks._pendingEffects = [];
+			if (hooks._pendingEffects.length) {
+				flushAfterPaintEffects();
+			}
 			currentIndex = 0;
 		}
 	}

--- a/hooks/test/browser/useEffect.test.jsx
+++ b/hooks/test/browser/useEffect.test.jsx
@@ -1,5 +1,5 @@
 import { act, teardown as teardownAct } from 'preact/test-utils';
-import { createElement, render, Fragment, Component } from 'preact';
+import { createElement, render, Fragment, Component, options } from 'preact';
 import { useEffect, useState, useRef } from 'preact/hooks';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { useEffectAssertions } from './useEffectAssertions';
@@ -664,5 +664,63 @@ describe('useEffect', () => {
 		act(() => {
 			setVal(1);
 		});
+	});
+
+	it('should flush all pending effects when one component re-renders before afterPaint', () => {
+		// Regression test: when only one component re-renders (via setState)
+		// before afterPaint has flushed effects, ALL pending effects from
+		// ALL components should be flushed as a batch before the re-render
+		// proceeds. This matches React's flushPendingEffects() behavior.
+		//
+		// Without the fix, only the re-rendering component's stale effects
+		// were flushed in _render, leaving sibling effects unflushed until
+		// they got their own re-render or afterPaint fired.
+		const order = [];
+		let setB;
+
+		function A() {
+			useEffect(() => {
+				order.push('A effect');
+			}, []);
+			return <div>A</div>;
+		}
+
+		function B() {
+			const [val, _setB] = useState(0);
+			setB = _setB;
+			useEffect(() => {
+				order.push('B effect');
+			}, []);
+			return <div>{val}</div>;
+		}
+
+		function App() {
+			return (
+				<div>
+					<A />
+					<B />
+				</div>
+			);
+		}
+
+		render(<App />, scratch);
+
+		// Effects are queued but not yet flushed (afterPaint hasn't fired).
+		expect(order).to.deep.equal([]);
+
+		// Force B to re-render synchronously by overriding debounceRendering.
+		// This simulates what happens when a store subscription or
+		// useLayoutEffect triggers a re-render before afterPaint.
+		const prev = options.debounceRendering;
+		options.debounceRendering = cb => cb();
+		setB(1);
+		options.debounceRendering = prev;
+
+		// With the fix: B's _render detects stale effects and calls
+		// flushAfterPaintEffects(), which flushes BOTH A's and B's effects.
+		// Without the fix: only B's effects would flush here; A's effect
+		// would be deferred.
+		expect(order).to.include('A effect');
+		expect(order).to.include('B effect');
 	});
 });


### PR DESCRIPTION
Reproduction at https://stackblitz.com/edit/vitejs-vite-yxpjutvm?file=package.json - notice how the fade-out animation never triggers and instead it just dissapears

## Problem

When libraries like `motion/react` (framer-motion) and `@base-ui/react` are used together with Preact/compat, exit animations break. The popup disappears instantly instead of animating out.

The root cause is a timing issue: when a component re-renders before its `useEffect` callbacks have fired (via `afterPaint`), Preact flushes only that component's stale effects during `options._render`. This causes effects from different components to run in separate render cycles instead of as a single batch.

In the concrete case:

1. Select closes → base-ui store updates → multiple components re-render
2. Base-ui's stale `useEffect` flushes during one render cycle → calls `getAnimations()` → finds 0 animations
3. Motion's stale `useEffect` flushes during a later render cycle → starts WAAPI animation → too late
4. Base-ui has already concluded no animations are running → sets `hidden` → popup disappears

## How React handles this

React calls [`flushPendingEffects()`](https://github.com/facebook/react/blob/main/packages/react-reconciler/src/ReactFiberRootScheduler.js) at the start of `performSyncWorkOnRoot` before beginning any new render work. This flushes **all** pending passive effects (from all components) as a batch, not just the re-rendering component's effects.

From React's `ReactFiberRootScheduler.js`:

```js
// In performSyncWorkOnRoot:
const didFlushPassiveEffects = flushPendingEffects();
if (didFlushPassiveEffects) {
  return null; // Exit to recompute priority
}
// Then proceed with rendering
```

```js
// In performWorkOnRootViaSchedulerTask (concurrent path):
const didFlushPassiveEffects = flushPendingEffectsDelayed();
if (didFlushPassiveEffects) {
  if (root.callbackNode !== originalCallbackNode) {
    return null;
  }
}
// Then proceed with rendering
```

This guarantees that all `useEffect` callbacks from render N complete before render N+1 begins, regardless of which component is re-rendering.

## What Preact did before

In `options._render`, when a component re-renders with unflushed effects (`previousComponent !== currentComponent`):

```js
// Old behavior: flush ONLY this component's stale effects
hooks._pendingEffects.some(invokeCleanup);
hooks._pendingEffects.some(invokeEffect);
hooks._pendingEffects = [];
```

This meant effects from different components could be spread across multiple render cycles when intermediate `setState` calls triggered cascading re-renders.

## The fix

Replace the per-component flush with a call to `flushAfterPaintEffects()`, which drains the entire pending effects queue:

```js
// New behavior: flush ALL pending effects (matching React)
if (hooks._pendingEffects.length) {
  flushAfterPaintEffects();
}
```

This matches React's approach: before starting new render work, ensure all effects from previous renders have completed.

## Behavioral differences from the old code

| Aspect | Old behavior | New behavior (matches React) |
|--------|-------------|------------------------------|
| Which effects flush | Only the re-rendering component's | All components with pending effects |
| Flush order | Re-rendering component first | Tree order (children before parents, as queued by `diffed`) |
| When sibling effects run | Deferred to their own re-render or `afterPaint` | Eagerly, before any re-render proceeds |

- Parent-effects may fire **earlier** than before, but at the correct time per React's contract
- Effect ordering changes from "re-rendering component first" to "tree order" which matches React
