### PR TITLE
feat: add support for `dangerouslySetInnerHTML` on `Fragments`

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -255,6 +255,21 @@ export function diff(
 					? cloneNode(tmp.props.children)
 					: tmp;
 
+			// Teardown old html fragment markers if content changed or transitioning away
+			if (newType === Fragment && oldVNode._dom && oldVNode._dom._endHtml) {
+				const endMarker = oldVNode._dom._endHtml;
+				oldDom = endMarker.nextSibling;
+				const newDSIH = newVNode.props.dangerouslySetInnerHTML;
+				if (
+					!newDSIH ||
+					newDSIH.__html !== oldVNode.props.dangerouslySetInnerHTML.__html
+				) {
+					removeRange(oldVNode._dom, endMarker);
+				} else {
+					newVNode._dom = oldVNode._dom;
+				}
+			}
+
 			if (newType === Fragment && newVNode.props.dangerouslySetInnerHTML) {
 				const html = newVNode.props.dangerouslySetInnerHTML.__html;
 				newVNode._children = [];
@@ -294,43 +309,25 @@ export function diff(
 						startMarker._endHtml = endMarker;
 					}
 					oldDom = endMarker ? endMarker.nextSibling : NULL;
-				} else if (oldVNode._dom && oldVNode._dom._endHtml) {
-					// Update: old Fragment also had dangerouslySetInnerHTML
-					const startMarker = oldVNode._dom;
-					const endMarker = startMarker._endHtml;
-					newVNode._dom = startMarker;
+				}
 
-					if (html !== oldVNode.props.dangerouslySetInnerHTML.__html) {
-						// Clear content between markers
-						let node = startMarker.nextSibling;
-						while (node && node !== endMarker) {
-							let next = node.nextSibling;
-							removeNode(node);
-							node = next;
-						}
-						setHtmlContent(html, parentDom, endMarker);
-					}
-					oldDom = endMarker.nextSibling;
-				} else {
-					// First client-side mount
+				// Mount: first render or update that cleared old markers
+				if (!newVNode._dom) {
 					const startMarker = document.createComment('$h');
 					const endMarker = document.createComment('/$h');
 					startMarker._endHtml = endMarker;
 
 					parentDom.insertBefore(startMarker, oldDom);
-					setHtmlContent(html, parentDom, oldDom);
+					if (html) {
+						const tpl = document.createElement('template');
+						tpl.innerHTML = html;
+						parentDom.insertBefore(tpl.content, oldDom);
+					}
 					parentDom.insertBefore(endMarker, oldDom);
 
 					newVNode._dom = startMarker;
 				}
 			} else {
-				// Reverse transition: old had dangerouslySetInnerHTML, new has normal children
-				if (newType === Fragment && oldVNode._dom && oldVNode._dom._endHtml) {
-					const endMarker = oldVNode._dom._endHtml;
-					oldDom = endMarker.nextSibling;
-					removeRange(oldVNode._dom, endMarker);
-				}
-
 				oldDom = diffChildren(
 					parentDom,
 					isArray(renderResult) ? renderResult : [renderResult],
@@ -431,15 +428,6 @@ function removeRange(start, end) {
 		removeNode(node);
 		if (node === end) break;
 		node = next;
-	}
-}
-
-/** Parse `html` and insert the resulting nodes before `ref` in `parent`. */
-function setHtmlContent(html, parent, ref) {
-	if (html) {
-		const tpl = document.createElement('template');
-		tpl.innerHTML = html;
-		parent.insertBefore(tpl.content, ref);
 	}
 }
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -274,15 +274,13 @@ export function diff(
 					// We can't rely on oldDom because insert() skips comment nodes.
 					let startMarker, endMarker;
 					if (excessDomChildren) {
-						let claiming = false;
 						for (let j = 0; j < excessDomChildren.length; j++) {
 							const edc = excessDomChildren[j];
 							if (!edc) continue;
-							if (!claiming && edc.nodeType === 8 && edc.data === '$h') {
+							if (!startMarker && edc.nodeType === 8 && edc.data === '$h') {
 								startMarker = edc;
-								claiming = true;
 							}
-							if (claiming) {
+							if (startMarker) {
 								excessDomChildren[j] = NULL;
 								if (edc.nodeType === 8 && edc.data === '/$h') {
 									endMarker = edc;
@@ -303,17 +301,14 @@ export function diff(
 					newVNode._dom = startMarker;
 
 					if (html !== oldVNode.props.dangerouslySetInnerHTML.__html) {
+						// Clear content between markers
 						let node = startMarker.nextSibling;
 						while (node && node !== endMarker) {
 							let next = node.nextSibling;
 							removeNode(node);
 							node = next;
 						}
-						if (html) {
-							const tpl = document.createElement('template');
-							tpl.innerHTML = html;
-							parentDom.insertBefore(tpl.content, endMarker);
-						}
+						setHtmlContent(html, parentDom, endMarker);
 					}
 					oldDom = endMarker.nextSibling;
 				} else {
@@ -323,11 +318,7 @@ export function diff(
 					startMarker._endHtml = endMarker;
 
 					parentDom.insertBefore(startMarker, oldDom);
-					if (html) {
-						const tpl = document.createElement('template');
-						tpl.innerHTML = html;
-						parentDom.insertBefore(tpl.content, oldDom);
-					}
+					setHtmlContent(html, parentDom, oldDom);
 					parentDom.insertBefore(endMarker, oldDom);
 
 					newVNode._dom = startMarker;
@@ -337,13 +328,7 @@ export function diff(
 				if (newType === Fragment && oldVNode._dom && oldVNode._dom._endHtml) {
 					const endMarker = oldVNode._dom._endHtml;
 					oldDom = endMarker.nextSibling;
-					let node = oldVNode._dom;
-					while (node) {
-						let next = node.nextSibling;
-						removeNode(node);
-						if (node === endMarker) break;
-						node = next;
-					}
+					removeRange(oldVNode._dom, endMarker);
 				}
 
 				oldDom = diffChildren(
@@ -435,6 +420,26 @@ function markAsForce(vnode) {
 	if (vnode) {
 		if (vnode._component) vnode._component._force = true;
 		if (vnode._children) vnode._children.some(markAsForce);
+	}
+}
+
+/** Remove all DOM nodes from `start` through `end` inclusive. */
+function removeRange(start, end) {
+	let node = start;
+	while (node) {
+		let next = node.nextSibling;
+		removeNode(node);
+		if (node === end) break;
+		node = next;
+	}
+}
+
+/** Parse `html` and insert the resulting nodes before `ref` in `parent`. */
+function setHtmlContent(html, parent, ref) {
+	if (html) {
+		const tpl = document.createElement('template');
+		tpl.innerHTML = html;
+		parent.insertBefore(tpl.content, ref);
 	}
 }
 
@@ -759,15 +764,7 @@ export function unmount(vnode, parentVNode, skipRemove) {
 
 	if (!skipRemove) {
 		if (vnode.type === Fragment && vnode._dom && vnode._dom._endHtml) {
-			// HTML Fragment: remove start marker, all content, and end marker
-			const endMarker = vnode._dom._endHtml;
-			let node = vnode._dom;
-			while (node) {
-				let next = node.nextSibling;
-				removeNode(node);
-				if (node === endMarker) break;
-				node = next;
-			}
+			removeRange(vnode._dom, vnode._dom._endHtml);
 		} else {
 			removeNode(vnode._dom);
 		}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -255,19 +255,111 @@ export function diff(
 					? cloneNode(tmp.props.children)
 					: tmp;
 
-			oldDom = diffChildren(
-				parentDom,
-				isArray(renderResult) ? renderResult : [renderResult],
-				newVNode,
-				oldVNode,
-				globalContext,
-				namespace,
-				excessDomChildren,
-				commitQueue,
-				oldDom,
-				isHydrating,
-				refQueue
-			);
+			if (newType === Fragment && newVNode.props.dangerouslySetInnerHTML) {
+				const html = newVNode.props.dangerouslySetInnerHTML.__html;
+				newVNode._children = [];
+
+				// Unmount old children if transitioning from normal children
+				if (oldVNode._children && oldVNode._children.length) {
+					oldDom = getDomSibling(oldVNode);
+					for (let j = 0; j < oldVNode._children.length; j++) {
+						if (oldVNode._children[j]) {
+							unmount(oldVNode._children[j], newVNode);
+						}
+					}
+				}
+
+				if (isHydrating) {
+					// Find start/end markers in excessDomChildren.
+					// We can't rely on oldDom because insert() skips comment nodes.
+					let startMarker, endMarker;
+					if (excessDomChildren) {
+						let claiming = false;
+						for (let j = 0; j < excessDomChildren.length; j++) {
+							const edc = excessDomChildren[j];
+							if (!edc) continue;
+							if (!claiming && edc.nodeType === 8 && edc.data === '$h') {
+								startMarker = edc;
+								claiming = true;
+							}
+							if (claiming) {
+								excessDomChildren[j] = NULL;
+								if (edc.nodeType === 8 && edc.data === '/$h') {
+									endMarker = edc;
+									break;
+								}
+							}
+						}
+					}
+					if (startMarker) {
+						newVNode._dom = startMarker;
+						startMarker._endHtml = endMarker;
+					}
+					oldDom = endMarker ? endMarker.nextSibling : NULL;
+				} else if (oldVNode._dom && oldVNode._dom._endHtml) {
+					// Update: old Fragment also had dangerouslySetInnerHTML
+					const startMarker = oldVNode._dom;
+					const endMarker = startMarker._endHtml;
+					newVNode._dom = startMarker;
+
+					if (html !== oldVNode.props.dangerouslySetInnerHTML.__html) {
+						let node = startMarker.nextSibling;
+						while (node && node !== endMarker) {
+							let next = node.nextSibling;
+							removeNode(node);
+							node = next;
+						}
+						if (html) {
+							const tpl = document.createElement('template');
+							tpl.innerHTML = html;
+							parentDom.insertBefore(tpl.content, endMarker);
+						}
+					}
+					oldDom = endMarker.nextSibling;
+				} else {
+					// First client-side mount
+					const startMarker = document.createComment('$h');
+					const endMarker = document.createComment('/$h');
+					startMarker._endHtml = endMarker;
+
+					parentDom.insertBefore(startMarker, oldDom);
+					if (html) {
+						const tpl = document.createElement('template');
+						tpl.innerHTML = html;
+						parentDom.insertBefore(tpl.content, oldDom);
+					}
+					parentDom.insertBefore(endMarker, oldDom);
+
+					newVNode._dom = startMarker;
+				}
+			} else {
+				// Reverse transition: old had dangerouslySetInnerHTML, new has normal children
+				if (newType === Fragment && oldVNode._dom && oldVNode._dom._endHtml) {
+					const endMarker = oldVNode._dom._endHtml;
+					oldDom = endMarker.nextSibling;
+					let node = oldVNode._dom;
+					while (node) {
+						let next = node.nextSibling;
+						removeNode(node);
+						if (node === endMarker) break;
+						node = next;
+					}
+				}
+
+				oldDom = diffChildren(
+					parentDom,
+					isArray(renderResult) ? renderResult : [renderResult],
+					newVNode,
+					oldVNode,
+					globalContext,
+					namespace,
+					excessDomChildren,
+					commitQueue,
+					oldDom,
+					isHydrating,
+					refQueue
+				);
+			}
 
 			c.base = newVNode._dom;
 
@@ -330,6 +422,11 @@ export function diff(
 	}
 
 	if ((tmp = options.diffed)) tmp(newVNode);
+
+	// For html Fragments (bail-out path), advance oldDom past the end marker
+	if (newType === Fragment && newVNode._dom && newVNode._dom._endHtml) {
+		return newVNode._dom._endHtml.nextSibling;
+	}
 
 	return newVNode._flags & MODE_SUSPENDED ? undefined : oldDom;
 }
@@ -661,7 +758,19 @@ export function unmount(vnode, parentVNode, skipRemove) {
 	}
 
 	if (!skipRemove) {
-		removeNode(vnode._dom);
+		if (vnode.type === Fragment && vnode._dom && vnode._dom._endHtml) {
+			// HTML Fragment: remove start marker, all content, and end marker
+			const endMarker = vnode._dom._endHtml;
+			let node = vnode._dom;
+			while (node) {
+				let next = node.nextSibling;
+				removeNode(node);
+				if (node === endMarker) break;
+				node = next;
+			}
+		} else {
+			removeNode(vnode._dom);
+		}
 	}
 
 	vnode._component = vnode._parent = vnode._dom = UNDEFINED;

--- a/src/index-5.d.ts
+++ b/src/index-5.d.ts
@@ -331,7 +331,9 @@ export function cloneElement<P>(
 // -----------------------------------
 
 // TODO: Revisit what the public type of this is...
-export const Fragment: FunctionComponent<{}>;
+export const Fragment: FunctionComponent<{
+	dangerouslySetInnerHTML?: PreactDOMAttributes['dangerouslySetInnerHTML'];
+}>;
 
 //
 // Preact options

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -304,7 +304,9 @@ export function cloneElement<P>(
 // -----------------------------------
 
 // TODO: Revisit what the public type of this is...
-export const Fragment: FunctionComponent<{}>;
+export const Fragment: FunctionComponent<{
+	dangerouslySetInnerHTML?: PreactDOMAttributes['dangerouslySetInnerHTML'];
+}>;
 
 //
 // Preact options

--- a/test/browser/hydrate.test.js
+++ b/test/browser/hydrate.test.js
@@ -515,4 +515,99 @@ describe('hydrate()', () => {
 		rerender();
 		expect(scratch.innerHTML).to.equal('<div>Error!</div>');
 	});
+
+	describe('Fragment dangerouslySetInnerHTML', () => {
+		it('should hydrate Fragment with dangerouslySetInnerHTML', () => {
+			scratch.innerHTML =
+				'<div>before<!--$h--><b>content</b><!--/$h-->after</div>';
+			clearLog();
+
+			hydrate(
+				<div>
+					before
+					<Fragment dangerouslySetInnerHTML={{ __html: '<b>content</b>' }} />
+					after
+				</div>,
+				scratch
+			);
+
+			expect(serializeHtml(scratch)).to.equal(
+				'<div>before<!--$h--><b>content</b><!--/$h-->after</div>'
+			);
+			expect(getLog()).to.deep.equal([]);
+		});
+
+		it('should hydrate then update Fragment dangerouslySetInnerHTML', () => {
+			scratch.innerHTML = '<div><!--$h--><b>first</b><!--/$h--></div>';
+			clearLog();
+
+			/** @type {(v) => void} */
+			let set;
+			class App extends Component {
+				constructor(props) {
+					super(props);
+					set = this.setState.bind(this);
+					this.state = { html: '<b>first</b>' };
+				}
+				render() {
+					return (
+						<div>
+							<Fragment dangerouslySetInnerHTML={{ __html: this.state.html }} />
+						</div>
+					);
+				}
+			}
+
+			hydrate(<App />, scratch);
+			expect(serializeHtml(scratch)).to.equal(
+				'<div><!--$h--><b>first</b><!--/$h--></div>'
+			);
+			expect(getLog()).to.deep.equal([]);
+
+			set({ html: '<i>second</i>' });
+			rerender();
+			expect(serializeHtml(scratch)).to.equal(
+				'<div><!--$h--><i>second</i><!--/$h--></div>'
+			);
+		});
+
+		it('should hydrate with siblings around html Fragment', () => {
+			scratch.innerHTML =
+				'<div><span>before</span><!--$h--><b>html</b><!--/$h--><span>after</span></div>';
+			clearLog();
+
+			hydrate(
+				<div>
+					<span>before</span>
+					<Fragment dangerouslySetInnerHTML={{ __html: '<b>html</b>' }} />
+					<span>after</span>
+				</div>,
+				scratch
+			);
+
+			expect(serializeHtml(scratch)).to.equal(
+				'<div><span>before</span><!--$h--><b>html</b><!--/$h--><span>after</span></div>'
+			);
+			expect(getLog()).to.deep.equal([]);
+		});
+
+		it('should hydrate multiple html Fragments as siblings', () => {
+			scratch.innerHTML =
+				'<div><!--$h--><b>a</b><!--/$h--><!--$h--><i>b</i><!--/$h--></div>';
+			clearLog();
+
+			hydrate(
+				<div>
+					<Fragment dangerouslySetInnerHTML={{ __html: '<b>a</b>' }} />
+					<Fragment dangerouslySetInnerHTML={{ __html: '<i>b</i>' }} />
+				</div>,
+				scratch
+			);
+
+			expect(serializeHtml(scratch)).to.equal(
+				'<div><!--$h--><b>a</b><!--/$h--><!--$h--><i>b</i><!--/$h--></div>'
+			);
+			expect(getLog()).to.deep.equal([]);
+		});
+	});
 });

--- a/test/browser/render.test.js
+++ b/test/browser/render.test.js
@@ -788,6 +788,212 @@ describe('render()', () => {
 			rerender();
 			expect(scratch.innerHTML).to.equal('');
 		});
+
+		describe('Fragment dangerouslySetInnerHTML', () => {
+			it('should mount Fragment with dangerouslySetInnerHTML', () => {
+				render(
+					<div>
+						before
+						<Fragment dangerouslySetInnerHTML={{ __html: '<b>foo</b>' }} />
+						after
+					</div>,
+					scratch
+				);
+				expect(serializeHtml(scratch)).to.equal(
+					'<div>before<!--$h--><b>foo</b><!--/$h-->after</div>'
+				);
+			});
+
+			it('should update Fragment dangerouslySetInnerHTML content', () => {
+				/** @type {(v) => void} */
+				let set;
+				class App extends Component {
+					constructor(props) {
+						super(props);
+						set = this.setState.bind(this);
+						this.state = { html: '<b>first</b>' };
+					}
+					render() {
+						return (
+							<div>
+								<Fragment
+									dangerouslySetInnerHTML={{ __html: this.state.html }}
+								/>
+							</div>
+						);
+					}
+				}
+
+				render(<App />, scratch);
+				expect(serializeHtml(scratch)).to.equal(
+					'<div><!--$h--><b>first</b><!--/$h--></div>'
+				);
+
+				set({ html: '<i>second</i>' });
+				rerender();
+				expect(serializeHtml(scratch)).to.equal(
+					'<div><!--$h--><i>second</i><!--/$h--></div>'
+				);
+			});
+
+			it('should not mutate DOM when __html is unchanged', () => {
+				/** @type {Component} */
+				let thing;
+				class Thing extends Component {
+					constructor(props) {
+						super(props);
+						thing = this;
+					}
+					render() {
+						return (
+							<div>
+								<Fragment
+									dangerouslySetInnerHTML={{ __html: '<span>same</span>' }}
+								/>
+							</div>
+						);
+					}
+				}
+
+				render(<Thing />, scratch);
+				const startMarker = scratch.firstChild.firstChild;
+				const innerSpan = startMarker.nextSibling;
+
+				thing.forceUpdate();
+				rerender();
+
+				expect(startMarker.nextSibling).to.equal(innerSpan);
+			});
+
+			it('should unmount Fragment with dangerouslySetInnerHTML', () => {
+				/** @type {(v) => void} */
+				let set;
+				class App extends Component {
+					constructor(props) {
+						super(props);
+						set = this.setState.bind(this);
+						this.state = { show: true };
+					}
+					render() {
+						return this.state.show ? (
+							<div>
+								<Fragment
+									dangerouslySetInnerHTML={{ __html: '<b>content</b>' }}
+								/>
+							</div>
+						) : (
+							<div />
+						);
+					}
+				}
+
+				render(<App />, scratch);
+				expect(serializeHtml(scratch)).to.equal(
+					'<div><!--$h--><b>content</b><!--/$h--></div>'
+				);
+
+				set({ show: false });
+				rerender();
+				expect(serializeHtml(scratch)).to.equal('<div></div>');
+			});
+
+			it('should handle falsy __html values', () => {
+				render(
+					<div>
+						<Fragment dangerouslySetInnerHTML={{ __html: '' }} />
+					</div>,
+					scratch
+				);
+				expect(serializeHtml(scratch)).to.equal(
+					'<div><!--$h--><!--/$h--></div>'
+				);
+			});
+
+			it('should handle multiple html Fragments as siblings', () => {
+				render(
+					<div>
+						<Fragment dangerouslySetInnerHTML={{ __html: '<b>a</b>' }} />
+						<Fragment dangerouslySetInnerHTML={{ __html: '<i>b</i>' }} />
+					</div>,
+					scratch
+				);
+				expect(serializeHtml(scratch)).to.equal(
+					'<div><!--$h--><b>a</b><!--/$h--><!--$h--><i>b</i><!--/$h--></div>'
+				);
+			});
+
+			it('should transition from normal children to dangerouslySetInnerHTML', () => {
+				/** @type {(v) => void} */
+				let set;
+				class App extends Component {
+					constructor(props) {
+						super(props);
+						set = this.setState.bind(this);
+						this.state = { useHtml: false };
+					}
+					render() {
+						return (
+							<div>
+								{this.state.useHtml ? (
+									<Fragment
+										dangerouslySetInnerHTML={{ __html: '<b>raw</b>' }}
+									/>
+								) : (
+									<Fragment>
+										<span>children</span>
+									</Fragment>
+								)}
+							</div>
+						);
+					}
+				}
+
+				render(<App />, scratch);
+				expect(scratch.innerHTML).to.equal('<div><span>children</span></div>');
+
+				set({ useHtml: true });
+				rerender();
+				expect(serializeHtml(scratch)).to.equal(
+					'<div><!--$h--><b>raw</b><!--/$h--></div>'
+				);
+			});
+
+			it('should transition from dangerouslySetInnerHTML to normal children', () => {
+				/** @type {(v) => void} */
+				let set;
+				class App extends Component {
+					constructor(props) {
+						super(props);
+						set = this.setState.bind(this);
+						this.state = { useHtml: true };
+					}
+					render() {
+						return (
+							<div>
+								{this.state.useHtml ? (
+									<Fragment
+										dangerouslySetInnerHTML={{ __html: '<b>raw</b>' }}
+									/>
+								) : (
+									<Fragment>
+										<span>children</span>
+									</Fragment>
+								)}
+							</div>
+						);
+					}
+				}
+
+				render(<App />, scratch);
+				expect(serializeHtml(scratch)).to.equal(
+					'<div><!--$h--><b>raw</b><!--/$h--></div>'
+				);
+
+				set({ useHtml: false });
+				rerender();
+				expect(scratch.innerHTML).to.equal('<div><span>children</span></div>');
+			});
+		});
 	});
 
 	it('should reconcile mutated DOM attributes', () => {


### PR DESCRIPTION
This PR adds support for setting `dangerouslySetInnerHTML` on Fragments. It allows you to inject raw unsafe HTML without a container element. This is useful for styling through CSS like with grids or flexbox which are sensitive to child elements.

Before:

```jsx
<article>
  <h1>{post.title}</h1>
  <div dangerouslySetInnerHTML={...} />
</article>
```
After:
```jsx
<article>
  <h1>{post.title}</h1>
  <Fragment dangerouslySetInnerHTML={...} />
</article>
```

This is the client-side equivalent of https://github.com/preactjs/preact-render-to-string/pull/453/ 

Given the size increase I'm not sure if we want to land this, but seems useful enough. Long-term we could make the byte increase worth it by generalizing the concept of a "virtual element between markers" for suspense, streaming, etc. That would make the size increase more worth it.