### PR TITLE
Fix incorrect DOM order with conditional ContextProvider and inner keys

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -124,6 +124,14 @@ export function diffChildren(
 		let shouldPlace = !!(childVNode._flags & INSERT_VNODE);
 		if (shouldPlace || oldVNode._children === childVNode._children) {
 			oldDom = insert(childVNode, oldDom, parentDom, shouldPlace);
+
+			// When a matched VNode is physically moved via INSERT_VNODE, its old
+			// _dom pointer becomes a stale positional reference. Clear it so that
+			// getDomSibling (called from nested diffs) won't return this stale
+			// reference and mis-place subsequent DOM nodes. See #5065.
+			if (shouldPlace && oldVNode._dom) {
+				oldVNode._dom = NULL;
+			}
 		} else if (typeof childVNode.type == 'function' && result !== UNDEFINED) {
 			oldDom = result;
 		} else if (newDom) {

--- a/test/browser/keys.test.jsx
+++ b/test/browser/keys.test.jsx
@@ -1,4 +1,11 @@
-import { createElement, Component, render, createRef } from 'preact';
+import {
+	createElement,
+	Component,
+	render,
+	createRef,
+	createContext,
+	Fragment
+} from 'preact';
 import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../_util/helpers';
 import { logCall, clearLog, getLog } from '../_util/logCall';
@@ -1150,5 +1157,218 @@ describe('keys', () => {
 			'<li>.appendChild(#text)',
 			'<ol>2345.appendChild(<li>6)'
 		]);
+	});
+
+	// https://github.com/preactjs/preact/issues/5065
+	it('should maintain correct DOM order with conditional ContextProvider and inner keys', () => {
+		const Ctx = createContext(null);
+
+		class Label extends Component {
+			render({ todo }) {
+				return <li key={todo.text}>{todo.text}</li>;
+			}
+		}
+
+		class App extends Component {
+			render() {
+				const { todos } = this.props;
+				return (
+					<ul>
+						{todos.map((todo, index) =>
+							todo.text === '1' || todo.text === '2' || todo.text === '3' ? (
+								<Ctx.Provider value={null}>
+									<Label todo={todo} index={index} />
+								</Ctx.Provider>
+							) : (
+								<Label todo={todo} index={index} />
+							)
+						)}
+					</ul>
+				);
+			}
+		}
+
+		// Initial: 3 collapsed rows
+		render(
+			<App todos={[{ text: '1' }, { text: '2' }, { text: '3' }]} />,
+			scratch
+		);
+		expect(scratch.querySelector('ul').textContent).to.equal('123');
+
+		// Expand row 1: adds sub-items 1A, 1B, 1C (not wrapped in Provider)
+		render(
+			<App
+				todos={[
+					{ text: '1' },
+					{ text: '1A' },
+					{ text: '1B' },
+					{ text: '1C' },
+					{ text: '2' },
+					{ text: '3' }
+				]}
+			/>,
+			scratch
+		);
+		expect(scratch.querySelector('ul').textContent).to.equal('11A1B1C23');
+
+		// Expand row 2: adds sub-items 2A, 2B, 2C
+		render(
+			<App
+				todos={[
+					{ text: '1' },
+					{ text: '1A' },
+					{ text: '1B' },
+					{ text: '1C' },
+					{ text: '2' },
+					{ text: '2A' },
+					{ text: '2B' },
+					{ text: '2C' },
+					{ text: '3' }
+				]}
+			/>,
+			scratch
+		);
+		expect(scratch.querySelector('ul').textContent).to.equal('11A1B1C22A2B2C3');
+
+		// Collapse row 1: removes 1A, 1B, 1C
+		render(
+			<App
+				todos={[
+					{ text: '1' },
+					{ text: '2' },
+					{ text: '2A' },
+					{ text: '2B' },
+					{ text: '2C' },
+					{ text: '3' }
+				]}
+			/>,
+			scratch
+		);
+		expect(scratch.querySelector('ul').textContent).to.equal('122A2B2C3');
+	});
+
+	// https://github.com/preactjs/preact/issues/5065
+	it('should maintain correct DOM order when collapsing row 2 with conditional Provider', () => {
+		const Ctx = createContext(null);
+
+		class Label extends Component {
+			render({ todo }) {
+				return <li key={todo.text}>{todo.text}</li>;
+			}
+		}
+
+		class App extends Component {
+			render() {
+				const { todos } = this.props;
+				return (
+					<ul>
+						{todos.map((todo, index) =>
+							todo.text === '1' || todo.text === '2' || todo.text === '3' ? (
+								<Ctx.Provider value={null}>
+									<Label todo={todo} index={index} />
+								</Ctx.Provider>
+							) : (
+								<Label todo={todo} index={index} />
+							)
+						)}
+					</ul>
+				);
+			}
+		}
+
+		// Both rows expanded
+		render(
+			<App
+				todos={[
+					{ text: '1' },
+					{ text: '1A' },
+					{ text: '1B' },
+					{ text: '1C' },
+					{ text: '2' },
+					{ text: '2A' },
+					{ text: '2B' },
+					{ text: '2C' },
+					{ text: '3' }
+				]}
+			/>,
+			scratch
+		);
+		expect(scratch.querySelector('ul').textContent).to.equal('11A1B1C22A2B2C3');
+
+		// Collapse row 2: removes 2A, 2B, 2C
+		render(
+			<App
+				todos={[
+					{ text: '1' },
+					{ text: '1A' },
+					{ text: '1B' },
+					{ text: '1C' },
+					{ text: '2' },
+					{ text: '3' }
+				]}
+			/>,
+			scratch
+		);
+		expect(scratch.querySelector('ul').textContent).to.equal('11A1B1C23');
+	});
+
+	// https://github.com/preactjs/preact/issues/5065
+	it('should maintain correct DOM order expanding then collapsing with conditional Provider', () => {
+		const Ctx = createContext(null);
+
+		class Label extends Component {
+			render({ todo }) {
+				return <li key={todo.text}>{todo.text}</li>;
+			}
+		}
+
+		class App extends Component {
+			render() {
+				const { todos } = this.props;
+				return (
+					<ul>
+						{todos.map((todo, index) =>
+							todo.text === '1' || todo.text === '2' || todo.text === '3' ? (
+								<Ctx.Provider value={null}>
+									<Label todo={todo} index={index} />
+								</Ctx.Provider>
+							) : (
+								<Label todo={todo} index={index} />
+							)
+						)}
+					</ul>
+				);
+			}
+		}
+
+		// Initial: 3 rows collapsed
+		render(
+			<App todos={[{ text: '1' }, { text: '2' }, { text: '3' }]} />,
+			scratch
+		);
+		expect(scratch.querySelector('ul').textContent).to.equal('123');
+
+		// Expand row 1
+		render(
+			<App
+				todos={[
+					{ text: '1' },
+					{ text: '1A' },
+					{ text: '1B' },
+					{ text: '1C' },
+					{ text: '2' },
+					{ text: '3' }
+				]}
+			/>,
+			scratch
+		);
+		expect(scratch.querySelector('ul').textContent).to.equal('11A1B1C23');
+
+		// Collapse row 1
+		render(
+			<App todos={[{ text: '1' }, { text: '2' }, { text: '3' }]} />,
+			scratch
+		);
+		expect(scratch.querySelector('ul').textContent).to.equal('123');
 	});
 });


### PR DESCRIPTION
Resolves #5065

When a VNode is moved via INSERT_VNODE during diffChildren, its old _dom pointer becomes a stale positional reference. Nested diffs that call getDomSibling would traverse the old VNode tree and find this stale _dom, causing subsequent DOM insertions at the wrong position.

Clear the old VNode's _dom after insert so getDomSibling skips moved VNodes and finds the correct insertion point.