### PR TITLE
10.29.1

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -13,7 +13,7 @@ export function initDevTools() {
 		globalVar !== undefined &&
 		globalVar.__PREACT_DEVTOOLS__
 	) {
-		globalVar.__PREACT_DEVTOOLS__.attachPreact('10.29.0', options, {
+		globalVar.__PREACT_DEVTOOLS__.attachPreact('10.29.1', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "10.29.0",
+  "version": "10.29.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "10.29.0",
+      "version": "10.29.1",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.29.0",
+  "version": "10.29.1",
   "private": false,
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",


### PR DESCRIPTION
## Fixes

- Create a unique event-clock for each Preact instance on a page. (#5068, thanks @JoviDeCroock)
- Fix incorrect DOM order with conditional ContextProvider and inner keys (#5067, thanks @JoviDeCroock)

## Maintenance

- fix: Remove postinstall script for playwright setup (#5063, thanks @rschristian)
- chore: speed up tests by using playwright instead of webdriverio (#5060, thanks @marvinhagemeister)
- chore: migrate remaining .js -> .jsx files (#5059, thanks @marvinhagemeister)
- chore: rename `.test.js` -> `.test.jsx` when JSX is used (#5058, thanks @marvinhagemeister)
- Migrate from biome to oxfmt (#5033, thanks @JoviDeCroock)
