### PR TITLE
Trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,70 @@
 name: Release
-on: create
+
+on:
+  push:
+    tags:
+      - '10.*'
 
 jobs:
   build:
-    if: github.ref_type == 'tag'
     uses: preactjs/preact/.github/workflows/build-test.yml@v10.x
 
   release:
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: npm-package
       - name: Create draft release
         id: create-release
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const script = require('./scripts/release/create-gh-release.js')
             return script({ github, context })
       - name: Upload release artifact
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        env:
+          RELEASE_DATA: ${{ steps.create-release.outputs.result }}
         with:
           script: |
             const script = require('./scripts/release/upload-gh-asset.js')
-            return script({ require, github, context, glob, release: ${{ steps.create-release.outputs.result }} })
+            const release = JSON.parse(process.env.RELEASE_DATA)
+            return script({ require, github, context, glob, release })
+
+  publish:
+    needs: [build, release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: npm-package
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: 'package.json'
+          registry-url: 'https://registry.npmjs.org'
+      # Determine the npm dist-tag from the git tag:
+      # - Prerelease versions (e.g. 10.29.0-rc.1) publish with --tag matching
+      #   the prerelease identifier (rc, alpha, beta, etc.)
+      # - Stable versions publish with --tag latest
+      - name: Determine dist-tag
+        id: dist-tag
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          if [[ "$TAG" =~ -([a-zA-Z]+) ]]; then
+            echo "tag=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+      # TODO: Decide whether to add a GitHub environment (e.g. "npm") with
+      # required reviewers as an approval gate before publishing. This would
+      # prevent accidental publishes while still keeping the workflow automated.
+      - name: Publish to npm
+        run: npm publish preact.tgz --tag ${{ steps.dist-tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,8 @@ jobs:
           name: npm-package
 
       - name: Update npm
-        run: npm install -g npm@11.12
+        run: npm install -g npm@11.11
+
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: 'package.json'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
   publish:
     needs: [build, release]
     runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/preact
     permissions:
       contents: read
       id-token: write
@@ -46,6 +49,9 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: npm-package
+
+      - name: Update npm
+        run: npm install -g npm@11.12
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: 'package.json'
@@ -63,8 +69,5 @@ jobs:
           else
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
-      # TODO: Decide whether to add a GitHub environment (e.g. "npm") with
-      # required reviewers as an approval gate before publishing. This would
-      # prevent accidental publishes while still keeping the workflow automated.
       - name: Publish to npm
-        run: npm publish preact.tgz --tag ${{ steps.dist-tag.outputs.tag }}
+        run: npm publish preact.tgz --provenance --tag ${{ steps.dist-tag.outputs.tag }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,11 +203,7 @@ rights to publish new releases on npm.
 5. Wait for the Release workflow to complete
    - It'll create a draft release and upload the built npm package as an asset to the release
 6. [Fill in the release notes](#writing-release-notes) in GitHub and publish them
-7. Run the publish script with the tag you created
-   1. `node ./scripts/release/publish.mjs 10.0.0`
-   2. Make sure you have 2FA enabled in npm, otherwise the above command will fail.
-   3. If you're doing a pre-release add `--npm-tag next` to the `publish.mjs` command to publish it under a different tag (default is `latest`)
-8. Tweet it out
+7. Tweet it out
 
 ## Legacy Releases (8.x)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,7 @@ rights to publish new releases on npm.
 4. Create and push a tag for the new version you want to publish:
    1. `git tag 10.0.0`
    2. `git push --tags`
-5. Wait for the Release workflow to complete
+5. Wait for the Release workflow to reach the `npm` environment approval gate, approve it, and let it complete
    - It'll create a draft release and upload the built npm package as an asset to the release
 6. [Fill in the release notes](#writing-release-notes) in GitHub and publish them
 7. Tweet it out

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "amdName": "preact",
   "version": "10.29.0",
   "private": false,
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "description": "Fast 3kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",
   "module": "dist/preact.module.js",


### PR DESCRIPTION
## Summary

- Adds a `publish` job to the release workflow that publishes to npm with provenance using OIDC
- Derives the npm dist-tag from the git tag (prerelease identifier or `latest`)
- Adds `publishConfig` with `provenance: true` and `access: "public"` to package.json
- Uses `id-token: write` permission for provenance attestation

## Security hardening

In addition to the new publish job, this PR nails down some loose ends in the existing workflow:

- **Trigger scoped to `on: push: tags: ['10.*']`** instead of `on: create`, which fired for both tags and branches. This also restricts to 10.x version tags only.
- **Potential script injection fixed** in the `release` job — `${{ steps.create-release.outputs.result }}` was interpolated directly into a `script:` block. Now passed via `RELEASE_DATA` env var and parsed with `JSON.parse`.
- **All actions pinned to commit SHAs** instead of mutable major version tags, preventing supply-chain attacks via tag mutation.
- **Explicit permissions** on all jobs — `release` declares `contents: write`, `publish` declares `contents: read` + `id-token: write`.

## Open question

- **Environment protection gate**: Should the `publish` job require manual approval via a GitHub Environment (e.g. `npm`) with required reviewers? Currently noted as a TODO — any collaborator with write access can push a tag and trigger a publish without approval. See https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments

## Setup required

- On npmjs.com, link the package to the `preactjs/preact` GitHub repo for provenance verification
