### PR TITLE
Fix grammar/typo in createElement JSDoc and a test fixture

### DIFF
--- a/compat/test/browser/render.test.jsx
+++ b/compat/test/browser/render.test.jsx
@@ -823,7 +823,7 @@ describe('compat render', () => {
 			'grid-row-end': 2,
 			'grid-row-gap': 23,
 			'grid-row-start': 2,
-			'inital-letter': 2,
+			'initial-letter': 2,
 			'line-height': 2,
 			'line-clamp': 2,
 			'mask-border': 2,

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -5,7 +5,7 @@ import { NULL, UNDEFINED } from './constants';
 let vnodeId = 0;
 
 /**
- * Create an virtual node (used for JSX)
+ * Create a virtual node (used for JSX)
  * @param {import('./internal').VNode["type"]} type The node name or Component constructor for this
  * virtual node
  * @param {object | null | undefined} [props] The properties of the virtual node
@@ -79,7 +79,7 @@ export function Fragment(props) {
 }
 
 /**
- * Check if a the argument is a valid Preact VNode.
+ * Check if the argument is a valid Preact VNode.
  * @param {*} vnode
  * @returns {vnode is VNode}
  */


### PR DESCRIPTION

**Repo:** preactjs/preact (⭐ 36000)
**Type:** docs
**Files changed:** 2
**Lines:** +3/-3

## What
Corrects two small grammar mistakes in the JSDoc of `src/create-element.js`
("Create an virtual node" → "Create a virtual node", "Check if a the argument"
→ "Check if the argument") and fixes a typo in a CSS property name used in
the compat render test (`'inital-letter'` → `'initial-letter'`).

## Why
The JSDoc for `createElement` and `isValidElement` is the primary public
API documentation surfaced by editors and TypeScript tooling, so the
ungrammatical "an virtual" / "a the" wording is user-visible. The
`'inital-letter'` key in `compat/test/browser/render.test.jsx` is a
misspelling of the real CSS property `initial-letter`; spelling it
correctly keeps the test data faithful to the spec it is exercising
(the non-dimensional `^ini` branch in `IS_NON_DIMENSIONAL`).

## Testing
Pure text/comment changes plus a renamed object key in a test fixture
that is only used as a string. No behavior change. No build needed —
the regex this fixture exercises matches `^ini`, which still matches
`initial-letter`. Verified by inspection of `compat/src/util.js:16`.

## Risk
Low — JSDoc-only changes plus a string key in a test fixture; no runtime code paths affected.
