### PR TITLE
fix: vnode clone compatible with frozen intrinsics

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -4,7 +4,7 @@ import {
 	FORCE_PROPS_REVALIDATE,
 	MODE_HYDRATE
 } from '../../src/constants';
-import { assign } from './util';
+import { cloneVNode } from '../../src/util';
 
 const oldCatchError = options._catchError;
 options._catchError = (error, newVNode, oldVNode, errorInfo) => {
@@ -49,7 +49,7 @@ function detachedClone(vnode, detachedParent, parentDom) {
 			vnode._component.__hooks = null;
 		}
 
-		vnode = assign({}, vnode);
+		vnode = cloneVNode(vnode);
 		if (vnode._component != null) {
 			if (vnode._component._parentDom === parentDom) {
 				vnode._component._parentDom = detachedParent;

--- a/src/component.js
+++ b/src/component.js
@@ -7,7 +7,7 @@ import {
 import { Fragment } from './create-element';
 import { commitRoot, diff } from './diff/index';
 import options from './options';
-import { assign } from './util';
+import { assign, cloneVNode } from './util';
 
 /**
  * Base Component class. Provides `setState()` and `forceUpdate()`, which
@@ -133,7 +133,7 @@ function renderComponent(component) {
 
 	const parentDom = component._parentDom;
 	if (parentDom) {
-		const newVNode = assign({}, oldVNode);
+		const newVNode = cloneVNode(oldVNode);
 		newVNode._original = oldVNode._original + 1;
 		if (options.vnode) options.vnode(newVNode);
 

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -49,6 +49,10 @@ export function createVNode(type, props, key, ref, original) {
 	// Do not inline into createElement and coerceToVNode!
 	/** @type {import('./internal').VNode} */
 	const vnode = {
+		// `constructor` first so the shape matches the target object pre-seeded
+		// in `cloneVNode`, keeping the same hidden class for freshly-created
+		// and cloned vnodes.
+		constructor: UNDEFINED,
 		type,
 		props,
 		key,
@@ -58,7 +62,6 @@ export function createVNode(type, props, key, ref, original) {
 		_depth: 0,
 		_dom: NULL,
 		_component: NULL,
-		constructor: UNDEFINED,
 		_original: original == NULL ? ++vnodeId : original,
 		_index: -1,
 		_flags: 0

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -19,7 +19,7 @@ import {
 } from '../constants';
 import { Fragment } from '../create-element';
 import options from '../options';
-import { assign, isArray, removeNode, slice } from '../util';
+import { assign, cloneVNode, isArray, removeNode, slice } from '../util';
 import { diffChildren } from './children';
 import { setProperty } from './props';
 
@@ -435,7 +435,7 @@ function cloneNode(node) {
 
 	if (node.constructor !== UNDEFINED) return null;
 
-	return assign({}, node);
+	return cloneVNode(node);
 }
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -1,8 +1,20 @@
-import { EMPTY_ARR } from './constants';
+import { EMPTY_ARR, UNDEFINED } from './constants';
 
 export const isArray = Array.isArray;
 export const slice = EMPTY_ARR.slice;
 export const assign = Object.assign;
+
+/**
+ * Shallow-copy a vnode. Like `Object.assign({}, vnode)`, but safe when
+ * `Object.prototype` is frozen (e.g. Hardened JS): assigning the vnode's own
+ * `constructor: undefined` property to a plain `{}` would hit the frozen
+ * `Object.prototype.constructor` and throw, so pre-seed the target with its
+ * own `constructor` slot.
+ * @template T
+ * @param {T} vnode
+ * @returns {T}
+ */
+export const cloneVNode = vnode => assign({ constructor: UNDEFINED }, vnode);
 
 /**
  * Remove a child node from its parent if attached.

--- a/test/node/frozen-intrinsics.subprocess.js
+++ b/test/node/frozen-intrinsics.subprocess.js
@@ -1,0 +1,71 @@
+// Subprocess entry point for frozen-intrinsics.test.js: bundled by esbuild
+// and run with `node --frozen-intrinsics`. Not a `*.test.js`, so vitest does
+// not auto-collect it. Prints `OK` on success, `FAIL: <msg>` + exit 2
+// otherwise.
+import { createElement, cloneElement, isValidElement } from '../../src/index';
+import { cloneVNode } from '../../src/util';
+
+const fail = msg => {
+	console.error('FAIL: ' + msg);
+	process.exit(2);
+};
+const assert = (cond, msg) => {
+	if (!cond) fail(msg);
+};
+
+// Sanity: --frozen-intrinsics actually applied to this realm.
+assert(Object.isFrozen(Object.prototype), 'Object.prototype is not frozen');
+
+// Regression sentinel: Node tames the override mistake by replacing
+// `Object.prototype.constructor` with an accessor pair. If a future Node
+// makes it a plain non-writable data property instead, the bug fixed by
+// `cloneVNode` reproduces under this flag and this should fail loudly.
+const ctorDesc = Object.getOwnPropertyDescriptor(
+	Object.prototype,
+	'constructor'
+);
+assert(
+	typeof ctorDesc.get === 'function' && typeof ctorDesc.set === 'function',
+	'Object.prototype.constructor is no longer a tamed accessor — ' +
+		'override-mistake bug may now reproduce under --frozen-intrinsics'
+);
+
+// createElement produces vnodes with the `constructor: undefined`
+// JSON-injection guard — the property whose copy semantics drive the bug.
+const vnode = createElement('div', { id: 'x' }, 'hi');
+assert(vnode.type === 'div', 'createElement: wrong .type');
+assert(
+	Object.prototype.hasOwnProperty.call(vnode, 'constructor'),
+	'createElement vnode missing own constructor guard'
+);
+assert(
+	vnode.constructor === undefined,
+	'createElement vnode constructor !== undefined'
+);
+assert(
+	isValidElement(vnode),
+	'isValidElement returned false on a createElement output'
+);
+
+// cloneVNode round-trips faithfully.
+const copy = cloneVNode(vnode);
+assert(copy !== vnode, 'cloneVNode returned same reference');
+assert(
+	Object.prototype.hasOwnProperty.call(copy, 'constructor'),
+	'cloneVNode dropped constructor own-property guard'
+);
+assert(copy.constructor === undefined, 'cloneVNode constructor !== undefined');
+assert(
+	isValidElement(copy),
+	'isValidElement returned false on a cloneVNode output'
+);
+for (const k of Object.keys(vnode)) {
+	assert(copy[k] === vnode[k], 'cloneVNode dropped key: ' + k);
+}
+
+// cloneElement (the public clone API) also works under the flag.
+const re = cloneElement(vnode, { id: 'y' });
+assert(re.props.id === 'y', 'cloneElement did not override prop');
+assert(isValidElement(re), 'cloneElement output failed isValidElement');
+
+console.log('OK');

--- a/test/node/frozen-intrinsics.test.js
+++ b/test/node/frozen-intrinsics.test.js
@@ -1,0 +1,65 @@
+import { expect } from 'chai';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildSync } from 'esbuild';
+
+// Boot Preact in a real `node --frozen-intrinsics` subprocess.
+//
+// Note: current Node tames the override mistake under this flag (it replaces
+// `Object.prototype.constructor` with an accessor pair), so this does NOT
+// directly trip the bug fixed by `cloneVNode` — that path is unit-tested in
+// `object-prototype-freeze.test.js`. What this adds is end-to-end smoke
+// coverage that module init and the public API work under Node's recommended
+// hardening flag, plus a sentinel (in the subprocess script) that fails
+// loudly if a future Node drops the taming and the bug becomes reproducible
+// here.
+//
+// The subprocess code lives in a sibling file so it is linted and
+// IDE-resolved; we bundle it with esbuild (already a devDep) so the test
+// runs from a fresh checkout without `npm run build`.
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const subprocessEntry = path.join(__dirname, 'frozen-intrinsics.subprocess.js');
+
+describe('node --frozen-intrinsics compatibility', () => {
+	it('Preact loads and core API works under Node hardening', () => {
+		const built = buildSync({
+			entryPoints: [subprocessEntry],
+			bundle: true,
+			format: 'esm',
+			platform: 'node',
+			target: 'node18',
+			write: false
+		});
+
+		const tmpDir = mkdtempSync(path.join(tmpdir(), 'preact-frozen-'));
+		const scriptFile = path.join(tmpDir, 'run.mjs');
+		writeFileSync(scriptFile, built.outputFiles[0].text);
+
+		const result = spawnSync(
+			process.execPath,
+			// --no-warnings mutes the "ExperimentalWarning: Frozen intrinsics"
+			// notice so stderr stays readable when the test fails.
+			['--frozen-intrinsics', '--no-warnings', scriptFile],
+			{ encoding: 'utf8' }
+		);
+
+		if (result.status !== 0) {
+			throw new Error(
+				'frozen-intrinsics subprocess failed (status=' +
+					result.status +
+					', signal=' +
+					result.signal +
+					')\nstdout:\n' +
+					result.stdout +
+					'\nstderr:\n' +
+					result.stderr
+			);
+		}
+
+		expect(result.stdout.trim()).to.equal('OK');
+	});
+});

--- a/test/node/object-prototype-freeze.test.js
+++ b/test/node/object-prototype-freeze.test.js
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+import { createElement } from '../../src/index';
+import { cloneVNode } from '../../src/util';
+
+// Under Hardened JavaScript (https://hardenedjs.org/),
+// `Object.prototype.constructor` is non-writable. Freezing `Object.prototype`
+// outright is the narrowest reproduction of that failure mode. We freeze
+// AFTER importing so module init can still complete; the freeze is one-way
+// per realm, so this file lives in `test/node/` where each test file runs in
+// an isolated worker.
+describe('Object.freeze(Object.prototype) compatibility', () => {
+	beforeAll(() => {
+		Object.freeze(Object.prototype);
+	});
+
+	it('Object.prototype is frozen and its constructor is non-writable', () => {
+		expect(Object.isFrozen(Object.prototype)).to.equal(true);
+		expect(
+			Object.getOwnPropertyDescriptor(Object.prototype, 'constructor').writable
+		).to.equal(false);
+	});
+
+	// The original failure: vnodes have `constructor: undefined` as an own
+	// property (JSON-injection guard, see createVNode), and a bare
+	// `Object.assign({}, vnode)` walks up to the now-frozen
+	// `Object.prototype.constructor` and throws.
+	it('Object.assign({}, vnode) throws under frozen Object.prototype', () => {
+		const vnode = createElement('div', null, 'x');
+		expect(() => Object.assign({}, vnode)).to.throw(TypeError, /constructor/);
+	});
+
+	it('cloneVNode copies a vnode under frozen Object.prototype', () => {
+		const vnode = createElement('div', { id: 'x' }, 'hi');
+		let copy;
+		expect(() => {
+			copy = cloneVNode(vnode);
+		}).not.to.throw();
+
+		expect(copy).to.not.equal(vnode);
+		expect(copy.type).to.equal('div');
+		expect(copy.props).to.equal(vnode.props);
+		expect(copy.key).to.equal(vnode.key);
+		expect(copy.ref).to.equal(vnode.ref);
+		// constructor sentinel is preserved so isValidElement still recognizes
+		// the copy as a vnode.
+		expect(Object.prototype.hasOwnProperty.call(copy, 'constructor')).to.equal(
+			true
+		);
+		expect(copy.constructor).to.equal(undefined);
+	});
+
+	it('cloneVNode preserves all enumerable own properties of the source', () => {
+		const vnode = createElement('span', null, 'x');
+		const copy = cloneVNode(vnode);
+		for (const k of Object.keys(vnode)) {
+			expect(copy[k], k).to.equal(vnode[k]);
+		}
+	});
+});

--- a/test/shared/createElement.test.jsx
+++ b/test/shared/createElement.test.jsx
@@ -66,12 +66,14 @@ describe('createElement(jsx)', () => {
 	});
 
 	it('should have ordered VNode properties', () => {
+		// `constructor` comes first to match the vnode shape produced by
+		// `cloneVNode` (see src/util.js).
 		expect(Object.keys(<div />).filter(key => !/^_/.test(key))).to.deep.equal([
+			'constructor',
 			'type',
 			'props',
 			'key',
-			'ref',
-			'constructor'
+			'ref'
 		]);
 	});
 


### PR DESCRIPTION
Disclaimer: I (a human) identified this issue years ago and have always just worked around it via a local patch. I used an LLM (opus 4.7) to generate the fix. I reviewed the change and wrote most of the PR description.

This PR fixes a compatibility issue when Preact is run in [Hardened JavaScript](https://hardenedjs.org/) environments such as:
- [Nodejs with frozen intrinsics](https://nodejs.org/download/release/v12.22.12/docs/api/cli.html#cli_frozen_intrinsics), as recommended by Nodejs's own [Security Best Practices](https://nodejs.org/learn/getting-started/security-best-practices#monkey-patching-cwe-349).
- the [LavaMoat supplychain security runtime](https://github.com/lavamoat/lavamoat)

The compatibility issue comes from a javascript quirk known as ["the override mistake"](https://github.com/endojs/endo/discussions/1855) related to frozen intrinsics. For this bug, the minimal environment change is just `Object.freeze(Object.prototype)`.

In this environment, assigning the `constructor` property via assignment syntax (`=`) or `Object.assign` causes an error.
```
  TypeError: Cannot assign to read only property 'constructor'
```

Specifically, `Object.assign({}, vnode)` in `renderComponent()` (and `cloneNode` in `src/diff/index.js`) tries to copy a vnode's `constructor: undefined` own property via `[[Set]]`. Under environments with a frozen `Object.prototype` the `Object.prototype.constructor` is non-writable, so the assignment fails.

This PR introduces a `cloneVNode` utility that ensures `VNodes` are cloned safely. It also reorders the `constructor` key for consistent object shape between `VNodes` and their clones.

Note: I erred on the side of excessive documentation in comments, let me know if you would like this reduced.