### PR TITLE
Fix hydration when we have defaultValue or value on a textarea

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -474,7 +474,10 @@ function diffElementNodes(
 		}
 	} else {
 		// If excessDomChildren was not null, repopulate it with the current element's children:
-		excessDomChildren = excessDomChildren && slice.call(dom.childNodes);
+		excessDomChildren =
+			nodeType == 'textarea' && newProps.defaultValue != NULL
+				? NULL
+				: excessDomChildren && slice.call(dom.childNodes);
 
 		// If we are in a situation where we are not hydrating but are using
 		// existing DOM (e.g. replaceNode) we should read the existing DOM
@@ -562,7 +565,7 @@ function diffElementNodes(
 		}
 
 		// As above, don't diff props during hydration
-		if (!isHydrating) {
+		if (!isHydrating || nodeType == 'textarea') {
 			i = 'value';
 			if (nodeType == 'progress' && inputValue == NULL) {
 				dom.removeAttribute('value');

--- a/test/browser/hydrate.test.jsx
+++ b/test/browser/hydrate.test.jsx
@@ -67,6 +67,20 @@ describe('hydrate()', () => {
 		expect(scratch.firstChild.value).to.equal('foo');
 	});
 
+	// Test for preactjs/preact#5080
+	it('should respect textarea defaultValue in hydrate', () => {
+		scratch.innerHTML = '<textarea>foo</textarea>';
+		hydrate(<textarea defaultValue="foo" />, scratch);
+		expect(scratch.firstChild.value).to.equal('foo');
+		expect(scratch.firstChild.defaultValue).to.equal('foo');
+	});
+
+	it('should respect textarea value in hydrate', () => {
+		scratch.innerHTML = '<textarea>foo</textarea>';
+		hydrate(<textarea value="foo" />, scratch);
+		expect(scratch.firstChild.value).to.equal('foo');
+	});
+
 	it('should respect defaultChecked in hydrate', () => {
 		scratch.innerHTML = '<input checked="true">';
 		hydrate(<input defaultChecked />, scratch);


### PR DESCRIPTION
Fixes #5080.

## Summary
- Preserve SSR textarea text during hydration when using `defaultValue`
- Re-apply controlled textarea `value` during hydration
- Add hydration coverage for textarea `defaultValue` and `value`