### PR TITLE
Fix trusted publishing workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,8 +29,6 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: 'package.json'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
       - run: npm ci
       - name: test
         env:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,15 +15,18 @@ on:
         required: false
         default: 'npm-package'
 
+permissions:
+  contents: read
+
 jobs:
   build_test:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.ref || '' }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: 'package.json'
           cache: 'npm'
@@ -37,7 +40,7 @@ jobs:
         # Not using `npm test` since it rebuilds source which npm ci has already done
         run: npm run lint && npm run test:unit
       - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@v2.3.0
+        uses: coverallsapp/github-action@643bc377ffa44ace6394b2b5d0d3950076de9f63 # v2.3.0
         timeout-minutes: 2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -48,7 +51,7 @@ jobs:
           npm pack --ignore-scripts
           mv preact-*.tgz preact.tgz
       - name: Upload npm package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ inputs.artifact_name || 'npm-package' }}
           path: preact.tgz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,15 @@ on:
     tags:
       - '10.*'
 
+permissions:
+  contents: read
+
 jobs:
   build:
-    uses: preactjs/preact/.github/workflows/build-test.yml@v10.x
+    if: github.event.deleted == false
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-test.yml
 
   release:
     runs-on: ubuntu-latest
@@ -50,25 +56,62 @@ jobs:
         with:
           name: npm-package
 
-      - name: Update npm
-        run: npm install -g npm@11.11
-
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version-file: 'package.json'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm
+        run: npm install -g npm@11.11.1
+
+      - name: Validate package
+        run: |
+          set -euo pipefail
+
+          TAG="${GITHUB_REF_NAME}"
+          mkdir -p package-metadata
+          tar -xOf preact.tgz package/package.json > package-metadata/package.json
+
+          PACKAGE_NAME="$(node -p "require('./package-metadata/package.json').name")"
+          PACKAGE_VERSION="$(node -p "require('./package-metadata/package.json').version")"
+
+          if [[ "$PACKAGE_NAME" != "preact" ]]; then
+            echo "::error::Expected package name 'preact', got '$PACKAGE_NAME'"
+            exit 1
+          fi
+
+          if [[ "$PACKAGE_VERSION" != "$TAG" ]]; then
+            echo "::error::Tag '$TAG' does not match package version '$PACKAGE_VERSION'"
+            exit 1
+          fi
+
       # Determine the npm dist-tag from the git tag:
-      # - Prerelease versions (e.g. 10.29.0-rc.1) publish with --tag matching
-      #   the prerelease identifier (rc, alpha, beta, etc.)
       # - Stable versions publish with --tag latest
+      # - Prerelease versions must use an approved prerelease identifier as the
+      #   dist-tag (10.29.0-rc.1 -> rc, 10.29.0-beta.1 -> beta)
       - name: Determine dist-tag
         id: dist-tag
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          if [[ "$TAG" =~ -([a-zA-Z]+) ]]; then
-            echo "tag=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
-          else
+          set -euo pipefail
+
+          TAG="${GITHUB_REF_NAME}"
+          if [[ "$TAG" =~ ^10\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
             echo "tag=latest" >> "$GITHUB_OUTPUT"
+          elif [[ "$TAG" =~ ^10\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-([0-9A-Za-z-]+)(\.[0-9A-Za-z-]+)*$ ]]; then
+            DIST_TAG="${BASH_REMATCH[3]}"
+            case "$DIST_TAG" in
+              alpha|beta|rc|next)
+                echo "tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+                ;;
+              *)
+                echo "::error::Refusing to publish prerelease '$TAG' with unapproved npm dist-tag '$DIST_TAG'"
+                exit 1
+                ;;
+            esac
+          else
+            echo "::error::Unexpected release tag '$TAG'"
+            exit 1
           fi
+
       - name: Publish to npm
-        run: npm publish preact.tgz --provenance --tag ${{ steps.dist-tag.outputs.tag }}
+        run: npm publish preact.tgz --provenance --access public --tag "${{ steps.dist-tag.outputs.tag }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,14 +194,17 @@ We closely watch our issues and have a pretty active [Slack workspace](https://c
 This guide is intended for core team members that have the necessary
 rights to publish new releases on npm.
 
+Before using the automated npm publishing flow, make sure npm trusted publishing is configured for the `preactjs/preact` repository, the `release.yml` workflow, and the `npm` environment. The GitHub `npm` environment should require reviewer approval, and repository rules should protect `10.*` tags.
+
 1. Make a PR where **only** the version number is incremented in `package.json` and everywhere else. A simple search and replace works. (note: We follow `SemVer` conventions)
 2. Wait until the PR is approved and merged.
 3. Switch back to the `v10.x` branch and pull the merged PR
 4. Create and push a tag for the new version you want to publish:
    1. `git tag 10.0.0`
-   2. `git push --tags`
+   2. `git push origin 10.0.0`
 5. Wait for the Release workflow to reach the `npm` environment approval gate, approve it, and let it complete
-   - It'll create a draft release and upload the built npm package as an asset to the release
+   - It'll validate that the tag matches the package version, create a draft release, upload the built npm package as a release asset, and publish it to npm.
+   - Stable releases publish to the `latest` npm dist-tag; prereleases publish to the approved prerelease dist-tag (`alpha`, `beta`, `rc`, or `next`).
 6. [Fill in the release notes](#writing-release-notes) in GitHub and publish them
 7. Tweet it out
 


### PR DESCRIPTION
## Summary

- Fix the npm publish job by setting up Node 24 before updating npm to 11.11.1
- Validate that `preact.tgz` contains the `preact` package and that its version matches the pushed git tag before publishing
- Make prerelease npm dist-tags fail closed to approved identifiers (`alpha`, `beta`, `rc`, `next`) instead of falling back to `latest`
- Use the local reusable build workflow for release builds and pin the actions that produce the release artifact
- Document trusted publisher/environment prerequisites and push only the intended release tag

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml .github/workflows/build-test.yml`
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json ok')"`
- Manually exercised the dist-tag parsing for stable, rc/beta, numeric prerelease, unknown prerelease, and non-10.x tags
- Manually exercised the package tarball validation snippet against a test `preact.tgz`

## Notes

Out-of-band repository/package settings still need to be correct for trusted publishing: npm should trust `preactjs/preact` + `release.yml` + the `npm` environment, the GitHub `npm` environment should require reviewers, and repo rules should protect `10.*` tags.
