### PR TITLE
Add trusted publishing workflow for main

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,19 +15,20 @@ on:
         required: false
         default: 'npm-package'
 
+permissions:
+  contents: read
+
 jobs:
   build_test:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.ref || '' }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: 'package.json'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
       - run: npm ci
       - name: test
         env:
@@ -37,7 +38,7 @@ jobs:
         # Not using `npm test` since it rebuilds source which npm ci has already done
         run: npm run lint && npm run test:unit
       - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@v2.3.0
+        uses: coverallsapp/github-action@643bc377ffa44ace6394b2b5d0d3950076de9f63 # v2.3.0
         timeout-minutes: 2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -48,7 +49,7 @@ jobs:
           npm pack --ignore-scripts
           mv preact-*.tgz preact.tgz
       - name: Upload npm package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ inputs.artifact_name || 'npm-package' }}
           path: preact.tgz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,117 @@
 name: Release
-on: create
+
+on:
+  push:
+    tags:
+      - '11.*'
+
+permissions:
+  contents: read
 
 jobs:
   build:
-    if: github.ref_type == 'tag'
-    uses: preactjs/preact/.github/workflows/build-test.yml@main
+    if: github.event.deleted == false
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-test.yml
 
   release:
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: npm-package
       - name: Create draft release
         id: create-release
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const script = require('./scripts/release/create-gh-release.js')
             return script({ github, context })
       - name: Upload release artifact
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        env:
+          RELEASE_DATA: ${{ steps.create-release.outputs.result }}
         with:
           script: |
             const script = require('./scripts/release/upload-gh-asset.js')
-            return script({ require, github, context, glob, release: ${{ steps.create-release.outputs.result }} })
+            const release = JSON.parse(process.env.RELEASE_DATA)
+            return script({ require, github, context, glob, release })
+
+  publish:
+    needs: [build, release]
+    runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/preact
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: npm-package
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm
+        run: npm install -g npm@11.11.1
+
+      - name: Validate package
+        run: |
+          set -euo pipefail
+
+          TAG="${GITHUB_REF_NAME}"
+          mkdir -p package-metadata
+          tar -xOf preact.tgz package/package.json > package-metadata/package.json
+
+          PACKAGE_NAME="$(node -p "require('./package-metadata/package.json').name")"
+          PACKAGE_VERSION="$(node -p "require('./package-metadata/package.json').version")"
+
+          if [[ "$PACKAGE_NAME" != "preact" ]]; then
+            echo "::error::Expected package name 'preact', got '$PACKAGE_NAME'"
+            exit 1
+          fi
+
+          if [[ "$PACKAGE_VERSION" != "$TAG" ]]; then
+            echo "::error::Tag '$TAG' does not match package version '$PACKAGE_VERSION'"
+            exit 1
+          fi
+
+      # Determine the npm dist-tag from the git tag:
+      # - Stable versions publish with --tag latest
+      # - Prerelease versions must use an approved prerelease identifier as the
+      #   dist-tag (11.0.0-rc.1 -> rc, 11.0.0-beta.1 -> beta)
+      - name: Determine dist-tag
+        id: dist-tag
+        run: |
+          set -euo pipefail
+
+          TAG="${GITHUB_REF_NAME}"
+          if [[ "$TAG" =~ ^11\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          elif [[ "$TAG" =~ ^11\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-([0-9A-Za-z-]+)(\.[0-9A-Za-z-]+)*$ ]]; then
+            DIST_TAG="${BASH_REMATCH[3]}"
+            case "$DIST_TAG" in
+              alpha|beta|rc|next)
+                echo "tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+                ;;
+              *)
+                echo "::error::Refusing to publish prerelease '$TAG' with unapproved npm dist-tag '$DIST_TAG'"
+                exit 1
+                ;;
+            esac
+          else
+            echo "::error::Unexpected release tag '$TAG'"
+            exit 1
+          fi
+
+      - name: Publish to npm
+        run: npm publish preact.tgz --provenance --access public --tag "${{ steps.dist-tag.outputs.tag }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,20 +193,19 @@ We closely watch our issues and have a pretty active [Slack workspace](https://c
 This guide is intended for core team members that have the necessary
 rights to publish new releases on npm.
 
+Before using the automated npm publishing flow, make sure npm trusted publishing is configured for the `preactjs/preact` repository, the `release.yml` workflow, and the `npm` environment. The GitHub `npm` environment should require reviewer approval, and repository rules should protect `11.*` tags.
+
 1. Make a PR where **only** the version number is incremented in `package.json` and everywhere else. A simple search and replace works. (note: We follow `SemVer` conventions)
 2. Wait until the PR is approved and merged.
 3. Switch back to the `main` branch and pull the merged PR
 4. Create and push a tag for the new version you want to publish:
-   1. `git tag 10.0.0`
-   2. `git push --tags`
-5. Wait for the Release workflow to complete
-   - It'll create a draft release and upload the built npm package as an asset to the release
+   1. `git tag 11.0.0`
+   2. `git push origin 11.0.0`
+5. Wait for the Release workflow to reach the `npm` environment approval gate, approve it, and let it complete
+   - It'll validate that the tag matches the package version, create a draft release, upload the built npm package as a release asset, and publish it to npm.
+   - Stable releases publish to the `latest` npm dist-tag; prereleases publish to the approved prerelease dist-tag (`alpha`, `beta`, `rc`, or `next`).
 6. [Fill in the release notes](#writing-release-notes) in GitHub and publish them
-7. Run the publish script with the tag you created
-   1. `node ./scripts/release/publish.mjs 10.0.0`
-   2. Make sure you have 2FA enabled in npm, otherwise the above command will fail.
-   3. If you're doing a pre-release add `--npm-tag next` to the `publish.mjs` command to publish it under a different tag (default is `latest`)
-8. Tweet it out
+7. Tweet it out
 
 ## Legacy Releases (8.x)
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "amdName": "preact",
   "version": "11.0.0-beta.1",
   "private": false,
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "description": "Fast 4kb React-compatible Virtual DOM library.",
   "main": "dist/preact.js",
   "module": "dist/preact.mjs",


### PR DESCRIPTION
Ports the trusted publishing release workflow changes from the v10.x PRs to main for 11.x releases.

- switches the release workflow to 11.* tag pushes
- publishes the built package through npm trusted publishing with provenance
- adds the npm environment approval gate
- validates the package name/version against the pushed tag before publishing
- restricts prerelease dist-tags to alpha, beta, rc, and next
- pins release-path actions
- removes dependency caching from the release build path
- documents the automated publishing flow and adds publishConfig provenance