### PR TITLE
Forwardport v10.x fixes since 2026-03-25

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Request review for GitHub configuration changes.
+.github/ @JoviDeCroock

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -128,6 +128,14 @@ export function diffChildren(
 		let shouldPlace = childVNode._flags & INSERT_VNODE;
 		if (shouldPlace || oldVNode._children === childVNode._children) {
 			oldDom = insert(childVNode, oldDom, parentDom, shouldPlace);
+
+			// When a matched VNode is physically moved via INSERT_VNODE, its old
+			// _dom pointer becomes a stale positional reference. Clear it so that
+			// getDomSibling (called from nested diffs) won't return this stale
+			// reference and mis-place subsequent DOM nodes. See #5065.
+			if (shouldPlace && oldVNode._dom) {
+				oldVNode._dom = NULL;
+			}
 		} else if (typeof childVNode.type == 'function' && result !== UNDEFINED) {
 			oldDom = result;
 		} else if (newDom) {

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -528,7 +528,10 @@ function diffElementNodes(
 		}
 	} else {
 		// If excessDomChildren was not null, repopulate it with the current element's children:
-		excessDomChildren = excessDomChildren && slice.call(dom.childNodes);
+		excessDomChildren =
+			nodeType == 'textarea' && newProps.defaultValue != NULL
+				? NULL
+				: excessDomChildren && slice.call(dom.childNodes);
 
 		// If we are in a situation where we are not hydrating but are using
 		// existing DOM (e.g. replaceNode) we should read the existing DOM
@@ -625,7 +628,7 @@ function diffElementNodes(
 		}
 
 		// As above, don't diff props during hydration
-		if (!isHydrating) {
+		if (!isHydrating || nodeType == 'textarea') {
 			i = 'value';
 			if (nodeType == 'progress' && inputValue == NULL) {
 				dom.removeAttribute('value');

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -1,6 +1,17 @@
 import { NULL, SVG_NAMESPACE } from '../constants';
 import options from '../options';
 
+// Per-instance unique key for event clock stamps. Each Preact copy on the page
+// gets its own random suffix so that `_dispatched` / `_attached` properties on
+// shared event objects and handler functions cannot collide across instances.
+// ~1 in 60M collision odds - if you have that many praect versions on the page,
+// you deserve some weird bugs.
+// In 11 we can replace this with a
+// Symbol
+let _id = Math.random().toString(8),
+	EVENT_DISPATCHED = '__d' + _id,
+	EVENT_ATTACHED = '__a' + _id;
+
 function setStyle(style, key, value) {
 	if (key[0] == '-') {
 		style.setProperty(key, value == NULL ? '' : value);
@@ -74,14 +85,14 @@ export function setProperty(dom, name, value, oldValue, namespace) {
 
 		if (value) {
 			if (!oldValue) {
-				value._attached = eventClock;
+				value[EVENT_ATTACHED] = eventClock;
 				dom.addEventListener(
 					name,
 					useCapture ? eventProxyCapture : eventProxy,
 					useCapture
 				);
 			} else {
-				value._attached = oldValue._attached;
+				value[EVENT_ATTACHED] = oldValue[EVENT_ATTACHED];
 			}
 		} else {
 			dom.removeEventListener(
@@ -150,13 +161,13 @@ function createEventProxy(useCapture) {
 	return function (e) {
 		if (this._listeners) {
 			const eventHandler = this._listeners[e.type + useCapture];
-			if (e._dispatched == NULL) {
-				e._dispatched = eventClock++;
+			if (e[EVENT_DISPATCHED] == NULL) {
+				e[EVENT_DISPATCHED] = eventClock++;
 
-				// When `e._dispatched` is smaller than the time when the targeted event
+				// When `e[EVENT_DISPATCHED]` is smaller than the time when the targeted event
 				// handler was attached we know we have bubbled up to an element that was added
 				// during patching the DOM.
-			} else if (e._dispatched < eventHandler._attached) {
+			} else if (e[EVENT_DISPATCHED] < eventHandler[EVENT_ATTACHED]) {
 				return;
 			}
 			return eventHandler(options.event ? options.event(e) : e);

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -127,7 +127,9 @@ export interface PreactElement extends preact.ContainerNode {
 }
 
 export interface PreactEvent extends Event {
-	_dispatched?: number;
+	// Keyed by a per-instance unique string (e.g. `__dXXXXX`) so that
+	// multiple Preact copies on the same page don't share event clock stamps.
+	[key: string]: any;
 }
 
 // We use the `current` property to differentiate between the two kinds of Refs so

--- a/test/browser/hydrate.test.jsx
+++ b/test/browser/hydrate.test.jsx
@@ -69,6 +69,20 @@ describe('hydrate()', () => {
 		expect(scratch.firstChild.value).to.equal('foo');
 	});
 
+	// Test for preactjs/preact#5080
+	it('should respect textarea defaultValue in hydrate', () => {
+		scratch.innerHTML = '<textarea>foo</textarea>';
+		hydrate(<textarea defaultValue="foo" />, scratch);
+		expect(scratch.firstChild.value).to.equal('foo');
+		expect(scratch.firstChild.defaultValue).to.equal('foo');
+	});
+
+	it('should respect textarea value in hydrate', () => {
+		scratch.innerHTML = '<textarea>foo</textarea>';
+		hydrate(<textarea value="foo" />, scratch);
+		expect(scratch.firstChild.value).to.equal('foo');
+	});
+
 	it('should respect defaultChecked in hydrate', () => {
 		scratch.innerHTML = '<input checked="true">';
 		hydrate(<input defaultChecked />, scratch);

--- a/test/browser/keys.test.jsx
+++ b/test/browser/keys.test.jsx
@@ -1,4 +1,11 @@
-import { createElement, Component, render, createRef } from 'preact';
+import {
+	createElement,
+	Component,
+	render,
+	createRef,
+	createContext,
+	Fragment
+} from 'preact';
 import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../_util/helpers';
 import { logCall, clearLog, getLog } from '../_util/logCall';
@@ -1165,5 +1172,218 @@ describe('keys', () => {
 			'<li>.appendChild(#text)',
 			'<ol>2345.appendChild(<li>6)'
 		]);
+	});
+
+	// https://github.com/preactjs/preact/issues/5065
+	it('should maintain correct DOM order with conditional ContextProvider and inner keys', () => {
+		const Ctx = createContext(null);
+
+		class Label extends Component {
+			render({ todo }) {
+				return <li key={todo.text}>{todo.text}</li>;
+			}
+		}
+
+		class App extends Component {
+			render() {
+				const { todos } = this.props;
+				return (
+					<ul>
+						{todos.map((todo, index) =>
+							todo.text === '1' || todo.text === '2' || todo.text === '3' ? (
+								<Ctx.Provider value={null}>
+									<Label todo={todo} index={index} />
+								</Ctx.Provider>
+							) : (
+								<Label todo={todo} index={index} />
+							)
+						)}
+					</ul>
+				);
+			}
+		}
+
+		// Initial: 3 collapsed rows
+		render(
+			<App todos={[{ text: '1' }, { text: '2' }, { text: '3' }]} />,
+			scratch
+		);
+		expect(scratch.querySelector('ul').textContent).to.equal('123');
+
+		// Expand row 1: adds sub-items 1A, 1B, 1C (not wrapped in Provider)
+		render(
+			<App
+				todos={[
+					{ text: '1' },
+					{ text: '1A' },
+					{ text: '1B' },
+					{ text: '1C' },
+					{ text: '2' },
+					{ text: '3' }
+				]}
+			/>,
+			scratch
+		);
+		expect(scratch.querySelector('ul').textContent).to.equal('11A1B1C23');
+
+		// Expand row 2: adds sub-items 2A, 2B, 2C
+		render(
+			<App
+				todos={[
+					{ text: '1' },
+					{ text: '1A' },
+					{ text: '1B' },
+					{ text: '1C' },
+					{ text: '2' },
+					{ text: '2A' },
+					{ text: '2B' },
+					{ text: '2C' },
+					{ text: '3' }
+				]}
+			/>,
+			scratch
+		);
+		expect(scratch.querySelector('ul').textContent).to.equal('11A1B1C22A2B2C3');
+
+		// Collapse row 1: removes 1A, 1B, 1C
+		render(
+			<App
+				todos={[
+					{ text: '1' },
+					{ text: '2' },
+					{ text: '2A' },
+					{ text: '2B' },
+					{ text: '2C' },
+					{ text: '3' }
+				]}
+			/>,
+			scratch
+		);
+		expect(scratch.querySelector('ul').textContent).to.equal('122A2B2C3');
+	});
+
+	// https://github.com/preactjs/preact/issues/5065
+	it('should maintain correct DOM order when collapsing row 2 with conditional Provider', () => {
+		const Ctx = createContext(null);
+
+		class Label extends Component {
+			render({ todo }) {
+				return <li key={todo.text}>{todo.text}</li>;
+			}
+		}
+
+		class App extends Component {
+			render() {
+				const { todos } = this.props;
+				return (
+					<ul>
+						{todos.map((todo, index) =>
+							todo.text === '1' || todo.text === '2' || todo.text === '3' ? (
+								<Ctx.Provider value={null}>
+									<Label todo={todo} index={index} />
+								</Ctx.Provider>
+							) : (
+								<Label todo={todo} index={index} />
+							)
+						)}
+					</ul>
+				);
+			}
+		}
+
+		// Both rows expanded
+		render(
+			<App
+				todos={[
+					{ text: '1' },
+					{ text: '1A' },
+					{ text: '1B' },
+					{ text: '1C' },
+					{ text: '2' },
+					{ text: '2A' },
+					{ text: '2B' },
+					{ text: '2C' },
+					{ text: '3' }
+				]}
+			/>,
+			scratch
+		);
+		expect(scratch.querySelector('ul').textContent).to.equal('11A1B1C22A2B2C3');
+
+		// Collapse row 2: removes 2A, 2B, 2C
+		render(
+			<App
+				todos={[
+					{ text: '1' },
+					{ text: '1A' },
+					{ text: '1B' },
+					{ text: '1C' },
+					{ text: '2' },
+					{ text: '3' }
+				]}
+			/>,
+			scratch
+		);
+		expect(scratch.querySelector('ul').textContent).to.equal('11A1B1C23');
+	});
+
+	// https://github.com/preactjs/preact/issues/5065
+	it('should maintain correct DOM order expanding then collapsing with conditional Provider', () => {
+		const Ctx = createContext(null);
+
+		class Label extends Component {
+			render({ todo }) {
+				return <li key={todo.text}>{todo.text}</li>;
+			}
+		}
+
+		class App extends Component {
+			render() {
+				const { todos } = this.props;
+				return (
+					<ul>
+						{todos.map((todo, index) =>
+							todo.text === '1' || todo.text === '2' || todo.text === '3' ? (
+								<Ctx.Provider value={null}>
+									<Label todo={todo} index={index} />
+								</Ctx.Provider>
+							) : (
+								<Label todo={todo} index={index} />
+							)
+						)}
+					</ul>
+				);
+			}
+		}
+
+		// Initial: 3 rows collapsed
+		render(
+			<App todos={[{ text: '1' }, { text: '2' }, { text: '3' }]} />,
+			scratch
+		);
+		expect(scratch.querySelector('ul').textContent).to.equal('123');
+
+		// Expand row 1
+		render(
+			<App
+				todos={[
+					{ text: '1' },
+					{ text: '1A' },
+					{ text: '1B' },
+					{ text: '1C' },
+					{ text: '2' },
+					{ text: '3' }
+				]}
+			/>,
+			scratch
+		);
+		expect(scratch.querySelector('ul').textContent).to.equal('11A1B1C23');
+
+		// Collapse row 1
+		render(
+			<App todos={[{ text: '1' }, { text: '2' }, { text: '3' }]} />,
+			scratch
+		);
+		expect(scratch.querySelector('ul').textContent).to.equal('123');
 	});
 });

--- a/test/browser/keys.test.jsx
+++ b/test/browser/keys.test.jsx
@@ -3,8 +3,7 @@ import {
 	Component,
 	render,
 	createRef,
-	createContext,
-	Fragment
+	createContext
 } from 'preact';
 import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../_util/helpers';


### PR DESCRIPTION
## Summary
- forwardport the DOM ordering fix for conditional providers with keyed inner children (#5065 / #5067)
- forwardport the per-instance event clock fix for multiple Preact copies on one page (#5068)
- forwardport the textarea hydration fix for `value` / `defaultValue` migrations (#5081)
- add `.github/CODEOWNERS` from v10.x (#5088)

## Notes
- I did **not** forwardport the v10-only release/versioning commits from this window (`10.29.1`, trusted publishing adjustments, and the Playwright postinstall change) because main already has the relevant publishing/test setup or those changes are branch-version specific.
- I also dropped an unused `Fragment` import introduced by the backported test.

## Test Plan
- [x] `./node_modules/.bin/vitest run test/browser/keys.test.jsx test/browser/hydrate.test.jsx`
- [x] `MINIFY=true ./node_modules/.bin/vitest run test/browser/keys.test.jsx test/browser/hydrate.test.jsx`
- [x] `npm run test:ts`
- [x] `npm run lint`
