### PR TITLE
fix: accept Signalish for input type

### DIFF
--- a/src/dom.d.ts
+++ b/src/dom.d.ts
@@ -2130,6 +2130,7 @@ export interface PartialInputHTMLAttributes<T extends EventTarget>
 	size?: Signalish<number | undefined>;
 	src?: Signalish<string | undefined>;
 	step?: Signalish<number | string | undefined>;
+	type?: Signalish<HTMLInputTypeAttribute | undefined>;
 	value?: Signalish<string | number | undefined>;
 	width?: Signalish<number | string | undefined>;
 	onChange?: GenericEventHandler<T> | undefined;

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -416,6 +416,15 @@ h<InputHTMLAttributes>('input', { onClick: e => e.currentTarget.capture });
 createElement<InputHTMLAttributes>('input', {
 	onClick: e => e.currentTarget.capture
 });
+
+const inputAttributesWithSignalType: InputHTMLAttributes<HTMLInputElement> = {
+	type: createSignal('text' as const)
+};
+
+createElement<InputHTMLAttributes>('input', {
+	type: createSignal('email' as const)
+});
+
 <input onClick={e => e.currentTarget.capture} />;
 
 function Checkbox({ onChange }: HTMLAttributes<HTMLInputElement>) {


### PR DESCRIPTION
- Allow `InputHTMLAttributes.type` to accept `Signalish`
- Add a type test covering signal-backed `input` types
- `npm run test:ts:core`

Closes #5094
