### PR TITLE
fix: accept Signalish for input type

### DIFF
--- a/src/dom.d.ts
+++ b/src/dom.d.ts
@@ -1874,7 +1874,7 @@ export interface InputHTMLAttributes<
 	size?: Signalish<number | undefined>;
 	src?: Signalish<string | undefined>;
 	step?: Signalish<number | string | undefined>;
-	type?: HTMLInputTypeAttribute | undefined;
+	type?: Signalish<HTMLInputTypeAttribute | undefined>;
 	value?: Signalish<string | number | undefined>;
 	width?: Signalish<number | string | undefined>;
 	onChange?: GenericEventHandler<T> | undefined;

--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -1997,7 +1997,7 @@ export namespace JSXInternal {
 		size?: Signalish<number | undefined>;
 		src?: Signalish<string | undefined>;
 		step?: Signalish<number | string | undefined>;
-		type?: HTMLInputTypeAttribute | undefined;
+		type?: Signalish<HTMLInputTypeAttribute | undefined>;
 		value?: Signalish<string | number | undefined>;
 		width?: Signalish<number | string | undefined>;
 		onChange?: GenericEventHandler<T> | undefined;

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -408,6 +408,15 @@ h<JSX.InputHTMLAttributes>('input', { onClick: e => e.currentTarget.capture });
 createElement<JSX.InputHTMLAttributes>('input', {
 	onClick: e => e.currentTarget.capture
 });
+
+const inputAttributesWithSignalType: JSX.InputHTMLAttributes<HTMLInputElement> = {
+	type: createSignal('text' as const)
+};
+
+createElement<JSX.InputHTMLAttributes>('input', {
+	type: createSignal('email' as const)
+});
+
 <input onClick={e => e.currentTarget.capture} />;
 
 function Checkbox({ onChange }: JSX.HTMLAttributes<HTMLInputElement>) {


### PR DESCRIPTION
- Allow `InputHTMLAttributes.type` to accept `Signalish` on `v10.x`
- Update both namespace typings and the type test
- Refs #5094
