### PR TITLE
fix: remove erroneous 'type' attribute from select element types

### DIFF
--- a/src/dom.d.ts
+++ b/src/dom.d.ts
@@ -2639,7 +2639,6 @@ export interface SelectHTMLAttributes<T extends EventTarget = HTMLSelectElement>
 	extends PartialSelectHTMLAttributes<T> {
 	multiple?: Signalish<boolean | undefined>;
 	size?: Signalish<number | undefined>;
-	type?: Signalish<HTMLInputTypeAttribute | undefined>;
 	role?: Signalish<'combobox' | 'listbox' | 'menu' | undefined>;
 }
 


### PR DESCRIPTION
Mistake from #4882

Spotted when reviewing the input type PRs, noticed we were also using that type here which is incorrect. v10.x looks fine as it wasn't involved w/ the accessible roles changes