### PR TITLE
Use npm staged publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm
-        run: npm install -g npm@11.11.1
+        run: npm install -g npm@11.15.0
 
       - name: Validate package
         run: |
@@ -114,4 +114,4 @@ jobs:
           fi
 
       - name: Publish to npm
-        run: npm publish preact.tgz --provenance --access public --tag "${{ steps.dist-tag.outputs.tag }}"
+        run: npm stage publish preact.tgz --provenance --access public --tag "${{ steps.dist-tag.outputs.tag }}"


### PR DESCRIPTION
Updates the release workflow to stage npm packages with `npm stage publish` on npm 11.15. Maintainers can review the staged packages and approve them with 2FA before they go live.