### PR TITLE
Use npm staged publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm
-        run: npm install -g npm@11.11.1
+        run: npm install -g npm@11.15.0
 
       - name: Validate package
         run: |
@@ -114,4 +114,4 @@ jobs:
           fi
 
       - name: Publish to npm
-        run: npm publish preact.tgz --provenance --access public --tag "${{ steps.dist-tag.outputs.tag }}"
+        run: npm stage publish preact.tgz --provenance --access public --tag "${{ steps.dist-tag.outputs.tag }}"


### PR DESCRIPTION
## Summary
- Mirrors #5100 onto the `v10.x` branch
- Updates release workflow to npm 11.15.0
- Uses `npm stage publish` so maintainers can approve staged packages with 2FA before they go live

## Test Plan
- Verified `.github/workflows/release.yml` contains `npm install -g npm@11.15.0`
- Verified publish step uses `npm stage publish preact.tgz --provenance --access public --tag "${{ steps.dist-tag.outputs.tag }}"`
