### PR TITLE
ci: add explicit workflow-level permissions to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
       - restructure
       - v11
 
+permissions:
+  contents: read
+
 jobs:
   filter_jobs:
     name: Filter jobs


### PR DESCRIPTION
Declares `permissions: contents: read` at the workflow level for `ci.yml`.

The CI workflow is read-only. Setting an explicit minimum scope follows GitHub's [hardening guide](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) and the OpenSSF Scorecard Token-Permissions check, and limits blast radius if any third-party action used here is ever compromised (the March 2025 tj-actions/changed-files token-leak incident).

YAML parses cleanly. No other changes.
