### PR TITLE
fix(suspense): don't orphan server DOM when a hydration-suspended boundary resolves to non-matching content

### DIFF
--- a/compat/test/browser/suspense-hydration.test.jsx
+++ b/compat/test/browser/suspense-hydration.test.jsx
@@ -145,6 +145,35 @@ describe('suspense hydration', () => {
 		});
 	});
 
+	it('should remove server-rendered DOM but keep later siblings when resolving to different content', () => {
+		scratch.innerHTML = '<p>region</p><div>After</div>';
+		clearLog();
+
+		const [Lazy, resolve] = createLazy();
+		hydrate(
+			<Fragment>
+				<Suspense>
+					<Lazy />
+				</Suspense>
+				<div>After</div>
+			</Fragment>,
+			scratch
+		);
+		rerender(); // Flush rerender queue to mimic what preact will really do
+		expect(scratch.innerHTML).to.equal('<p>region</p><div>After</div>');
+		clearLog();
+
+		// The parked <p> is removed, but the sibling <div>After</div> that
+		// follows the boundary must stay in place. Guards against the leftover
+		// removal disturbing trailing siblings.
+		return resolve(() => <section>Goodbye</section>).then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.equal(
+				'<section>Goodbye</section><div>After</div>'
+			);
+		});
+	});
+
 	it('Should not crash when oldVNode._children is null during shouldComponentUpdate optimization', () => {
 		const originalHtml = '<div>Hello</div>';
 		scratch.innerHTML = originalHtml;

--- a/compat/test/browser/suspense-hydration.test.jsx
+++ b/compat/test/browser/suspense-hydration.test.jsx
@@ -97,6 +97,54 @@ describe('suspense hydration', () => {
 		});
 	});
 
+	it('should remove server-rendered DOM when suspending while hydrating then resolving to different content', () => {
+		scratch.innerHTML = '<div>Hello</div>';
+		clearLog();
+
+		const [Lazy, resolve] = createLazy();
+		hydrate(
+			<Suspense>
+				<Lazy />
+			</Suspense>,
+			scratch
+		);
+		rerender(); // Flush rerender queue to mimic what preact will really do
+		expect(scratch.innerHTML).to.equal('<div>Hello</div>');
+		clearLog();
+
+		return resolve(() => <section>Goodbye</section>).then(() => {
+			rerender();
+			// The boundary resolved to content that does NOT reuse the
+			// server-rendered <div>. The stale server DOM must be removed, not
+			// left orphaned alongside the new content.
+			expect(scratch.innerHTML).to.equal('<section>Goodbye</section>');
+		});
+	});
+
+	it('should remove server-rendered DOM when suspending while hydrating then resolving to null', () => {
+		scratch.innerHTML = '<div>Hello</div>';
+		clearLog();
+
+		const [Lazy, resolve] = createLazy();
+		hydrate(
+			<Suspense>
+				<Lazy />
+			</Suspense>,
+			scratch
+		);
+		rerender(); // Flush rerender queue to mimic what preact will really do
+		expect(scratch.innerHTML).to.equal('<div>Hello</div>');
+		clearLog();
+
+		// Mirrors a client-middleware redirect: the suspended boundary resolves
+		// to null (renders nothing) once the async work completes.
+		return resolve(() => null).then(() => {
+			rerender();
+			// The server-rendered <div> must be removed, not orphaned.
+			expect(scratch.innerHTML).to.equal('');
+		});
+	});
+
 	it('Should not crash when oldVNode._children is null during shouldComponentUpdate optimization', () => {
 		const originalHtml = '<div>Hello</div>';
 		scratch.innerHTML = originalHtml;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -269,6 +269,23 @@ export function diff(
 				refQueue
 			);
 
+			// When resuming a suspension that began while hydrating, the resume
+			// block above rebuilt excessDomChildren from the parked server DOM. If
+			// the resolved content did not reuse a parked node (it rendered a
+			// different element, or nothing), that node has no element ancestor in
+			// this re-entrant diff to clean it up the way diffElementNodes does for
+			// element children, so remove the leftovers here to avoid orphaning it.
+			if (oldVNode._flags & MODE_SUSPENDED && excessDomChildren != NULL) {
+				for (let i = excessDomChildren.length; i--; ) {
+					if (excessDomChildren[i] != NULL) {
+						if (excessDomChildren[i] == oldDom) {
+							oldDom = oldDom.nextSibling;
+						}
+						removeNode(excessDomChildren[i]);
+					}
+				}
+			}
+
 			c.base = newVNode._dom;
 
 			// We successfully rendered this VNode, unset any stored hydration/bailout state:

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -278,6 +278,10 @@ export function diff(
 			if (oldVNode._flags & MODE_SUSPENDED && excessDomChildren != NULL) {
 				for (let i = excessDomChildren.length; i--; ) {
 					if (excessDomChildren[i] != NULL) {
+						// If oldDom points at the node we're about to remove, advance it
+						// first so a stale, detached reference isn't returned as the
+						// insertion point (mirrors the oldDom handling before unmount in
+						// diffChildren's remaining-old-children removal).
 						if (excessDomChildren[i] == oldDom) {
 							oldDom = oldDom.nextSibling;
 						}


### PR DESCRIPTION
### What

A `<Suspense>` boundary that suspends *during hydration* and then resolves to content that does **not** reuse the server-rendered DOM (a different element, or `null`) leaves the original server DOM orphaned in the document instead of removing it.

### Repro

```jsx
scratch.innerHTML = '<div>Hello</div>';
const [Lazy, resolve] = createLazy();
hydrate(<Suspense><Lazy /></Suspense>, scratch);
rerender();
// resolve to different content:
await resolve(() => <section>Goodbye</section>);
rerender();
// expected: "<section>Goodbye</section>"
// actual:   "<section>Goodbye</section><div>Hello</div>"  <- server <div> orphaned
```

Resolving to `null` leaves `<div>Hello</div>` behind entirely. Same-content resolution is unaffected (it re-adopts the node by matching `localName`, which is why the existing "should leave DOM untouched when suspending while hydrating" test passes).

### Root cause

When a component suspends while hydrating, `diff`'s catch pins the server DOM as the suspended vnode's `_dom` and pulls it out of `excessDomChildren` so hydration won't delete it (flags `MODE_HYDRATE | MODE_SUSPENDED`). On resume, the resume block rebuilds `excessDomChildren = [parkedDom]` and re-enters hydrating mode. If the resolved content doesn't reuse the parked node, nothing removes it: excess-DOM cleanup only runs in `diffElementNodes` (for an element's own children), but the component-resume path calls `diffChildren` directly.

### Fix

After the resumed component's children are diffed, remove any leftover parked excess, advancing `oldDom` past a removed node the same way `diffChildren`'s own removal loop does. ~10 lines in `src/diff/index.js`.

### Testing

Two new cases in `compat/test/browser/suspense-hydration.test.jsx` (beside the existing same-content control). Full vitest suite green (1252 passed). oxfmt / oxlint / tsc clean.

### Note

This also reproduces on `main` (v11). Happy to port it there in a follow-up (or fold in here), whichever you prefer.
