### PR TITLE
ci: bump pinned GitHub actions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,19 +11,19 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Download locally built preact package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: npm-package
       - run: mv preact.tgz preact-local.tgz
       - name: Download base package
-        uses: andrewiggins/download-base-artifact@v3
+        uses: andrewiggins/download-base-artifact@53ea06f723a523ade534145b7ccc72c179fb96dd # v3.0.0
         with:
           artifact: npm-package
           workflow: ci.yml
           required: true
       - run: mv preact.tgz preact-main.tgz
       - name: Upload locally build & base preact package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-environment
           path: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,10 +23,10 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref || '' }}
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: 'package.json'
       - run: npm ci
@@ -38,7 +38,7 @@ jobs:
         # Not using `npm test` since it rebuilds source which npm ci has already done
         run: npm run lint && npm run test:unit
       - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@643bc377ffa44ace6394b2b5d0d3950076de9f63 # v2.3.0
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
         timeout-minutes: 2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
           npm pack --ignore-scripts
           mv preact-*.tgz preact.tgz
       - name: Upload npm package
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact_name || 'npm-package' }}
           path: preact.tgz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     outputs:
       jsChanged: ${{ steps.filter.outputs.jsChanged }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           # Should be kept in sync with the filter in the PR Reporter workflow

--- a/.github/workflows/pr-reporter.yml
+++ b/.github/workflows/pr-reporter.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       jsChanged: ${{ steps.filter.outputs.jsChanged }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Warning: This is kinda gnarly and weird! GitHub doesn't expose the `pull_request`
       # data if the PR is from a fork, nor does it let you access that data via their API
@@ -43,7 +43,7 @@ jobs:
 
           echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           # As this Workflow is triggered by a `workflow_run` event, the filter action
@@ -69,7 +69,7 @@ jobs:
       github.event.action == 'requested'
     steps:
       - name: Report Tachometer Running
-        uses: andrewiggins/tachometer-reporter-action@v2
+        uses: andrewiggins/tachometer-reporter-action@f4edc62a47169384c3f950a48f58000ce81cd07c # v2.4.1
         with:
           # Set initialize to true so this action just creates the comment or
           # adds the "benchmarks are running" text
@@ -88,7 +88,7 @@ jobs:
     steps:
       # Download the artifact from the triggering workflow that contains the
       # Tachometer results to report
-      - uses: dawidd6/action-download-artifact@v2
+      - uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           workflow: ${{ github.event.workflow.id }}
           run_id: ${{ github.event.workflow_run.id }}
@@ -98,7 +98,7 @@ jobs:
 
       # Create/update the comment with the latest results
       - name: Report Tachometer Results
-        uses: andrewiggins/tachometer-reporter-action@v2
+        uses: andrewiggins/tachometer-reporter-action@f4edc62a47169384c3f950a48f58000ce81cd07c # v2.4.1
         with:
           path: results/**/*.json
           base-bench-name: preact-main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,19 +21,19 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: npm-package
       - name: Create draft release
         id: create-release
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const script = require('./scripts/release/create-gh-release.js')
             return script({ github, context })
       - name: Upload release artifact
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RELEASE_DATA: ${{ steps.create-release.outputs.result }}
         with:
@@ -52,11 +52,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: npm-package
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           package-manager-cache: false
           node-version: '24'

--- a/.github/workflows/run-bench.yml
+++ b/.github/workflows/run-bench.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: 'recursive'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: 'package.json'
           cache: 'npm'
@@ -42,7 +42,7 @@ jobs:
 
       # Setup pnpm
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 8
           run_install: false
@@ -50,7 +50,7 @@ jobs:
         id: pnpm-cache
         run: |
           echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
@@ -59,7 +59,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       # Install benchmark dependencies
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bench-environment
       - name: Move tarballs from env to correct location
@@ -110,12 +110,12 @@ jobs:
           echo "clean_name=$NAME" >> $GITHUB_OUTPUT
           echo "artifact_name=logs_$NAME" >> $GITHUB_OUTPUT
       - name: Upload results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: results-${{ steps.log-artifact-name.outputs.clean_name }}
           path: benchmarks/out/results/${{ inputs.benchmark }}.json
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.log-artifact-name.outputs.artifact_name }}
           path: benchmarks/out/${{ inputs.benchmark }}_logs.tgz

--- a/.github/workflows/single-bench.yml
+++ b/.github/workflows/single-bench.yml
@@ -57,7 +57,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Download locally built preact package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: npm-package
       - run: mv preact.tgz preact-local.tgz
@@ -68,12 +68,12 @@ jobs:
           echo "===================="
           ls -al
       - name: Download base package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: base-npm-package
       - run: mv preact.tgz preact-main.tgz
       - name: Upload locally built & base preact package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-environment
           path: |

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -7,13 +7,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: 'package.json'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
-      - uses: preactjs/compressed-size-action@v2
+      - uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # 2.9.1
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           # Our `prepare` script already builds the app post-install,


### PR DESCRIPTION
Bumping GitHub Actions due to Node deprecation.

Pinned refs include version comments:
- actions/download-artifact: 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c -> v8.0.1
- andrewiggins/download-base-artifact: 53ea06f723a523ade534145b7ccc72c179fb96dd -> v3.0.0
- actions/upload-artifact: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a -> v7.0.1
- actions/checkout: df4cb1c069e1874edd31b4311f1884172cec0e10 -> v6.0.3
- actions/setup-node: 48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e -> v6.4.0
- coverallsapp/github-action: 5cbfd81b66ca5d10c19b062c04de0199c215fb6e -> v2.3.7
- dorny/paths-filter: fbd0ab8f3e69293af611ebaee6363fc25e6d187d -> v4.0.1
- andrewiggins/tachometer-reporter-action: f4edc62a47169384c3f950a48f58000ce81cd07c -> v2.4.1
- dawidd6/action-download-artifact: b6e2e70617bc3265edd6dab6c906732b2f1ae151 -> v21
- actions/github-script: 3a2844b7e9c422d3c10d287c895573f7108da1b3 -> v9.0.0
- pnpm/action-setup: 0e279bb959325dab635dd2c09392533439d90093 -> v6.0.8
- actions/cache: 27d5ce7f107fe9357f9df03efb73ab90386fccae -> v5.0.5
- preactjs/compressed-size-action: 66325aad6443cb7cf89c4bfcd414aea2367cda94 -> 2.9.1
