### PR TITLE
fix: typo in vitest config

### DIFF
--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -137,7 +137,7 @@ export default defineConfig({
 	esbuild: {
 		loader: 'jsx',
 		include: /.*\.jsx$/,
-		exclude: ['node_nodules'],
+		exclude: ['node_modules'],
 		jsx: 'transform',
 		jsxFactory: 'createElement',
 		jsxFragment: 'Fragment',


### PR DESCRIPTION
looks like a typo. committed here https://github.com/preactjs/preact/commit/3a8db214803b53fc9fb531a79b13340b2f76426a