### PR TITLE
Fix memory leak hotspots

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -654,7 +654,7 @@ export function unmount(vnode, parentVNode, skipRemove) {
 			}
 		}
 
-		r.base = r._parentDom = NULL;
+		r.base = r._parentDom = r._globalContext = NULL;
 	}
 
 	if ((r = vnode._children)) {

--- a/src/render.js
+++ b/src/render.js
@@ -66,6 +66,9 @@ export function render(vnode, parentDom, replaceNode) {
 
 	// Flush all queued effects
 	commitRoot(commitQueue, vnode, refQueue);
+
+	// The live children are tracked on _children after diffing.
+	vnode.props.children = NULL;
 }
 
 /**

--- a/test/browser/render.test.jsx
+++ b/test/browser/render.test.jsx
@@ -240,6 +240,30 @@ describe('render()', () => {
 		expect(scratch.innerHTML).to.equal('<span class="hello">Hello!</span>');
 	});
 
+	it('should not keep the root input vnode in props.children', () => {
+		let update;
+		class App extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { value: 'a' };
+				update = this.setState.bind(this);
+			}
+
+			render() {
+				return <button>{this.state.value}</button>;
+			}
+		}
+
+		render(<App />, scratch);
+		let firstAppVNode = scratch._children._children[0];
+
+		update({ value: 'b' });
+		rerender();
+
+		expect(scratch._children._children[0]).to.not.equal(firstAppVNode);
+		expect(scratch._children.props.children).to.equal(null);
+	});
+
 	it('should nest empty nodes', () => {
 		render(
 			<div>


### PR DESCRIPTION
- `render()`: clear the root Fragment's `props.children` after commit so `_children` is the only live tree reference (#4909, #4905)
- `unmount()`: clear `component._globalContext` with the other component references

Local `replace1k` check: `run-final` 10.99ms vs 10.79ms main, overlapping CI.