### PR TITLE
fix: check `nodeType` instead of the global `document`

### DIFF
--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -105,6 +105,8 @@ export interface PreactElement extends preact.ContainerNode {
 
 	// Used to match DOM nodes to VNodes during hydration
 	readonly ownerDocument: Document;
+	// Used to retarget a Document render to its root element
+	readonly documentElement?: PreactElement | null;
 
 	// Setting styles
 	readonly style?: CSSStyleDeclaration;

--- a/src/render.js
+++ b/src/render.js
@@ -11,8 +11,9 @@ import { slice } from './util';
  */
 export function render(vnode, parentDom) {
 	// https://github.com/preactjs/preact/issues/3794
-	if (parentDom == document) {
-		parentDom = document.documentElement;
+	// https://github.com/preactjs/preact/issues/5118
+	if (parentDom.nodeType == 9) {
+		parentDom = parentDom.documentElement;
 	}
 
 	if (options._root) options._root(vnode, parentDom);

--- a/src/render.js
+++ b/src/render.js
@@ -10,13 +10,13 @@ import { slice } from './util';
  * @param {import('./internal').PreactElement} parentDom The DOM element to render into
  */
 export function render(vnode, parentDom) {
+	if (options._root) options._root(vnode, parentDom);
+
 	// https://github.com/preactjs/preact/issues/3794
 	// https://github.com/preactjs/preact/issues/5118
 	if (parentDom.nodeType == 9) {
 		parentDom = parentDom.documentElement;
 	}
-
-	if (options._root) options._root(vnode, parentDom);
 
 	// @ts-expect-error
 	let isHydrating = vnode && vnode._flags & MODE_HYDRATE;


### PR DESCRIPTION
Using `nodeType == 9` aligns `render()` with the existing `parentNode.ownerDocument` lookups (#2569, #4851) and removes the last reference to the global `document` in the codebase (#4500, closes #5118).

It's also more robust. `parentDom == document` tested identity against the global `document`, which meant a document from `contentDocument`/`DOMParser`/`createHTMLDocument()` would be diffed straight into its `Document` node. `nodeType == 9` matches any document and correctly retargets to its own `documentElement`.

Resolves https://github.com/preactjs/preact/issues/5118
