### PR TITLE
10.29.3

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -13,7 +13,7 @@ export function initDevTools() {
 		globalVar !== undefined &&
 		globalVar.__PREACT_DEVTOOLS__
 	) {
-		globalVar.__PREACT_DEVTOOLS__.attachPreact('10.29.2', options, {
+		globalVar.__PREACT_DEVTOOLS__.attachPreact('10.29.3', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "10.29.2",
+  "version": "10.29.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "10.29.2",
+      "version": "10.29.3",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "10.29.2",
+  "version": "10.29.3",
   "private": false,
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Fixes

- Fix error recovery for partially rendered subtrees (#5120, thanks @JoviDeCroock)
- Fix `useId` stability across async `Suspense` (#5108, thanks @JoviDeCroock)
- Flush subtree effects when rendering a pending node (#5055, thanks @JoviDeCroock)
- Fix hydrate recovery with null excess DOM children (#5112, thanks @JoviDeCroock)

## Performance

- Address and guard memory leak hotspots (#5116, thanks @JoviDeCroock)
- Avoid redundant allocations and writes (#5115, thanks @JoviDeCroock)

## Types

- Accept `Signalish` for `input` DOM-type (#5096, thanks @JoviDeCroock)

## Maintenance

- Use npm staged publishing (#5101, thanks @JoviDeCroock)
- Add tier 3 sponsor logos (#5098, thanks @JoviDeCroock)