### PR TITLE
fix(compat): restore defaultValue fallback for textarea in IE11

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -144,7 +144,7 @@ function handleDomVNode(vnode) {
 		}
 
 		let lowerCased = i.toLowerCase();
-		if (i === 'defaultValue' && 'value' in props && props.value == null) {
+		if (i === 'defaultValue' && (!('value' in props) || props.value == null)) {
 			// `defaultValue` is treated as a fallback `value` when a value prop is present but null/undefined.
 			// `defaultValue` for Elements with no value prop is the same as the DOM defaultValue property.
 			i = 'value';


### PR DESCRIPTION
Closes #5123

Restores defaultValue fallback for textarea in IE11.