### PR TITLE
feat(hooks): add use hook

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -130,6 +130,8 @@ declare namespace React {
 		subscribe: (flush: () => void) => () => void,
 		getSnapshot: () => T
 	): T;
+	// React 19 hooks
+	export import use = _hooks.use;
 	export function useEffectEvent<T extends Function>(cb: T): T;
 
 	// Preact Defaults

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -19,7 +19,8 @@ import {
 	useMemo,
 	useReducer,
 	useRef,
-	useState
+	useState,
+	use
 } from 'preact/hooks';
 import { Children } from './Children';
 import { PureComponent } from './PureComponent';
@@ -208,6 +209,7 @@ export default {
 	useMemo,
 	useCallback,
 	useContext,
+	use,
 	useDebugValue,
 	version,
 	Children,

--- a/compat/test/browser/exports.test.js
+++ b/compat/test/browser/exports.test.js
@@ -41,6 +41,7 @@ describe('compat exports', () => {
 		expect(Compat.useInsertionEffect).to.be.a('function');
 		expect(Compat.useTransition).to.be.a('function');
 		expect(Compat.useDeferredValue).to.be.a('function');
+		expect(Compat.use).to.be.a('function');
 
 		// Suspense
 		expect(Compat.Suspense).to.be.a('function');
@@ -82,6 +83,7 @@ describe('compat exports', () => {
 		expect(Named.useMemo).to.be.a('function');
 		expect(Named.useCallback).to.be.a('function');
 		expect(Named.useContext).to.be.a('function');
+		expect(Named.use).to.be.a('function');
 
 		// Suspense
 		expect(Named.Suspense).to.be.a('function');

--- a/compat/test/ts/index.tsx
+++ b/compat/test/ts/index.tsx
@@ -17,6 +17,12 @@ React.createPortal(<div />, document.createDocumentFragment());
 React.createPortal(<div />, document.body.shadowRoot!);
 
 const Ctx = React.createContext({ contextValue: '' });
+const contextValue: { contextValue: string } = React.use(Ctx);
+const promiseValue: string = React.use(Promise.resolve('value'));
+
+contextValue.contextValue.toLowerCase();
+promiseValue.toLowerCase();
+
 class SimpleComponentWithContextAsProvider extends React.Component {
 	componentProp = 'componentProp';
 	render() {

--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -123,6 +123,8 @@ export function useMemo<T>(factory: () => T, inputs: Inputs | undefined): T;
  */
 export function useContext<T>(context: PreactContext<T>): T;
 
+export function use<T>(resource: Promise<T> | PreactContext<T>): T;
+
 /**
  * Customize the displayed value in the devtools panel.
  *

--- a/hooks/src/index.d.ts
+++ b/hooks/src/index.d.ts
@@ -123,6 +123,15 @@ export function useMemo<T>(factory: () => T, inputs: Inputs | undefined): T;
  */
 export function useContext<T>(context: PreactContext<T>): T;
 
+/**
+ * Read the value of a resource like a Promise or a Context. Unlike other
+ * hooks, `use` may be called conditionally.
+ *
+ * When passed a pending Promise the component suspends until it settles,
+ * rethrowing the rejection reason if it rejects.
+ *
+ * @param resource The Promise or Context to read
+ */
 export function use<T>(resource: Promise<T> | PreactContext<T>): T;
 
 /**

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -165,6 +165,8 @@ function getHookState(index, type) {
 }
 
 /**
+ * Read the value of a Promise (suspending while pending) or a Context.
+ * Unlike other hooks, `use` may be called conditionally.
  * @template T
  * @param {Promise<T> | import('preact').PreactContext<T>} resource
  * @returns {T}
@@ -174,53 +176,34 @@ export function use(resource) {
 		options._hook(currentComponent, currentIndex, 12);
 	}
 
-	if (resource && typeof resource.then == 'function') {
-		return usePromise(/** @type {Promise<T>} */ (resource));
+	if (typeof resource.then == 'function') {
+		const thenable =
+			/** @type {Promise<T> & { status?: string, value?: T, reason?: any }} */ (
+				resource
+			);
+		if (thenable.status == 'fulfilled') return thenable.value;
+		if (thenable.status == 'rejected') throw thenable.reason;
+		if (thenable.status != 'pending') {
+			thenable.status = 'pending';
+			thenable.then(
+				value => {
+					thenable.status = 'fulfilled';
+					thenable.value = value;
+				},
+				reason => {
+					thenable.status = 'rejected';
+					thenable.reason = reason;
+				}
+			);
+		}
+		throw thenable;
 	}
 
-	const context = /** @type {import('./internal').PreactContext} */ (
-		/** @type {unknown} */ (resource)
-	);
+	const context = /** @type {import('./internal').PreactContext} */ (resource);
 	const provider = currentComponent.context[context._id];
 	if (!provider) return context._defaultValue;
-
-	const contexts =
-		currentComponent._contexts || (currentComponent._contexts = {});
-	if (!contexts[context._id]) {
-		contexts[context._id] = true;
-		provider.sub(currentComponent);
-	}
-
+	provider.sub(currentComponent);
 	return provider.props.value;
-}
-
-/**
- * @template T
- * @param {Promise<T>} promise
- * @returns {T}
- */
-function usePromise(promise) {
-	/** @type {Promise<T> & { status?: string, value?: T, reason?: unknown }} */
-	const p = promise;
-
-	if (p.status == 'fulfilled') return /** @type {T} */ (p.value);
-	if (p.status == 'rejected') throw p.reason;
-
-	if (p.status != 'pending') {
-		p.status = 'pending';
-		p.then(
-			value => {
-				p.status = 'fulfilled';
-				p.value = value;
-			},
-			reason => {
-				p.status = 'rejected';
-				p.reason = reason;
-			}
-		);
-	}
-
-	throw p;
 }
 
 /**

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -165,6 +165,65 @@ function getHookState(index, type) {
 }
 
 /**
+ * @template T
+ * @param {Promise<T> | import('preact').PreactContext<T>} resource
+ * @returns {T}
+ */
+export function use(resource) {
+	if (options._hook) {
+		options._hook(currentComponent, currentIndex, 12);
+	}
+
+	if (resource && typeof resource.then == 'function') {
+		return usePromise(/** @type {Promise<T>} */ (resource));
+	}
+
+	const context = /** @type {import('./internal').PreactContext} */ (
+		/** @type {unknown} */ (resource)
+	);
+	const provider = currentComponent.context[context._id];
+	if (!provider) return context._defaultValue;
+
+	const contexts =
+		currentComponent._contexts || (currentComponent._contexts = {});
+	if (!contexts[context._id]) {
+		contexts[context._id] = true;
+		provider.sub(currentComponent);
+	}
+
+	return provider.props.value;
+}
+
+/**
+ * @template T
+ * @param {Promise<T>} promise
+ * @returns {T}
+ */
+function usePromise(promise) {
+	/** @type {Promise<T> & { status?: string, value?: T, reason?: unknown }} */
+	const p = promise;
+
+	if (p.status == 'fulfilled') return /** @type {T} */ (p.value);
+	if (p.status == 'rejected') throw p.reason;
+
+	if (p.status != 'pending') {
+		p.status = 'pending';
+		p.then(
+			value => {
+				p.status = 'fulfilled';
+				p.value = value;
+			},
+			reason => {
+				p.status = 'rejected';
+				p.reason = reason;
+			}
+		);
+	}
+
+	throw p;
+}
+
+/**
  * @template {unknown} S
  * @param {import('./index').Dispatch<import('./index').StateUpdater<S>>} [initialState]
  * @returns {[S, (state: S) => void]}

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -38,7 +38,6 @@ export interface Component extends Omit<
 	'_renderCallbacks'
 > {
 	__hooks?: ComponentHooks;
-	_contexts?: Record<string, boolean>;
 	// Extend to include HookStates
 	_renderCallbacks?: Array<HookState | (() => void)>;
 	_hasScuFromHooks?: boolean;

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -38,6 +38,7 @@ export interface Component extends Omit<
 	'_renderCallbacks'
 > {
 	__hooks?: ComponentHooks;
+	_contexts?: Record<string, boolean>;
 	// Extend to include HookStates
 	_renderCallbacks?: Array<HookState | (() => void)>;
 	_hasScuFromHooks?: boolean;

--- a/hooks/test/browser/use.test.jsx
+++ b/hooks/test/browser/use.test.jsx
@@ -1,0 +1,293 @@
+import { createElement, render, createContext, Component } from 'preact';
+import { setupRerender } from 'preact/test-utils';
+import { Suspense } from 'preact/compat';
+import { use, useState } from 'preact/hooks';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+
+describe('use(promise)', () => {
+	/** @type {HTMLDivElement} */
+	let scratch;
+
+	/** @type {() => void} */
+	let rerender;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+		rerender = setupRerender();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	async function flushPromise(promise) {
+		await promise;
+		rerender();
+		rerender();
+	}
+
+	it('suspends while pending and renders the fulfilled value', async () => {
+		/** @type {(value: string) => void} */
+		let resolve;
+		const promise = new Promise(res => {
+			resolve = res;
+		});
+
+		function Data() {
+			return <div>Data: {use(promise)}</div>;
+		}
+
+		render(
+			<Suspense fallback={<div>Loading</div>}>
+				<Data />
+			</Suspense>,
+			scratch
+		);
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div>Loading</div>');
+
+		resolve('hello');
+		await flushPromise(promise);
+		expect(scratch.innerHTML).to.equal('<div>Data: hello</div>');
+	});
+
+	it('supports falsy fulfilled values', async () => {
+		const promise = Promise.resolve(0);
+
+		function Data() {
+			return <div>{use(promise)}</div>;
+		}
+
+		render(
+			<Suspense fallback={<div>Loading</div>}>
+				<Data />
+			</Suspense>,
+			scratch
+		);
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div>Loading</div>');
+
+		await flushPromise(promise);
+		expect(scratch.innerHTML).to.equal('<div>0</div>');
+	});
+
+	it('renders multiple consumers of the same fulfilled promise', async () => {
+		/** @type {(value: string) => void} */
+		let resolve;
+		const promise = new Promise(res => {
+			resolve = res;
+		});
+
+		function A() {
+			return <div>A: {use(promise)}</div>;
+		}
+
+		function B() {
+			return <div>B: {use(promise)}</div>;
+		}
+
+		render(
+			<Suspense fallback={<div>Loading</div>}>
+				<A />
+				<B />
+			</Suspense>,
+			scratch
+		);
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div>Loading</div>');
+
+		resolve('x');
+		await flushPromise(promise);
+		expect(scratch.innerHTML).to.equal('<div>A: x</div><div>B: x</div>');
+	});
+
+	it('throws the rejection reason after suspension', async () => {
+		/** @type {(error: Error) => void} */
+		let reject;
+		const promise = new Promise((_res, rej) => {
+			reject = rej;
+		});
+
+		class ErrorBoundary extends Component {
+			state = { error: null };
+
+			componentDidCatch(error) {
+				this.setState({ error });
+			}
+
+			render(props, state) {
+				return state.error ? (
+					<div>Caught: {state.error.message}</div>
+				) : (
+					props.children
+				);
+			}
+		}
+
+		function Data() {
+			return <div>Data: {use(promise)}</div>;
+		}
+
+		render(
+			<ErrorBoundary>
+				<Suspense fallback={<div>Loading</div>}>
+					<Data />
+				</Suspense>
+			</ErrorBoundary>,
+			scratch
+		);
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div>Loading</div>');
+
+		reject(new Error('boom'));
+		await flushPromise(promise.catch(() => {}));
+		expect(scratch.innerHTML).to.equal('<div>Caught: boom</div>');
+	});
+
+	it('can be called conditionally without shifting hook state', () => {
+		const promise =
+			/** @type {Promise<string> & { status: string, value: string }} */ (
+				Promise.resolve('done')
+			);
+		promise.status = 'fulfilled';
+		promise.value = 'done';
+		/** @type {(value: string) => void} */
+		let setSecond;
+
+		function App(props) {
+			const [first] = useState('first');
+			let value = 'skipped';
+			if (props.show) value = use(promise);
+			const [second, updateSecond] = useState('second');
+			setSecond = updateSecond;
+			return (
+				<div>
+					{first}:{value}:{second}
+				</div>
+			);
+		}
+
+		render(<App show={false} />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>first:skipped:second</div>');
+
+		setSecond('updated');
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div>first:skipped:updated</div>');
+
+		render(<App show={true} />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>first:done:updated</div>');
+	});
+});
+
+describe('use(context)', () => {
+	/** @type {HTMLDivElement} */
+	let scratch;
+
+	/** @type {() => void} */
+	let rerender;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+		rerender = setupRerender();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('reads the current context value', () => {
+		const Context = createContext(13);
+
+		function App() {
+			return <div>{use(Context)}</div>;
+		}
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>13</div>');
+
+		render(
+			<Context.Provider value={42}>
+				<App />
+			</Context.Provider>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal('<div>42</div>');
+	});
+
+	it('subscribes to provider updates', () => {
+		const Context = createContext('a');
+
+		class NoUpdate extends Component {
+			shouldComponentUpdate() {
+				return false;
+			}
+
+			render() {
+				return this.props.children;
+			}
+		}
+
+		function App() {
+			return <div>{use(Context)}</div>;
+		}
+
+		render(
+			<Context.Provider value="a">
+				<NoUpdate>
+					<App />
+				</NoUpdate>
+			</Context.Provider>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal('<div>a</div>');
+
+		render(
+			<Context.Provider value="b">
+				<NoUpdate>
+					<App />
+				</NoUpdate>
+			</Context.Provider>,
+			scratch
+		);
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div>b</div>');
+	});
+
+	it('can be called conditionally without shifting hook state', () => {
+		const Context = createContext('context');
+		/** @type {(value: string) => void} */
+		let setSecond;
+
+		function App(props) {
+			const [first] = useState('first');
+			const value = props.show ? use(Context) : 'skipped';
+			const [second, updateSecond] = useState('second');
+			setSecond = updateSecond;
+			return (
+				<div>
+					{first}:{value}:{second}
+				</div>
+			);
+		}
+
+		render(
+			<Context.Provider value="provided">
+				<App show={false} />
+			</Context.Provider>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal('<div>first:skipped:second</div>');
+
+		setSecond('updated');
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div>first:skipped:updated</div>');
+
+		render(
+			<Context.Provider value="provided">
+				<App show={true} />
+			</Context.Provider>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal('<div>first:provided:updated</div>');
+	});
+});

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -12,7 +12,8 @@ export enum HookType {
 	useContext = 9,
 	useErrorBoundary = 10,
 	// Not a real hook, but the devtools treat is as such
-	useDebugvalue = 11
+	useDebugvalue = 11,
+	use = 12
 }
 
 export interface DevSource {

--- a/test/ts/hooks.test.tsx
+++ b/test/ts/hooks.test.tsx
@@ -1,0 +1,20 @@
+import { createContext } from '../../';
+import { use } from '../../hooks';
+
+const Context = createContext(1);
+
+function UseTypes() {
+	const contextValue: number = use(Context);
+	const promiseValue: number = use(Promise.resolve(1));
+
+	contextValue.toFixed();
+	promiseValue.toFixed();
+
+	return null;
+}
+
+void UseTypes;
+
+describe('hooks types', () => {
+	it('typechecks use()', () => {});
+});


### PR DESCRIPTION
## Summary
- add React 19-style `use()` support in `preact/hooks` for Promises and Contexts
- keep `use()` order-insensitive by avoiding `useState`/`useContext` internally
- expose `use` through compat default/types and add coverage for Promise, Context, conditional calls, falsy values, rejection, exports, and TS types

## Tests
- `npm test`