### PR TITLE
Experiment: cache prop values in createElement

### DIFF
--- a/src/create-element.js
+++ b/src/create-element.js
@@ -17,11 +17,13 @@ export function createElement(type, props, children) {
 	let normalizedProps = {},
 		key,
 		ref,
-		i;
+		i,
+		value;
 	for (i in props) {
-		if (i == 'key') key = props[i];
-		else if (i == 'ref') ref = props[i];
-		else normalizedProps[i] = props[i];
+		value = props[i];
+		if (i == 'key') key = value;
+		else if (i == 'ref') ref = value;
+		else normalizedProps[i] = value;
 	}
 
 	if (arguments.length > 2) {


### PR DESCRIPTION
Experiment performed by GPT5.5 while investigating V8 deopts.

This caches the current prop value in createElement's prop normalization loop so key/ref/prop assignment share a single dynamic lookup. It intentionally does not include the defaultProps or arguments.length experiments.

Targeting v10.x so benchmark CI can tell us whether this is positive, neutral, or negative.