### PR TITLE
Experiment: cache component hooks in options

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -78,9 +78,10 @@ options.diffed = vnode => {
 	if (oldAfterDiff) oldAfterDiff(vnode);
 
 	const c = vnode._component;
-	if (c && c.__hooks) {
-		if (c.__hooks._pendingEffects.length) afterPaint(afterPaintEffects.push(c));
-		c.__hooks._list.some(hookItem => {
+	const hooks = c && c.__hooks;
+	if (hooks) {
+		if (hooks._pendingEffects.length) afterPaint(afterPaintEffects.push(c));
+		hooks._list.some(hookItem => {
 			if (hookItem._pendingArgs) {
 				hookItem._args = hookItem._pendingArgs;
 				hookItem._pendingArgs = undefined;
@@ -116,9 +117,10 @@ options.unmount = vnode => {
 	if (oldBeforeUnmount) oldBeforeUnmount(vnode);
 
 	const c = vnode._component;
-	if (c && c.__hooks) {
+	const hooks = c && c.__hooks;
+	if (hooks) {
 		let hasErrored;
-		c.__hooks._list.some(s => {
+		hooks._list.some(s => {
 			try {
 				invokeCleanup(s);
 			} catch (e) {


### PR DESCRIPTION
Experiment performed by GPT5.5 while investigating V8 deopts.

This caches c.__hooks in the hooks options.diffed and options.unmount paths to avoid repeated hook-state property reads. No behavior changes intended.

Targeting v10.x so benchmark CI can tell us whether this is positive, neutral, or negative. This should realistically only show up in the todo benchmark