### PR TITLE
fix: setState callback dropped when update is falsy

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -51,6 +51,18 @@ BaseComponent.prototype.setState = function (update, callback) {
 	} else if (!callback) {
 		// nothing to apply and no callback to flush, so this is a true no-op
 		return;
+	} else if (this._vnode && !(this._bits & COMPONENT_DIRTY)) {
+		// The update itself was a no-op (e.g. an updater bailing out by
+		// returning null/undefined), and there's no render already queued to
+		// piggyback the callback on. This mirrors React: a no-op update
+		// doesn't schedule a render, but the callback still fires. Calling it
+		// directly here avoids enqueueing a render cycle just to flush it.
+		try {
+			callback.call(this);
+		} catch (e) {
+			options._catchError(e, this._vnode);
+		}
+		return;
 	}
 
 	if (this._vnode) {

--- a/src/component.js
+++ b/src/component.js
@@ -48,7 +48,8 @@ BaseComponent.prototype.setState = function (update, callback) {
 
 	if (update) {
 		assign(s, update);
-	} else {
+	} else if (!callback) {
+		// nothing to apply and no callback to flush, so this is a true no-op
 		return;
 	}
 

--- a/test/browser/components.test.jsx
+++ b/test/browser/components.test.jsx
@@ -1985,6 +1985,50 @@ describe('Components', () => {
 				rerender();
 			}).to.not.throw();
 		});
+
+		it('should still invoke the callback when the updater function bails out by returning null', () => {
+			let spy = vi.fn();
+			let update;
+			class Foo extends Component {
+				constructor(props) {
+					super(props);
+					this.state = { count: 0 };
+					update = () => this.setState(() => null, spy);
+				}
+
+				render() {
+					return <div>{this.state.count}</div>;
+				}
+			}
+
+			render(<Foo />, scratch);
+			update();
+			rerender();
+
+			expect(spy).toHaveBeenCalledOnce();
+		});
+
+		it('should still invoke the callback when passing a falsy update directly', () => {
+			let spy = vi.fn();
+			let update;
+			class Foo extends Component {
+				constructor(props) {
+					super(props);
+					this.state = { count: 0 };
+					update = () => this.setState(null, spy);
+				}
+
+				render() {
+					return <div>{this.state.count}</div>;
+				}
+			}
+
+			render(<Foo />, scratch);
+			update();
+			rerender();
+
+			expect(spy).toHaveBeenCalledOnce();
+		});
 	});
 
 	describe('forceUpdate', () => {

--- a/test/browser/components.test.jsx
+++ b/test/browser/components.test.jsx
@@ -2029,6 +2029,111 @@ describe('Components', () => {
 
 			expect(spy).toHaveBeenCalledOnce();
 		});
+
+		it('should not schedule a render when flushing a callback for a no-op update', () => {
+			let spy = vi.fn();
+			let update;
+			class Foo extends Component {
+				constructor(props) {
+					super(props);
+					this.state = { count: 0 };
+					update = () => this.setState(() => null, spy);
+				}
+
+				render() {
+					return <div>{this.state.count}</div>;
+				}
+			}
+
+			vi.spyOn(Foo.prototype, 'render');
+
+			render(<Foo />, scratch);
+			expect(Foo.prototype.render).toHaveBeenCalledOnce();
+
+			update();
+			// The callback should have fired immediately/synchronously, without
+			// waiting on the render queue, since there's nothing to commit.
+			expect(spy).toHaveBeenCalledOnce();
+			// No render was enqueued to flush it, so draining the render queue
+			// must not cause an additional render call.
+			rerender();
+
+			expect(Foo.prototype.render).toHaveBeenCalledOnce();
+		});
+
+		it('should invoke the callback exactly once for multiple stacked no-op updates', () => {
+			let spy = vi.fn();
+			let update;
+			class Foo extends Component {
+				constructor(props) {
+					super(props);
+					this.state = { count: 0 };
+					update = () => {
+						this.setState(() => null, spy);
+						this.setState(() => null, spy);
+						this.setState(() => null, spy);
+					};
+				}
+
+				render() {
+					return <div>{this.state.count}</div>;
+				}
+			}
+
+			vi.spyOn(Foo.prototype, 'render');
+
+			render(<Foo />, scratch);
+			expect(Foo.prototype.render).toHaveBeenCalledOnce();
+
+			update();
+
+			expect(spy).toHaveBeenCalledTimes(3);
+			rerender();
+
+			expect(Foo.prototype.render).toHaveBeenCalledOnce();
+		});
+
+		it('should batch a no-op callback onto an already-pending render instead of firing it early', () => {
+			let calls = [];
+			let update;
+			class Foo extends Component {
+				constructor(props) {
+					super(props);
+					this.state = { count: 0 };
+					update = () => {
+						// A real update enqueues a render for this component...
+						this.setState({ count: 1 }, () => calls.push('real'));
+						// ...so this no-op callback should be attached to that same
+						// pending render instead of being invoked synchronously.
+						this.setState(
+							() => null,
+							() => calls.push('noop')
+						);
+					};
+				}
+
+				render() {
+					return <div>{this.state.count}</div>;
+				}
+			}
+
+			vi.spyOn(Foo.prototype, 'render');
+
+			render(<Foo />, scratch);
+			expect(Foo.prototype.render).toHaveBeenCalledOnce();
+
+			update();
+			// Neither callback should have run yet: both are attached to the
+			// still-pending render triggered by the real update.
+			expect(calls).to.deep.equal([]);
+
+			rerender();
+
+			// Exactly one additional render for the real update, and both
+			// callbacks fired, in the order they were registered.
+			expect(Foo.prototype.render).toHaveBeenCalledTimes(2);
+			expect(calls).to.deep.equal(['real', 'noop']);
+		});
 	});
 
 	describe('forceUpdate', () => {


### PR DESCRIPTION
setState(() => null, cb) never calls cb. The early-return for a falsy update happens before the callback ever gets pushed onto `_stateCallbacks`, and since that array only flushes during a render pass triggered by `enqueueRender`, the callback just never runs — not deferred, just gone.

This matters because bailing out of an update by returning null/undefined from the updater function is explicitly typed as valid (`index.d.ts` allows `Pick<S,K> | Partial<S> | null`), so it's a real pattern people rely on, not an edge case someone made up. `setState(null, cb)` has the same problem.

Fixed by only skipping the early return when there's a callback to flush — if there's truly nothing to apply and nothing to call, it still bails out the same as before, so the perf shortcut is intact. Added tests for both the updater-returns-null case and passing null directly.