### PR TITLE
ci: add CVE Lite dependency audit workflow

### DIFF
--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -1,0 +1,36 @@
+name: CVE Lite dependency audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Scan dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Scan for vulnerabilities
+        uses: OWASP/cve-lite-cli@2eed959b8641042472d2810444393b88d5454e62 # v1
+        with:
+          fail-on: high
+          sarif: 'true'
+
+      - name: Upload SARIF to Code Scanning
+        if: always() && hashFiles('*.sarif') != ''
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          sarif_file: cve-lite-*.sarif
+          category: cve-lite


### PR DESCRIPTION
This adds a CVE Lite CLI dependency audit workflow to preact. CVE Lite CLI is an OWASP Lab Project that reads your lockfile directly - no npm install needed - and cross-references every resolved package version against the OSV vulnerability database.

A scan of preact's current lockfile found 41 findings across 699 packages: 5 critical, 22 high, 13 medium, and 1 low. Of those, 4 have direct fixable counterparts with copy-run upgrade commands (vitest, playwright, undici, vite). The workflow gates on high severity so CI will catch new critical and high findings before they reach main.

The workflow runs on push and pull_request to main, plus a weekly Monday morning scheduled scan to catch newly published advisories against the existing lockfile. Results are uploaded to GitHub Code Scanning as SARIF so findings surface in the Security tab alongside any other static analysis the project runs.

All three actions are pinned to immutable commit SHAs rather than floating version tags, which removes the supply chain risk of a tag being moved.

More about CVE Lite CLI and the OWASP Lab Project at owasp.org/cve-lite-cli
