### PR TITLE
Beta.2

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -13,7 +13,7 @@ export function initDevTools() {
 		globalVar !== undefined &&
 		globalVar.__PREACT_DEVTOOLS__
 	) {
-		globalVar.__PREACT_DEVTOOLS__.attachPreact('11.0.0-beta.1', options, {
+		globalVar.__PREACT_DEVTOOLS__.attachPreact('11.0.0-beta.2', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "11.0.0-beta.1",
+  "version": "11.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "11.0.0-beta.1",
+      "version": "11.0.0-beta.2",
       "license": "MIT",
       "devDependencies": {
         "@actions/github": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "11.0.0-beta.1",
+  "version": "11.0.0-beta.2",
   "private": false,
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Forward porting

- Frontport 10.29.4 (#5139, thanks @JoviDeCroock)
- Frontport 10.29.3 (#5122, thanks @JoviDeCroock)
- Forwardport v10.x fixes since 2026-03-25 (#5089, thanks @JoviDeCroock)
- Forwardport from v10 (#5053, thanks @JoviDeCroock)

## Features

- Implement streamed hydration rfc (#5035, thanks @JoviDeCroock)

## Types

- Remove erroneous 'type' attribute from select element types (#5097, thanks @rschristian)
- Accept Signalish for input type (#5095, thanks @JoviDeCroock)

## Fixes

- Fix compat Suspense hydration children recovery (#5146, thanks @JoviDeCroock)
- Check `nodeType` instead of the global `document` (#5119, thanks @natemoo-re)
- Fix Suspense undefined prop revalidation (#5133, thanks @JoviDeCroock)
- Fix error recovery for partially rendered subtrees (#5120, thanks @JoviDeCroock)
- Fix useId stability across async Suspense (#5108, thanks @JoviDeCroock)
- Flush subtree effects (#5055, thanks @JoviDeCroock)
- Fix memory leak hotspots (#5116, thanks @JoviDeCroock)
- Fix hydrate recovery with null excess DOM children (#5112, thanks @JoviDeCroock)
- Fix buggy edge case (#5092, thanks @JoviDeCroock)
- Preserve falsy key and ref values in cloneElement (#5082, thanks @Olexandr88)

## Performance

- Use Symbols for the event clock keys (#5143, thanks @JoviDeCroock)
- Performance: compat `shallowDiffers` (#4780, thanks @romgrk)
- Avoid redundant allocations and writes (#5115, thanks @JoviDeCroock)
- Use .push.apply (#5024, thanks @JoviDeCroock)

## Maintenance

- Bump pinned GitHub actions (#5110, thanks @JoviDeCroock)
- Fix typo in vitest config (#5111, thanks @kumavis)
- Use npm staged publishing (#5100, thanks @JoviDeCroock)
- Harden trusted publish workflow (#5099, thanks @JoviDeCroock)
- Add tier 3 sponsor logos (#5093, thanks @JoviDeCroock)
- Add trusted publishing workflow for main (#5086, thanks @JoviDeCroock)
- Add `chai` to dev dependencies to make pnpm install work (#5043, thanks @marvinhagemeister)
