### PR TITLE
[Proposal] use Symbols for the event clock

### DIFF
--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -1,16 +1,12 @@
 import { NULL, SVG_NAMESPACE } from '../constants';
 import options from '../options';
 
-// Per-instance unique key for event clock stamps. Each Preact copy on the page
-// gets its own random suffix so that `_dispatched` / `_attached` properties on
-// shared event objects and handler functions cannot collide across instances.
-// ~1 in 60M collision odds - if you have that many praect versions on the page,
-// you deserve some weird bugs.
-// In 11 we can replace this with a
-// Symbol
-let _id = Math.random().toString(8),
-	EVENT_DISPATCHED = '__d' + _id,
-	EVENT_ATTACHED = '__a' + _id;
+// Per-instance unique keys for event clock stamps. Each Preact copy on the
+// page gets its own Symbols so that `_dispatched` / `_attached` stamps on
+// shared event objects and handler functions can never collide across
+// instances.
+let EVENT_DISPATCHED = Symbol(),
+	EVENT_ATTACHED = Symbol();
 
 function setStyle(style, key, value) {
 	if (key[0] == '-') {

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -129,9 +129,9 @@ export interface PreactElement extends preact.ContainerNode {
 }
 
 export interface PreactEvent extends Event {
-	// Keyed by a per-instance unique string (e.g. `__dXXXXX`) so that
-	// multiple Preact copies on the same page don't share event clock stamps.
-	[key: string]: any;
+	// Keyed by a per-instance unique Symbol so that multiple Preact copies
+	// on the same page don't share event clock stamps.
+	[key: symbol]: any;
 }
 
 // We use the `current` property to differentiate between the two kinds of Refs so


### PR DESCRIPTION
The code comment in `src/diff/props.js` already suggested doing this in v11 — Symbols can never collide across multiple Preact copies on the same page (no more ~1-in-60M odds) and it saves bytes/simplifies the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code) and reviewed by me