### PR TITLE
Fix compat Suspense hydration children recovery

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -13,7 +13,7 @@ options._catchError = function (error, newVNode, oldVNode, errorInfo) {
 			if ((component = vnode._component) && component._childDidSuspend) {
 				if (newVNode._dom == null) {
 					newVNode._dom = oldVNode._dom;
-					newVNode._children = oldVNode._children;
+					newVNode._children = oldVNode._children || [];
 				}
 				// Don't call oldCatchError if we found a Suspense
 				return component._childDidSuspend(error, newVNode);

--- a/compat/test/browser/suspense-hydration.test.jsx
+++ b/compat/test/browser/suspense-hydration.test.jsx
@@ -198,6 +198,49 @@ describe('suspense hydration', () => {
 		clearLog();
 	});
 
+	it('does not crash when a hydrated suspended component with no DOM bails out with shouldComponentUpdate', () => {
+		scratch.innerHTML = '';
+		clearLog();
+
+		const promise = new Promise(() => {});
+		let update;
+
+		class Suspender extends React.Component {
+			shouldComponentUpdate() {
+				return false;
+			}
+
+			render() {
+				throw promise;
+			}
+		}
+
+		class App extends React.Component {
+			constructor(props) {
+				super(props);
+				this.state = { tick: 0 };
+				update = () => this.setState({ tick: this.state.tick + 1 });
+			}
+
+			render() {
+				return (
+					<Suspense fallback={<div>loading</div>}>
+						<Suspender tick={this.state.tick} />
+					</Suspense>
+				);
+			}
+		}
+
+		hydrate(<App />, scratch);
+		expect(scratch.innerHTML).to.equal('');
+
+		update();
+		expect(() => rerender()).not.to.throw();
+		expect(scratch.innerHTML).to.equal('');
+		expect(getLog()).to.deep.equal([]);
+		clearLog();
+	});
+
 	it('should leave DOM untouched when suspending while hydrating', () => {
 		scratch.innerHTML = '<!-- test --><div>Hello</div>';
 		clearLog();


### PR DESCRIPTION
Hydrated Suspense can recover a VNode with no DOM and no initialized children, then compat's Suspense catch path can copy `oldVNode._children` back to `null`. A later bailout expects `_children` to be iterable and crashes.

This normalizes recovered compat Suspense children to an empty array and adds a regression for the no-DOM hydrated suspension bailout path.