### PR TITLE
[Claude experiment] perf: hoist loop invariants in child diffing and unmount (main)

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -175,6 +175,10 @@ function constructNewChildrenArray(
 
 	let skew = 0;
 
+	// Hoisted out of the per-child loop below, it can't change while diffing
+	// this set of children.
+	let childDepth = newParentVNode._depth + 1;
+
 	newParentVNode._children = new Array(newChildrenLength);
 	for (i = 0; i < newChildrenLength; i++) {
 		// @ts-expect-error We are reusing the childVNode variable to hold both the
@@ -232,7 +236,7 @@ function constructNewChildrenArray(
 
 		const skewedIndex = i + skew;
 		childVNode._parent = newParentVNode;
-		childVNode._depth = newParentVNode._depth + 1;
+		childVNode._depth = childDepth;
 
 		// Temporarily store the matchingIndex on the _index property so we can pull
 		// out the oldVNode in diffChildren. We'll override this to the VNode's

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -727,13 +727,11 @@ export function unmount(vnode, parentVNode, skipRemove) {
 	}
 
 	if ((r = vnode._children)) {
+		// Hoisted out of the loop, it's the same for every child.
+		let childSkipRemove = skipRemove || typeof vnode.type != 'function';
 		for (let i = 0; i < r.length; i++) {
 			if (r[i]) {
-				unmount(
-					r[i],
-					parentVNode,
-					skipRemove || typeof vnode.type != 'function'
-				);
+				unmount(r[i], parentVNode, childSkipRemove);
 			}
 		}
 	}


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR is a Claude (Anthropic AI agent) experiment**, opened as a draft on purpose. @JoviDeCroock asked Claude to investigate what performance improvements are realistically available in Preact using the tachometer benches in `benches/`, under the constraint that changes must be surgical and size-conscious. This PR is the tip-applicable remainder of that investigation — treat it as data and a discussion starter, not as a merge request. A sibling draft targets `v10.x`.

## What

Two loop-invariant hoists in the hottest per-child loops:

- `constructNewChildrenArray`: `newParentVNode._depth + 1` was recomputed (property load + add) for every child; it cannot change during the loop.
- `unmount`: `skipRemove || typeof vnode.type != 'function'` was re-evaluated for every child being unmounted.

## Measured trade-off

- **Size: +10 B minified / +11 B brotli** (`dist/preact.mjs`, 11851 → 11861 / 4445 → 4456) — a hoisted variable is never free.
- **Perf:** removes a property load + add per child in the diff path and a `typeof` per child in the unmount path; sub-noise on the tachometer suite.
- **Tests:** full vitest suite green — 1252 passed / 0 failed.

Given Preact's size-first goal it is entirely reasonable to close this; it exists to make the bytes-vs-cycles trade explicit.

## Context from the wider experiment

Claude first ran the full tachometer suite on a 10.16-era workspace (25+ samples/bench, Chrome headless), comparing the 10.16 baseline against the 10.17–10.19 structural children-diffing rewrite and against byte-neutral micro-optimizations:

- The structural rewrite measured **−10%** on `many_updates` and **−4.8%** on `todo`, ~wash on `filter_list` / `03_update10th1k_x16`, but **+3.2%** (slower) on `text_update`, **+0.7%** on `07_create10k`, and **+2–4.5% heap** across the board — its real value is the pathological keyed-reorder cases (move-to-front = 1 `insertBefore` instead of O(n)) that the bench suite doesn't exercise.
- Every byte-neutral micro-opt found on the 10.16 baseline (event-name `toLowerCase()` dedup, closure-free sCU-bailout reparenting, dropping the redundant `'value' in props` / `'checked' in props` checks, preallocated `_children` arrays, `NULL`/`UNDEFINED` constants) turned out to have **already landed here over the years** — the low-hanging fruit is genuinely gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
