### PR TITLE
Anchor useId to the server boundary id during resumed hydration

### DIFF
--- a/compat/src/internal.d.ts
+++ b/compat/src/internal.d.ts
@@ -44,5 +44,5 @@ export interface SuspenseComponent
 	_pendingSuspensionCount: number;
 	_suspenders: Component[];
 	_detachOnNextRender: null | VNode<any>;
-	_mask?: [number, number];
+	_mask?: [string | number, number];
 }

--- a/compat/test/browser/suspense-hydration.test.jsx
+++ b/compat/test/browser/suspense-hydration.test.jsx
@@ -5,6 +5,7 @@ import React, {
 	Fragment,
 	Suspense,
 	memo,
+	useId,
 	useState
 } from 'preact/compat';
 import { logCall, getLog, clearLog } from '../../../test/_util/logCall';
@@ -995,6 +996,135 @@ describe('suspense hydration', () => {
 				.dispatchEvent(createEvent('click'));
 			expect(listeners[3]).toHaveBeenCalledTimes(2);
 		});
+	});
+
+	it('restores useId namespaces from boundary markers regardless of resolution order', async () => {
+		const originalHtml =
+			'<div>' +
+			'<!--$s:0--><span id="PS0-0">A</span><!--/$s:0-->' +
+			'<!--$s:1--><span id="PS1-0">B</span><!--/$s:1-->' +
+			'</div>';
+		scratch.innerHTML = originalHtml;
+
+		const ids = {};
+		function Field({ name }) {
+			const id = useId();
+			ids[name] = id;
+			return <span id={id}>{name}</span>;
+		}
+
+		const [LazyA, resolveA] = createLazy();
+		const [LazyB, resolveB] = createLazy();
+		hydrate(
+			<div>
+				<Suspense fallback={null}>
+					<LazyA />
+				</Suspense>
+				<Suspense fallback={null}>
+					<LazyB />
+				</Suspense>
+			</div>,
+			scratch
+		);
+		rerender();
+
+		// Resolve in the reverse of the order the server resolved in
+		await resolveB(() => <Field name="B" />);
+		rerender();
+		await resolveA(() => <Field name="A" />);
+		rerender();
+
+		expect(ids).to.deep.equal({ A: 'PS0-0', B: 'PS1-0' });
+		expect(scratch.innerHTML).to.equal(originalHtml);
+	});
+
+	it('keeps marker-derived ids stable when client-only boundaries render during hydration', async () => {
+		scratch.innerHTML =
+			'<!--$s:0-->' +
+			'<span id="PS0-0">outer</span>' +
+			'<!--$s:1--><span id="PS1-0">nested</span><!--/$s:1-->' +
+			'<!--/$s:0-->';
+
+		const ids = {};
+		function Field({ name }) {
+			const id = useId();
+			ids[name] = id;
+			return <span id={id}>{name}</span>;
+		}
+
+		const [LazyOuter, resolveOuter] = createLazy();
+		const [LazyNested, resolveNested] = createLazy();
+
+		let showClientContent;
+		function App() {
+			const [showClient, setShowClient] = useState(false);
+			showClientContent = () => setShowClient(true);
+			return (
+				<Fragment>
+					{showClient && (
+						<Suspense fallback={null}>
+							<Field name="client" />
+						</Suspense>
+					)}
+					<Suspense fallback={null}>
+						<LazyOuter />
+					</Suspense>
+				</Fragment>
+			);
+		}
+
+		hydrate(<App />, scratch);
+		rerender();
+
+		// Client-only content appears while the boundary is still suspended
+		showClientContent();
+		rerender();
+
+		await resolveOuter(() => (
+			<Fragment>
+				<Field name="outer" />
+				<Suspense fallback={null}>
+					<LazyNested />
+				</Suspense>
+			</Fragment>
+		));
+		rerender();
+
+		await resolveNested(() => <Field name="nested" />);
+		rerender();
+
+		// The hydrated boundaries keep the ids the server rendered, the
+		// client-only boundary draws from the root id space and cannot
+		// collide with a marker namespace
+		expect(ids).to.deep.equal({
+			client: 'P0-0',
+			outer: 'PS0-0',
+			nested: 'PS1-0'
+		});
+	});
+
+	it('falls back to the root id space when the marker carries no namespace', async () => {
+		scratch.innerHTML = '<!--$s--><span id="P0-0">A</span><!--/$s-->';
+
+		let renderedId;
+		function Field() {
+			renderedId = useId();
+			return <span id={renderedId}>A</span>;
+		}
+
+		const [Lazy, resolve] = createLazy();
+		hydrate(
+			<Suspense fallback={null}>
+				<Lazy />
+			</Suspense>,
+			scratch
+		);
+		rerender();
+
+		await resolve(() => <Field />);
+		rerender();
+
+		expect(renderedId).to.equal('P0-0');
 	});
 
 	it('Should hydrate a fragment with multiple children correctly', () => {

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -42,7 +42,7 @@ export interface Component
 }
 
 export interface VNode extends Omit<PreactVNode, '_component'> {
-	_mask?: [number, number];
+	_mask?: [string | number, number];
 	_component?: Component; // Override with our specific Component type
 }
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -86,6 +86,12 @@ export function diff(
 		let excess = oldVNode._component._excess;
 		excessDomChildren = [];
 		if (excess.nodeType == 8) {
+			// The opening marker can carry the boundary id the server rendered
+			// with (<!--$s:1-->). Anchoring useId to it keeps ids stable no
+			// matter the order in which boundaries resume.
+			if (excess.data[2] == ':') {
+				newVNode._mask = ['S' + excess.data.slice(3), 0];
+			}
 			// Re-scan DOM from stored start marker for streamed hydration
 			for (
 				let depth = 1, node = excess.nextSibling;
@@ -102,7 +108,6 @@ export function diff(
 			excessDomChildren.push(excess);
 		}
 		oldDom = excessDomChildren[0];
-		oldVNode._component._excess = NULL;
 	}
 
 	if ((tmp = options._diff)) tmp(newVNode);
@@ -314,6 +319,7 @@ export function diff(
 
 			// We successfully rendered this VNode, unset any stored hydration/bailout state:
 			newVNode._flags &= RESET_MODE;
+			c._excess = NULL;
 
 			if (c._renderCallbacks.length) {
 				commitQueue.push(c);
@@ -361,10 +367,7 @@ export function diff(
 						}
 					}
 
-					if (startMarker) {
-						// Store start marker directly; children re-scanned on resume
-						newVNode._component._excess = startMarker;
-					} else {
+					if (!startMarker) {
 						while (oldDom && oldDom.nodeType == 8 && oldDom.nextSibling) {
 							oldDom = oldDom.nextSibling;
 						}
@@ -372,7 +375,13 @@ export function diff(
 						if (excessDomChildren != NULL) {
 							excessDomChildren[excessDomChildren.indexOf(oldDom)] = NULL;
 						}
-						newVNode._component._excess = oldDom;
+					}
+
+					// Store the start marker directly; children are re-scanned on
+					// resume. When a resumed boundary suspends again we keep the
+					// marker it originally started from.
+					if (!newVNode._component._excess) {
+						newVNode._component._excess = startMarker || oldDom;
 					}
 					newVNode._dom = oldDom;
 				} else if (excessDomChildren != NULL) {

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -159,6 +159,11 @@ export interface VNode<P = {}> extends preact.VNode<P> {
 	_original: number;
 	_index: number;
 	_flags: number;
+	/**
+	 * The id namespace for useId, restored from the server-emitted boundary
+	 * marker when a suspended subtree resumes hydration
+	 */
+	_mask?: [string | number, number];
 }
 
 export interface Component<P = {}, S = {}>


### PR DESCRIPTION
## Summary

- derive the `useId` namespace of a resumed subtree from the boundary id embedded in the server-emitted suspense marker (`<!--$s:0-->`) instead of a client-side counter
- keep the stored start marker when a suspended-while-hydrating boundary re-renders before it resolves, so ancestor updates can no longer drift the boundary onto a nested boundary's marker
- boundaries whose marker carries no id, and client-only boundaries, keep the existing root-counter behavior and cannot collide with a server namespace (`PS<id>-N` vs `P0-N`)

## Problem

`useId` draws ids from a shared counter in render order. With resumed hydration, the content of a suspended boundary renders when its promise resolves, so sibling boundaries that resolve in a different order on the client than on the server consume the counter in a different order and derive ids that don't match the ids already sitting in the server HTML (and referenced by `aria-*` attributes).

We tried deriving a per-boundary namespace from an encounter-order counter in #5108, but had to revert it in #5135: a client-only boundary (`{isHydrated && <Suspense>…}`) rendering in the middle of hydration consumes a namespace the server never allocated and shifts every boundary after it. Any scheme that allocates namespaces by *when* a boundary renders has this failure mode; the namespace has to come from *what* the boundary is.

The streamed-hydration markers already carry exactly that: a stable, document-ordered boundary id assigned by the server. Reading it back from the DOM when the boundary resumes sidesteps re-deriving anything on the client — resolution order becomes irrelevant, and client-only boundaries simply have no marker.

While testing the client-only case this surfaced a second issue: when an ancestor update re-rendered a boundary that was still suspended, the resume path consumed the stored start marker and the re-suspension then stored the first marker found in the rebuilt (inner) range — a nested boundary's marker. The boundary would later resume from the wrong range with the wrong namespace. Re-suspensions now keep the marker they originally started from, and the stored marker is cleared once the boundary renders successfully.

## Server side

`renderToStringAsync` currently emits bare `<!--$s-->` markers; the streamed variant emits `<!--$s:N-->`. The follow-up in preact-render-to-string is to emit the boundary id in both modes and to hand out `PS<id>-N` ids inside a suspended subtree, mirroring the mask this PR restores on the client.

Size: +27 B brotli on core.