### PR TITLE
Fix DocumentFragment missing createElementNS

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -529,7 +529,9 @@ function diffElementNodes(
 			return doc.createTextNode(newProps);
 		}
 
-		dom = doc.createElementNS(namespace, nodeType, newProps.is && newProps);
+		dom = doc.createElementNS
+			? doc.createElementNS(namespace, nodeType, newProps.is && newProps)
+			: doc.createElement(nodeType);
 
 		// we are creating a new node, so we can assume this is a new subtree (in
 		// case we are hydrating), this deopts the hydrate

--- a/test/browser/render.test.jsx
+++ b/test/browser/render.test.jsx
@@ -2093,5 +2093,24 @@ describe('render()', () => {
 			expect(rootCreateElementSpy).not.toBeCalled();
 			expect(iframeCreateElementSpy).toBeCalled();
 		});
+
+		it('falls back to createElement when createElementNS is unavailable', () => {
+			const iframe = document.createElement('iframe');
+			scratch.appendChild(iframe);
+
+			const iframeDocument = iframe.contentDocument;
+			const iframeCreateElementSpy = vi.spyOn(iframeDocument, 'createElement');
+			Object.defineProperty(iframeDocument, 'createElementNS', {
+				configurable: true,
+				value: undefined
+			});
+
+			const iframeBody = iframeDocument.getElementsByTagName('body')[0];
+
+			render(<div />, iframeBody);
+
+			expect(iframeDocument.body.innerHTML).to.equal('<div></div>');
+			expect(iframeCreateElementSpy).toBeCalledWith('div');
+		});
 	});
 });


### PR DESCRIPTION
Fixes #4539

Falls back to `createElement` when `createElementNS` is unavailable. With passing ownerDocument to the portal we save part of the issue, however the faux-DOM passed from the library is missing createElementNS.

Do we want to land this? Hypothetically it's a compat concern