### PR TITLE
Investigate the possibility for a yielding hydration step

### DIFF
--- a/compat/test/browser/hydrationYield.test.jsx
+++ b/compat/test/browser/hydrationYield.test.jsx
@@ -1,0 +1,163 @@
+import { setupRerender } from 'preact/test-utils';
+import React, {
+	createElement,
+	hydrate,
+	Suspense,
+	useState,
+	useLayoutEffect
+} from 'preact/compat';
+import { options } from 'preact';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+import { createLazy } from './suspense-utils';
+
+/* eslint-env browser */
+
+/**
+ * Time-sliced hydration (options._yield, see #407) must compose with real
+ * suspensions: the slicing sentinel is intercepted by the scheduler's
+ * _catchError wrapper while genuine thenables (lazy/data suspensions) fall
+ * through to compat's Suspense handling.
+ */
+describe('hydration yielding + Suspense interop', () => {
+	/** @type {HTMLDivElement} */
+	let scratch, rerender;
+	let unhandledEvents = [];
+
+	let budget;
+	let queue;
+	let uninstall;
+
+	function onUnhandledRejection(event) {
+		unhandledEvents.push(event);
+	}
+
+	function installSlicing() {
+		// eslint-disable-next-line unicorn/no-thenable
+		const sentinel = { then() {} };
+		queue = [];
+		budget = Infinity;
+
+		const prevYield = options._yield;
+		const prevCatchError = options._catchError;
+
+		options._yield = vnode => {
+			if (vnode._parent && --budget < 0) throw sentinel;
+		};
+
+		options._catchError = (error, vnode, oldVNode, errorInfo) => {
+			if (error === sentinel) {
+				queue.push(vnode._component);
+				return;
+			}
+			prevCatchError(error, vnode, oldVNode, errorInfo);
+		};
+
+		uninstall = () => {
+			options._yield = prevYield;
+			options._catchError = prevCatchError;
+		};
+	}
+
+	function flushSlice(n) {
+		budget = n;
+		const pending = queue.splice(0);
+		pending.forEach(c => c.forceUpdate());
+		rerender();
+	}
+
+	beforeEach(() => {
+		scratch = setupScratch();
+		rerender = setupRerender();
+		installSlicing();
+
+		unhandledEvents = [];
+		if ('onunhandledrejection' in window) {
+			window.addEventListener('unhandledrejection', onUnhandledRejection);
+		}
+	});
+
+	afterEach(() => {
+		uninstall();
+		teardown(scratch);
+
+		if ('onunhandledrejection' in window) {
+			window.removeEventListener('unhandledrejection', onUnhandledRejection);
+			if (unhandledEvents.length) {
+				throw unhandledEvents[0].reason;
+			}
+		}
+	});
+
+	it('slices around a real lazy suspension without interfering', () => {
+		const clicks = [];
+		const [Lazy, resolve] = createLazy();
+		const Item = ({ name }) => (
+			<li onClick={() => clicks.push(name)}>{name}</li>
+		);
+		const App = () => (
+			<ul>
+				<Item name="a" />
+				<Suspense fallback={null}>
+					<Lazy />
+				</Suspense>
+				<Item name="c" />
+			</ul>
+		);
+
+		const html = '<ul><li>a</li><li>b</li><li>c</li></ul>';
+		scratch.innerHTML = html;
+		const lis = Array.from(scratch.querySelectorAll('li'));
+
+		// App + Item a mount; Suspense, Lazy and Item c all defer: Lazy via a
+		// real promise, the others via the slicing sentinel
+		budget = 2;
+		hydrate(<App />, scratch);
+		expect(scratch.innerHTML).to.equal(html);
+
+		// Resume the sliced components; the lazy subtree stays pending
+		flushSlice(Infinity);
+		expect(scratch.innerHTML).to.equal(html);
+		lis[0].click();
+		lis[2].click();
+		expect(clicks).to.deep.equal(['a', 'c']);
+		lis[1].click();
+		expect(clicks).to.deep.equal(['a', 'c']); // lazy still inert
+
+		return resolve(() => <Item name="b" />).then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.equal(html);
+			expect(Array.from(scratch.querySelectorAll('li'))).to.deep.equal(lis);
+			lis[1].click();
+			expect(clicks).to.deep.equal(['a', 'c', 'b']);
+		});
+	});
+
+	it('runs hooks and effects exactly once for components resumed in a slice', () => {
+		let effects = 0;
+		function Counter() {
+			const [n, setN] = useState(0);
+			useLayoutEffect(() => {
+				effects++;
+			}, []);
+			return <button onClick={() => setN(n + 1)}>{n}</button>;
+		}
+
+		scratch.innerHTML = '<button>0</button>';
+		const button = scratch.firstChild;
+
+		budget = 0;
+		hydrate(<Counter />, scratch);
+		expect(queue.length).to.equal(1);
+		expect(effects).to.equal(0);
+
+		flushSlice(Infinity);
+		expect(effects).to.equal(1);
+		expect(scratch.firstChild).to.equal(button);
+
+		button.click();
+		rerender();
+		expect(effects).to.equal(1);
+		expect(scratch.firstChild).to.equal(button);
+		expect(button.textContent).to.equal('1');
+	});
+});

--- a/mangle.json
+++ b/mangle.json
@@ -77,7 +77,8 @@
       "$_skipEffects": "__s",
       "$_forwarded": "__f",
       "$_isSuspended": "__i",
-      "$_bits": "__g"
+      "$_bits": "__g",
+      "$_yield": "__y"
     }
   }
 }

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -70,6 +70,7 @@ export function diff(
 ) {
 	/** @type {any} */
 	let tmp,
+		resumedExcess,
 		newType = newVNode.type;
 
 	// When passing through createElement it assigns the object
@@ -84,7 +85,7 @@ export function diff(
 		oldVNode._component._excess
 	) {
 		let excess = oldVNode._component._excess;
-		excessDomChildren = [];
+		resumedExcess = excessDomChildren = [];
 		if (excess.nodeType == 8) {
 			// Re-scan DOM from stored start marker for streamed hydration
 			for (
@@ -321,6 +322,15 @@ export function diff(
 
 			// We successfully rendered this VNode, unset any stored hydration/bailout state:
 			newVNode._flags &= RESET_MODE;
+
+			// The resume-owned excess array is not shared with any parent frame,
+			// so nodes the resumed subtree didn't adopt are SSR leftovers (e.g. a
+			// node claimed by a component that then rendered null) — remove them.
+			if (resumedExcess) {
+				for (tmp = resumedExcess.length; tmp--; ) {
+					removeNode(resumedExcess[tmp]);
+				}
+			}
 
 			if (c._renderCallbacks.length) {
 				commitQueue.push(c);

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -253,6 +253,13 @@ export function diff(
 			c._parentDom = parentDom;
 			c._bits &= ~COMPONENT_FORCE;
 
+			// Freshly mounting components during hydration may self-suspend to
+			// slice up the hydration walk; the hook throws a thenable to bail
+			// out here and resume from `_excess` later.
+			if (isHydrating && !oldVNode._component && (tmp = options._yield)) {
+				tmp(newVNode);
+			}
+
 			let renderHook = options._render,
 				count = 0;
 			if (isClassComponent) {
@@ -333,6 +340,11 @@ export function diff(
 				if (e.then) {
 					let commentMarkersToFind = 0,
 						startMarker;
+
+					// Components that suspend before their first render still have
+					// COMPONENT_DIRTY set from instantiation; clear it so that the
+					// resuming forceUpdate isn't ignored by enqueueRender.
+					newVNode._component._bits &= ~COMPONENT_DIRTY;
 
 					newVNode._flags |= isHydrating
 						? MODE_HYDRATE | MODE_SUSPENDED

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -49,6 +49,12 @@ export interface Options extends preact.Options {
 		vnode: VNode,
 		excessDomChildren: Array<PreactElement | null>
 	): void;
+	/**
+	 * Attach a hook that is invoked before a freshly mounting component renders
+	 * during hydration. Throwing a thenable from this hook suspends the
+	 * component, allowing the hydration walk to be sliced into multiple tasks.
+	 */
+	_yield?(vnode: VNode): void;
 }
 
 export type ComponentChild =

--- a/test/browser/hydrationYield.test.jsx
+++ b/test/browser/hydrationYield.test.jsx
@@ -1,0 +1,252 @@
+import { createElement, hydrate, options, Component } from 'preact';
+import { setupRerender } from 'preact/test-utils';
+import { setupScratch, teardown } from '../_util/helpers';
+import { logCall, clearLog, getLog } from '../_util/logCall';
+
+/**
+ * Tests for time-sliced (interruptible) hydration, see #407.
+ *
+ * Core exposes `options._yield`, invoked right before a freshly mounting
+ * component renders during hydration. Throwing a thenable from the hook
+ * suspends that component via the regular suspended-hydration machinery
+ * (MODE_SUSPENDED | MODE_HYDRATE + `_excess`); calling `forceUpdate()` on the
+ * suspended component later resumes hydrating its subtree in place. The
+ * orchestration below is what an opt-in addon would ship: a sentinel, a
+ * `_catchError` wrapper that queues suspended components, and a scheduler
+ * that resumes them in budgeted slices.
+ */
+describe('hydration yielding (#407)', () => {
+	/** @type {HTMLElement} */
+	let scratch;
+	let rerender;
+
+	/** Components allowed to freshly mount before the walk suspends */
+	let budget;
+	/** Suspended components waiting for the next slice */
+	let queue;
+	let uninstall;
+
+	function installSlicing() {
+		// The sentinel must be thenable so diff() treats it as a suspension
+		// eslint-disable-next-line unicorn/no-thenable
+		const sentinel = { then() {} };
+		queue = [];
+		budget = Infinity;
+
+		const prevYield = options._yield;
+		const prevCatchError = options._catchError;
+
+		options._yield = vnode => {
+			// Never suspend the root fragment: its DOM span is the whole tree
+			if (vnode._parent && --budget < 0) throw sentinel;
+		};
+
+		options._catchError = (error, vnode, oldVNode, errorInfo) => {
+			if (error === sentinel) {
+				queue.push(vnode._component);
+				return;
+			}
+			prevCatchError(error, vnode, oldVNode, errorInfo);
+		};
+
+		uninstall = () => {
+			options._yield = prevYield;
+			options._catchError = prevCatchError;
+		};
+	}
+
+	/** Resume all suspended components, allowing `n` new mounts this slice */
+	function flushSlice(n) {
+		budget = n;
+		const pending = queue.splice(0);
+		pending.forEach(c => c.forceUpdate());
+		rerender();
+	}
+
+	let resetAppendChild;
+	let resetInsertBefore;
+	let resetRemove;
+
+	beforeAll(() => {
+		resetAppendChild = logCall(Element.prototype, 'appendChild');
+		resetInsertBefore = logCall(Element.prototype, 'insertBefore');
+		resetRemove = logCall(Element.prototype, 'remove');
+	});
+
+	afterAll(() => {
+		resetAppendChild();
+		resetInsertBefore();
+		resetRemove();
+	});
+
+	beforeEach(() => {
+		rerender = setupRerender();
+		scratch = setupScratch();
+		installSlicing();
+		clearLog();
+	});
+
+	afterEach(() => {
+		uninstall();
+		teardown(scratch);
+	});
+
+	let mounts, clicks;
+	class Section extends Component {
+		componentDidMount() {
+			mounts.push(this.props.name);
+		}
+		render() {
+			return <section>{this.props.children}</section>;
+		}
+	}
+	const Item = ({ children, name }) => (
+		<li onClick={() => clicks.push(name)}>{children}</li>
+	);
+	const App = () => (
+		<div>
+			<Section name="a">
+				<Item name="A">A</Item>
+			</Section>
+			<Section name="b">
+				<Item name="B">B</Item>
+			</Section>
+			<Section name="c">
+				<Item name="C">C</Item>
+			</Section>
+		</div>
+	);
+	const APP_HTML =
+		'<div>' +
+		'<section><li>A</li></section>' +
+		'<section><li>B</li></section>' +
+		'<section><li>C</li></section>' +
+		'</div>';
+
+	beforeEach(() => {
+		mounts = [];
+		clicks = [];
+	});
+
+	it('suspends the hydration walk without touching the SSR DOM', () => {
+		scratch.innerHTML = APP_HTML;
+		const sections = Array.from(scratch.querySelectorAll('section'));
+		const items = Array.from(scratch.querySelectorAll('li'));
+		clearLog();
+
+		// Allow App, Section a and Item A to mount, then suspend
+		budget = 3;
+		hydrate(<App />, scratch);
+
+		expect(queue.length).to.equal(2); // Section b + Section c
+		expect(mounts).to.deep.equal(['a']);
+		expect(scratch.innerHTML).to.equal(APP_HTML);
+		expect(getLog()).to.deep.equal([]);
+
+		flushSlice(Infinity);
+
+		expect(queue.length).to.equal(0);
+		expect(mounts).to.deep.equal(['a', 'b', 'c']);
+		expect(scratch.innerHTML).to.equal(APP_HTML);
+		// Every SSR node was adopted, none recreated or moved
+		expect(Array.from(scratch.querySelectorAll('section'))).to.deep.equal(
+			sections
+		);
+		expect(Array.from(scratch.querySelectorAll('li'))).to.deep.equal(items);
+		expect(getLog()).to.deep.equal([]);
+	});
+
+	it('makes hydrated slices interactive while later slices are pending', () => {
+		scratch.innerHTML = APP_HTML;
+		clearLog();
+
+		budget = 3;
+		hydrate(<App />, scratch);
+
+		const [liA, , liC] = scratch.querySelectorAll('li');
+		liA.click();
+		liC.click();
+		// Item C hasn't hydrated yet, so only A responds
+		expect(clicks).to.deep.equal(['A']);
+
+		flushSlice(Infinity);
+
+		liC.click();
+		expect(clicks).to.deep.equal(['A', 'C']);
+	});
+
+	it('re-suspends fresh mounts in later slices until the walk completes', () => {
+		scratch.innerHTML = APP_HTML;
+		clearLog();
+
+		// Only App itself mounts; all three sections suspend
+		budget = 1;
+		hydrate(<App />, scratch);
+		expect(queue.length).to.equal(3);
+		expect(mounts).to.deep.equal([]);
+
+		// Resumed components always render, but their children are fresh
+		// mounts and re-suspend with an exhausted budget
+		flushSlice(0);
+		expect(queue.length).to.equal(3); // Item A, B, C
+		expect(mounts).to.deep.equal(['a', 'b', 'c']);
+		expect(scratch.innerHTML).to.equal(APP_HTML);
+
+		flushSlice(Infinity);
+		expect(queue.length).to.equal(0);
+		expect(scratch.innerHTML).to.equal(APP_HTML);
+		expect(getLog()).to.deep.equal([]);
+	});
+
+	it('reuses the SSR text node when a text-root component resumes', () => {
+		const Txt = () => 'hello';
+		const TextApp = () => (
+			<div>
+				<Txt />
+			</div>
+		);
+
+		scratch.innerHTML = '<div>hello</div>';
+		const textNode = scratch.firstChild.firstChild;
+		clearLog();
+
+		budget = 1;
+		hydrate(<TextApp />, scratch);
+		expect(queue.length).to.equal(1);
+
+		flushSlice(Infinity);
+		expect(scratch.firstChild.firstChild).to.equal(textNode);
+		expect(scratch.innerHTML).to.equal('<div>hello</div>');
+	});
+
+	it('still propagates real errors thrown during hydration', () => {
+		const Boom = () => {
+			throw new Error('boom');
+		};
+
+		scratch.innerHTML = '<div></div>';
+		budget = Infinity;
+		expect(() =>
+			hydrate(
+				<div>
+					<Boom />
+				</div>,
+				scratch
+			)
+		).to.throw('boom');
+	});
+
+	it('does not affect hydration when no hook is installed', () => {
+		uninstall();
+		// Reinstall a noop uninstall so afterEach stays happy
+		uninstall = () => {};
+
+		scratch.innerHTML = APP_HTML;
+		clearLog();
+		hydrate(<App />, scratch);
+
+		expect(mounts).to.deep.equal(['a', 'b', 'c']);
+		expect(scratch.innerHTML).to.equal(APP_HTML);
+		expect(getLog()).to.deep.equal([]);
+	});
+});

--- a/test/browser/hydrationYield.test.jsx
+++ b/test/browser/hydrationYield.test.jsx
@@ -506,9 +506,10 @@ describe('hydration yielding (#407)', () => {
 			expect(lis[1]).to.not.equal(li2);
 		});
 
-		it('null-root: steals the next sibling node, duplicating it permanently', () => {
+		it('null-root: transiently duplicates the stolen sibling node until resume', () => {
 			const Nothing = () => null;
 			scratch.innerHTML = '<ul><li>3</li></ul>';
+			const li = scratch.querySelector('li');
 
 			budget = 0;
 			hydrate(
@@ -518,11 +519,16 @@ describe('hydration yielding (#407)', () => {
 				</ul>,
 				scratch
 			);
+			// The suspended null-renderer claimed <li>3</li> as its resume
+			// point, so the real sibling deopted and created a duplicate
+			expect(scratch.innerHTML).to.equal('<ul><li>3</li><li>3</li></ul>');
+
 			flushSlice(Infinity);
 
-			// The suspended null-renderer claimed <li>3</li> as its resume
-			// point, so the real sibling deopted and created a duplicate.
-			expect(scratch.innerHTML).to.equal('<ul><li>3</li><li>3</li></ul>');
+			// On resume the unclaimed stolen node is removed again: the final
+			// markup is correct, but the surviving <li> is the recreated one
+			expect(scratch.innerHTML).to.equal('<ul><li>3</li></ul>');
+			expect(scratch.querySelector('li')).to.not.equal(li);
 		});
 
 		it('a shape-learning policy avoids both pitfalls', () => {

--- a/test/browser/hydrationYield.test.jsx
+++ b/test/browser/hydrationYield.test.jsx
@@ -1,20 +1,15 @@
-import { createElement, hydrate, options, Component } from 'preact';
+import {
+	createElement,
+	hydrate,
+	options,
+	Component,
+	createContext,
+	createRef
+} from 'preact';
 import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../_util/helpers';
 import { logCall, clearLog, getLog } from '../_util/logCall';
 
-/**
- * Tests for time-sliced (interruptible) hydration, see #407.
- *
- * Core exposes `options._yield`, invoked right before a freshly mounting
- * component renders during hydration. Throwing a thenable from the hook
- * suspends that component via the regular suspended-hydration machinery
- * (MODE_SUSPENDED | MODE_HYDRATE + `_excess`); calling `forceUpdate()` on the
- * suspended component later resumes hydrating its subtree in place. The
- * orchestration below is what an opt-in addon would ship: a sentinel, a
- * `_catchError` wrapper that queues suspended components, and a scheduler
- * that resumes them in budgeted slices.
- */
 describe('hydration yielding (#407)', () => {
 	/** @type {HTMLElement} */
 	let scratch;
@@ -248,5 +243,384 @@ describe('hydration yielding (#407)', () => {
 		expect(mounts).to.deep.equal(['a', 'b', 'c']);
 		expect(scratch.innerHTML).to.equal(APP_HTML);
 		expect(getLog()).to.deep.equal([]);
+	});
+
+	it('provides context to components resuming in a later slice', () => {
+		const Ctx = createContext('default');
+		class Reader extends Component {
+			render() {
+				return <span>{this.context}</span>;
+			}
+		}
+		Reader.contextType = Ctx;
+
+		scratch.innerHTML = '<span>live</span>';
+		const span = scratch.firstChild;
+
+		// Provider mounts, Reader suspends
+		budget = 1;
+		hydrate(
+			<Ctx.Provider value="live">
+				<Reader />
+			</Ctx.Provider>,
+			scratch
+		);
+		expect(queue.length).to.equal(1);
+
+		flushSlice(Infinity);
+		expect(scratch.firstChild).to.equal(span);
+		expect(scratch.innerHTML).to.equal('<span>live</span>');
+	});
+
+	it('applies refs to adopted DOM when a suspended component resumes', () => {
+		const ref = createRef();
+		const Widget = () => <span ref={ref}>w</span>;
+
+		scratch.innerHTML = '<div><span>w</span></div>';
+		const span = scratch.firstChild.firstChild;
+
+		budget = 0;
+		hydrate(
+			<div>
+				<Widget />
+			</div>,
+			scratch
+		);
+		expect(ref.current).to.equal(null);
+
+		flushSlice(Infinity);
+		expect(ref.current).to.equal(span);
+	});
+
+	it('resumes components whose shouldComponentUpdate returns false', () => {
+		class Gate extends Component {
+			shouldComponentUpdate() {
+				return false;
+			}
+			render() {
+				return <li onClick={() => clicks.push('gate')}>g</li>;
+			}
+		}
+
+		scratch.innerHTML = '<li>g</li>';
+		const li = scratch.firstChild;
+
+		budget = 0;
+		hydrate(<Gate />, scratch);
+		expect(queue.length).to.equal(1);
+
+		flushSlice(Infinity);
+		expect(scratch.firstChild).to.equal(li);
+		li.click();
+		expect(clicks).to.deep.equal(['gate']);
+	});
+
+	it('resumes a suspended child inline when its parent re-renders first', () => {
+		/** @type {Parent} */
+		let parent;
+		const Kid = () => <li onClick={() => clicks.push('kid')}>k</li>;
+		class Parent extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { label: 'x' };
+				parent = this;
+			}
+			render() {
+				return (
+					<div>
+						<span>{this.state.label}</span>
+						<Kid />
+					</div>
+				);
+			}
+		}
+
+		scratch.innerHTML = '<div><span>x</span><li>k</li></div>';
+		const li = scratch.querySelector('li');
+
+		// Parent mounts, Kid suspends
+		budget = 1;
+		hydrate(<Parent />, scratch);
+		expect(queue.length).to.equal(1);
+
+		// A state update above the suspended child resumes it inline through
+		// the MODE_SUSPENDED path in diff()
+		parent.setState({ label: 'y' });
+		rerender();
+
+		expect(scratch.querySelector('span').textContent).to.equal('y');
+		expect(scratch.querySelector('li')).to.equal(li);
+		li.click();
+		expect(clicks).to.deep.equal(['kid']);
+
+		// The stale queue entry must be a harmless no-op
+		flushSlice(Infinity);
+		expect(scratch.querySelector('li')).to.equal(li);
+		li.click();
+		expect(clicks).to.deep.equal(['kid', 'kid']);
+	});
+
+	it('completes hydration with the deadline-based scheduler from the PR example', async () => {
+		// This test runs the realistic orchestrator: performance.now() deadline
+		// + setTimeout flushes, with preact's default microtask render queue.
+		uninstall();
+		const prevDebounce = options.debounceRendering;
+		options.debounceRendering = undefined;
+
+		const BUDGET = 1;
+		// eslint-disable-next-line unicorn/no-thenable
+		const sentinel = { then() {} };
+		const pending = [];
+		let deadline = 0;
+		let scheduled = false;
+		let slices = 0;
+
+		options._yield = vnode => {
+			if (vnode._parent && performance.now() > deadline) throw sentinel;
+		};
+		const prevCatchError = options._catchError;
+		options._catchError = (error, vnode, oldVNode, errorInfo) => {
+			if (error === sentinel) {
+				pending.push(vnode._component);
+				schedule();
+				return;
+			}
+			prevCatchError(error, vnode, oldVNode, errorInfo);
+		};
+		uninstall = () => {
+			options._yield = undefined;
+			options._catchError = prevCatchError;
+			options.debounceRendering = prevDebounce;
+		};
+
+		function schedule() {
+			if (!scheduled) {
+				scheduled = true;
+				setTimeout(flush);
+			}
+		}
+
+		// Resumed components render unconditionally, so the queue must be
+		// pumped one component at a time with a deadline check after each
+		// render — force-updating the whole queue at once would hydrate all
+		// remaining flat siblings in a single task.
+		function flush() {
+			slices++;
+			deadline = performance.now() + BUDGET;
+			pump();
+		}
+
+		function pump() {
+			const c = pending.shift();
+			if (!c) {
+				scheduled = false;
+				if (pending.length) schedule();
+				return;
+			}
+			c.forceUpdate();
+			// preact renders in its own microtask; check the deadline after it
+			queueMicrotask(() => {
+				if (performance.now() > deadline) {
+					scheduled = false;
+					if (pending.length) schedule();
+				} else {
+					pump();
+				}
+			});
+		}
+
+		const spin = ms => {
+			const end = performance.now() + ms;
+			while (performance.now() < end);
+		};
+		const COUNT = 40;
+		const SpinItem = ({ i }) => {
+			spin(0.5);
+			return <li onClick={() => clicks.push(i)}>{`c${i}`}</li>;
+		};
+		const BigApp = () => (
+			<ul>
+				{Array.from({ length: COUNT }, (_, i) => (
+					<SpinItem key={i} i={i} />
+				))}
+			</ul>
+		);
+		const html =
+			'<ul>' +
+			Array.from({ length: COUNT }, (_, i) => `<li>c${i}</li>`).join('') +
+			'</ul>';
+
+		scratch.innerHTML = html;
+		const lis = Array.from(scratch.querySelectorAll('li'));
+		clearLog();
+
+		deadline = performance.now() + BUDGET;
+		hydrate(<BigApp />, scratch);
+
+		// Hydration must not have completed synchronously
+		expect(pending.length).to.be.greaterThan(0);
+
+		// Wait until the scheduler drains
+		for (let guard = 0; (pending.length || scheduled) && guard < 200; guard++) {
+			await new Promise(r => setTimeout(r, 5));
+		}
+		await new Promise(r => setTimeout(r, 10));
+
+		expect(pending.length).to.equal(0);
+		expect(slices).to.be.greaterThan(1);
+		expect(scratch.innerHTML).to.equal(html);
+		expect(Array.from(scratch.querySelectorAll('li'))).to.deep.equal(lis);
+		expect(getLog()).to.deep.equal([]);
+		lis[0].click();
+		lis[COUNT - 1].click();
+		expect(clicks).to.deep.equal([0, COUNT - 1]);
+	});
+
+	describe('documented limitations (single-DOM-root components only)', () => {
+		// `_excess` stores a single resume node, so suspending a component whose
+		// SSR output isn't exactly one DOM node misbehaves. These tests pin down
+		// the current behavior so any improvement (e.g. RTS-emitted markers)
+		// shows up as a diff. A real scheduler must only suspend components
+		// known to render a single root node.
+
+		it('fragment-root: loses trailing nodes mid-slice, recreates them on resume', () => {
+			const Multi = () => [<li>1</li>, <li>2</li>];
+			scratch.innerHTML = '<ul><li>1</li><li>2</li></ul>';
+			const [li1, li2] = scratch.querySelectorAll('li');
+
+			budget = 0;
+			hydrate(
+				<ul>
+					<Multi />
+				</ul>,
+				scratch
+			);
+			// The second root node is dropped while the component is suspended
+			expect(scratch.innerHTML).to.equal('<ul><li>1</li></ul>');
+
+			flushSlice(Infinity);
+			// Final markup is correct, but <li>2</li> was recreated, not adopted
+			expect(scratch.innerHTML).to.equal('<ul><li>1</li><li>2</li></ul>');
+			const lis = scratch.querySelectorAll('li');
+			expect(lis[0]).to.equal(li1);
+			expect(lis[1]).to.not.equal(li2);
+		});
+
+		it('null-root: steals the next sibling node, duplicating it permanently', () => {
+			const Nothing = () => null;
+			scratch.innerHTML = '<ul><li>3</li></ul>';
+
+			budget = 0;
+			hydrate(
+				<ul>
+					<Nothing />
+					<li>3</li>
+				</ul>,
+				scratch
+			);
+			flushSlice(Infinity);
+
+			// The suspended null-renderer claimed <li>3</li> as its resume
+			// point, so the real sibling deopted and created a duplicate.
+			expect(scratch.innerHTML).to.equal('<ul><li>3</li><li>3</li></ul>');
+		});
+
+		it('a shape-learning policy avoids both pitfalls', () => {
+			// The scheduler-side fix: never suspend a component type until one
+			// instance has rendered and proven to produce exactly one DOM root.
+			// First instances hydrate synchronously, null/fragment-root types
+			// are never suspended, and repeated single-root types (the common
+			// list case) remain sliceable.
+			uninstall();
+
+			const shapes = new WeakMap();
+			// eslint-disable-next-line unicorn/no-thenable
+			const sentinel = { then() {} };
+			const pending = [];
+			let allow = Infinity;
+
+			const isSingleRoot = vnode => {
+				const children = vnode._children;
+				let root = null;
+				if (children) {
+					for (let i = 0; i < children.length; i++) {
+						if (children[i] != null) {
+							if (root) return false;
+							root = children[i];
+						}
+					}
+				}
+				if (!root) return false;
+				return typeof root.type != 'function' || isSingleRoot(root);
+			};
+
+			options._yield = vnode => {
+				if (vnode._parent && shapes.get(vnode.type) && --allow < 0) {
+					throw sentinel;
+				}
+			};
+			const prevCatchError = options._catchError;
+			options._catchError = (error, vnode, oldVNode, errorInfo) => {
+				if (error === sentinel) {
+					pending.push(vnode._component);
+					return;
+				}
+				prevCatchError(error, vnode, oldVNode, errorInfo);
+			};
+			const prevDiffed = options.diffed;
+			options.diffed = vnode => {
+				// Unknown types can never be suspended, so any vnode we learn
+				// from here rendered for real
+				if (typeof vnode.type == 'function' && !shapes.has(vnode.type)) {
+					shapes.set(vnode.type, isSingleRoot(vnode));
+				}
+				if (prevDiffed) prevDiffed(vnode);
+			};
+			uninstall = () => {
+				options._yield = undefined;
+				options._catchError = prevCatchError;
+				options.diffed = prevDiffed;
+			};
+
+			const Nothing = () => null;
+			const Pair = () => [<li>p1</li>, <li>p2</li>];
+			const Note = ({ n }) => <li onClick={() => clicks.push(n)}>{n}</li>;
+			const PolicyApp = () => (
+				<ul>
+					<Note n="1" />
+					<Nothing />
+					<Note n="2" />
+					<Pair />
+					<Note n="3" />
+					<Note n="4" />
+				</ul>
+			);
+			const html =
+				'<ul><li>1</li><li>2</li><li>p1</li><li>p2</li><li>3</li><li>4</li></ul>';
+
+			scratch.innerHTML = html;
+			const lis = Array.from(scratch.querySelectorAll('li'));
+			clearLog();
+
+			// One learned-single-root instance beyond the first may render
+			allow = 1;
+			hydrate(<PolicyApp />, scratch);
+
+			// Note 1 taught the policy (rendered sync), Nothing and Pair were
+			// never suspended, Note 2 used the allowance, Notes 3+4 deferred
+			expect(pending.length).to.equal(2);
+			// No corruption at any point: the DOM is untouched mid-slice
+			expect(scratch.innerHTML).to.equal(html);
+
+			allow = Infinity;
+			pending.splice(0).forEach(c => c.forceUpdate());
+			rerender();
+
+			expect(scratch.innerHTML).to.equal(html);
+			expect(Array.from(scratch.querySelectorAll('li'))).to.deep.equal(lis);
+			expect(getLog()).to.deep.equal([]);
+			lis[5].click();
+			expect(clicks).to.deep.equal(['4']);
+		});
 	});
 });


### PR DESCRIPTION
This would allow a self-serve kind of yield mechanism, an example can be seen below

```js
function installSlicing() {
	// Published builds mangle option/vnode internals:
	//   options._yield -> __y, options._catchError -> __e,
	//   vnode._parent -> __, vnode._component -> __c
	options.__y = vnode => {
		if (vnode.__ && performance.now() > deadline) throw sentinel;
	};
	const prevCatchError = options.__e;
	options.__e = (error, vnode, oldVNode, errorInfo) => {
		if (error === sentinel) {
			pending.push(vnode.__c);
			schedule();
			return;
		}
		prevCatchError(error, vnode, oldVNode, errorInfo);
	};
}
```

Now my concern is that this is quite open-ended and the main thing this hook gives is the point of invocation as well as only invoking during hydration. Another thing that would warrant change if we introduce this is to enable yielding during updates i.e. if our render queue contains 5 items and the first takes up 30ms we should be able to pause and then resume the 4 next items.

This PR is very much tentative but wanted to show what I've been thinking about.