### PR TITLE
Support createPortal in core

### DIFF
--- a/compat/src/portals.js
+++ b/compat/src/portals.js
@@ -1,66 +1,4 @@
-import { createElement, render } from 'preact';
-
-/**
- * @param {import('../../src/index').RenderableProps<{ context: any }>} props
- */
-function ContextProvider(props) {
-	this.getChildContext = () => props.context;
-	return props.children;
-}
-
-/**
- * Portal component
- * @this {import('./internal').Component}
- * @param {object | null | undefined} props
- *
- * TODO: use createRoot() instead of fake root
- */
-function Portal(props) {
-	const _this = this;
-	let container = props._container;
-
-	_this.componentWillUnmount = function () {
-		render(null, _this._temp);
-		_this._temp = null;
-		_this._container = null;
-	};
-
-	// When we change container we should clear our old container and
-	// indicate a new mount.
-	if (_this._container && _this._container !== container) {
-		_this.componentWillUnmount();
-	}
-
-	if (!_this._temp) {
-		// Ensure the element has a mask for useId invocations
-		let root = _this._vnode;
-		while (root !== null && !root._mask && root._parent !== null) {
-			root = root._parent;
-		}
-
-		_this._container = container;
-
-		// Create a fake DOM parent node that manages a subset of `container`'s children:
-		_this._temp = {
-			nodeType: 1,
-			parentNode: container,
-			childNodes: [],
-			_children: { _mask: root._mask },
-			ownerDocument: container.ownerDocument,
-			namespaceURI: container.namespaceURI,
-			insertBefore(child, before) {
-				this.childNodes.push(child);
-				_this._container.insertBefore(child, before);
-			}
-		};
-	}
-
-	// Render our wrapping element into temp.
-	render(
-		createElement(ContextProvider, { context: _this.context }, props._vnode),
-		_this._temp
-	);
-}
+import { createPortal as corePortal } from 'preact';
 
 /**
  * Create a `Portal` to continue rendering the vnode tree at a different DOM node
@@ -68,7 +6,7 @@ function Portal(props) {
  * @param {import('./internal').PreactElement} container The DOM node to continue rendering in to.
  */
 export function createPortal(vnode, container) {
-	const el = createElement(Portal, { _vnode: vnode, _container: container });
+	const el = corePortal(vnode, container);
 	el.containerInfo = container;
 	return el;
 }

--- a/compat/test/browser/portals.test.jsx
+++ b/compat/test/browser/portals.test.jsx
@@ -1,32 +1,29 @@
-import React, {
+import {
 	createElement,
 	render,
 	createPortal,
-	useState,
-	Component,
 	useEffect,
 	Fragment,
 	useId
 } from 'preact/compat';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
-import { setupRerender, act } from 'preact/test-utils';
+import { act } from 'preact/test-utils';
 import { expect } from 'chai';
-import { vi } from 'vitest';
 
 /* eslint-disable react/jsx-boolean-value, react/display-name, prefer-arrow-callback */
 
+// The hooks-free portal behavior is tested in test/browser/portals.test.jsx;
+// this file covers the compat-only `containerInfo` property and the
+// hooks-based portal tests (useId, effect ordering).
 describe('Portal', () => {
 	/** @type {HTMLDivElement} */
 	let scratch;
 	/** @type {HTMLDivElement} */
 	let scratch2;
 
-	let rerender;
-
 	beforeEach(() => {
 		scratch = setupScratch();
 		scratch2 = setupScratch('scratch-2');
-		rerender = setupRerender();
 	});
 
 	afterEach(() => {
@@ -34,185 +31,27 @@ describe('Portal', () => {
 		teardown(scratch2);
 	});
 
-	it('should render into a different root node', () => {
+	it('should include containerInfo', () => {
 		let root = document.createElement('div');
 		document.body.appendChild(root);
 
+		const A = () => <span>A</span>;
+
+		let portal;
 		function Foo(props) {
-			return <div>{createPortal(props.children, root)}</div>;
+			portal = createPortal(props.children, root);
+			return <div>{portal}</div>;
 		}
-		render(<Foo>foobar</Foo>, scratch);
-
-		expect(root.innerHTML).to.equal('foobar');
-
-		root.parentNode.removeChild(root);
-	});
-
-	it('should insert the portal', () => {
-		/** @type {() => void} */
-		let setFalse;
-		function Foo(props) {
-			const [mounted, setMounted] = useState(true);
-			setFalse = () => setMounted(() => false);
-			return (
-				<div>
-					<p>Hello</p>
-					{mounted && createPortal(props.children, scratch)}
-				</div>
-			);
-		}
-		render(<Foo>foobar</Foo>, scratch);
-		expect(scratch.innerHTML).to.equal('foobar<div><p>Hello</p></div>');
-
-		setFalse();
-		rerender();
-		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
-	});
-
-	it('should order portal children well', () => {
-		/** @type {() => void} */
-		let bump;
-
-		function Modal() {
-			const [state, setState] = useState(0);
-			bump = () => setState(() => 1);
-
-			return (
-				<Fragment>
-					{state === 1 && <div>top</div>}
-					<div>middle</div>
-					<div>bottom</div>
-				</Fragment>
-			);
-		}
-
-		function Foo(props) {
-			return createPortal(<Modal />, scratch);
-		}
-		render(<Foo />, scratch);
-		expect(scratch.innerHTML).to.equal('<div>middle</div><div>bottom</div>');
-
-		bump();
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div>top</div><div>middle</div><div>bottom</div>'
-		);
-	});
-
-	it('should toggle the portal', () => {
-		/** @type {() => void} */
-		let toggle;
-
-		function Foo(props) {
-			const [mounted, setMounted] = useState(true);
-			toggle = () => setMounted(s => !s);
-			return (
-				<div>
-					<p>Hello</p>
-					{mounted && createPortal(props.children, scratch)}
-				</div>
-			);
-		}
-
 		render(
 			<Foo>
-				<div>foobar</div>
+				<A />
 			</Foo>,
 			scratch
 		);
-		expect(scratch.innerHTML).to.equal(
-			'<div>foobar</div><div><p>Hello</p></div>'
-		);
 
-		toggle();
-		rerender();
-		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
+		expect(portal.containerInfo).to.equal(root);
 
-		toggle();
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div><p>Hello</p></div><div>foobar</div>'
-		);
-	});
-
-	it('should notice prop changes on the portal', () => {
-		/** @type {(c) => void} */
-		let set;
-
-		function Foo(props) {
-			const [additionalProps, setProps] = useState({
-				style: { backgroundColor: 'red' }
-			});
-			set = c => setProps(c);
-			return (
-				<div>
-					<p>Hello</p>
-					{createPortal(<p {...additionalProps}>Foo</p>, scratch)}
-				</div>
-			);
-		}
-
-		render(<Foo />, scratch);
-		expect(scratch.firstChild.style.backgroundColor).to.equal('red');
-
-		set({});
-		rerender();
-		expect(scratch.firstChild.style.backgroundColor).to.equal('');
-	});
-
-	it('should not unmount the portal component', () => {
-		let spy = vi.fn();
-		/** @type {(c) => void} */
-		let set;
-		class Child extends Component {
-			componentWillUnmount() {
-				spy();
-			}
-
-			render(props) {
-				return props.children;
-			}
-		}
-
-		function Foo(props) {
-			const [additionalProps, setProps] = useState({
-				style: { background: 'red' }
-			});
-			set = c => setProps(c);
-			return (
-				<div>
-					<p>Hello</p>
-					{createPortal(<Child {...additionalProps}>Foo</Child>, scratch)}
-				</div>
-			);
-		}
-
-		render(<Foo />, scratch);
-		expect(spy).not.toHaveBeenCalled();
-
-		set({});
-		rerender();
-		expect(spy).not.toHaveBeenCalled();
-	});
-
-	it('should not render <undefined> for Portal nodes', () => {
-		let root = document.createElement('div');
-		let dialog = document.createElement('div');
-		dialog.id = 'container';
-
-		scratch.appendChild(root);
-		scratch.appendChild(dialog);
-
-		function Dialog() {
-			return <div>Dialog content</div>;
-		}
-
-		function App() {
-			return <div>{createPortal(<Dialog />, dialog)}</div>;
-		}
-
-		render(<App />, root);
-		expect(scratch.firstChild.firstChild.childNodes.length).to.equal(0);
+		root.parentNode.removeChild(root);
 	});
 
 	it('should have unique ids for each portal', () => {
@@ -285,477 +124,6 @@ describe('Portal', () => {
 		);
 	});
 
-	it('should unmount Portal', () => {
-		let root = document.createElement('div');
-		let dialog = document.createElement('div');
-		dialog.id = 'container';
-
-		scratch.appendChild(root);
-		scratch.appendChild(dialog);
-
-		function Dialog() {
-			return <div>Dialog content</div>;
-		}
-
-		function App() {
-			return <div>{createPortal(<Dialog />, dialog)}</div>;
-		}
-
-		render(<App />, root);
-		expect(dialog.childNodes.length).to.equal(1);
-		render(null, root);
-		expect(dialog.childNodes.length).to.equal(0);
-	});
-
-	it('should leave a working root after the portal', () => {
-		/** @type {() => void} */
-		let toggle,
-			/** @type {() => void} */
-			toggle2;
-
-		function Foo(props) {
-			const [mounted, setMounted] = useState(false);
-			const [mounted2, setMounted2] = useState(true);
-			toggle = () => setMounted(s => !s);
-			toggle2 = () => setMounted2(s => !s);
-			return (
-				<div>
-					{mounted && createPortal(props.children, scratch)}
-					{mounted2 && <p>Hello</p>}
-				</div>
-			);
-		}
-
-		render(
-			<Foo>
-				<div>foobar</div>
-			</Foo>,
-			scratch
-		);
-		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
-
-		toggle();
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div><p>Hello</p></div><div>foobar</div>'
-		);
-
-		toggle2();
-		rerender();
-		expect(scratch.innerHTML).to.equal('<div></div><div>foobar</div>');
-
-		toggle2();
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div><p>Hello</p></div><div>foobar</div>'
-		);
-
-		toggle();
-		rerender();
-		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
-
-		toggle2();
-		rerender();
-		expect(scratch.innerHTML).to.equal('<div></div>');
-	});
-
-	it('should work with stacking portals', () => {
-		/** @type {() => void} */
-		let toggle,
-			/** @type {() => void} */
-			toggle2;
-
-		function Foo(props) {
-			const [mounted, setMounted] = useState(false);
-			const [mounted2, setMounted2] = useState(false);
-			toggle = () => setMounted(s => !s);
-			toggle2 = () => setMounted2(s => !s);
-			return (
-				<div>
-					<p>Hello</p>
-					{mounted && createPortal(props.children, scratch)}
-					{mounted2 && createPortal(props.children2, scratch)}
-				</div>
-			);
-		}
-
-		render(
-			<Foo children2={<div>foobar2</div>}>
-				<div>foobar</div>
-			</Foo>,
-			scratch
-		);
-		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
-
-		toggle();
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div><p>Hello</p></div><div>foobar</div>'
-		);
-
-		toggle2();
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div><p>Hello</p></div><div>foobar</div><div>foobar2</div>'
-		);
-
-		toggle2();
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div><p>Hello</p></div><div>foobar</div>'
-		);
-
-		toggle();
-		rerender();
-		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
-	});
-
-	it('should work with changing the container', () => {
-		/** @type {(c) => void} */
-		let set, ref;
-
-		function Foo(props) {
-			const [container, setContainer] = useState(scratch);
-			set = setContainer;
-
-			return (
-				<div
-					ref={r => {
-						ref = r;
-					}}
-				>
-					<p>Hello</p>
-					{createPortal(props.children, container)}
-				</div>
-			);
-		}
-
-		render(
-			<Foo>
-				<div>foobar</div>
-			</Foo>,
-			scratch
-		);
-		expect(scratch.innerHTML).to.equal(
-			'<div>foobar</div><div><p>Hello</p></div>'
-		);
-
-		set(() => ref);
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div><p>Hello</p><div>foobar</div></div>'
-		);
-	});
-
-	it('should work with replacing placeholder portals', () => {
-		/** @type {() => void} */
-		let toggle,
-			/** @type {() => void} */
-			toggle2;
-
-		function Foo(props) {
-			const [mounted, setMounted] = useState(false);
-			const [mounted2, setMounted2] = useState(false);
-			toggle = () => setMounted(s => !s);
-			toggle2 = () => setMounted2(s => !s);
-			return (
-				<div>
-					<p>Hello</p>
-					{createPortal(mounted && props.children, scratch)}
-					{createPortal(mounted2 && props.children, scratch)}
-				</div>
-			);
-		}
-
-		render(
-			<Foo>
-				<div>foobar</div>
-			</Foo>,
-			scratch
-		);
-		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
-
-		toggle();
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div><p>Hello</p></div><div>foobar</div>'
-		);
-
-		toggle();
-		rerender();
-		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
-
-		toggle2();
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div><p>Hello</p></div><div>foobar</div>'
-		);
-
-		toggle2();
-		rerender();
-		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
-	});
-
-	it('should work with removing an element from stacked container to new one', () => {
-		/** @type {() => void} */
-		let toggle, root2;
-
-		function Foo(props) {
-			const [root, setRoot] = useState(scratch);
-			toggle = () => setRoot(() => root2);
-			return (
-				<div
-					ref={r => {
-						root2 = r;
-					}}
-				>
-					<p>Hello</p>
-					{createPortal(props.children, scratch)}
-					{createPortal(props.children, root)}
-				</div>
-			);
-		}
-
-		render(
-			<Foo>
-				<div>foobar</div>
-			</Foo>,
-			scratch
-		);
-		expect(scratch.innerHTML).to.equal(
-			'<div>foobar</div><div>foobar</div><div><p>Hello</p></div>'
-		);
-
-		toggle();
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div>foobar</div><div><p>Hello</p><div>foobar</div></div>'
-		);
-	});
-
-	it('should support nested portals', () => {
-		/** @type {() => void} */
-		let toggle,
-			/** @type {() => void} */
-			toggle2,
-			inner;
-
-		function Bar() {
-			const [mounted, setMounted] = useState(false);
-			toggle2 = () => setMounted(s => !s);
-			return (
-				<div
-					ref={r => {
-						inner = r;
-					}}
-				>
-					<p>Inner</p>
-					{mounted && createPortal(<p>hiFromBar</p>, scratch)}
-					{mounted && createPortal(<p>innerPortal</p>, inner)}
-				</div>
-			);
-		}
-
-		function Foo(props) {
-			const [mounted, setMounted] = useState(false);
-			toggle = () => setMounted(s => !s);
-			return (
-				<div>
-					<p>Hello</p>
-					{mounted && createPortal(<Bar />, scratch)}
-				</div>
-			);
-		}
-
-		render(<Foo />, scratch);
-		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
-
-		toggle();
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div><p>Hello</p></div><div><p>Inner</p></div>'
-		);
-
-		toggle2();
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div><p>Hello</p></div><div><p>Inner</p><p>innerPortal</p></div><p>hiFromBar</p>'
-		);
-
-		toggle();
-		rerender();
-		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
-	});
-
-	it('should support nested portals remounting #2669', () => {
-		let setVisible;
-		let i = 0;
-
-		function PortalComponent(props) {
-			const innerVnode = <div id="inner">{i}</div>;
-			innerVnode.___id = 'inner_' + i++;
-			const outerVnode = (
-				<div id="outer">
-					{i}
-					{props.show && createPortal(innerVnode, scratch)}
-				</div>
-			);
-			outerVnode.___id = 'outer_' + i++;
-			return createPortal(outerVnode, scratch);
-		}
-
-		function App() {
-			const [visible, _setVisible] = useState(true);
-			setVisible = _setVisible;
-
-			return (
-				<div id="app">
-					test
-					<PortalComponent show={visible} />
-				</div>
-			);
-		}
-
-		render(<App />, scratch);
-		expect(scratch.innerHTML).to.equal(
-			'<div id="inner">0</div><div id="outer">1</div><div id="app">test</div>'
-		);
-
-		act(() => {
-			setVisible(false);
-		});
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div id="outer">3</div><div id="app">test</div>'
-		);
-
-		act(() => {
-			setVisible(true);
-		});
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div id="outer">5</div><div id="app">test</div><div id="inner">4</div>'
-		);
-
-		act(() => {
-			setVisible(false);
-		});
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div id="outer">7</div><div id="app">test</div>'
-		);
-	});
-
-	it('should not unmount when parent renders', () => {
-		let root = document.createElement('div');
-		let dialog = document.createElement('div');
-		dialog.id = 'container';
-
-		scratch.appendChild(root);
-		scratch.appendChild(dialog);
-
-		let spy = vi.fn();
-		class Child extends Component {
-			componentDidMount() {
-				spy();
-			}
-
-			render() {
-				return <div id="child">child</div>;
-			}
-		}
-
-		let spyParent = vi.fn();
-		class App extends Component {
-			componentDidMount() {
-				spyParent();
-			}
-			render() {
-				return <div>{createPortal(<Child />, dialog)}</div>;
-			}
-		}
-
-		render(<App />, root);
-		let dom = document.getElementById('child');
-		expect(spyParent).toHaveBeenCalledOnce();
-		expect(spy).toHaveBeenCalledOnce();
-
-		// Render twice to trigger update scenario
-		render(<App />, root);
-		render(<App />, root);
-
-		let domNew = document.getElementById('child');
-		expect(dom).to.equal(domNew);
-		expect(spyParent).toHaveBeenCalledOnce();
-		expect(spy).toHaveBeenCalledOnce();
-	});
-
-	it('should switch between non portal and portal node (Modal as lastChild)', () => {
-		/** @type {() => void} */
-		let toggle;
-		const Modal = ({ children, open }) =>
-			open ? createPortal(<div>{children}</div>, scratch) : <div>Closed</div>;
-
-		const App = () => {
-			const [open, setOpen] = useState(false);
-			toggle = setOpen.bind(this, x => !x);
-			return (
-				<div>
-					<button onClick={() => setOpen(!open)}>Show</button>
-					{open ? 'Open' : 'Closed'}
-					<Modal open={open}>Hello</Modal>
-				</div>
-			);
-		};
-
-		render(<App />, scratch);
-		expect(scratch.innerHTML).to.equal(
-			'<div><button>Show</button>Closed<div>Closed</div></div>'
-		);
-
-		toggle();
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div><button>Show</button>Open</div><div>Hello</div>'
-		);
-	});
-
-	it('should switch between non portal and portal node (Modal as firstChild)', () => {
-		/** @type {() => void} */
-		let toggle;
-		const Modal = ({ children, open }) =>
-			open ? createPortal(<div>{children}</div>, scratch) : <div>Closed</div>;
-
-		const App = () => {
-			const [open, setOpen] = useState(false);
-			toggle = setOpen.bind(this, x => !x);
-			return (
-				<div>
-					<Modal open={open}>Hello</Modal>
-					<button onClick={() => setOpen(!open)}>Show</button>
-					{open ? 'Open' : 'Closed'}
-				</div>
-			);
-		};
-
-		render(<App />, scratch);
-		expect(scratch.innerHTML).to.equal(
-			'<div><div>Closed</div><button>Show</button>Closed</div>'
-		);
-
-		toggle();
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div><button>Show</button>Open</div><div>Hello</div>'
-		);
-
-		toggle();
-		rerender();
-		expect(scratch.innerHTML).to.equal(
-			'<div><div>Closed</div><button>Show</button>Closed</div>'
-		);
-	});
-
 	it('should order effects well', () => {
 		const calls = [];
 		const Modal = ({ children }) => {
@@ -791,29 +159,6 @@ describe('Portal', () => {
 		});
 
 		expect(calls).to.deep.equal(['Button 1', 'Button 2', 'Modal', 'App']);
-	});
-
-	it('should include containerInfo', () => {
-		let root = document.createElement('div');
-		document.body.appendChild(root);
-
-		const A = () => <span>A</span>;
-
-		let portal;
-		function Foo(props) {
-			portal = createPortal(props.children, root);
-			return <div>{portal}</div>;
-		}
-		render(
-			<Foo>
-				<A />
-			</Foo>,
-			scratch
-		);
-
-		expect(portal.containerInfo).to.equal(root);
-
-		root.parentNode.removeChild(root);
 	});
 
 	it('should order complex effects well', () => {
@@ -852,10 +197,10 @@ describe('Portal', () => {
 			));
 
 			return (
-				<React.Fragment>
+				<Fragment>
 					<Parent>{content}</Parent>
 					<Portal />
-				</React.Fragment>
+				</Fragment>
 			);
 		};
 
@@ -874,36 +219,5 @@ describe('Portal', () => {
 			'Portal Parent',
 			'Portal'
 		]);
-	});
-
-	// #4992
-	it('should maintain SVG namespace when rendering through a portal', () => {
-		const svgRoot = document.createElementNS(
-			'http://www.w3.org/2000/svg',
-			'svg'
-		);
-		document.body.appendChild(svgRoot);
-
-		function App() {
-			return (
-				<svg>
-					<g>
-						<rect width="100" height="100" fill="red" />
-						{createPortal(
-							<g id="test-portal">
-								<rect width="50" height="50" fill="blue" />
-							</g>,
-							svgRoot
-						)}
-					</g>
-				</svg>
-			);
-		}
-
-		render(<App />, scratch);
-
-		const portalG = svgRoot.querySelector('g#test-portal');
-		expect(portalG.namespaceURI).to.equal('http://www.w3.org/2000/svg');
-		expect(portalG.constructor.name).to.equal('SVGGElement');
 	});
 });

--- a/src/component.js
+++ b/src/component.js
@@ -117,8 +117,10 @@ export function getDomSibling(vnode, childIndex) {
 	// We must resume from this vnode's sibling (in it's parent _children array)
 	// Only climb up and search the parent if we aren't searching through a DOM
 	// VNode (meaning we reached the DOM parent of the original vnode that began
-	// the search)
-	return typeof vnode.type == 'function' ? getDomSibling(vnode) : NULL;
+	// the search). New roots (_parentDom) are a DOM boundary too.
+	return typeof vnode.type == 'function' && !vnode.props._parentDom
+		? getDomSibling(vnode)
+		: NULL;
 }
 
 /**
@@ -166,7 +168,12 @@ function renderComponent(component) {
  * @param {import('./internal').VNode} vnode
  */
 function updateParentDomPointers(vnode) {
-	if ((vnode = vnode._parent) != NULL && vnode._component != NULL) {
+	// Stop at root boundaries (_parentDom)
+	if (
+		(vnode = vnode._parent) != NULL &&
+		vnode._component != NULL &&
+		!vnode.props._parentDom
+	) {
 		vnode._dom = NULL;
 		vnode._children.some(child => {
 			if (child != NULL && child._dom != NULL) {

--- a/src/create-portal.js
+++ b/src/create-portal.js
@@ -1,0 +1,20 @@
+import { createElement } from './create-element';
+
+/**
+ * Portal component. A unique type is used instead of Fragment so that a
+ * portal returned directly from a component isn't collapsed into the
+ * component's children array by the Fragment unwrapping in `diff()`.
+ * @param {object} props
+ */
+function Portal(props) {
+	return props.children;
+}
+
+/**
+ * Create a `Portal` to continue rendering the vnode tree at a different DOM node
+ * @param {import('./internal').ComponentChildren} vnode The vnode to render
+ * @param {import('./internal').PreactElement} container The DOM node to continue rendering in to
+ */
+export function createPortal(vnode, container) {
+	return createElement(Portal, { _parentDom: container }, vnode);
+}

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -357,6 +357,9 @@ function constructNewChildrenArray(
 function insert(parentVNode, oldDom, parentDom, shouldPlace, isMounting) {
 	// Note: VNodes in nested suspended trees may be missing _children.
 	if (typeof parentVNode.type == 'function') {
+		// Root children live in another container, they never move with the
+		// host tree and contribute nothing to the host insertion cursor.
+		if (parentVNode.props._parentDom) return oldDom;
 		let children = parentVNode._children;
 		for (let i = 0; children && i < children.length; i++) {
 			if (children[i]) {

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -297,6 +297,35 @@ export function diff(
 					? cloneNode(tmp.props.children)
 					: tmp;
 
+			// A vnode carrying a `_parentDom` prop, considered a new root,
+			// continues rendering into that container. The subtree must stay
+			// invisible to the host tree's DOM bookkeeping: the portal vnode
+			// keeps a `null` `_dom` and the host insertion cursor (`oldDom`)
+			// passes through unchanged.
+			let hostOldDom = oldDom;
+			if (newProps._parentDom) {
+				parentDom = newProps._parentDom;
+				// If we portal into a math or svg element we need
+				// to swap the namespace (chart libraries often do this)
+				// same for an iframe (different ownerDocument)
+				namespace = parentDom.namespaceURI;
+				doc = parentDom.ownerDocument;
+
+				// Changing the container remounts the children into the new one
+				if (
+					oldVNode.props &&
+					oldVNode.props._parentDom != parentDom &&
+					oldVNode._children
+				) {
+					oldVNode._children.forEach(child => {
+						if (child) unmount(child, child);
+					});
+					oldVNode._children = NULL;
+				}
+
+				oldDom = oldVNode._children ? getDomSibling(oldVNode, 0) : NULL;
+			}
+
 			oldDom = diffChildren(
 				parentDom,
 				isArray(renderResult) ? renderResult : [renderResult],
@@ -311,6 +340,13 @@ export function diff(
 				refQueue,
 				doc
 			);
+
+			// When we exit a portal we
+			// change up the oldDom
+			if (newProps._parentDom) {
+				newVNode._dom = NULL;
+				oldDom = hostOldDom;
+			}
 
 			// We successfully rendered this VNode, unset any stored hydration/bailout state:
 			newVNode._flags &= RESET_MODE;
@@ -732,7 +768,11 @@ export function unmount(vnode, parentVNode, skipRemove) {
 				unmount(
 					r[i],
 					parentVNode,
-					skipRemove || typeof vnode.type != 'function'
+					// A portal's children live in another container, so a removed
+					// host ancestor doesn't detach them; always remove them.
+					typeof vnode.type == 'function'
+						? skipRemove && !vnode.props._parentDom
+						: true
 				);
 			}
 		}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -273,6 +273,10 @@ export interface ContainerNode {
 
 export function render(vnode: ComponentChild, parent: ContainerNode): void;
 export function hydrate(vnode: ComponentChild, parent: ContainerNode): void;
+export function createPortal(
+	vnode: ComponentChildren,
+	container: ContainerNode
+): VNode<any>;
 export function cloneElement(
 	vnode: VNode<any>,
 	props?: any,

--- a/src/index.js
+++ b/src/index.js
@@ -9,5 +9,6 @@ export {
 export { BaseComponent as Component } from './component';
 export { cloneElement } from './clone-element';
 export { createContext } from './create-context';
+export { createPortal } from './create-portal';
 export { toChildArray } from './diff/children';
 export { default as options } from './options';

--- a/test/browser/portals.test.jsx
+++ b/test/browser/portals.test.jsx
@@ -1,0 +1,786 @@
+import {
+	createElement,
+	render,
+	createPortal,
+	Component,
+	Fragment
+} from 'preact';
+import { setupScratch, teardown } from '../_util/helpers';
+import { setupRerender, act } from 'preact/test-utils';
+import { expect } from 'chai';
+import { vi } from 'vitest';
+
+/* eslint-disable react/jsx-boolean-value, react/display-name, prefer-arrow-callback */
+
+describe('createPortal', () => {
+	/** @type {HTMLDivElement} */
+	let scratch;
+
+	let rerender;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+		rerender = setupRerender();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('should render into a different root node', () => {
+		let root = document.createElement('div');
+		document.body.appendChild(root);
+
+		function Foo(props) {
+			return <div>{createPortal(props.children, root)}</div>;
+		}
+		render(<Foo>foobar</Foo>, scratch);
+
+		expect(root.innerHTML).to.equal('foobar');
+
+		root.parentNode.removeChild(root);
+	});
+
+	it('should insert the portal', () => {
+		/** @type {() => void} */
+		let setFalse;
+		class Foo extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { mounted: true };
+				setFalse = () => this.setState({ mounted: false });
+			}
+			render(props, state) {
+				return (
+					<div>
+						<p>Hello</p>
+						{state.mounted && createPortal(props.children, scratch)}
+					</div>
+				);
+			}
+		}
+		render(<Foo>foobar</Foo>, scratch);
+		expect(scratch.innerHTML).to.equal('foobar<div><p>Hello</p></div>');
+
+		setFalse();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
+	});
+
+	it('should order portal children well', () => {
+		/** @type {() => void} */
+		let bump;
+
+		class Modal extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { top: false };
+				bump = () => this.setState({ top: true });
+			}
+			render(props, state) {
+				return (
+					<Fragment>
+						{state.top && <div>top</div>}
+						<div>middle</div>
+						<div>bottom</div>
+					</Fragment>
+				);
+			}
+		}
+
+		function Foo(props) {
+			return createPortal(<Modal />, scratch);
+		}
+		render(<Foo />, scratch);
+		expect(scratch.innerHTML).to.equal('<div>middle</div><div>bottom</div>');
+
+		bump();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div>top</div><div>middle</div><div>bottom</div>'
+		);
+	});
+
+	it('should toggle the portal', () => {
+		/** @type {() => void} */
+		let toggle;
+
+		class Foo extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { mounted: true };
+				toggle = () => this.setState(s => ({ mounted: !s.mounted }));
+			}
+			render(props, state) {
+				return (
+					<div>
+						<p>Hello</p>
+						{state.mounted && createPortal(props.children, scratch)}
+					</div>
+				);
+			}
+		}
+
+		render(
+			<Foo>
+				<div>foobar</div>
+			</Foo>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal(
+			'<div>foobar</div><div><p>Hello</p></div>'
+		);
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div><p>Hello</p></div><div>foobar</div>'
+		);
+	});
+
+	it('should notice prop changes on the portal', () => {
+		/** @type {(c) => void} */
+		let set;
+
+		class Foo extends Component {
+			constructor(props) {
+				super(props);
+				this.state = {
+					additionalProps: { style: { backgroundColor: 'red' } }
+				};
+				set = c => this.setState({ additionalProps: c });
+			}
+			render(props, state) {
+				return (
+					<div>
+						<p>Hello</p>
+						{createPortal(<p {...state.additionalProps}>Foo</p>, scratch)}
+					</div>
+				);
+			}
+		}
+
+		render(<Foo />, scratch);
+		expect(scratch.firstChild.style.backgroundColor).to.equal('red');
+
+		set({});
+		rerender();
+		expect(scratch.firstChild.style.backgroundColor).to.equal('');
+	});
+
+	it('should not unmount the portal component', () => {
+		let spy = vi.fn();
+		/** @type {(c) => void} */
+		let set;
+		class Child extends Component {
+			componentWillUnmount() {
+				spy();
+			}
+
+			render(props) {
+				return props.children;
+			}
+		}
+
+		class Foo extends Component {
+			constructor(props) {
+				super(props);
+				this.state = {
+					additionalProps: { style: { background: 'red' } }
+				};
+				set = c => this.setState({ additionalProps: c });
+			}
+			render(props, state) {
+				return (
+					<div>
+						<p>Hello</p>
+						{createPortal(
+							<Child {...state.additionalProps}>Foo</Child>,
+							scratch
+						)}
+					</div>
+				);
+			}
+		}
+
+		render(<Foo />, scratch);
+		expect(spy).not.toHaveBeenCalled();
+
+		set({});
+		rerender();
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it('should not render <undefined> for Portal nodes', () => {
+		let root = document.createElement('div');
+		let dialog = document.createElement('div');
+		dialog.id = 'container';
+
+		scratch.appendChild(root);
+		scratch.appendChild(dialog);
+
+		function Dialog() {
+			return <div>Dialog content</div>;
+		}
+
+		function App() {
+			return <div>{createPortal(<Dialog />, dialog)}</div>;
+		}
+
+		render(<App />, root);
+		expect(scratch.firstChild.firstChild.childNodes.length).to.equal(0);
+	});
+
+	it('should unmount Portal', () => {
+		let root = document.createElement('div');
+		let dialog = document.createElement('div');
+		dialog.id = 'container';
+
+		scratch.appendChild(root);
+		scratch.appendChild(dialog);
+
+		function Dialog() {
+			return <div>Dialog content</div>;
+		}
+
+		function App() {
+			return <div>{createPortal(<Dialog />, dialog)}</div>;
+		}
+
+		render(<App />, root);
+		expect(dialog.childNodes.length).to.equal(1);
+		render(null, root);
+		expect(dialog.childNodes.length).to.equal(0);
+	});
+
+	it('should leave a working root after the portal', () => {
+		/** @type {() => void} */
+		let toggle,
+			/** @type {() => void} */
+			toggle2;
+
+		class Foo extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { mounted: false, mounted2: true };
+				toggle = () => this.setState(s => ({ mounted: !s.mounted }));
+				toggle2 = () => this.setState(s => ({ mounted2: !s.mounted2 }));
+			}
+			render(props, state) {
+				return (
+					<div>
+						{state.mounted && createPortal(props.children, scratch)}
+						{state.mounted2 && <p>Hello</p>}
+					</div>
+				);
+			}
+		}
+
+		render(
+			<Foo>
+				<div>foobar</div>
+			</Foo>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div><p>Hello</p></div><div>foobar</div>'
+		);
+
+		toggle2();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div></div><div>foobar</div>');
+
+		toggle2();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div><p>Hello</p></div><div>foobar</div>'
+		);
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
+
+		toggle2();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div></div>');
+	});
+
+	it('should work with stacking portals', () => {
+		/** @type {() => void} */
+		let toggle,
+			/** @type {() => void} */
+			toggle2;
+
+		class Foo extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { mounted: false, mounted2: false };
+				toggle = () => this.setState(s => ({ mounted: !s.mounted }));
+				toggle2 = () => this.setState(s => ({ mounted2: !s.mounted2 }));
+			}
+			render(props, state) {
+				return (
+					<div>
+						<p>Hello</p>
+						{state.mounted && createPortal(props.children, scratch)}
+						{state.mounted2 && createPortal(props.children2, scratch)}
+					</div>
+				);
+			}
+		}
+
+		render(
+			<Foo children2={<div>foobar2</div>}>
+				<div>foobar</div>
+			</Foo>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div><p>Hello</p></div><div>foobar</div>'
+		);
+
+		toggle2();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div><p>Hello</p></div><div>foobar</div><div>foobar2</div>'
+		);
+
+		toggle2();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div><p>Hello</p></div><div>foobar</div>'
+		);
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
+	});
+
+	it('should work with changing the container', () => {
+		/** @type {(c) => void} */
+		let set, ref;
+
+		class Foo extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { container: scratch };
+				set = c => this.setState({ container: c });
+			}
+			render(props, state) {
+				return (
+					<div
+						ref={r => {
+							ref = r;
+						}}
+					>
+						<p>Hello</p>
+						{createPortal(props.children, state.container)}
+					</div>
+				);
+			}
+		}
+
+		render(
+			<Foo>
+				<div>foobar</div>
+			</Foo>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal(
+			'<div>foobar</div><div><p>Hello</p></div>'
+		);
+
+		set(ref);
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div><p>Hello</p><div>foobar</div></div>'
+		);
+	});
+
+	it('should work with replacing placeholder portals', () => {
+		/** @type {() => void} */
+		let toggle,
+			/** @type {() => void} */
+			toggle2;
+
+		class Foo extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { mounted: false, mounted2: false };
+				toggle = () => this.setState(s => ({ mounted: !s.mounted }));
+				toggle2 = () => this.setState(s => ({ mounted2: !s.mounted2 }));
+			}
+			render(props, state) {
+				return (
+					<div>
+						<p>Hello</p>
+						{createPortal(state.mounted && props.children, scratch)}
+						{createPortal(state.mounted2 && props.children, scratch)}
+					</div>
+				);
+			}
+		}
+
+		render(
+			<Foo>
+				<div>foobar</div>
+			</Foo>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div><p>Hello</p></div><div>foobar</div>'
+		);
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
+
+		toggle2();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div><p>Hello</p></div><div>foobar</div>'
+		);
+
+		toggle2();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
+	});
+
+	it('should work with removing an element from stacked container to new one', () => {
+		/** @type {() => void} */
+		let toggle, root2;
+
+		class Foo extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { root: scratch };
+				toggle = () => this.setState({ root: root2 });
+			}
+			render(props, state) {
+				return (
+					<div
+						ref={r => {
+							root2 = r;
+						}}
+					>
+						<p>Hello</p>
+						{createPortal(props.children, scratch)}
+						{createPortal(props.children, state.root)}
+					</div>
+				);
+			}
+		}
+
+		render(
+			<Foo>
+				<div>foobar</div>
+			</Foo>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal(
+			'<div>foobar</div><div>foobar</div><div><p>Hello</p></div>'
+		);
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div>foobar</div><div><p>Hello</p><div>foobar</div></div>'
+		);
+	});
+
+	it('should support nested portals', () => {
+		/** @type {() => void} */
+		let toggle,
+			/** @type {() => void} */
+			toggle2,
+			inner;
+
+		class Bar extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { mounted: false };
+				toggle2 = () => this.setState(s => ({ mounted: !s.mounted }));
+			}
+			render(props, state) {
+				return (
+					<div
+						ref={r => {
+							inner = r;
+						}}
+					>
+						<p>Inner</p>
+						{state.mounted && createPortal(<p>hiFromBar</p>, scratch)}
+						{state.mounted && createPortal(<p>innerPortal</p>, inner)}
+					</div>
+				);
+			}
+		}
+
+		class Foo extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { mounted: false };
+				toggle = () => this.setState(s => ({ mounted: !s.mounted }));
+			}
+			render(props, state) {
+				return (
+					<div>
+						<p>Hello</p>
+						{state.mounted && createPortal(<Bar />, scratch)}
+					</div>
+				);
+			}
+		}
+
+		render(<Foo />, scratch);
+		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div><p>Hello</p></div><div><p>Inner</p></div>'
+		);
+
+		toggle2();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div><p>Hello</p></div><div><p>Inner</p><p>innerPortal</p></div><p>hiFromBar</p>'
+		);
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div><p>Hello</p></div>');
+	});
+
+	it('should support nested portals remounting #2669', () => {
+		let setVisible;
+		let i = 0;
+
+		function PortalComponent(props) {
+			const innerVnode = <div id="inner">{i}</div>;
+			innerVnode.___id = 'inner_' + i++;
+			const outerVnode = (
+				<div id="outer">
+					{i}
+					{props.show && createPortal(innerVnode, scratch)}
+				</div>
+			);
+			outerVnode.___id = 'outer_' + i++;
+			return createPortal(outerVnode, scratch);
+		}
+
+		class App extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { visible: true };
+				setVisible = visible => this.setState({ visible });
+			}
+			render(props, state) {
+				return (
+					<div id="app">
+						test
+						<PortalComponent show={state.visible} />
+					</div>
+				);
+			}
+		}
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<div id="inner">0</div><div id="outer">1</div><div id="app">test</div>'
+		);
+
+		act(() => {
+			setVisible(false);
+		});
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div id="outer">3</div><div id="app">test</div>'
+		);
+
+		act(() => {
+			setVisible(true);
+		});
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div id="outer">5</div><div id="app">test</div><div id="inner">4</div>'
+		);
+
+		act(() => {
+			setVisible(false);
+		});
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div id="outer">7</div><div id="app">test</div>'
+		);
+	});
+
+	it('should not unmount when parent renders', () => {
+		let root = document.createElement('div');
+		let dialog = document.createElement('div');
+		dialog.id = 'container';
+
+		scratch.appendChild(root);
+		scratch.appendChild(dialog);
+
+		let spy = vi.fn();
+		class Child extends Component {
+			componentDidMount() {
+				spy();
+			}
+
+			render() {
+				return <div id="child">child</div>;
+			}
+		}
+
+		let spyParent = vi.fn();
+		class App extends Component {
+			componentDidMount() {
+				spyParent();
+			}
+			render() {
+				return <div>{createPortal(<Child />, dialog)}</div>;
+			}
+		}
+
+		render(<App />, root);
+		let dom = document.getElementById('child');
+		expect(spyParent).toHaveBeenCalledOnce();
+		expect(spy).toHaveBeenCalledOnce();
+
+		// Render twice to trigger update scenario
+		render(<App />, root);
+		render(<App />, root);
+
+		let domNew = document.getElementById('child');
+		expect(dom).to.equal(domNew);
+		expect(spyParent).toHaveBeenCalledOnce();
+		expect(spy).toHaveBeenCalledOnce();
+	});
+
+	it('should switch between non portal and portal node (Modal as lastChild)', () => {
+		/** @type {() => void} */
+		let toggle;
+		const Modal = ({ children, open }) =>
+			open ? createPortal(<div>{children}</div>, scratch) : <div>Closed</div>;
+
+		class App extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { open: false };
+				toggle = () => this.setState(s => ({ open: !s.open }));
+			}
+			render(props, state) {
+				return (
+					<div>
+						<button onClick={toggle}>Show</button>
+						{state.open ? 'Open' : 'Closed'}
+						<Modal open={state.open}>Hello</Modal>
+					</div>
+				);
+			}
+		}
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<div><button>Show</button>Closed<div>Closed</div></div>'
+		);
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div><button>Show</button>Open</div><div>Hello</div>'
+		);
+	});
+
+	it('should switch between non portal and portal node (Modal as firstChild)', () => {
+		/** @type {() => void} */
+		let toggle;
+		const Modal = ({ children, open }) =>
+			open ? createPortal(<div>{children}</div>, scratch) : <div>Closed</div>;
+
+		class App extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { open: false };
+				toggle = () => this.setState(s => ({ open: !s.open }));
+			}
+			render(props, state) {
+				return (
+					<div>
+						<Modal open={state.open}>Hello</Modal>
+						<button onClick={toggle}>Show</button>
+						{state.open ? 'Open' : 'Closed'}
+					</div>
+				);
+			}
+		}
+
+		render(<App />, scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<div><div>Closed</div><button>Show</button>Closed</div>'
+		);
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div><button>Show</button>Open</div><div>Hello</div>'
+		);
+
+		toggle();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<div><div>Closed</div><button>Show</button>Closed</div>'
+		);
+	});
+
+	// #4992
+	it('should maintain SVG namespace when rendering through a portal', () => {
+		const svgRoot = document.createElementNS(
+			'http://www.w3.org/2000/svg',
+			'svg'
+		);
+		document.body.appendChild(svgRoot);
+
+		function App() {
+			return (
+				<svg>
+					<g>
+						<rect width="100" height="100" fill="red" />
+						{createPortal(
+							<g id="test-portal">
+								<rect width="50" height="50" fill="blue" />
+							</g>,
+							svgRoot
+						)}
+					</g>
+				</svg>
+			);
+		}
+
+		render(<App />, scratch);
+
+		const portalG = svgRoot.querySelector('g#test-portal');
+		expect(portalG.namespaceURI).to.equal('http://www.w3.org/2000/svg');
+		expect(portalG.constructor.name).to.equal('SVGGElement');
+
+		svgRoot.parentNode.removeChild(svgRoot);
+	});
+});

--- a/test/browser/render.test.jsx
+++ b/test/browser/render.test.jsx
@@ -12,7 +12,6 @@ import {
 	createEvent
 } from '../_util/helpers';
 import { clearLog, getLog, logCall } from '../_util/logCall';
-import { useState } from 'preact/hooks';
 import { expect, vi } from 'vitest';
 
 function getAttributes(node) {
@@ -1046,16 +1045,20 @@ describe('render()', () => {
 		// This tests that we do not cause any cursor jumps in contenteditable fields
 		// See https://github.com/preactjs/preact/issues/2691
 
-		function Editable() {
-			const [value, setValue] = useState('Hello');
-
-			return (
-				<div
-					contentEditable
-					dangerouslySetInnerHTML={{ __html: value }}
-					onInput={e => setValue(e.currentTarget.innerHTML)}
-				/>
-			);
+		class Editable extends Component {
+			constructor(props) {
+				super(props);
+				this.state = { value: 'Hello' };
+			}
+			render(props, state) {
+				return (
+					<div
+						contentEditable
+						dangerouslySetInnerHTML={{ __html: state.value }}
+						onInput={e => this.setState({ value: e.currentTarget.innerHTML })}
+					/>
+				);
+			}
 		}
 
 		render(<Editable />, scratch);


### PR DESCRIPTION
This moves createPortal into core and adds support for a new primitive so we can support other libraries manipulating the roots. With `_parentDom` you can change up the root of the diff algorithm. As we already support `_parentDom` in mangle this will mangle to `__P`

Co-Authored with GPT5.6-sol for moving tests around and translating to class components