### PR TITLE
Add Activity compatibility component

### DIFF
--- a/compat/src/activity.d.ts
+++ b/compat/src/activity.d.ts
@@ -1,0 +1,9 @@
+import { ComponentChildren, FunctionComponent } from '../../src/index';
+
+export interface ActivityProps {
+	children: ComponentChildren;
+	mode?: 'hidden' | 'visible';
+	name?: string;
+}
+
+export const Activity: FunctionComponent<ActivityProps>;

--- a/compat/src/activity.js
+++ b/compat/src/activity.js
@@ -1,0 +1,18 @@
+import { createElement } from 'preact';
+
+/**
+ * A lightweight compatibility implementation of React's Activity component.
+ *
+ * Keeping the wrapper mounted preserves component state and DOM state when the
+ * activity is hidden. Unlike React, this does not disconnect effects or defer
+ * updates in hidden trees.
+ *
+ * @param {import('./activity').ActivityProps} props
+ */
+export function Activity(props) {
+	return createElement(
+		'div',
+		{ style: { display: props.mode == 'hidden' ? 'none' : 'contents' } },
+		props.children
+	);
+}

--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -1,6 +1,7 @@
 import * as _preact from '../../src/index';
 import { JSXInternal } from '../../src/jsx';
 import * as _hooks from '../../hooks';
+import * as _Activity from './activity';
 import * as _Suspense from './suspense';
 
 declare namespace preact {
@@ -154,6 +155,8 @@ declare namespace React {
 	export import Key = _preact.Key;
 
 	// Suspense
+	export const Activity: typeof _Activity.Activity;
+	export type ActivityProps = _Activity.ActivityProps;
 	export import Suspense = _Suspense.Suspense;
 	export import lazy = _Suspense.lazy;
 

--- a/compat/src/index.js
+++ b/compat/src/index.js
@@ -40,6 +40,7 @@ import {
 	render
 } from './render';
 import { Suspense, lazy } from './suspense';
+import { Activity } from './activity';
 
 const version = '18.3.1'; // trick libraries to think we are react
 
@@ -183,6 +184,7 @@ export {
 	useSyncExternalStore,
 	useTransition,
 	Fragment as StrictMode,
+	Activity,
 	Suspense,
 	lazy,
 	__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
@@ -230,6 +232,7 @@ export default {
 	flushSync,
 	unstable_batchedUpdates,
 	StrictMode: Fragment,
+	Activity,
 	Suspense,
 	lazy,
 	__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED

--- a/compat/test/browser/activity.test.jsx
+++ b/compat/test/browser/activity.test.jsx
@@ -1,0 +1,79 @@
+import { act } from 'preact/test-utils';
+import {
+	Activity,
+	createElement,
+	Fragment,
+	render,
+	useState
+} from 'preact/compat';
+import { setupScratch, teardown } from '../../../test/_util/helpers';
+
+describe('Activity', () => {
+	/** @type {HTMLDivElement} */
+	let scratch;
+
+	beforeEach(() => {
+		scratch = setupScratch();
+	});
+
+	afterEach(() => {
+		teardown(scratch);
+	});
+
+	it('preserves component and DOM state while hidden', () => {
+		let setMode;
+		let setCount;
+
+		function Child() {
+			const [count, updateCount] = useState(0);
+			setCount = updateCount;
+			return (
+				<>
+					<span>{count}</span>
+					<input />
+				</>
+			);
+		}
+
+		function App() {
+			const [mode, updateMode] = useState('visible');
+			setMode = updateMode;
+			return (
+				<Activity mode={mode}>
+					<Child />
+				</Activity>
+			);
+		}
+
+		render(<App />, scratch);
+
+		const wrapper = scratch.firstElementChild;
+		const input = scratch.querySelector('input');
+		input.value = 'draft';
+
+		act(() => setCount(1));
+		expect(scratch.querySelector('span').textContent).to.equal('1');
+
+		act(() => setMode('hidden'));
+		expect(wrapper.style.display).to.equal('none');
+		expect(scratch.querySelector('input')).to.equal(input);
+
+		act(() => setMode('visible'));
+		expect(wrapper.style.display).to.equal('contents');
+		expect(scratch.querySelector('span').textContent).to.equal('1');
+		expect(scratch.querySelector('input')).to.equal(input);
+		expect(input.value).to.equal('draft');
+	});
+
+	it('defaults to visible', () => {
+		render(
+			<Activity>
+				<span>content</span>
+			</Activity>,
+			scratch
+		);
+
+		expect(scratch.firstElementChild.style.display).to.equal('contents');
+		expect(scratch.textContent).to.equal('content');
+	});
+});

--- a/compat/test/browser/exports.test.js
+++ b/compat/test/browser/exports.test.js
@@ -43,6 +43,7 @@ describe('compat exports', () => {
 		expect(Compat.useDeferredValue).to.be.a('function');
 
 		// Suspense
+		expect(Compat.Activity).to.be.a('function');
 		expect(Compat.Suspense).to.be.a('function');
 		expect(Compat.lazy).to.be.a('function');
 
@@ -84,6 +85,7 @@ describe('compat exports', () => {
 		expect(Named.useContext).to.be.a('function');
 
 		// Suspense
+		expect(Named.Activity).to.be.a('function');
 		expect(Named.Suspense).to.be.a('function');
 		expect(Named.lazy).to.be.a('function');
 

--- a/compat/test/ts/activity.tsx
+++ b/compat/test/ts/activity.tsx
@@ -1,0 +1,21 @@
+import React, { Activity, ActivityProps } from '../../src';
+
+const props: ActivityProps = {
+	mode: 'hidden',
+	name: 'sidebar',
+	children: <div>Hidden</div>
+};
+
+export function Example() {
+	return (
+		<>
+			<Activity {...props} />
+			<Activity mode="visible">Visible</Activity>
+			<Activity>Visible by default</Activity>
+			{/* @ts-expect-error Activity only accepts supported modes */}
+			<Activity mode="collapsed">Invalid mode</Activity>
+			{/* @ts-expect-error Activity requires children */}
+			<Activity />
+		</>
+	);
+}


### PR DESCRIPTION
Relates to https://github.com/preactjs/preact/issues/4977

Differences to react

- We don't unmount effects
- We don't defer updates within the hidden subtree
- We add a wrapper div

Co-Authored with GPT5.6-sol for tests