### PR TITLE
Long continuous prefix move optimization

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -298,7 +298,18 @@ function constructNewChildrenArray(
 			// If we wanted to optimize for i.e. only swaps we'd just do the last two code-branches and have
 			// only the first item be a re-scouting and all the others fall in their skewed counter-part.
 			// We could also further optimize for swaps
-			if (matchingIndex == skewedIndex - 1) {
+			if (
+				matchingIndex > skewedIndex + 1 &&
+				matchingIndex - skewedIndex < oldChildrenLength - matchingIndex &&
+				renderResult[i + 1] != NULL &&
+				oldChildren[matchingIndex + 1] != NULL &&
+				renderResult[i + 1].key == oldChildren[matchingIndex + 1].key &&
+				renderResult[i + 1].type == oldChildren[matchingIndex + 1].type
+			) {
+				// A short prefix was moved to the end. Keep the long contiguous
+				// suffix in place and insert the displaced prefix when we reach it.
+				skew += matchingIndex - skewedIndex;
+			} else if (matchingIndex == skewedIndex - 1) {
 				skew--;
 			} else if (matchingIndex == skewedIndex + 1) {
 				skew++;

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -298,31 +298,31 @@ function constructNewChildrenArray(
 			// If we wanted to optimize for i.e. only swaps we'd just do the last two code-branches and have
 			// only the first item be a re-scouting and all the others fall in their skewed counter-part.
 			// We could also further optimize for swaps
-			if (
-				matchingIndex > skewedIndex + 1 &&
-				matchingIndex - skewedIndex < oldChildrenLength - matchingIndex &&
-				renderResult[i + 1] != NULL &&
-				oldChildren[matchingIndex + 1] != NULL &&
-				renderResult[i + 1].key == oldChildren[matchingIndex + 1].key &&
-				renderResult[i + 1].type == oldChildren[matchingIndex + 1].type
-			) {
-				// A short prefix was moved to the end. Keep the long contiguous
-				// suffix in place and insert the displaced prefix when we reach it.
-				skew += matchingIndex - skewedIndex;
-			} else if (matchingIndex == skewedIndex - 1) {
+			if (matchingIndex == skewedIndex - 1) {
 				skew--;
 			} else if (matchingIndex == skewedIndex + 1) {
 				skew++;
-			} else {
-				if (matchingIndex > skewedIndex) {
-					skew--;
+			} else if (matchingIndex > skewedIndex) {
+				if (
+					matchingIndex - skewedIndex < oldChildrenLength - matchingIndex &&
+					renderResult[i + 1] != NULL &&
+					oldChildren[matchingIndex + 1] != NULL &&
+					renderResult[i + 1].key == oldChildren[matchingIndex + 1].key &&
+					renderResult[i + 1].type == oldChildren[matchingIndex + 1].type
+				) {
+					// A short prefix was moved to the end. The match starts a longer
+					// contiguous suffix, so keep that suffix in place and insert the
+					// displaced prefix when reconciliation reaches it.
+					skew += matchingIndex - skewedIndex;
 				} else {
-					skew++;
-				}
+					skew--;
 
-				// Move this VNode's DOM if the original index (matchingIndex) doesn't
-				// match the new skew index (i + new skew)
-				// In the former two branches we know that it matches after skewing
+					// Move this VNode's DOM if the original index (matchingIndex)
+					// doesn't match the new skew index (i + new skew)
+					childVNode._flags |= INSERT_VNODE;
+				}
+			} else {
+				skew++;
 				childVNode._flags |= INSERT_VNODE;
 			}
 		}

--- a/test/browser/keys.test.jsx
+++ b/test/browser/keys.test.jsx
@@ -395,6 +395,24 @@ describe('keys', () => {
 		);
 	});
 
+	it('should displace multiple keyed children to the end efficiently', () => {
+		const values = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('abcdefghij');
+
+		values.push(...values.splice(0, 3));
+		clearLog();
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('defghijabc');
+		expect(getLog()).to.deep.equal([
+			'<ol>abcdefghij.appendChild(<li>a)',
+			'<ol>bcdefghija.appendChild(<li>b)',
+			'<ol>cdefghijab.appendChild(<li>c)'
+		]);
+	});
+
 	it('should move keyed children to the beginning on longer list', () => {
 		// Preact v10 worst case
 		const values = ['a', 'b', 'c', 'd', 'e', 'f'];

--- a/test/browser/keys.test.jsx
+++ b/test/browser/keys.test.jsx
@@ -366,6 +366,156 @@ describe('keys', () => {
 		);
 	});
 
+	it('should not displace when the suffix after the match is shorter than the jump', () => {
+		const values = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('abcdefghij');
+
+		// Swap two far apart children; the run following the match (j) is
+		// shorter than the jump, so the displacement path must not trigger.
+		[values[1], values[8]] = [values[8], values[1]];
+		clearLog();
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('aicdefghbj');
+		expect(getLog()).to.deep.equal([
+			'<ol>abcdefghij.insertBefore(<li>i, <li>b)',
+			'<ol>aibcdefghj.insertBefore(<li>b, <li>j)'
+		]);
+	});
+
+	it('should move the shorter suffix when more than half the list is displaced', () => {
+		const values = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('abcdef');
+
+		// Displacing 4 of 6 children: moving the displaced prefix would be more
+		// work than moving the two-child suffix, so the guard must not trigger.
+		values.push(...values.splice(0, 4));
+		clearLog();
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('efabcd');
+		expect(getLog()).to.deep.equal([
+			'<ol>abcdef.insertBefore(<li>e, <li>a)',
+			'<ol>eabcdf.insertBefore(<li>f, <li>a)'
+		]);
+	});
+
+	it('should displace multiple keyed children to the end while the list grows', () => {
+		const values = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('abcdefghij');
+
+		values.push(...values.splice(0, 3));
+		values.push('k');
+		clearLog();
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('defghijabck');
+		expect(getLog()).to.deep.equal([
+			'<ol>abcdefghij.appendChild(<li>a)',
+			'<ol>bcdefghija.appendChild(<li>b)',
+			'<ol>cdefghijab.appendChild(<li>c)',
+			'<li>.appendChild(#text)',
+			'<ol>defghijabc.appendChild(<li>k)'
+		]);
+	});
+
+	it('should displace multiple keyed children to the end while another is removed', () => {
+		const values = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('abcdefghij');
+
+		values.push(...values.splice(0, 3));
+		values.splice(values.indexOf('j'), 1);
+		clearLog();
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('defghiabc');
+		expect(getLog()).to.deep.equal([
+			'<li>j.remove()',
+			'<ol>abcdefghi.appendChild(<li>a)',
+			'<ol>bcdefghia.appendChild(<li>b)',
+			'<ol>cdefghiab.appendChild(<li>c)'
+		]);
+	});
+
+	it('should displace keyed children to the end repeatedly', () => {
+		const values = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+		const expectedDisplaceLogs = [
+			[
+				'<ol>abcdefghij.appendChild(<li>a)',
+				'<ol>bcdefghija.appendChild(<li>b)',
+				'<ol>cdefghijab.appendChild(<li>c)'
+			],
+			[
+				'<ol>defghijabc.appendChild(<li>d)',
+				'<ol>efghijabcd.appendChild(<li>e)',
+				'<ol>fghijabcde.appendChild(<li>f)'
+			],
+			[
+				'<ol>ghijabcdef.appendChild(<li>g)',
+				'<ol>hijabcdefg.appendChild(<li>h)',
+				'<ol>ijabcdefgh.appendChild(<li>i)'
+			]
+		];
+
+		render(<List values={values} />, scratch);
+		expect(scratch.textContent).to.equal('abcdefghij');
+
+		for (let n = 0; n < 3; n++) {
+			values.push(...values.splice(0, 3));
+			clearLog();
+
+			render(<List values={values} />, scratch);
+			expect(scratch.textContent).to.equal(values.join(''));
+			expect(getLog()).to.deep.equal(expectedDisplaceLogs[n], `round ${n}`);
+		}
+	});
+
+	it('should keep text siblings correct around displaced keyed children', () => {
+		// The displacement probe compares the key & type of the next pair; a raw
+		// text child passes that probe against any old text node. Ensure such a
+		// false positive can only cost extra moves, never correctness.
+		const content = condition => (
+			<ol>
+				{condition
+					? [
+							<li key="a">a</li>,
+							<li key="b">b</li>,
+							<li key="c">c</li>,
+							'mid',
+							<li key="d">d</li>,
+							<li key="e">e</li>
+						]
+					: [
+							<li key="c">c</li>,
+							'mid',
+							<li key="a">a</li>,
+							<li key="b">b</li>,
+							<li key="d">d</li>,
+							<li key="e">e</li>
+						]}
+			</ol>
+		);
+
+		render(content(true), scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<ol><li>a</li><li>b</li><li>c</li>mid<li>d</li><li>e</li></ol>'
+		);
+
+		clearLog();
+		render(content(false), scratch);
+		expect(scratch.innerHTML).to.equal(
+			'<ol><li>c</li>mid<li>a</li><li>b</li><li>d</li><li>e</li></ol>'
+		);
+	});
+
 	it('should move keyed children to the end of the list', () => {
 		const values = ['a', 'b', 'c', 'd'];
 


### PR DESCRIPTION
> [!NOTE]
> This PR was co-authored by GPT5.6-sol

### Summary

Optimize keyed reconciliation when a short prefix is moved to the end of a list.

The existing skew heuristic only recognizes one-position offsets. For a transition like:

```text
[a, b, c, d, …, z] → [d, …, z, a, b, c]
```

Preact moved the long suffix instead of the three displaced prefix nodes. In a 1,000-row benchmark, moving the first three rows caused 997 `insertBefore` calls.

This change detects when the matched node begins a longer contiguous suffix. It adjusts the skew to leave that suffix in place and moves the shorter prefix when reconciliation reaches it.

### Results

Measured with Octane’s `js-framework-reorder` benchmark:

| Operation | Before | After | Change |
|---|---:|---:|---:|
| `displace3` | 2.296 ms | 0.316 ms | −86% |
| `displace4` | 2.260 ms | 0.341 ms | −85% |
| `displace5` | 2.306 ms | 0.338 ms | −85% |
| `displace6` | 2.382 ms | 0.343 ms | −86% |
| `displace8` | 2.297 ms | 0.356 ms | −85% |
| Suite geomean | 1.305 ms | 0.655 ms | −50% |

For `displace3`, DOM moves drop from 997 to 3.

Other reorder operations remain effectively unchanged.


### Edge-case coverage

Beyond the displacement test itself, the suite now pins down the paths around the probe: a far swap whose following suffix is shorter than the jump must not trigger it, displacing more than half the list falls back to moving the shorter suffix (also minimal), displacement combined with an appended or removed child, three consecutive displacements (skew accumulation), and a raw-text sibling passing the probe's loose key/type comparison — a false positive that can only cost extra moves, never correctness.

### Reproducible benchmark

The displacement pattern is now covered by a dedicated benchmark in the benchmarks repo — see [preactjs/benchmarks#17](https://github.com/preactjs/benchmarks/pull/17) (`reorder1k`: move the first 3 of 1,000 keyed rows to the end). Tachometer results on this branch (Chrome headless):

| variant | reorder1k median |
|---|---:|
| v10.x baseline | 31.7 ms |
| this PR | 7.7 ms (−76%) |

`update10th1k`, `create10k`, and `many-updates` are unchanged within noise.

### Relation to v11

v11 generalizes this with a longest-increasing-subsequence pass that computes the minimal set of moves for *every* reorder shape (middle swaps, intermingled moves, …), at a higher byte cost — see #5174 (reorder1k median 8.3 ms there). The two supersede each other, so this heuristic stays v10.x-only: it is the cheaper fix (+~40 B vs +99 B brotli) for the release branch, while #5174 is the v11 form.


