### PR TITLE
Remove redundant portal children guard

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -312,12 +312,8 @@ export function diff(
 				doc = parentDom.ownerDocument;
 
 				// Changing the container remounts the children into the new one
-				if (
-					oldVNode.props &&
-					oldVNode.props._parentDom != parentDom &&
-					oldVNode._children
-				) {
-					oldVNode._children.forEach(child => {
+				if (oldVNode.props && oldVNode.props._parentDom != parentDom) {
+					/** @type {VNode[]} */ (oldVNode._children).forEach(child => {
 						if (child) unmount(child, child);
 					});
 					oldVNode._children = NULL;


### PR DESCRIPTION
Portal vnodes always have a `_children` array after diffing or error recovery, so this removes the redundant guard before remounting children into a new container.

Co-authored with GPT-5.6-sol.