### PR TITLE
refactor(core): derive document from parentDom instead of threading it

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -149,8 +149,7 @@ function renderComponent(component) {
 			commitQueue,
 			oldDom == NULL ? getDomSibling(oldVNode) : oldDom,
 			!!(oldVNode._flags & MODE_HYDRATE),
-			refQueue,
-			parentDom.ownerDocument
+			refQueue
 		);
 
 		newVNode._original = oldVNode._original;

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -40,7 +40,6 @@ import { getDomSibling } from '../component';
  * siblings. In most cases, it starts out as `oldChildren[0]._dom`.
  * @param {boolean} isHydrating Whether or not we are in hydration
  * @param {any[]} refQueue an array of elements needed to invoke refs
- * @param {Document} doc The document object to use for creating elements
  * @returns {PreactElement} The next sibling DOM element to insert new elements
  */
 export function diffChildren(
@@ -54,8 +53,7 @@ export function diffChildren(
 	commitQueue,
 	oldDom,
 	isHydrating,
-	refQueue,
-	doc
+	refQueue
 ) {
 	let i,
 		/** @type {VNode} */
@@ -105,8 +103,7 @@ export function diffChildren(
 			commitQueue,
 			oldDom,
 			isHydrating,
-			refQueue,
-			doc
+			refQueue
 		);
 
 		// Adjust DOM nodes

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -53,7 +53,6 @@ import { setProperty } from './props';
  * siblings. In most cases, it starts out as `oldChildren[0]._dom`.
  * @param {boolean} isHydrating Whether or not we are in hydration
  * @param {any[]} refQueue an array of elements needed to invoke refs
- * @param {Document} doc The document object to use for creating elements
  */
 export function diff(
 	parentDom,
@@ -65,8 +64,7 @@ export function diff(
 	commitQueue,
 	oldDom,
 	isHydrating,
-	refQueue,
-	doc
+	refQueue
 ) {
 	/** @type {any} */
 	let tmp,
@@ -306,10 +304,10 @@ export function diff(
 			if (newProps._parentDom) {
 				parentDom = newProps._parentDom;
 				// If we portal into a math or svg element we need
-				// to swap the namespace (chart libraries often do this)
-				// same for an iframe (different ownerDocument)
+				// to swap the namespace (chart libraries often do this).
+				// The document follows the container too (e.g. iframes) as
+				// diffElementNodes derives it from its parentDom.
 				namespace = parentDom.namespaceURI;
-				doc = parentDom.ownerDocument;
 
 				// Changing the container remounts the children into the new one
 				if (
@@ -337,8 +335,7 @@ export function diff(
 				commitQueue,
 				oldDom,
 				isHydrating,
-				refQueue,
-				doc
+				refQueue
 			);
 
 			// When we exit a portal we
@@ -438,7 +435,7 @@ export function diff(
 			commitQueue,
 			isHydrating,
 			refQueue,
-			doc
+			parentDom
 		);
 	}
 
@@ -506,7 +503,8 @@ function cloneNode(node) {
  * to invoke in commitRoot
  * @param {boolean} isHydrating Whether or not we are in hydration
  * @param {any[]} refQueue an array of elements needed to invoke refs
- * @param {Document} doc The document object to use for creating elements
+ * @param {PreactElement} parentDom The parent this element will be inserted
+ * into; new nodes are created from its ownerDocument (e.g. iframes)
  * @returns {PreactElement}
  */
 function diffElementNodes(
@@ -519,7 +517,7 @@ function diffElementNodes(
 	commitQueue,
 	isHydrating,
 	refQueue,
-	doc
+	parentDom
 ) {
 	let oldProps = oldVNode.props || EMPTY_OBJ;
 	const newProps = newVNode.props;
@@ -561,6 +559,7 @@ function diffElementNodes(
 	}
 
 	if (dom == NULL) {
+		const doc = parentDom.ownerDocument;
 		if (nodeType == NULL) {
 			return doc.createTextNode(newProps);
 		}
@@ -672,8 +671,7 @@ function diffElementNodes(
 					? excessDomChildren[0]
 					: oldVNode._children && getDomSibling(oldVNode, 0),
 				isHydrating,
-				refQueue,
-				doc
+				refQueue
 			);
 
 			// Remove children that are not part of any vnode.

--- a/src/render.js
+++ b/src/render.js
@@ -51,8 +51,7 @@ export function render(vnode, parentDom) {
 		oldVNode ? oldVNode._dom : parentDom.firstChild,
 		// @ts-expect-error we are doing a bit-wise operation so it's either 0 or true
 		isHydrating,
-		refQueue,
-		parentDom.ownerDocument
+		refQueue
 	);
 
 	// Flush all queued effects


### PR DESCRIPTION
The diff recursion threaded a dedicated `doc` parameter through `diff`, `diffChildren` and `diffElementNodes` solely so node creation could use the right document when portaling into iframes. `diffElementNodes` can derive it from the `parentDom` it inserts into instead: the portal boundary reassigns `parentDom` (and namespace) before the element path runs, so `parentDom.ownerDocument` is always the correct document — including iframe portals.

## Changes

- `diffElementNodes` now receives `parentDom` (which it previously didn't have) instead of `doc`, and derives the document only on the node-creation path.
- The `doc` parameter is removed from `diff` / `diffChildren` and every call site; `render()` and `renderComponent()` no longer pass `parentDom.ownerDocument`.

## Size

- core: **4973 → 4962 B gzip (−11)**

## Notes

- Perf: one `ownerDocument` property load per **created** DOM node, on the same path as `createElementNS` — not measurable.
- Children of `<template>` elements are now created from the template content document rather than the outer one. They're inserted into that content anyway and custom elements don't upgrade inside templates, so this isn't observable; all 1253 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
