### PR TITLE
build: recover arrow functions in minified output via per-package unsafe_arrows

### DIFF
--- a/debug/mangle.json
+++ b/debug/mangle.json
@@ -16,6 +16,9 @@
           "__self"
         ]
       }
+    },
+    "compress": {
+      "unsafe_arrows": true
     }
   }
 }

--- a/hooks/mangle.json
+++ b/hooks/mangle.json
@@ -16,6 +16,9 @@
           "__self"
         ]
       }
+    },
+    "compress": {
+      "unsafe_arrows": true
     }
   }
 }

--- a/jsx-runtime/mangle.json
+++ b/jsx-runtime/mangle.json
@@ -16,6 +16,9 @@
           "__self"
         ]
       }
+    },
+    "compress": {
+      "unsafe_arrows": true
     }
   }
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -98,7 +98,7 @@ function minifyPlugin(pkg) {
 					preserve_annotations: true
 				},
 				module: false,
-				ecma: 5,
+				ecma: 2017,
 				toplevel: true,
 				mangle: { properties: mangle.properties },
 				nameCache: mangle.nameCache,


### PR DESCRIPTION
## What

Lets terser re-emit `this`-free function expressions as arrow functions in the minified bundles, opt-in per package:

- `scripts/build.mjs`: terser `ecma: 5` → `2017` (this alone is **byte-identical** output for every package — verified — it only *allows* modern syntax)
- `hooks/mangle.json`, `debug/mangle.json`, `jsx-runtime/mangle.json`: add `minify.compress.unsafe_arrows: true`

Our dist is ES5 syntax: babel downlevels every source arrow to `function`, and with `ecma: 5` terser could never turn them back. `unsafe_arrows` recovers exactly those.

## Sizes

| Package | gz | br |
|---|---|---|
| hooks | **−16** (1518 → 1502) | **−19** (1387 → 1368) |
| debug | **−10** (3863 → 3853) | **−6** (3382 → 3376) |
| jsx-runtime | **−1** (826 → 825) | **−4** (740 → 736) |
| core | ±0 (not enabled) | ±0 |
| compat | ±0 (not enabled) | ±0 |

Core measured −5 gz but **+10 br**, compat +4 gz / −9 br — mixed, so they stay at `ecma: 5`-equivalent output (byte-identical dist).

## Why "unsafe" is safe here

The flag name refers to arrows not being constructible and having no `.prototype`. Inspecting the output shows terser only converts **inline function expressions that don't reference `this`/`arguments`** — i.e. precisely the callbacks that were arrows in our source before babel downleveled them. Function *declarations* (all exports) stay declarations, and anything touching `this` (`componentWillUpdate` wrapper, the hooks sCU) is untouched. Nothing a consumer could `new` or probe `.prototype` on changes shape.

Caveat: the conversion targets ES2015+ engines. Since the affected artifacts are `.mjs` ES modules, every engine that can load them supports arrows.

## Verification

- `pnpm test:vitest`: 102 files, 1253 passed / 12 skipped
- `pnpm test:vitest:min` (runs against these exact dist files): 102 files, 1253 passed / 12 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
