### PR TITLE
Avoid traversing retained subtrees

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -122,16 +122,21 @@ export function diffChildren(
 		}
 
 		let shouldPlace = !!(childVNode._flags & INSERT_VNODE);
-		if (shouldPlace || oldVNode._children === childVNode._children) {
-			oldDom = insert(childVNode, oldDom, parentDom, shouldPlace);
+		if (shouldPlace) {
+			oldDom = insert(childVNode, oldDom, parentDom);
 
 			// When a matched VNode is physically moved via INSERT_VNODE, its old
 			// _dom pointer becomes a stale positional reference. Clear it so that
 			// getDomSibling (called from nested diffs) won't return this stale
 			// reference and mis-place subsequent DOM nodes. See #5065.
-			if (shouldPlace && oldVNode._dom) {
+			if (oldVNode._dom) {
 				oldVNode._dom = NULL;
 			}
+		} else if (
+			childVNode._children != NULL &&
+			oldVNode._children === childVNode._children
+		) {
+			oldDom = getDomSibling(oldVNode);
 		} else if (typeof childVNode.type == 'function' && result !== UNDEFINED) {
 			oldDom = result;
 		} else if (newDom) {
@@ -341,10 +346,9 @@ function constructNewChildrenArray(
  * @param {VNode} parentVNode
  * @param {PreactElement} oldDom
  * @param {PreactElement} parentDom
- * @param {boolean} shouldPlace
  * @returns {PreactElement}
  */
-function insert(parentVNode, oldDom, parentDom, shouldPlace) {
+function insert(parentVNode, oldDom, parentDom) {
 	// Note: VNodes in nested suspended trees may be missing _children.
 
 	if (typeof parentVNode.type == 'function') {
@@ -356,18 +360,16 @@ function insert(parentVNode, oldDom, parentDom, shouldPlace) {
 				// children's _parent pointer to point to the newVNode (parentVNode
 				// here).
 				children[i]._parent = parentVNode;
-				oldDom = insert(children[i], oldDom, parentDom, shouldPlace);
+				oldDom = insert(children[i], oldDom, parentDom);
 			}
 		}
 
 		return oldDom;
 	} else if (parentVNode._dom != oldDom) {
-		if (shouldPlace) {
-			if (oldDom && parentVNode.type && !oldDom.parentNode) {
-				oldDom = getDomSibling(parentVNode);
-			}
-			parentDom.insertBefore(parentVNode._dom, oldDom || NULL);
+		if (oldDom && parentVNode.type && !oldDom.parentNode) {
+			oldDom = getDomSibling(parentVNode);
 		}
+		parentDom.insertBefore(parentVNode._dom, oldDom || NULL);
 		oldDom = parentVNode._dom;
 	}
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -121,8 +121,7 @@ export function diffChildren(
 			firstChildDom = newDom;
 		}
 
-		let shouldPlace = !!(childVNode._flags & INSERT_VNODE);
-		if (shouldPlace) {
+		if (childVNode._flags & INSERT_VNODE) {
 			oldDom = insert(childVNode, oldDom, parentDom);
 
 			// When a matched VNode is physically moved via INSERT_VNODE, its old
@@ -132,11 +131,6 @@ export function diffChildren(
 			if (oldVNode._dom) {
 				oldVNode._dom = NULL;
 			}
-		} else if (
-			childVNode._children != NULL &&
-			oldVNode._children === childVNode._children
-		) {
-			oldDom = getDomSibling(oldVNode);
 		} else if (typeof childVNode.type == 'function' && result !== UNDEFINED) {
 			oldDom = result;
 		} else if (newDom) {
@@ -369,8 +363,7 @@ function insert(parentVNode, oldDom, parentDom) {
 		if (oldDom && parentVNode.type && !oldDom.parentNode) {
 			oldDom = getDomSibling(parentVNode);
 		}
-		parentDom.insertBefore(parentVNode._dom, oldDom || NULL);
-		oldDom = parentVNode._dom;
+		oldDom = parentDom.insertBefore(parentVNode._dom, oldDom || NULL);
 	}
 
 	do {

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -197,6 +197,11 @@ export function diff(
 						commitQueue.push(c);
 					}
 
+					// Skip over the retained subtree without traversing it; the
+					// `result` branch in diffChildren picks this up as the next
+					// oldDom.
+					oldDom = getDomSibling(oldVNode);
+
 					break outer;
 				}
 

--- a/test/browser/lifecycles/shouldComponentUpdate.test.jsx
+++ b/test/browser/lifecycles/shouldComponentUpdate.test.jsx
@@ -86,6 +86,57 @@ describe('Lifecycle methods', () => {
 			expect(ShouldNot.prototype.render).toHaveBeenCalledOnce();
 		});
 
+		it('should not traverse a retained subtree after bailing out', () => {
+			const Inner = () => (
+				<Fragment>
+					<span>A</span>
+					<span>B</span>
+				</Fragment>
+			);
+
+			class Bailout extends Component {
+				shouldComponentUpdate() {
+					return false;
+				}
+
+				render() {
+					return <Inner />;
+				}
+			}
+
+			render(
+				<div>
+					<Bailout value={0} />
+					<span>C</span>
+				</div>,
+				scratch
+			);
+
+			const root = scratch._children;
+			const bailoutVNode = root._children[0]._children[0];
+			const innerVNode = bailoutVNode._children[0];
+			const children = innerVNode._children;
+			let reads = 0;
+			bailoutVNode._children[0] = new Proxy(innerVNode, {
+				get(target, property, receiver) {
+					const value = Reflect.get(target, property, receiver);
+					if (value === children) reads++;
+					return value;
+				}
+			});
+
+			render(
+				<div>
+					<Bailout value={1} />
+					<span>C</span>
+				</div>,
+				scratch
+			);
+
+			expect(scratch.textContent).to.equal('ABC');
+			expect(reads).to.equal(0);
+		});
+
 		it('should reorder non-updating text children', () => {
 			const rows = [
 				{ id: '1', a: 5, b: 100 },


### PR DESCRIPTION
## Summary

Use `getDomSibling()` after successful `shouldComponentUpdate`/memo bailouts instead of recursively walking retained child trees through `insert()`. Actual placements still use `insert()`.