### PR TITLE
Remove debug re-throw

### DIFF
--- a/debug/src/debug.js
+++ b/debug/src/debug.js
@@ -98,21 +98,15 @@ export function initDebug() {
 			}
 		}
 
-		try {
-			errorInfo = errorInfo || {};
-			errorInfo.componentStack = getOwnerStack(vnode);
-			oldCatchError(error, vnode, oldVNode, errorInfo);
+		errorInfo = errorInfo || {};
+		errorInfo.componentStack = getOwnerStack(vnode);
+		oldCatchError(error, vnode, oldVNode, errorInfo);
 
-			// when an error was handled by an ErrorBoundary we will nonetheless emit an error
-			// event on the window object. This is to make up for react compatibility in dev mode
-			// and thus make the Next.js dev overlay work.
-			if (typeof error.then != 'function') {
-				setTimeout(() => {
-					throw error;
-				});
-			}
-		} catch (e) {
-			throw e;
+		// when an error was handled by an ErrorBoundary we still log it, matching what
+		// React does in development. Errors that were not handled are rethrown by the
+		// core and thus surface as regular uncaught errors.
+		if (typeof error.then != 'function') {
+			console.error(error);
 		}
 	};
 

--- a/debug/test/browser/debug.options.test.jsx
+++ b/debug/test/browser/debug.options.test.jsx
@@ -24,9 +24,6 @@ describe('debug options', () => {
 	/** @type {(count: number) => void} */
 	let setCount;
 
-	/** @type {import('vitest').VitestUtils | undefined} */
-	let clock;
-
 	beforeEach(() => {
 		scratch = setupScratch();
 		rerender = setupRerender();
@@ -41,7 +38,6 @@ describe('debug options', () => {
 
 	afterEach(() => {
 		teardown(scratch);
-		if (clock) vi.useRealTimers();
 	});
 
 	class ClassApp extends Component {
@@ -122,15 +118,20 @@ describe('debug options', () => {
 			}
 		}
 
-		clock = vi.useFakeTimers();
+		// even though the error was handled by an error boundary we still log it,
+		// this matches what React does in development
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-		render(<ErrorApp />, scratch);
-		rerender();
+		let loggedErrors;
+		try {
+			render(<ErrorApp />, scratch);
+			rerender();
+		} finally {
+			loggedErrors = errorSpy.mock.calls.map(args => args[0]);
+			errorSpy.mockRestore();
+		}
 
 		expect(catchErrorSpy).toHaveBeenCalled();
-
-		// we expect to throw after setTimeout to trigger a window.onerror
-		// this is to ensure react compat (i.e. with next.js' dev overlay)
-		expect(() => clock.advanceTimersByTime(0)).to.throw(e);
+		expect(loggedErrors).to.deep.equal([e]);
 	});
 });


### PR DESCRIPTION
> [!NOTE]
> Research done with AI

`preact/debug` re-threw errors that were handled by an `ErrorBoundary` from a `setTimeout`, so that they would surface as uncaught errors:

```js
if (typeof error.then != 'function') {
	setTimeout(() => {
		throw error;
	});
}
```

The idea was that dev overlays listen for global errors, so this would make them show up there as well. That justification no longer holds, and the re-throw actively breaks test runners: under jsdom a throw from a timer callback never reaches `window`'s error event, it becomes a Node `uncaughtException`, so a global error handler never even sees it and vitest reports it as an unhandled error (see #5185).

This logs the error instead, which is what React does for caught errors as well.

### Who actually listens for a global error event in dev?

`preact/debug` is dev-only, so dev overlays and test runners are the entire audience:

| stack | listens? | affected by removal? |
|---|---|---|
| Vite + `@preactjs/preset-vite` / prefresh | **no** — `vite/src/client/client.ts` only handles HMR/build payloads, there is no runtime window listener | no |
| Astro | **no** client listener, `vite-error-overlay` is server driven and their e2e notes even say JSX runtime errors can't be detected | no |
| Fresh | **no** — the error overlay is a server middleware | no |
| preact-cli | webpack-dev-server, but with `client: { overlay: false }` | no |
| Storybook | listens, but only forwards errors tagged `fromStorybook` to telemetry | no |
| Parcel | runtime overlay is only wired through `react-refresh-wrap`, which needs the react-refresh runtime | effectively no |
| Next.js | **yes**, but `next-plugin-preact` was last published in 2022 (Next 12) | no |
| webpack-dev-server, custom configs | **yes** (`client-src/overlay.js`), `overlay.runtimeErrors` defaults to on | loses the overlay for *handled* errors |
| Rsbuild / Rspack | **yes** (`client/hmr.ts` → "Runtime errors" overlay) | loses the overlay for *handled* errors |
| vitest (jsdom + browser mode) | **yes** — reports it as an unhandled error | improves |

React 19 doesn't do this either: `defaultOnCaughtError` is a `console.error`, `reportGlobalError` (`reportError` → `ErrorEvent` → `process.emit`) is only used for uncaught and recoverable errors. Frameworks that want caught errors read them from the root options instead, i.e. Next feeds its overlay from `onCaughtError`. Showing a full screen overlay for an error a boundary handled is what vercel/next.js#36908 was about.

Uncaught errors are unaffected: core `_catchError` rethrows synchronously when no boundary handles the error, so it escapes the diff for real (v11 schedules rerenders with `queueMicrotask` → `error` event, v10 uses `Promise.then` → `unhandledrejection`, both of which those overlays listen for).

Keeping the `console.error` matters for the Vite based stacks, where the re-throw is currently the only signal an error boundary catch produces at all.

Resolves #5185
