### PR TITLE
11-rc.0

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -13,7 +13,7 @@ export function initDevTools() {
 		globalVar !== undefined &&
 		globalVar.__PREACT_DEVTOOLS__
 	) {
-		globalVar.__PREACT_DEVTOOLS__.attachPreact('11.0.0-beta.2', options, {
+		globalVar.__PREACT_DEVTOOLS__.attachPreact('11.0.0-rc.0', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "11.0.0-beta.2",
+  "version": "11.0.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "11.0.0-beta.2",
+      "version": "11.0.0-rc.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.28.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "11.0.0-beta.2",
+  "version": "11.0.0-rc.0",
   "private": false,
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Features

- implement `use` in compat (#5186, thanks @JoviDeCroock)
- Implement getServerSnapshot for useSyncExternalStore (#4979, thanks @ssssota)
- Support createPortal in core (#5168, thanks @JoviDeCroock)
- Add useEffectEvent hook to compat (#5141, thanks @Mesoptier)

## Correctness

- Leverage `moveBefore` rather than `insertBefore` when available (#5161, thanks @JoviDeCroock)
- Avoid mutating user-provided style objects when appending px (#5117, thanks @JSap0914)
- Fix reusing template element content (#5192, thanks @JoviDeCroock)
- Fix dirty child strict equality bailout (#5193, thanks @JoviDeCroock)
- Add the constructor in when cloning VNodes (#5195, thanks @JoviDeCroock)
- Defer passive effect cleanup on unmount (#5196, thanks @JoviDeCroock)

## Performance

- Compute minimal child moves with a longest increasing subsequence (#5174, thanks @JoviDeCroock)
- Batch updates in flushSync (#5175, thanks @JoviDeCroock)
- Avoid traversing retained subtrees (#5183, thanks @JoviDeCroock)
- Reduce core bundle size in v11 (#5167, thanks @JoviDeCroock)
- Reduce bundle size before release candidates go live (#5197, thanks @JoviDeCroock)
- Hoist `_children` into a local in `constructNewChildrenArray` (#5198, thanks @JoviDeCroock)
- Reduce Preact core compressed size (#5199, thanks @JoviDeCroock)

## Maintenance

- Bump reported React version to 19.0.0 (#5171, thanks @JoviDeCroock)
- Remove debug re-throw (#5190, thanks @JoviDeCroock)
- Commit pending hook state in `options._render` (#5187, thanks @JoviDeCroock)
- Remove straggler forwarded (#5178, thanks @JoviDeCroock)
- Derive document from parentDom instead of threading it (#5180, thanks @JoviDeCroock)
- Remove redundant portal children guard (#5179, thanks @JoviDeCroock)
- Restore `_bits` mangle for Preact ISO (#5200, thanks @JoviDeCroock)
- Update contribution build commands (#5166, thanks @Minsecrus)
- Remove unused dependencies (#5160, thanks @JoviDeCroock)
- Avoid Trusted Types violation when dangerouslySetInnerHTML is re… (#4935, thanks @lukewarlow)
- Introduce a modern build setup (#5159, thanks @JoviDeCroock)
