### PR TITLE
Fix dirty child strict equality bailout

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -200,7 +200,8 @@ export function diff(
 				}
 
 				if (
-					newVNode._original == oldVNode._original ||
+					(newVNode._original == oldVNode._original &&
+						!(c._bits & COMPONENT_DIRTY)) ||
 					(!(c._bits & COMPONENT_FORCE) &&
 						c.shouldComponentUpdate &&
 						c.shouldComponentUpdate(

--- a/test/browser/components.test.jsx
+++ b/test/browser/components.test.jsx
@@ -2083,6 +2083,52 @@ describe('Components', () => {
 			expect(isSCUCalled).to.be.false;
 			expect(scratch.innerHTML).to.equal('<div>Updated: yes</div>');
 		});
+
+		it('should render a dirty child through strict equality in a single pass', () => {
+			// A child holding on to a reused vnode has to render as part of its
+			// parent's diff when it's already scheduled, so that both land in the
+			// same commit. See #4737
+			let updateChild, updateParent;
+			let commits = 0;
+			let prevCommit = options._commit;
+			options._commit = () => commits++;
+
+			class Child extends Component {
+				constructor(props) {
+					super(props);
+					this.state = { value: 'old' };
+					updateChild = () => this.setState({ value: 'new' });
+				}
+				render() {
+					return <div>{this.state.value}</div>;
+				}
+			}
+
+			class App extends Component {
+				constructor(props) {
+					super(props);
+					this.children = <Child />;
+					updateParent = () => this.setState({});
+				}
+				render() {
+					return this.children;
+				}
+			}
+
+			try {
+				render(<App />, scratch);
+				commits = 0;
+
+				updateParent();
+				updateChild();
+				rerender();
+
+				expect(scratch.innerHTML).to.equal('<div>new</div>');
+				expect(commits).to.equal(1);
+			} finally {
+				options._commit = prevCommit;
+			}
+		});
 	});
 
 	it('should reset the rerender queue if rendering throws', () => {

--- a/test/browser/select.test.jsx
+++ b/test/browser/select.test.jsx
@@ -1,11 +1,13 @@
-import { createElement, render } from 'preact';
+import { createElement, render, Component } from 'preact';
+import { setupRerender } from 'preact/test-utils';
 import { setupScratch, teardown } from '../_util/helpers';
 
 describe('Select', () => {
-	let scratch;
+	let scratch, rerender;
 
 	beforeEach(() => {
 		scratch = setupScratch();
+		rerender = setupRerender();
 	});
 
 	afterEach(() => {
@@ -66,5 +68,54 @@ describe('Select', () => {
 			}
 		});
 		expect(scratch.firstChild.value).to.equal('B');
+	});
+
+	// #4737: the `<select>` and its `<option>`s live in different components
+	// which both subscribe to the same external store. The `<option>` producer
+	// has to render in the same pass, otherwise the new value is applied to the
+	// `<select>` before the matching `<option>` exists.
+	it('should select an option added by a separate component in the same update', () => {
+		/** @type {Array<() => void>} */
+		let subscribers = [];
+		let store = { items: ['A', 'B'], selected: 'B' };
+
+		class Subscriber extends Component {
+			componentDidMount() {
+				subscribers.push(() => this.forceUpdate());
+			}
+		}
+
+		class Options extends Subscriber {
+			render() {
+				return store.items.map(item => (
+					<option key={item} value={item}>
+						{item}
+					</option>
+				));
+			}
+		}
+
+		class Select extends Subscriber {
+			render(props) {
+				return <select value={store.selected}>{props.children}</select>;
+			}
+		}
+
+		function App() {
+			return (
+				<Select>
+					<Options />
+				</Select>
+			);
+		}
+
+		render(<App />, scratch);
+		expect(scratch.firstChild.value).to.equal('B');
+
+		store = { items: ['A', 'B', 'C'], selected: 'C' };
+		subscribers.forEach(update => update());
+		rerender();
+
+		expect(scratch.firstChild.value).to.equal('C');
 	});
 });


### PR DESCRIPTION
This ensures we can do renders in one pass, when a component is dirtied during a render pass we  know that we'll render it in the next pass of going through the renderQueue. However if this is a direct descendant of a component applying the strict equality bailout then we should just render it to skip work of trampolining back up, ...

Fixes https://github.com/preactjs/preact/issues/4737