### PR TITLE
Reduce Preact core compressed size

### DIFF
--- a/mangle.json
+++ b/mangle.json
@@ -1,7 +1,8 @@
 {
   "help": {
     "what is this file?": "It controls protected/private property mangling so that minified builds have consistent property names.",
-    "why are there duplicate minified properties?": "Most properties are only used on one type of objects, so they can have the same name since they will never collide. Doing this reduces size."
+    "why are there duplicate minified properties?": "Most properties are only used on one type of objects, so they can have the same name since they will never collide. Doing this reduces size, and reusing a name that is already frequent compresses better than introducing a new one.",
+    "careful": "Aliases are only safe while the owning object types stay disjoint. Today: _bits/_listeners share __e with _dom/_catchError (Component / DOM element / VNode / options), and _stateCallbacks shares __k with _children (Component / VNode + root container). Adding one of these props to another owner type silently corrupts state."
   },
   "minify": {
     "mangle": {
@@ -26,7 +27,7 @@
     "cname": 6,
     "props": {
       "$_hasScuFromHooks": "__f",
-      "$_listeners": "__l",
+      "$_listeners": "__e",
       "$_cleanup": "__c",
       "$__hooks": "__H",
       "$_hydrationMismatch": "__m",
@@ -43,7 +44,7 @@
       "$_excess": "__z",
       "$_nextState": "__s",
       "$_renderCallbacks": "__h",
-      "$_stateCallbacks": "_sb",
+      "$_stateCallbacks": "__k",
       "$_vnode": "__v",
       "$_children": "__k",
       "$_pendingSuspensionCount": "__u",
@@ -61,7 +62,6 @@
       "$_context": "c",
       "$_defaultValue": "__",
       "$_id": "__c",
-      "$_contextRef": "__l",
       "$_parentDom": "__P",
       "$_originalParentDom": "__O",
       "$_prevState": "__u",
@@ -76,7 +76,7 @@
       "$_owner": "__o",
       "$_skipEffects": "__s",
       "$_isSuspended": "__i",
-      "$_bits": "__g"
+      "$_bits": "__e"
     }
   }
 }

--- a/src/component.js
+++ b/src/component.js
@@ -34,10 +34,8 @@ export function BaseComponent(props, context) {
  */
 BaseComponent.prototype.setState = function (update, callback) {
 	// only clone state when copying to nextState the first time.
-	let s;
-	if (this._nextState && this._nextState != this.state) {
-		s = this._nextState;
-	} else {
+	let s = this._nextState;
+	if (!s || s == this.state) {
 		s = this._nextState = assign({}, this.state);
 	}
 
@@ -148,7 +146,7 @@ function renderComponent(component) {
 			parentDom.namespaceURI,
 			oldVNode._flags & MODE_HYDRATE ? [oldDom] : NULL,
 			commitQueue,
-			oldDom == NULL ? getDomSibling(oldVNode) : oldDom,
+			oldDom || getDomSibling(oldVNode),
 			oldVNode._flags & MODE_HYDRATE,
 			refQueue
 		);
@@ -170,12 +168,10 @@ function renderComponent(component) {
 function updateParentDomPointers(vnode) {
 	// Stop at root boundaries (_parentDom)
 	if ((vnode = vnode._parent) && vnode._component && !vnode.props._parentDom) {
+		// _dom starts nulled, so re-assigning a null child._dom is a no-op and
+		// the first truthy _dom stops the walk.
 		vnode._dom = NULL;
-		vnode._children.some(child => {
-			if (child && child._dom) {
-				return (vnode._dom = child._dom);
-			}
-		});
+		vnode._children.some(child => child && (vnode._dom = child._dom));
 
 		return updateParentDomPointers(vnode);
 	}

--- a/src/constants.js
+++ b/src/constants.js
@@ -34,5 +34,7 @@ export const EMPTY_ARR = [];
 
 export const MATHML_TOKEN_ELEMENTS = /m(i|n|o|s$|te|sp)/;
 
+// `typeof x < 'u'` is `!= 'undefined'`: every other typeof result sorts
+// before "u", while "undefined" sorts after it.
 export const HAS_MOVE_BEFORE_SUPPORT =
-	typeof window !== 'undefined' && 'moveBefore' in Element.prototype;
+	typeof Element < 'u' && 'moveBefore' in Element.prototype;

--- a/src/create-context.js
+++ b/src/create-context.js
@@ -44,11 +44,7 @@ export function createContext(defaultValue) {
 		return props.children(contextValue);
 	};
 
-	// we could also get rid of _contextRef entirely
-	Context.Provider =
-		Context._contextRef =
-		Context.Consumer.contextType =
-			Context;
+	Context.Provider = Context.Consumer.contextType = Context;
 
 	return Context;
 }

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -125,12 +125,7 @@ export function diffChildren(
 		firstChildDom = firstChildDom || newDom;
 
 		if (childVNode._flags & INSERT_VNODE) {
-			oldDom = insert(
-				childVNode,
-				oldDom,
-				parentDom,
-				oldVNode._original == NULL
-			);
+			oldDom = insert(childVNode, oldDom, parentDom, !oldVNode._original);
 
 			// When a matched VNode is physically moved via INSERT_VNODE, its old
 			// _dom pointer becomes a stale positional reference. Clear it so that
@@ -185,7 +180,7 @@ function constructNewChildrenArray(
 	// Hoisted: every normalization branch below writes through this array, so
 	// reading `_children` off the vnode each time is a wasted property load.
 	/** @type {VNode[]} */
-	let newChildren = (newParentVNode._children = new Array(newChildrenLength));
+	let newChildren = (newParentVNode._children = Array(newChildrenLength));
 	for (i = 0; i < newChildrenLength; i++) {
 		// @ts-expect-error We are reusing the childVNode variable to hold both the
 		// pre and post normalized childVNode
@@ -209,22 +204,12 @@ function constructNewChildrenArray(
 			typeof childVNode != 'object' ||
 			childVNode.constructor == String
 		) {
-			childVNode = newChildren[i] = createVNode(
-				NULL,
-				childVNode,
-				NULL,
-				NULL,
-				NULL
-			);
+			childVNode = newChildren[i] = createVNode(NULL, childVNode);
 		} else if (isArray(childVNode)) {
-			childVNode = newChildren[i] = createVNode(
-				Fragment,
-				{ children: childVNode },
-				NULL,
-				NULL,
-				NULL
-			);
-		} else if (childVNode.constructor === UNDEFINED && childVNode._depth > 0) {
+			childVNode = newChildren[i] = createVNode(Fragment, {
+				children: childVNode
+			});
+		} else if (childVNode.constructor === UNDEFINED && childVNode._depth) {
 			// VNode is already in use, clone it. This can happen in the following
 			// scenario:
 			//   const reuse = <div />
@@ -233,7 +218,7 @@ function constructNewChildrenArray(
 				childVNode.type,
 				childVNode.props,
 				childVNode.key,
-				childVNode.ref || NULL,
+				childVNode.ref,
 				childVNode._original
 			);
 		} else {
@@ -334,18 +319,14 @@ function constructNewChildrenArray(
 		for (i = 0; i < newChildrenLength; i++) {
 			childVNode = newChildren[i];
 			if (childVNode && childVNode._flags & MATCHED) {
-				// Binary search for the insertion point, keeping the pass at
-				// O(n log n) even for pathological reorders.
-				let lo = 0,
-					hi = tails.length;
-				while (lo < hi) {
-					const mid = (lo + hi) >> 1;
-					if (tails[mid] < childVNode._index) {
-						lo = mid + 1;
-					} else {
-						hi = mid;
-					}
-				}
+				// `tails` is strictly increasing, so walking back from its end is a
+				// lower-bound search. It settles in O(1) for the shapes that
+				// dominate real reorders — appends land past the end, reversals
+				// keep `tails` a single entry — and costs a handful of extra
+				// comparisons for the shuffles in between. (A forward scan would
+				// be smaller still but degenerates to O(n²) on swap-rows.)
+				let lo = tails.length;
+				while (lo && tails[lo - 1] >= childVNode._index) lo--;
 				tails[lo] = childVNode._index;
 				lisLengths[i] = lo + 1;
 			}
@@ -401,14 +382,16 @@ function insert(parentVNode, oldDom, parentDom, isMounting) {
 		// host tree and contribute nothing to the host insertion cursor.
 		if (parentVNode.props._parentDom) return oldDom;
 		let children = parentVNode._children;
-		for (let i = 0; children && i < children.length; i++) {
-			if (children[i]) {
-				// If we enter this code path on sCU bailout, where we copy
-				// oldVNode._children to newVNode._children, we need to update the old
-				// children's _parent pointer to point to the newVNode (parentVNode
-				// here).
-				children[i]._parent = parentVNode;
-				oldDom = insert(children[i], oldDom, parentDom, false);
+		if (children) {
+			for (let i = 0; i < children.length; i++) {
+				if (children[i]) {
+					// If we enter this code path on sCU bailout, where we copy
+					// oldVNode._children to newVNode._children, we need to update the old
+					// children's _parent pointer to point to the newVNode (parentVNode
+					// here).
+					children[i]._parent = parentVNode;
+					oldDom = insert(children[i], oldDom, parentDom, false);
+				}
 			}
 		}
 

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -319,14 +319,18 @@ function constructNewChildrenArray(
 		for (i = 0; i < newChildrenLength; i++) {
 			childVNode = newChildren[i];
 			if (childVNode && childVNode._flags & MATCHED) {
-				// `tails` is strictly increasing, so walking back from its end is a
-				// lower-bound search. It settles in O(1) for the shapes that
-				// dominate real reorders — appends land past the end, reversals
-				// keep `tails` a single entry — and costs a handful of extra
-				// comparisons for the shuffles in between. (A forward scan would
-				// be smaller still but degenerates to O(n²) on swap-rows.)
-				let lo = tails.length;
-				while (lo && tails[lo - 1] >= childVNode._index) lo--;
+				// Binary search for the insertion point, keeping the pass at
+				// O(n log n) even for pathological reorders.
+				let lo = 0,
+					hi = tails.length;
+				while (lo < hi) {
+					const mid = (lo + hi) >> 1;
+					if (tails[mid] < childVNode._index) {
+						lo = mid + 1;
+					} else {
+						hi = mid;
+					}
+				}
 				tails[lo] = childVNode._index;
 				lisLengths[i] = lo + 1;
 			}

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -75,21 +75,21 @@ export function diff(
 	if (newVNode.constructor !== UNDEFINED) return NULL;
 
 	// If the previous diff bailed out, resume creating/hydrating.
+	// `tmp` holds the stored excess node until the options._diff call below.
 	if (
 		oldVNode._flags & MODE_SUSPENDED &&
 		// @ts-expect-error This is 1 or 0 (true or false)
 		(isHydrating = oldVNode._flags & MODE_HYDRATE) &&
-		oldVNode._component._excess
+		(tmp = oldVNode._component._excess)
 	) {
 		newVNode._flags |= MODE_HYDRATE;
-		let excess = oldVNode._component._excess;
 		excessDomChildren = [];
-		if (excess.nodeType == 8) {
+		if (tmp.nodeType == 8) {
 			// Re-scan DOM from stored start marker for streamed hydration.
 			// `depth` only ever reaches 0 through the `break` below, so it
 			// doesn't need to be re-tested in the loop condition.
 			for (
-				let depth = 1, node = excess.nextSibling;
+				let depth = 1, node = tmp.nextSibling;
 				node;
 				node = node.nextSibling
 			) {
@@ -100,7 +100,7 @@ export function diff(
 				excessDomChildren.push(node);
 			}
 		} else {
-			excessDomChildren.push(excess);
+			excessDomChildren.push(tmp);
 		}
 		oldDom = excessDomChildren[0];
 		oldVNode._component._excess = NULL;
@@ -116,7 +116,7 @@ export function diff(
 				oldState,
 				snapshot,
 				newProps = newVNode.props;
-			const isClassComponent = newType.prototype && newType.prototype.render;
+			const isClassComponent = (tmp = newType.prototype) && tmp.render;
 
 			// Necessary for createContext api. Setting this property will pass
 			// the context value as `this.context` just for this component.
@@ -309,8 +309,11 @@ export function diff(
 			// invisible to the host tree's DOM bookkeeping: the portal vnode
 			// keeps a `null` `_dom` and the host insertion cursor (`oldDom`)
 			// passes through unchanged.
-			let hostOldDom = oldDom;
+			// `tmp` (the raw render result, already unwrapped into renderResult)
+			// doubles as the saved host insertion cursor while we render into
+			// the portal's container.
 			if (newProps._parentDom) {
+				tmp = oldDom;
 				parentDom = newProps._parentDom;
 				// If we portal into a math or svg element we need
 				// to swap the namespace (chart libraries often do this).
@@ -347,7 +350,7 @@ export function diff(
 			// change up the oldDom
 			if (newProps._parentDom) {
 				newVNode._dom = NULL;
-				oldDom = hostOldDom;
+				oldDom = tmp;
 			}
 
 			// We successfully rendered this VNode, unset any stored hydration/bailout state:
@@ -357,9 +360,9 @@ export function diff(
 				commitQueue.push(c);
 			}
 
-			if (c._bits & COMPONENT_PENDING_ERROR) {
-				c._bits &= ~(COMPONENT_PROCESSING_EXCEPTION | COMPONENT_PENDING_ERROR);
-			}
+			// PROCESSING_EXCEPTION is only ever set together with PENDING_ERROR,
+			// so the clear doesn't need a guard.
+			c._bits &= ~(COMPONENT_PROCESSING_EXCEPTION | COMPONENT_PENDING_ERROR);
 		} catch (e) {
 			// We remove any componentDidMount, ...
 			// that have been invalidated by us
@@ -382,28 +385,23 @@ export function diff(
 							if (!child) continue;
 
 							if (child.nodeType == 8) {
+								excessDomChildren[i] = NULL;
 								if (child.data.startsWith('$s')) {
-									if (!commentMarkersToFind) startMarker = child;
-									commentMarkersToFind++;
+									if (!commentMarkersToFind++) startMarker = child;
 								} else if (
 									child.data.startsWith('/$s') &&
 									!--commentMarkersToFind
 								) {
 									oldDom = child;
-									excessDomChildren[i] = NULL;
 									break;
 								}
-								excessDomChildren[i] = NULL;
 							} else if (commentMarkersToFind) {
 								excessDomChildren[i] = NULL;
 							}
 						}
 					}
 
-					if (startMarker) {
-						// Store start marker directly; children re-scanned on resume
-						newVNode._component._excess = startMarker;
-					} else {
+					if (!startMarker) {
 						while (oldDom && oldDom.nodeType == 8 && oldDom.nextSibling) {
 							oldDom = oldDom.nextSibling;
 						}
@@ -411,8 +409,10 @@ export function diff(
 						if (excessDomChildren) {
 							excessDomChildren[excessDomChildren.indexOf(oldDom)] = NULL;
 						}
-						newVNode._component._excess = oldDom;
+						startMarker = oldDom;
 					}
+					// Store the start marker directly; children re-scanned on resume
+					newVNode._component._excess = startMarker;
 					newVNode._dom = oldDom;
 				} else if (excessDomChildren) {
 					excessDomChildren.some(removeNode);
@@ -461,8 +461,8 @@ function markAsForce(vnode) {
  * @param {VNode} root
  */
 export function commitRoot(commitQueue, root, refQueue) {
-	for (let i = 0; i < refQueue.length; i++) {
-		applyRef(refQueue[i], refQueue[++i], refQueue[++i]);
+	for (let i = 0; i < refQueue.length; ) {
+		applyRef(refQueue[i++], refQueue[i++], refQueue[i++]);
 	}
 
 	if (options._commit) options._commit(root, commitQueue);
@@ -483,7 +483,7 @@ export function commitRoot(commitQueue, root, refQueue) {
 }
 
 function cloneNode(node) {
-	if (typeof node != 'object' || node == NULL || node._depth > 0) {
+	if (typeof node != 'object' || node == NULL || node._depth) {
 		return node;
 	}
 

--- a/src/diff/props.js
+++ b/src/diff/props.js
@@ -75,8 +75,7 @@ export function setProperty(dom, name, value, oldValue, namespace) {
 		// Infer correct casing for DOM built-in events:
 		name = name.slice(2).toLowerCase();
 
-		if (!dom._listeners) dom._listeners = {};
-		dom._listeners[name + useCapture] = value;
+		(dom._listeners || (dom._listeners = {}))[name + useCapture] = value;
 
 		if (value) {
 			if (!oldValue) {

--- a/src/internal.d.ts
+++ b/src/internal.d.ts
@@ -65,10 +65,6 @@ export interface FunctionComponent<P = {}> extends preact.FunctionComponent<P> {
 	// implement the Consumer component
 	contextType?: PreactContext;
 
-	// Internally, createContext stores a ref to the context object on the Provider
-	// Function component to help devtools
-	_contextRef?: PreactContext;
-
 	// Define these properties as undefined on FunctionComponent to get rid of
 	// some errors in `diff()`
 	getDerivedStateFromProps?: undefined;
@@ -76,8 +72,6 @@ export interface FunctionComponent<P = {}> extends preact.FunctionComponent<P> {
 }
 
 export interface ComponentClass<P = {}> extends preact.ComponentClass<P> {
-	_contextRef?: any;
-
 	// Override public contextType with internal PreactContext type
 	contextType?: PreactContext;
 }


### PR DESCRIPTION
Reduces Preact core's compressed size by simplifying component, context, hydration, child-diff, and DOM property paths. Reuses existing mangled property names while retaining the bounded LIS binary search. Core output drops from 4,911 to 4,842 bytes gzip and from 4,483 to 4,425 bytes Brotli.