### PR TITLE
Improve hooks performance with a cold unmount queue

### DIFF
--- a/hooks/mangle.json
+++ b/hooks/mangle.json
@@ -17,5 +17,13 @@
         ]
       }
     }
+  },
+  "props": {
+    "props": {
+      "$_unmounts": "t",
+      "$_reducer": "u",
+      "$_passive": "i",
+      "$_pendingArgs": "o"
+    }
   }
 }

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -22,9 +22,9 @@ let afterPaintEffects = [];
  * still pending. Deferred to the after-paint flush to match React, which runs
  * passive destroys after the commit has painted. Each state's `_passive` holds
  * the surviving component its errors should be routed to.
- * @type {Array<import('./internal').EffectHookState>}
  */
-let unmountCleanups = [];
+flushAfterPaintEffects._unmounts =
+	/** @type {Array<import('./internal').EffectHookState>} */ ([]);
 
 // Cast to use internal Options type
 const options = /** @type {import('./internal').Options} */ (_options);
@@ -150,7 +150,7 @@ options.unmount = vnode => {
 				// `_passive` repurposed to hold the error-routing component.
 				if (s._passive) {
 					s._passive = errorParent && errorParent._component;
-					afterPaint(unmountCleanups.push(s));
+					afterPaint(flushAfterPaintEffects._unmounts.push(s));
 				} else {
 					invokeCleanup(s);
 				}
@@ -454,7 +454,7 @@ function flushAfterPaintEffects() {
 	do {
 		// Unmounted components' passive cleanups run before any new passive
 		// effect, mirroring React running all destroys before any create.
-		while ((component = unmountCleanups.shift())) {
+		while ((component = flushAfterPaintEffects._unmounts.shift())) {
 			try {
 				invokeCleanup(component);
 			} catch (e) {
@@ -475,7 +475,7 @@ function flushAfterPaintEffects() {
 				options._catchError(e, component._vnode);
 			}
 		}
-	} while (unmountCleanups.length);
+	} while (flushAfterPaintEffects._unmounts.length);
 }
 
 let HAS_RAF = typeof requestAnimationFrame == 'function';


### PR DESCRIPTION
## Summary

- store the deferred passive-unmount queue on the after-paint flush function instead of in a mutable module-level binding
- pin the affected private hook property mangles so production output remains deterministic

This preserves passive cleanup ordering and deferred error routing while reducing the aggregate overhead measured in the Preact 11 hook paths.

## Performance

Paired production Chromium runs against the previous Preact 11 build:

| Octane suite | Geomean |
| --- | ---: |
| `js-framework` | 8.0% faster |
| `memo-wall` | 11.4% faster |
| `effectful-list` | 1.9% slower |

All exact Octane correctness gates passed. The result is mixed at the individual-operation level: `js-framework` `run` and `replace` were 7.1% and 10.5% slower, while update/select/reorder/removal paths drove the aggregate improvement. The effectful-list result was mostly neutral, with `remove_100_scattered` 8.3% slower.