### PR TITLE
Tree-shake feature-specific compat hooks

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -24,6 +24,7 @@ import { assign, IS_NON_DIMENSIONAL } from './util';
 export const REACT_ELEMENT_TYPE = Symbol.for('react.element');
 
 const MODE_HYDRATE = 1 << 5;
+let currentComponent, hydrationRoot, renderTrackingInitialized;
 
 const CAMEL_PROPS =
 	/^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|dominant|fill|flood|font|glyph(?!R)|horiz|image(!S)|letter|lighting|marker(?!H|W|U)|overline|paint|pointer|shape|stop|strikethrough|stroke|text(?!L)|transform|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/;
@@ -35,47 +36,45 @@ const IS_DOM = typeof document != 'undefined';
  * on a high level this cuts out the warnings, ... and attempts a smaller implementation
  * @typedef {{ _value: any; _getSnapshot: () => any }} Store
  */
-export function useSyncExternalStore(
-	subscribe,
-	getSnapshot,
-	getServerSnapshot
-) {
-	const serverRendering = options._skipEffects || hydrationRoot;
-	const value = serverRendering
-		? (getServerSnapshot || getSnapshot)()
-		: getSnapshot();
+export const useSyncExternalStore = /* @__PURE__ */ initRenderTracking(
+	function useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot) {
+		const serverRendering = options._skipEffects || hydrationRoot;
+		const value = serverRendering
+			? (getServerSnapshot || getSnapshot)()
+			: getSnapshot();
 
-	/**
-	 * @typedef {{ _instance: Store }} StoreRef
-	 * @type {[StoreRef, (store: StoreRef) => void]}
-	 */
-	const [{ _instance }, forceUpdate] = useState({
-		_instance: { _value: value, _getSnapshot: getSnapshot }
-	});
+		/**
+		 * @typedef {{ _instance: Store }} StoreRef
+		 * @type {[StoreRef, (store: StoreRef) => void]}
+		 */
+		const [{ _instance }, forceUpdate] = useState({
+			_instance: { _value: value, _getSnapshot: getSnapshot }
+		});
 
-	useLayoutEffect(() => {
-		_instance._value = value;
-		_instance._getSnapshot = getSnapshot;
+		useLayoutEffect(() => {
+			_instance._value = value;
+			_instance._getSnapshot = getSnapshot;
 
-		if (didSnapshotChange(_instance)) {
-			forceUpdate({ _instance });
-		}
-	}, [subscribe, value, getSnapshot]);
-
-	useEffect(() => {
-		if (didSnapshotChange(_instance)) {
-			forceUpdate({ _instance });
-		}
-
-		return subscribe(() => {
 			if (didSnapshotChange(_instance)) {
 				forceUpdate({ _instance });
 			}
-		});
-	}, [subscribe]);
+		}, [subscribe, value, getSnapshot]);
 
-	return value;
-}
+		useEffect(() => {
+			if (didSnapshotChange(_instance)) {
+				forceUpdate({ _instance });
+			}
+
+			return subscribe(() => {
+				if (didSnapshotChange(_instance)) {
+					forceUpdate({ _instance });
+				}
+			});
+		}, [subscribe]);
+
+		return value;
+	}
+);
 
 /** @type {(inst: Store) => boolean} */
 function didSnapshotChange(inst) {
@@ -310,17 +309,6 @@ options.vnode = vnode => {
 	if (oldVNodeHook) oldVNodeHook(vnode);
 };
 
-// Only needed for react-relay
-let currentComponent, hydrationRoot;
-const oldBeforeRender = options._render;
-options._render = function (vnode) {
-	if (oldBeforeRender) {
-		oldBeforeRender(vnode);
-	}
-	if (vnode._flags & MODE_HYDRATE) hydrationRoot = vnode;
-	currentComponent = vnode._component;
-};
-
 const oldDiffed = options.diffed;
 /** @type {(vnode: import('./internal').VNode) => void} */
 options.diffed = function (vnode) {
@@ -339,10 +327,30 @@ options.diffed = function (vnode) {
 	) {
 		dom.value = props.value == null ? '' : props.value;
 	}
-
-	currentComponent = null;
-	if (hydrationRoot == vnode) hydrationRoot = null;
 };
+
+// Only needed for react-relay and useSyncExternalStore hydration.
+function initRenderTracking(value) {
+	if (!renderTrackingInitialized) {
+		renderTrackingInitialized = true;
+
+		const oldBeforeRender = options._render;
+		options._render = vnode => {
+			if (oldBeforeRender) oldBeforeRender(vnode);
+			if (vnode._flags & MODE_HYDRATE) hydrationRoot = vnode;
+			currentComponent = vnode._component;
+		};
+
+		const oldDiffed = options.diffed;
+		options.diffed = vnode => {
+			if (oldDiffed) oldDiffed(vnode);
+			currentComponent = null;
+			if (hydrationRoot == vnode) hydrationRoot = null;
+		};
+	}
+
+	return value;
+}
 
 /**
  * Read the value of a Promise (suspending while pending) or a Context.
@@ -351,7 +359,7 @@ options.diffed = function (vnode) {
  * @param {(Promise<T> & { status?: string, value?: T, reason?: any }) | import('../../src/internal').PreactContext} resource
  * @returns {T}
  */
-export const use = resource => {
+export const use = /* @__PURE__ */ initRenderTracking(function use(resource) {
 	// A Context is a function without a `then`, a thenable has one.
 	if (resource.then) {
 		if (resource.status == 'fulfilled') return resource.value;
@@ -383,7 +391,7 @@ export const use = resource => {
 		provider.sub(currentComponent);
 	}
 	return provider.props.value;
-};
+});
 
 // This is a very very private internal function for React it
 // is used to sort-of do runtime dependency injection.

--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -7,38 +7,40 @@ import {
 } from '../../src/constants';
 import { assign } from './util';
 
-const oldCatchError = options._catchError;
-options._catchError = (error, newVNode, oldVNode, errorInfo) => {
-	if (error.then) {
-		/** @type {import('./internal').Component} */
-		let component;
-		let vnode = newVNode;
+function initSuspenseHooks() {
+	const oldCatchError = options._catchError;
+	options._catchError = (error, newVNode, oldVNode, errorInfo) => {
+		if (error.then) {
+			/** @type {import('./internal').Component} */
+			let component;
+			let vnode = newVNode;
 
-		while ((vnode = vnode._parent)) {
-			if ((component = vnode._component) && component._childDidSuspend) {
-				if (newVNode._dom == null) {
-					newVNode._dom = oldVNode._dom;
-					newVNode._children = oldVNode._children || [];
+			while ((vnode = vnode._parent)) {
+				if ((component = vnode._component) && component._childDidSuspend) {
+					if (newVNode._dom == null) {
+						newVNode._dom = oldVNode._dom;
+						newVNode._children = oldVNode._children || [];
+					}
+					// Don't call oldCatchError if we found a Suspense
+					return component._childDidSuspend(error, newVNode);
 				}
-				// Don't call oldCatchError if we found a Suspense
-				return component._childDidSuspend(error, newVNode);
 			}
 		}
-	}
-	oldCatchError(error, newVNode, oldVNode, errorInfo);
-};
+		oldCatchError(error, newVNode, oldVNode, errorInfo);
+	};
 
-const oldUnmount = options.unmount;
-options.unmount = vnode => {
-	/** @type {import('./internal').Component} */
-	const component = vnode._component;
-	if (component) component._unmounted = true;
-	if (component && component._onResolve) {
-		component._onResolve();
-	}
+	const oldUnmount = options.unmount;
+	options.unmount = vnode => {
+		/** @type {import('./internal').Component} */
+		const component = vnode._component;
+		if (component) component._unmounted = true;
+		if (component && component._onResolve) {
+			component._onResolve();
+		}
 
-	if (oldUnmount) oldUnmount(vnode);
-};
+		if (oldUnmount) oldUnmount(vnode);
+	};
+}
 
 function detachedClone(vnode, detachedParent, parentDom) {
 	if (vnode) {
@@ -99,121 +101,129 @@ function removeOriginal(vnode, detachedParent, originalParent) {
 }
 
 // having custom inheritance instead of a class here saves a lot of bytes
-export function Suspense() {
-	// we do not call super here to golf some bytes...
-	this._pendingSuspensionCount = 0;
-	this._suspenders = null;
-	this._detachOnNextRender = null;
-}
+function createSuspense() {
+	initSuspenseHooks();
 
-// Things we do here to save some bytes but are not proper JS inheritance:
-// - call `new Component()` as the prototype
-// - do not set `Suspense.prototype.constructor` to `Suspense`
-Suspense.prototype = new Component();
-
-/**
- * @this {import('./internal').SuspenseComponent}
- * @param {Promise} promise The thrown promise
- * @param {import('./internal').VNode<any, any>} suspendingVNode The suspending component
- */
-Suspense.prototype._childDidSuspend = function (promise, suspendingVNode) {
-	const suspendingComponent = suspendingVNode._component;
-
-	if (this._suspenders == null) {
-		this._suspenders = [];
-	}
-	this._suspenders.push(suspendingComponent);
-
-	let resolved = false;
-	const onResolved = () => {
-		if (resolved || this._unmounted) return;
-
-		resolved = true;
-		suspendingComponent._onResolve = null;
-
-		onSuspensionComplete();
-	};
-
-	suspendingComponent._onResolve = onResolved;
-
-	// Store and null _parentDom to prevent setState/forceUpdate from
-	// scheduling renders while suspended. Render would be a no-op anyway
-	// since renderComponent checks _parentDom, but this avoids queue churn.
-	const originalParentDom = suspendingComponent._parentDom;
-	suspendingComponent._parentDom = null;
-
-	const onSuspensionComplete = () => {
-		if (!--this._pendingSuspensionCount) {
-			// If the suspension was during hydration we don't need to restore the
-			// suspended children into the _children array
-			if (this.state._suspended) {
-				const suspendedVNode = this.state._suspended;
-				this._vnode._children[0] = removeOriginal(
-					suspendedVNode,
-					suspendedVNode._component._parentDom,
-					suspendedVNode._component._originalParentDom
-				);
-			}
-
-			this.setState({ _suspended: (this._detachOnNextRender = null) });
-
-			let suspended;
-			while ((suspended = this._suspenders.pop())) {
-				// Restore _parentDom before forceUpdate so render can proceed
-				suspended._parentDom = originalParentDom;
-				suspended.forceUpdate();
-			}
-		}
-	};
-
-	/**
-	 * We do not set `suspended: true` during hydration because we want the actual markup
-	 * to remain on screen and hydrate it when the suspense actually gets resolved.
-	 * While in non-hydration cases the usual fallback -> component flow would occour.
-	 */
-	if (
-		!this._pendingSuspensionCount++ &&
-		!(suspendingVNode._flags & MODE_HYDRATE)
-	) {
-		this.setState({
-			_suspended: (this._detachOnNextRender = this._vnode._children[0])
-		});
-	}
-	promise.then(onResolved, onResolved);
-};
-
-Suspense.prototype.componentWillUnmount = function () {
-	this._suspenders = [];
-};
-
-/**
- * @this {import('./internal').SuspenseComponent}
- * @param {import('./internal').SuspenseComponent["props"]} props
- * @param {import('./internal').SuspenseState} state
- */
-Suspense.prototype.render = function (props, state) {
-	if (this._detachOnNextRender) {
-		// When the Suspense's _vnode was created by a call to createVNode
-		// (i.e. due to a setState further up in the tree)
-		// it's _children prop is null, in this case we "forget" about the parked vnodes to detach
-		if (this._vnode._children) {
-			const detachedParent = document.createElement('div');
-			const detachedComponent = this._vnode._children[0]._component;
-			this._vnode._children[0] = detachedClone(
-				this._detachOnNextRender,
-				detachedParent,
-				(detachedComponent._originalParentDom = detachedComponent._parentDom)
-			);
-		}
-
+	function Suspense() {
+		// we do not call super here to golf some bytes...
+		this._pendingSuspensionCount = 0;
+		this._suspenders = null;
 		this._detachOnNextRender = null;
 	}
 
-	return [
-		createElement(Fragment, null, state._suspended ? null : props.children),
-		state._suspended && createElement(Fragment, null, props.fallback)
-	];
-};
+	// Things we do here to save some bytes but are not proper JS inheritance:
+	// - call `new Component()` as the prototype
+	// - do not set `Suspense.prototype.constructor` to `Suspense`
+	Suspense.prototype = new Component();
+
+	/**
+	 * @this {import('./internal').SuspenseComponent}
+	 * @param {Promise} promise The thrown promise
+	 * @param {import('./internal').VNode<any, any>} suspendingVNode The suspending component
+	 */
+	Suspense.prototype._childDidSuspend = function (promise, suspendingVNode) {
+		const suspendingComponent = suspendingVNode._component;
+
+		if (this._suspenders == null) {
+			this._suspenders = [];
+		}
+		this._suspenders.push(suspendingComponent);
+
+		let resolved = false;
+		const onResolved = () => {
+			if (resolved || this._unmounted) return;
+
+			resolved = true;
+			suspendingComponent._onResolve = null;
+
+			onSuspensionComplete();
+		};
+
+		suspendingComponent._onResolve = onResolved;
+
+		// Store and null _parentDom to prevent setState/forceUpdate from
+		// scheduling renders while suspended. Render would be a no-op anyway
+		// since renderComponent checks _parentDom, but this avoids queue churn.
+		const originalParentDom = suspendingComponent._parentDom;
+		suspendingComponent._parentDom = null;
+
+		const onSuspensionComplete = () => {
+			if (!--this._pendingSuspensionCount) {
+				// If the suspension was during hydration we don't need to restore the
+				// suspended children into the _children array
+				if (this.state._suspended) {
+					const suspendedVNode = this.state._suspended;
+					this._vnode._children[0] = removeOriginal(
+						suspendedVNode,
+						suspendedVNode._component._parentDom,
+						suspendedVNode._component._originalParentDom
+					);
+				}
+
+				this.setState({ _suspended: (this._detachOnNextRender = null) });
+
+				let suspended;
+				while ((suspended = this._suspenders.pop())) {
+					// Restore _parentDom before forceUpdate so render can proceed
+					suspended._parentDom = originalParentDom;
+					suspended.forceUpdate();
+				}
+			}
+		};
+
+		/**
+		 * We do not set `suspended: true` during hydration because we want the actual markup
+		 * to remain on screen and hydrate it when the suspense actually gets resolved.
+		 * While in non-hydration cases the usual fallback -> component flow would occour.
+		 */
+		if (
+			!this._pendingSuspensionCount++ &&
+			!(suspendingVNode._flags & MODE_HYDRATE)
+		) {
+			this.setState({
+				_suspended: (this._detachOnNextRender = this._vnode._children[0])
+			});
+		}
+		promise.then(onResolved, onResolved);
+	};
+
+	Suspense.prototype.componentWillUnmount = function () {
+		this._suspenders = [];
+	};
+
+	/**
+	 * @this {import('./internal').SuspenseComponent}
+	 * @param {import('./internal').SuspenseComponent["props"]} props
+	 * @param {import('./internal').SuspenseState} state
+	 */
+	Suspense.prototype.render = function (props, state) {
+		if (this._detachOnNextRender) {
+			// When the Suspense's _vnode was created by a call to createVNode
+			// (i.e. due to a setState further up in the tree)
+			// it's _children prop is null, in this case we "forget" about the parked vnodes to detach
+			if (this._vnode._children) {
+				const detachedParent = document.createElement('div');
+				const detachedComponent = this._vnode._children[0]._component;
+				this._vnode._children[0] = detachedClone(
+					this._detachOnNextRender,
+					detachedParent,
+					(detachedComponent._originalParentDom = detachedComponent._parentDom)
+				);
+			}
+
+			this._detachOnNextRender = null;
+		}
+
+		return [
+			createElement(Fragment, null, state._suspended ? null : props.children),
+			state._suspended && createElement(Fragment, null, props.fallback)
+		];
+	};
+
+	return Suspense;
+}
+
+export const Suspense = /* @__PURE__ */ createSuspense();
 
 export function lazy(loader) {
 	let prom;


### PR DESCRIPTION
> [!NOTE]
> The idea was created by Jovi and this PR was authored by GPT5.6-sol

Resolves https://github.com/preactjs/preact/issues/1529

## Description

We need tree-shaking in preact/compat. A lot of the options hooks are exclusive to a given feature. In this PR we target use/uSES/Suspense.

Measured from the production `compat/dist/compat.mjs` generated by `npm run build`, then tree-shaken with Rollup's defaults, minified with Terser, and compressed with gzip:

- `useState`: 2146 B → 1551 B (-595 B / 27.7%)
- `forwardRef`: 2248 B → 1650 B (-598 B / 26.6%)
- `memo`: 2262 B → 1674 B (-588 B / 26.0%)
- `useSyncExternalStore`: 2341 B → 1785 B (-556 B / 23.8%)
- `use`: 2280 B → 1734 B (-546 B / 23.9%)
- `Suspense`: 2154 B → 2159 B (+5 B / 0.2%)
- `lazy`: 2241 B → 1649 B (-592 B / 26.4%)

The production build preserves the `/* @__PURE__ */` initializers. These results use Rollup's default `propertyReadSideEffects: true`; setting it to `false` produced identical output.

The compressed-size check measures the complete compat artifact, where every export is present, so it instead reports +62 B gzip. The build reports +67 B Brotli, and a downstream consumer retaining the default export grows by 38 B.

## Notes

In an ideal world we could also remove the `options.event`, `options.vnode`, and textarea `options.diffed` hooks from the base cost of compat. That would let people select individual React compatibility features without incurring the cost of those hooks.

A production-build experiment gating all three behind pure `render`/`hydrate` initializers produced these representative gzip results compared with this PR:

- `useState`: 1551 B → 369 B (-1182 B)
- `forwardRef`: 1650 B → 496 B (-1154 B)
- `Suspense`: 2159 B → 1026 B (-1133 B)
- `render`: 1609 B → 1628 B (+19 B)
- default import: unchanged
- complete compat artifact: 3916 B → 3930 B (+14 B)

This would be a breaking change. If an application does not retain `render` or `hydrate` from compat, `isValidElement(createElement('div'))` can return `false`. It can also skip `$$typeof`, `defaultProps`, class-component ref handling, DOM prop normalization, React event normalization, and the textarea fix when compat VNodes are consumed by another or separately bundled renderer.

Installing the hooks inside the runtime `render()` call is too late because the root VNode, and often its children, have already been created. If we want this, we should chase it separately.