### PR TITLE
fix(demo): declare the sass dependency vite's scss compilation needs

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -26,6 +26,7 @@
       "devDependencies": {
         "@babel/plugin-proposal-class-properties": "^7.0.0-beta.55",
         "@babel/plugin-proposal-decorators": "^7.4.0",
+        "sass": "^1.53.0",
         "vite": "^5.4.10"
       }
     },

--- a/demo/package.json
+++ b/demo/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.0.0-beta.55",
     "@babel/plugin-proposal-decorators": "^7.4.0",
+    "sass": "^1.53.0",
     "vite": "^5.4.10"
   },
   "dependencies": {


### PR DESCRIPTION
`demo/index.jsx` imports `style.scss`, but `sass` was never declared in `demo/package.json` — only an orphaned `node_modules/sass@1.53.0` entry in `demo/package-lock.json` kept it working:

- `npm ci` installs the lockfile verbatim (orphaned entries included), so the demo happens to run;
- a fresh `npm install` prunes the unreachable entry and rewrites the lockfile, after which `npm run dev` fails with:

```
[vite] Internal server error: Preprocessor dependency "sass-embedded" not found. Did you install it?
  Plugin: vite:css
  File: demo/style.scss
```

This reproduces on current `main` as well as the 10.x line (the orphaned entry dates back to the vite migration of the demo).

The fix declares `sass@^1.53.0` — matching the version already present in the lockfile — so the lockfile change is a single line turning the orphaned entry into a reachable one. Verified that both `npm ci` and a fresh `npm install` now produce a demo where vite compiles `style.scss` successfully.