### PR TITLE
test: cover JSX refs and event bubbling

### DIFF
--- a/debug/src/component-stack.js
+++ b/debug/src/component-stack.js
@@ -149,9 +149,10 @@ export function setupComponentStack() {
 }
 
 /**
- * Return the component stack that was captured up to this point.
- * @returns {string}
+ * Return the owner stack captured for the current render, or null when unavailable.
+ * @returns {string | null}
  */
 export function captureOwnerStack() {
-	return getOwnerStack(getCurrentVNode());
+	const vnode = getCurrentVNode();
+	return vnode ? getOwnerStack(vnode) : null;
 }

--- a/debug/src/index.d.ts
+++ b/debug/src/index.d.ts
@@ -1,9 +1,9 @@
 import { VNode } from '../../src/index';
 
 /**
- * Return the component stack that was captured up to this point.
+ * Return the owner stack captured for the current render, or null when unavailable.
  */
-export function captureOwnerStack(): string;
+export function captureOwnerStack(): string | null;
 
 /**
  * Get the currently rendered `vnode`

--- a/debug/test/browser/component-stack.test.jsx
+++ b/debug/test/browser/component-stack.test.jsx
@@ -1,5 +1,5 @@
 import { createElement, render, Component } from 'preact';
-import 'preact/debug';
+import { captureOwnerStack } from 'preact/debug';
 import { vi } from 'vitest';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 
@@ -82,6 +82,24 @@ describe('component stack', () => {
 		expect(lines[0].indexOf('tr') > -1).to.equal(true);
 		expect(lines[1].indexOf('Thrower') > -1).to.equal(true);
 		expect(lines[2].indexOf('Bar') > -1).to.equal(true);
+	});
+
+	it('should capture the owner stack during render and return null otherwise', () => {
+		let capturedStack;
+
+		function Child() {
+			capturedStack = captureOwnerStack();
+			return null;
+		}
+
+		function Parent() {
+			return <Child />;
+		}
+
+		expect(captureOwnerStack()).to.equal(null);
+		render(<Parent />, scratch);
+		expect(capturedStack).to.match(/in Child[\s\S]*in Parent/);
+		expect(captureOwnerStack()).to.equal(null);
 	});
 
 	it('should not print a warning when "@babel/plugin-transform-react-jsx-source" is installed', () => {

--- a/jsx-runtime/test/browser/jsx-runtime.test.js
+++ b/jsx-runtime/test/browser/jsx-runtime.test.js
@@ -1,4 +1,4 @@
-import { Component, createElement, createRef, options } from 'preact';
+import { Component, createElement, options } from 'preact';
 import {
 	jsx,
 	jsxs,
@@ -51,12 +51,15 @@ describe('Babel jsx/jsxDEV', () => {
 		expect(typeof Fragment).to.equal('function');
 	});
 
-	it('should keep ref in props', () => {
+	it('should separate ref from intrinsic VNode props without mutating the input', () => {
 		const ref = () => null;
-		const props = { ref };
+		const props = { ref, id: 'foo', children: 'bar' };
 		const vnode = jsx('div', props);
+
 		expect(vnode.ref).to.equal(ref);
+		expect(vnode.props).to.deep.equal({ id: 'foo', children: 'bar' });
 		expect(vnode.props).to.not.equal(props);
+		expect(props).to.deep.equal({ ref, id: 'foo', children: 'bar' });
 	});
 
 	it('should not copy props wen there is no ref in props', () => {
@@ -87,14 +90,6 @@ describe('Babel jsx/jsxDEV', () => {
 		delete jsxVNode._original;
 		delete elementVNode._original;
 		expect(jsxVNode).to.deep.equal(elementVNode);
-	});
-
-	// #2839
-	it('should remove ref from props', () => {
-		const ref = createRef();
-		const vnode = jsx('div', { ref }, null);
-		expect(vnode.props).to.deep.equal({});
-		expect(vnode.ref).to.equal(ref);
 	});
 
 	it('should call options.vnode with the vnode', () => {

--- a/test/browser/events.test.jsx
+++ b/test/browser/events.test.jsx
@@ -118,6 +118,31 @@ describe('event handling', () => {
 		expect(click).toHaveBeenCalledWith(1);
 	});
 
+	it('should not invoke an ancestor handler attached while an event bubbles', () => {
+		const onAncestorClick = vi.fn();
+		const onButtonClick = () => {
+			render(
+				<div onClick={onAncestorClick}>
+					<button onClick={onButtonClick}>Click me</button>
+				</div>,
+				scratch
+			);
+		};
+
+		render(
+			<div>
+				<button onClick={onButtonClick}>Click me</button>
+			</div>,
+			scratch
+		);
+
+		fireEvent(scratch.querySelector('button'), 'click');
+		expect(onAncestorClick).not.toHaveBeenCalled();
+
+		fireEvent(scratch.querySelector('button'), 'click');
+		expect(onAncestorClick).toHaveBeenCalledOnce();
+	});
+
 	it('should update event handlers', () => {
 		let click1 = vi.fn();
 		let click2 = vi.fn();


### PR DESCRIPTION
Adds regression coverage for intrinsic JSX refs and event handlers attached during bubbling. Aligns debug captureOwnerStack with its nullable public contract.