### PR TITLE
refactor(compat): remove redundant textarea hydration hook

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -309,26 +309,6 @@ options.vnode = vnode => {
 	if (oldVNodeHook) oldVNodeHook(vnode);
 };
 
-const oldDiffed = options.diffed;
-/** @type {(vnode: import('./internal').VNode) => void} */
-options.diffed = function (vnode) {
-	if (oldDiffed) {
-		oldDiffed(vnode);
-	}
-
-	const props = vnode.props;
-	const dom = vnode._dom;
-
-	if (
-		dom != null &&
-		vnode.type == 'textarea' &&
-		'value' in props &&
-		props.value !== dom.value
-	) {
-		dom.value = props.value == null ? '' : props.value;
-	}
-};
-
 // Only needed for react-relay and useSyncExternalStore hydration.
 function initRenderTracking(value) {
 	if (!renderTrackingInitialized) {

--- a/compat/test/browser/textarea.test.jsx
+++ b/compat/test/browser/textarea.test.jsx
@@ -1,5 +1,4 @@
 import React, { createElement, render, hydrate, useState } from 'preact/compat';
-import ReactDOMServer from 'preact/compat/server';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { act } from 'preact/test-utils';
 
@@ -21,19 +20,19 @@ describe('Textarea', () => {
 		expect(scratch.firstElementChild.value).to.equal('foo');
 	});
 
-	it('should hydrate textarea value', () => {
-		function App() {
-			return <textarea value="foo" />;
+	it('should preserve textarea values when nullish values are uncontrolled', () => {
+		for (const value of [null, undefined]) {
+			const root = document.createElement('div');
+			root.innerHTML = '<textarea></textarea>';
+			root.firstChild.value = 'user';
+			scratch.appendChild(root);
+
+			hydrate(<textarea value={value} />, root);
+			expect(root.firstChild.value).to.equal('user');
+
+			render(<textarea value={value} />, root);
+			expect(root.firstChild.value).to.equal('user');
 		}
-
-		scratch.innerHTML = ReactDOMServer.renderToString(<App />);
-		expect(scratch.firstElementChild.value).to.equal('foo');
-		expect(scratch.innerHTML).to.be.equal('<textarea>foo</textarea>');
-
-		hydrate(<App />, scratch);
-		expect(scratch.firstElementChild.value).to.equal('foo');
-
-		expect(scratch.innerHTML).to.be.equal('<textarea></textarea>');
 	});
 
 	it('should alias defaultValue to children', () => {

--- a/test/browser/hydrate.test.jsx
+++ b/test/browser/hydrate.test.jsx
@@ -77,10 +77,10 @@ describe('hydrate()', () => {
 		expect(scratch.firstChild.defaultValue).to.equal('foo');
 	});
 
-	it('should respect textarea value in hydrate', () => {
-		scratch.innerHTML = '<textarea>foo</textarea>';
-		hydrate(<textarea value="foo" />, scratch);
-		expect(scratch.firstChild.value).to.equal('foo');
+	it('should synchronize textarea values during hydration', () => {
+		scratch.innerHTML = '<textarea>server</textarea>';
+		hydrate(<textarea value="client" />, scratch);
+		expect(scratch.firstChild.value).to.equal('client');
 	});
 
 	it('should respect defaultChecked in hydrate', () => {


### PR DESCRIPTION
Core now synchronizes textarea values during hydration, so compat no longer needs its diffed hook. Coverage exercises a core hydration mismatch and nullish uncontrolled compat textareas across hydration and rerenders.