### PR TITLE
perf(hooks): remove unused memo factory state

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -351,7 +351,6 @@ export function useMemo(factory, args) {
 	if (argsChanged(state._args, args)) {
 		state._value = factory();
 		state._args = args;
-		state._factory = factory;
 	}
 
 	return state._value;

--- a/hooks/src/internal.d.ts
+++ b/hooks/src/internal.d.ts
@@ -87,7 +87,6 @@ export interface MemoHookState<T = unknown> extends BaseHookState {
 	_pendingValue?: T;
 	_args?: unknown[];
 	_pendingArgs?: unknown[];
-	_factory?: () => T;
 }
 
 export interface ReducerHookState<

--- a/mangle.json
+++ b/mangle.json
@@ -36,7 +36,6 @@
       "$_nextValue": "__N",
       "$_original": "__v",
       "$_args": "__H",
-      "$_factory": "__h",
       "$_depth": "__b",
       "$_mask": "__m",
       "$_detachOnNextRender": "__b",


### PR DESCRIPTION
Remove the unused `useMemo` factory reference from memo hook state. This eliminates a hot-path property write and reduces the hooks bundle by 8 B raw / 4 B gzip / 6 B Brotli.