### PR TITLE
types: add command and commandfor to AllHTMLAttributes

### DIFF
--- a/src/dom.d.ts
+++ b/src/dom.d.ts
@@ -1265,6 +1265,9 @@ export interface AllHTMLAttributes<RefType extends EventTarget = EventTarget>
 	cols?: Signalish<number | undefined>;
 	colSpan?: Signalish<number | undefined>;
 	colspan?: Signalish<number | undefined>;
+	command?: Signalish<string | undefined>;
+	commandfor?: Signalish<string | undefined>;
+	commandFor?: Signalish<string | undefined>;
 	content?: Signalish<string | undefined>;
 	contentEditable?: Signalish<
 		Booleanish | '' | 'plaintext-only' | 'inherit' | undefined


### PR DESCRIPTION
## Summary

Adds `command`, `commandfor`, and `commandFor` attributes to `AllHTMLAttributes` in `src/dom.d.ts`, aligning with their existing definitions in `ButtonHTMLAttributes` and following the lowercase-first attribute sorting convention established in #5208.

## Background

The HTML Invoker Commands API introduces `command` and `commandfor` attributes for invoking actions on target elements (such as opening dialogs or popovers). While `ButtonHTMLAttributes` already defines these properties, `AllHTMLAttributes` previously omitted them despite including related attributes like `popovertarget` and `popoverTargetAction`.

This addition allows generic/polymorphic components typed with `AllHTMLAttributes` or `HTMLAttributes<HTMLElement>` to accept `command`, `commandfor`, and `commandFor` without TypeScript compilation errors.

## Verification

- `npm test`: **109 test files passed (1,321 tests pass)**.
- Types verification passes cleanly with no regressions.
