### PR TITLE
perf(hooks): resolve unmount error routing lazily (fixes #5217)

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -129,27 +129,25 @@ options.unmount = vnode => {
 
 	const c = vnode._component;
 	if (c && c.__hooks) {
-		let hasErrored,
-			errorParent = vnode._parent;
-		// The removed subtree is detached (`_parent` nulled) by flush time, so
-		// grab the nearest surviving component now; its current vnode can still
-		// route deferred cleanup errors to a mounted error boundary. Unmounting
-		// is pre-order and nulls each component's `_parentDom` before its
-		// children unmount, so removed ancestors are already recognizable here.
-		while (
-			errorParent &&
-			!(errorParent._component && errorParent._component._parentDom)
-		) {
-			errorParent = errorParent._parent;
-		}
+		let hasErrored, errorParent;
 		c.__hooks._list.some(s => {
 			try {
 				// Layout cleanups have to run before the new DOM is in place, so
 				// they stay in the commit phase (see #1886). Passive cleanups run
 				// after paint, before any new passive effect (see #4299), with
 				// `_passive` repurposed to hold the error-routing component.
-				if (s._passive) {
-					s._passive = errorParent && errorParent._component;
+				if (s._passive && s._cleanup) {
+					if (errorParent === undefined) {
+						errorParent = vnode._parent;
+						while (
+							errorParent &&
+							!(errorParent._component && errorParent._component._parentDom)
+						) {
+							errorParent = errorParent._parent;
+						}
+						errorParent = errorParent && errorParent._component;
+					}
+					s._passive = errorParent;
 					afterPaint(unmountCleanups.push(s));
 				} else {
 					invokeCleanup(s);


### PR DESCRIPTION
Fixes #5217

The ancestor walk added in 46ddd2f9 ran for every unmounted component with hooks, but its result is only consumed when a passive cleanup gets deferred to the after-paint flush. During a whole-tree unmount every ancestor's `_parentDom` is already nulled, so each walk scanned all the way to the root — making teardown O(hook components × depth). The ReactLynx repro (useState-only leaves) paid the full cost for a value it never used.

This resolves the surviving error-routing component lazily: only when a state is both passive **and** has a cleanup to defer (`s._passive && s._cleanup`), and at most once per component. Consequences:

- `useState`/`useReducer`-only components no longer run the walk at all
- effects that never returned a cleanup no longer run the walk, and no longer get pushed into `unmountCleanups` / schedule an after-paint flush on teardown (deferring them was a no-op anyway — a pending effect of an unmounted component never runs, so no cleanup can appear later)
- components with real passive cleanups run the walk once, as before

Reproducing the issue's benchmark (5000 useState leaves, best of 7, fastest run) with a throwaway `test/browser` case:

| depth | main | this PR |
|---|---|---|
| 1 | 0.70ms | 0.70ms |
| 60 | 1.80ms (2.57x) | 0.70ms (1.00x) |

Size: `hooks/dist/hooks.mjs` 1423 → 1446 B brotli (**+23 B**).

Existing coverage guards the semantics this touches: deferred-cleanup error routing ("should route deferred cleanup errors after a state update", "should route a deferred cleanup error past boundaries inside the removed subtree") and the #4299 deferral-ordering tests. Full suite green (1301 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)