### PR TITLE
Add a Preact 10 to 11 migration codemod

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ You can find some awesome libraries in the [awesome-preact list](https://github.
 
 > 💁 _**Note:** You [don't need ES2015 to use Preact](https://github.com/developit/preact-in-es3)... but give it a try!_
 
+Upgrading an existing application from Preact 10? Read the
+[Preact 11 upgrade guide](https://preactjs.com/guide/v11/upgrade-guide/) and use
+the bundled [10-to-11 codemod](./codemods/README.md) for the mechanical changes.
+
 #### Tutorial: Building UI with Preact
 
 With Preact, you create user interfaces by assembling trees of components and elements. Components are functions or classes that return a description of what their tree should output. These descriptions are typically written in [JSX](https://react.dev/learn/writing-markup-with-jsx) (shown underneath), or [HTM](https://github.com/developit/htm) which leverages standard JavaScript Tagged Templates. Both syntaxes can express trees of elements with "props" (similar to HTML attributes) and children.

--- a/codemods/10-to-11.cjs
+++ b/codemods/10-to-11.cjs
@@ -1,0 +1,779 @@
+const MOVED_JSX_TYPES = new Set([
+	'DOMCSSProperties',
+	'AllCSSProperties',
+	'CSSProperties',
+	'SignalLike',
+	'Signalish',
+	'UnpackSignal',
+	'SVGAttributes',
+	'PathAttributes',
+	'TargetedEvent',
+	'TargetedAnimationEvent',
+	'TargetedClipboardEvent',
+	'TargetedCommandEvent',
+	'TargetedCompositionEvent',
+	'TargetedDragEvent',
+	'TargetedFocusEvent',
+	'TargetedInputEvent',
+	'TargetedKeyboardEvent',
+	'TargetedMouseEvent',
+	'TargetedPointerEvent',
+	'TargetedSnapEvent',
+	'TargetedSubmitEvent',
+	'TargetedTouchEvent',
+	'TargetedToggleEvent',
+	'TargetedTransitionEvent',
+	'TargetedUIEvent',
+	'TargetedWheelEvent',
+	'TargetedPictureInPictureEvent',
+	'EventHandler',
+	'AnimationEventHandler',
+	'ClipboardEventHandler',
+	'CommandEventHandler',
+	'CompositionEventHandler',
+	'DragEventHandler',
+	'ToggleEventHandler',
+	'FocusEventHandler',
+	'GenericEventHandler',
+	'InputEventHandler',
+	'KeyboardEventHandler',
+	'MouseEventHandler',
+	'PointerEventHandler',
+	'SnapEventHandler',
+	'SubmitEventHandler',
+	'TouchEventHandler',
+	'TransitionEventHandler',
+	'UIEventHandler',
+	'WheelEventHandler',
+	'PictureInPictureEventHandler',
+	'DOMAttributes',
+	'AriaAttributes',
+	'WAIAriaRole',
+	'DPubAriaRole',
+	'AriaRole',
+	'AllHTMLAttributes',
+	'HTMLAttributes',
+	'HTMLAttributeReferrerPolicy',
+	'HTMLAttributeAnchorTarget',
+	'AnchorHTMLAttributes',
+	'AreaHTMLAttributes',
+	'AudioHTMLAttributes',
+	'BaseHTMLAttributes',
+	'BlockquoteHTMLAttributes',
+	'ButtonHTMLAttributes',
+	'CanvasHTMLAttributes',
+	'ColHTMLAttributes',
+	'ColgroupHTMLAttributes',
+	'DataHTMLAttributes',
+	'DelHTMLAttributes',
+	'DetailsHTMLAttributes',
+	'DialogHTMLAttributes',
+	'EmbedHTMLAttributes',
+	'FieldsetHTMLAttributes',
+	'FormHTMLAttributes',
+	'IframeHTMLAttributes',
+	'HTMLAttributeCrossOrigin',
+	'ImgHTMLAttributes',
+	'HTMLInputTypeAttribute',
+	'InputHTMLAttributes',
+	'InsHTMLAttributes',
+	'KeygenHTMLAttributes',
+	'LabelHTMLAttributes',
+	'LiHTMLAttributes',
+	'LinkHTMLAttributes',
+	'MapHTMLAttributes',
+	'MarqueeHTMLAttributes',
+	'MediaHTMLAttributes',
+	'MenuHTMLAttributes',
+	'MetaHTMLAttributes',
+	'MeterHTMLAttributes',
+	'ObjectHTMLAttributes',
+	'OlHTMLAttributes',
+	'OptgroupHTMLAttributes',
+	'OptionHTMLAttributes',
+	'OutputHTMLAttributes',
+	'ParamHTMLAttributes',
+	'ProgressHTMLAttributes',
+	'QuoteHTMLAttributes',
+	'ScriptHTMLAttributes',
+	'SelectHTMLAttributes',
+	'SlotHTMLAttributes',
+	'SourceHTMLAttributes',
+	'StyleHTMLAttributes',
+	'TableHTMLAttributes',
+	'TdHTMLAttributes',
+	'TextareaHTMLAttributes',
+	'ThHTMLAttributes',
+	'TimeHTMLAttributes',
+	'TrackHTMLAttributes',
+	'VideoHTMLAttributes',
+	'DetailedHTMLProps',
+	'MathMLAttributes',
+	'AnnotationMathMLAttributes',
+	'AnnotationXmlMathMLAttributes',
+	'MActionMathMLAttributes',
+	'MathMathMLAttributes',
+	'MEncloseMathMLAttributes',
+	'MErrorMathMLAttributes',
+	'MFencedMathMLAttributes',
+	'MFracMathMLAttributes',
+	'MiMathMLAttributes',
+	'MmultiScriptsMathMLAttributes',
+	'MNMathMLAttributes',
+	'MOMathMLAttributes',
+	'MOverMathMLAttributes',
+	'MPaddedMathMLAttributes',
+	'MPhantomMathMLAttributes',
+	'MPrescriptsMathMLAttributes',
+	'MRootMathMLAttributes',
+	'MRowMathMLAttributes',
+	'MSMathMLAttributes',
+	'MSpaceMathMLAttributes',
+	'MSqrtMathMLAttributes',
+	'MStyleMathMLAttributes',
+	'MSubMathMLAttributes',
+	'MSubsupMathMLAttributes',
+	'MSupMathMLAttributes',
+	'MTableMathMLAttributes',
+	'MTdMathMLAttributes',
+	'MTextMathMLAttributes',
+	'MTrMathMLAttributes',
+	'MUnderMathMLAttributes',
+	'MUnderoverMathMLAttributes',
+	'SemanticsMathMLAttributes'
+]);
+
+// Kept in sync with the Preact 10 core style matcher. Numeric values for
+// properties not matching this expression received an automatic `px` suffix.
+const IS_NON_DIMENSIONAL =
+	/acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i;
+
+const TYPESCRIPT_EXTENSION = /\.(?:cts|mts|ts|tsx)$/i;
+
+function getImportedName(specifier) {
+	return (
+		specifier.imported && (specifier.imported.name || specifier.imported.value)
+	);
+}
+
+function getLocalName(specifier) {
+	return specifier.local && specifier.local.name;
+}
+
+function isNamedImport(specifier, name) {
+	return (
+		specifier.type === 'ImportSpecifier' && getImportedName(specifier) === name
+	);
+}
+
+function propertyName(property) {
+	if (property.computed) return null;
+	if (property.key.type === 'Identifier') return property.key.name;
+	return property.key.value;
+}
+
+function migratedDistributionPath(source) {
+	if (/^preact\/dist\/[^/]+$/.test(source)) return 'preact';
+
+	const match = source.match(
+		/^preact\/(compat|debug|devtools|hooks|jsx-runtime|test-utils)\/dist\/[^/]+$/
+	);
+	return match ? `preact/${match[1]}` : source;
+}
+
+function isReference(path, bindingScope, name) {
+	if (path.scope.lookup(name) !== bindingScope) return false;
+
+	const parent = path.parent && path.parent.node;
+	if (!parent) return true;
+
+	if (
+		parent.type === 'ImportSpecifier' ||
+		parent.type === 'ImportDefaultSpecifier' ||
+		parent.type === 'ImportNamespaceSpecifier'
+	) {
+		return false;
+	}
+
+	if (
+		(parent.type === 'MemberExpression' ||
+			parent.type === 'OptionalMemberExpression') &&
+		path.name === 'property' &&
+		!parent.computed
+	) {
+		return false;
+	}
+
+	if (
+		(parent.type === 'Property' || parent.type === 'ObjectProperty') &&
+		path.name === 'key' &&
+		!parent.computed
+	) {
+		return false;
+	}
+
+	return true;
+}
+
+function transform(file, api) {
+	const isTypeScript = TYPESCRIPT_EXTENSION.test(file.path || '');
+	const j = api.jscodeshift.withParser(isTypeScript ? 'tsx' : 'babylon');
+	const root = j(file.source);
+	const programPath = root.find(j.Program).paths()[0];
+	const reservedNames = new Set(Object.keys(programPath.scope.getBindings()));
+	const importsToClean = new Set();
+	for (const declarationType of [
+		j.TSTypeAliasDeclaration,
+		j.TSInterfaceDeclaration,
+		j.TSEnumDeclaration,
+		j.TSModuleDeclaration
+	]) {
+		root.find(declarationType).forEach(path => {
+			if (path.node.id && path.node.id.name)
+				reservedNames.add(path.node.id.name);
+		});
+	}
+
+	function stat(name) {
+		if (api.stats) api.stats(name);
+	}
+
+	function insertImport(declaration, source) {
+		const body = root.get().node.program.body;
+		let index = -1;
+
+		for (let i = 0; i < body.length; i++) {
+			if (
+				body[i].type === 'ImportDeclaration' &&
+				body[i].source.value === source
+			) {
+				index = i;
+			}
+		}
+
+		if (index === -1) {
+			for (let i = 0; i < body.length; i++) {
+				if (body[i].type === 'ImportDeclaration' || body[i].directive)
+					index = i;
+			}
+		}
+
+		body.splice(index + 1, 0, declaration);
+	}
+
+	function findImportedLocal(source, importedName, typeOnly) {
+		let localName = null;
+		root
+			.find(j.ImportDeclaration, { source: { value: source } })
+			.forEach(path => {
+				for (const specifier of path.node.specifiers || []) {
+					if (
+						isNamedImport(specifier, importedName) &&
+						(typeOnly ||
+							(path.node.importKind !== 'type' &&
+								specifier.importKind !== 'type'))
+					) {
+						localName = getLocalName(specifier);
+						return;
+					}
+				}
+			});
+		return localName;
+	}
+
+	function availableLocalName(importedName) {
+		let localName = importedName;
+		if (reservedNames.has(localName)) localName = `Preact${importedName}`;
+		let suffix = 2;
+		while (reservedNames.has(localName)) {
+			localName = `Preact${importedName}${suffix++}`;
+		}
+		reservedNames.add(localName);
+		return localName;
+	}
+
+	function addNamedImport(source, importedName, localName, typeOnly) {
+		let target = null;
+		root
+			.find(j.ImportDeclaration, { source: { value: source } })
+			.forEach(path => {
+				if (target) return;
+				const declaration = path.node;
+				const hasNamespace = (declaration.specifiers || []).some(
+					specifier => specifier.type === 'ImportNamespaceSpecifier'
+				);
+				if (
+					!hasNamespace &&
+					(typeOnly
+						? declaration.importKind === 'type'
+						: declaration.importKind !== 'type')
+				) {
+					target = declaration;
+				}
+			});
+
+		const specifier = j.importSpecifier(
+			j.identifier(importedName),
+			j.identifier(localName)
+		);
+		if (typeOnly) specifier.importKind = 'value';
+
+		if (target) {
+			target.specifiers.push(specifier);
+		} else {
+			const declaration = j.importDeclaration([specifier], j.literal(source));
+			if (typeOnly) declaration.importKind = 'type';
+			insertImport(declaration, source);
+		}
+	}
+
+	function ensureNamedImport(source, importedName, typeOnly = false) {
+		const existing = findImportedLocal(source, importedName, typeOnly);
+		if (existing) return existing;
+
+		const localName = availableLocalName(importedName);
+		addNamedImport(source, importedName, localName, typeOnly);
+		return localName;
+	}
+
+	function rewriteModuleLiteral(literal) {
+		if (!literal || typeof literal.value !== 'string') return;
+		literal.value = migratedDistributionPath(literal.value);
+		if (literal.extra) {
+			delete literal.extra.raw;
+			delete literal.extra.rawValue;
+		}
+	}
+
+	// Preact 11 no longer ships public files below `dist`. Standardize direct
+	// ESM imports and re-exports before collecting bindings for later transforms.
+	root.find(j.ImportDeclaration).forEach(path => {
+		rewriteModuleLiteral(path.node.source);
+	});
+	root.find(j.ExportNamedDeclaration).forEach(path => {
+		if (path.node.source) {
+			rewriteModuleLiteral(path.node.source);
+		}
+	});
+	root.find(j.ExportAllDeclaration).forEach(path => {
+		rewriteModuleLiteral(path.node.source);
+	});
+	root.find(j.CallExpression).forEach(path => {
+		const callee = path.node.callee;
+		const source = path.node.arguments[0];
+		const isDynamicImport = callee.type === 'Import';
+		const isGlobalRequire =
+			callee.type === 'Identifier' &&
+			callee.name === 'require' &&
+			path.scope.lookup('require') === null;
+		if (
+			(isDynamicImport || isGlobalRequire) &&
+			source &&
+			(source.type === 'StringLiteral' || source.type === 'Literal')
+		) {
+			rewriteModuleLiteral(source);
+			if (isGlobalRequire && source.value.startsWith('preact')) {
+				stat('manual review: CommonJS import');
+			}
+		}
+	});
+
+	const forwardRefBindings = [];
+	const useRefBindings = [];
+	const renderBindings = [];
+	const jsxBindings = [];
+
+	root.find(j.ImportDeclaration).forEach(importPath => {
+		const source = importPath.node.source.value;
+		for (const specifier of importPath.node.specifiers || []) {
+			const localName = getLocalName(specifier);
+			if (!localName) continue;
+			const bindingScope = importPath.scope.lookup(localName);
+
+			if (
+				source === 'preact/compat' &&
+				isNamedImport(specifier, 'forwardRef')
+			) {
+				forwardRefBindings.push({
+					bindingScope,
+					importPath,
+					localName,
+					specifier,
+					transformed: false
+				});
+			}
+
+			if (
+				(source === 'preact/hooks' || source === 'preact/compat') &&
+				isNamedImport(specifier, 'useRef')
+			) {
+				useRefBindings.push({ bindingScope, localName });
+			}
+
+			if (source === 'preact' && isNamedImport(specifier, 'render')) {
+				renderBindings.push({ bindingScope, localName });
+			}
+
+			if (source === 'preact' && isNamedImport(specifier, 'JSX')) {
+				jsxBindings.push({ bindingScope, importPath, localName, specifier });
+			}
+		}
+	});
+
+	function renderablePropsType(call, firstParameter) {
+		const typeParameters = call.typeParameters && call.typeParameters.params;
+		let propsType = null;
+		let refType = null;
+
+		if (typeParameters && typeParameters.length) {
+			refType = typeParameters[0];
+			propsType = typeParameters[1] || j.tsTypeLiteral([]);
+		} else if (firstParameter.typeAnnotation) {
+			propsType = firstParameter.typeAnnotation.typeAnnotation;
+		}
+
+		const localName = ensureNamedImport('preact', 'RenderableProps', true);
+		const parameters = [];
+		if (propsType) parameters.push(propsType);
+		if (refType) parameters.push(refType);
+
+		return j.tsTypeReference(
+			j.identifier(localName),
+			parameters.length ? j.tsTypeParameterInstantiation(parameters) : null
+		);
+	}
+
+	function refProperty(refName) {
+		const property = j.property(
+			'init',
+			j.identifier('ref'),
+			j.identifier(refName)
+		);
+		property.shorthand = refName === 'ref';
+		return property;
+	}
+
+	function unwrapForwardRef(call, callback) {
+		if (
+			(!isTypeScript &&
+				callback.params.some(parameter => parameter.typeAnnotation)) ||
+			(callback.type === 'FunctionExpression' &&
+				j(callback).find(j.Identifier, { name: 'arguments' }).size() > 0)
+		) {
+			return null;
+		}
+		if (callback.params.length === 0) return callback;
+		if (callback.params.length > 2) return null;
+
+		const first = callback.params[0];
+		const second = callback.params[1];
+		if (second && second.type !== 'Identifier') return null;
+
+		let pattern;
+		if (first.type === 'Identifier') {
+			if (!second) return null;
+			pattern = j.objectPattern([
+				refProperty(second.name),
+				j.restElement(j.identifier(first.name))
+			]);
+		} else if (first.type === 'ObjectPattern') {
+			const hasRest = first.properties.some(
+				property => property.type === 'RestElement'
+			);
+			const hasRef = first.properties.some(
+				property =>
+					(property.type === 'Property' ||
+						property.type === 'ObjectProperty') &&
+					propertyName(property) === 'ref'
+			);
+
+			if (hasRef || (!second && hasRest)) return null;
+			if (!second) {
+				pattern = first;
+			} else {
+				const properties = first.properties.slice();
+				const restIndex = properties.findIndex(
+					property => property.type === 'RestElement'
+				);
+				properties.splice(
+					restIndex === -1 ? properties.length : restIndex,
+					0,
+					refProperty(second.name)
+				);
+				pattern = j.objectPattern(properties);
+			}
+		} else {
+			return null;
+		}
+
+		if (isTypeScript) {
+			pattern.typeAnnotation = j.tsTypeAnnotation(
+				renderablePropsType(call, first)
+			);
+		}
+
+		callback.params = [pattern];
+		return callback;
+	}
+
+	for (const binding of forwardRefBindings) {
+		root
+			.find(j.CallExpression, {
+				callee: { type: 'Identifier', name: binding.localName }
+			})
+			.forEach(path => {
+				if (path.scope.lookup(binding.localName) !== binding.bindingScope)
+					return;
+
+				const call = path.node;
+				const callback = call.arguments.length === 1 && call.arguments[0];
+				if (
+					!callback ||
+					(callback.type !== 'ArrowFunctionExpression' &&
+						callback.type !== 'FunctionExpression')
+				) {
+					stat('manual review: non-inline forwardRef');
+					return;
+				}
+
+				const replacement = unwrapForwardRef(call, callback);
+				if (!replacement) {
+					stat('manual review: complex forwardRef parameters');
+					return;
+				}
+
+				replacement.comments = call.comments || replacement.comments;
+				j(path).replaceWith(replacement);
+				binding.transformed = true;
+			});
+	}
+
+	for (const binding of useRefBindings) {
+		root
+			.find(j.CallExpression, {
+				callee: { type: 'Identifier', name: binding.localName }
+			})
+			.forEach(path => {
+				if (
+					path.node.arguments.length === 0 &&
+					path.scope.lookup(binding.localName) === binding.bindingScope
+				) {
+					path.node.arguments.push(j.identifier('undefined'));
+				}
+			});
+	}
+
+	for (const binding of renderBindings) {
+		root
+			.find(j.CallExpression, {
+				callee: { type: 'Identifier', name: binding.localName }
+			})
+			.forEach(path => {
+				if (
+					path.scope.lookup(binding.localName) !== binding.bindingScope ||
+					path.node.arguments.length !== 3
+				) {
+					return;
+				}
+
+				const createRootFragment = ensureNamedImport(
+					'preact-root-fragment',
+					'createRootFragment'
+				);
+				const [, parent, replaceNode] = path.node.arguments;
+				path.node.arguments = [
+					path.node.arguments[0],
+					j.callExpression(j.identifier(createRootFragment), [
+						parent,
+						replaceNode
+					])
+				];
+			});
+	}
+
+	// Only numeric literals can be rewritten without changing expression
+	// evaluation. Dynamic values are intentionally left for manual review.
+	root.find(j.JSXAttribute, { name: { name: 'style' } }).forEach(path => {
+		const value = path.node.value;
+		if (
+			!value ||
+			value.type !== 'JSXExpressionContainer' ||
+			value.expression.type !== 'ObjectExpression'
+		) {
+			return;
+		}
+
+		for (const property of value.expression.properties) {
+			if (property.type !== 'Property' && property.type !== 'ObjectProperty') {
+				continue;
+			}
+			const name = propertyName(property);
+			if (!name || name[0] === '-' || IS_NON_DIMENSIONAL.test(name)) continue;
+
+			let number = null;
+			if (
+				(property.value.type === 'NumericLiteral' ||
+					property.value.type === 'Literal') &&
+				typeof property.value.value === 'number'
+			) {
+				number = property.value.value;
+			} else if (
+				property.value.type === 'UnaryExpression' &&
+				(property.value.operator === '-' || property.value.operator === '+') &&
+				(property.value.argument.type === 'NumericLiteral' ||
+					property.value.argument.type === 'Literal') &&
+				typeof property.value.argument.value === 'number'
+			) {
+				number =
+					property.value.operator === '-'
+						? -property.value.argument.value
+						: property.value.argument.value;
+			}
+
+			if (number !== null) property.value = j.literal(`${number}px`);
+		}
+	});
+
+	for (const binding of jsxBindings) {
+		root
+			.find(j.TSQualifiedName, {
+				left: { type: 'Identifier', name: binding.localName }
+			})
+			.forEach(path => {
+				if (
+					path.scope.lookup(binding.localName) !== binding.bindingScope ||
+					!MOVED_JSX_TYPES.has(path.node.right.name)
+				) {
+					return;
+				}
+
+				const localName = ensureNamedImport(
+					'preact',
+					path.node.right.name,
+					true
+				);
+				j(path).replaceWith(j.identifier(localName));
+			});
+	}
+
+	// `createPortal` remains available from compat, but core is now the smaller
+	// native entry point. Preserve aliases when moving imports and re-exports.
+	root
+		.find(j.ImportDeclaration, { source: { value: 'preact/compat' } })
+		.forEach(path => {
+			const originalLength = (path.node.specifiers || []).length;
+			const retained = [];
+			for (const specifier of path.node.specifiers || []) {
+				if (isNamedImport(specifier, 'createPortal')) {
+					addNamedImport(
+						'preact',
+						'createPortal',
+						getLocalName(specifier),
+						false
+					);
+				} else {
+					retained.push(specifier);
+				}
+			}
+			path.node.specifiers = retained;
+			if (originalLength && retained.length === 0)
+				importsToClean.add(path.node);
+		});
+
+	root
+		.find(j.ExportNamedDeclaration, { source: { value: 'preact/compat' } })
+		.forEach(path => {
+			const moved = [];
+			const retained = [];
+			for (const specifier of path.node.specifiers || []) {
+				const exported = specifier.local || specifier.exported;
+				if (exported && (exported.name || exported.value) === 'createPortal') {
+					moved.push(specifier);
+				} else {
+					retained.push(specifier);
+				}
+			}
+
+			if (!moved.length) return;
+			if (!retained.length) {
+				path.node.source = j.literal('preact');
+			} else {
+				path.node.specifiers = retained;
+				j(path).insertAfter(
+					j.exportNamedDeclaration(null, moved, j.literal('preact'))
+				);
+			}
+		});
+
+	function hasReferences(binding) {
+		return (
+			root
+				.find(j.Identifier, { name: binding.localName })
+				.filter(path =>
+					isReference(path, binding.bindingScope, binding.localName)
+				)
+				.size() > 0
+		);
+	}
+
+	for (const binding of forwardRefBindings) {
+		if (binding.transformed && !hasReferences(binding)) {
+			binding.importPath.node.specifiers =
+				binding.importPath.node.specifiers.filter(
+					specifier => specifier !== binding.specifier
+				);
+			if (binding.importPath.node.specifiers.length === 0) {
+				importsToClean.add(binding.importPath.node);
+			}
+		}
+	}
+
+	for (const binding of jsxBindings) {
+		if (!hasReferences(binding)) {
+			binding.importPath.node.specifiers =
+				binding.importPath.node.specifiers.filter(
+					specifier => specifier !== binding.specifier
+				);
+			if (binding.importPath.node.specifiers.length === 0) {
+				importsToClean.add(binding.importPath.node);
+			}
+		}
+	}
+
+	root.find(j.ImportDeclaration).forEach(path => {
+		if (importsToClean.has(path.node)) {
+			j(path).remove();
+		}
+	});
+
+	root
+		.find(j.AssignmentExpression, {
+			left: { type: 'MemberExpression', property: { name: 'defaultProps' } }
+		})
+		.forEach(() => stat('manual review: defaultProps'));
+	root
+		.find(j.MemberExpression, {
+			object: { type: 'ThisExpression' },
+			property: { name: 'base' }
+		})
+		.forEach(() => stat('manual review: Component.base'));
+	root
+		.find(j.ImportSpecifier, { imported: { name: 'SuspenseList' } })
+		.forEach(() => stat('manual review: SuspenseList'));
+
+	// Recast reuses a directive's original trailing semicolon and then emits a
+	// second one when imports are inserted. Print directives afresh instead.
+	for (const directive of root.get().node.program.directives || []) {
+		directive.loc = null;
+		directive.start = null;
+		directive.end = null;
+		directive.value.loc = null;
+		directive.value.start = null;
+		directive.value.end = null;
+	}
+
+	return root.toSource({ quote: 'single', trailingComma: false });
+}
+
+module.exports = transform;
+module.exports.parser = 'babylon';

--- a/codemods/10-to-11.test.js
+++ b/codemods/10-to-11.test.js
@@ -1,0 +1,225 @@
+import { createRequire } from 'node:module';
+import jscodeshift from 'jscodeshift';
+
+const require = createRequire(import.meta.url);
+const transform = require('./10-to-11.cjs');
+const parser = jscodeshift.withParser('tsx');
+
+function run(source, path = 'example.jsx') {
+	const stats = [];
+	const output = transform(
+		{ path, source },
+		{ jscodeshift, stats: name => stats.push(name) }
+	);
+	return { output, stats };
+}
+
+function comparableAst(source) {
+	const program = parser(source).find(jscodeshift.Program).nodes()[0];
+	return JSON.parse(
+		JSON.stringify(program, (key, value) => {
+			if (
+				key === 'loc' ||
+				key === 'start' ||
+				key === 'end' ||
+				key === 'tokens' ||
+				key === 'extra'
+			) {
+				return undefined;
+			}
+			return value;
+		})
+	);
+}
+
+function expectCode(output, expected) {
+	expect(comparableAst(output)).toEqual(comparableAst(expected));
+}
+
+describe('Preact 10 to 11 codemod', () => {
+	it('migrates native runtime APIs and behavior', () => {
+		const source = `
+			import { render } from 'preact/dist/preact.module.js';
+			import { createPortal, forwardRef, memo } from 'preact/compat';
+			import { useRef } from 'preact/hooks';
+
+			const Button = forwardRef((props, inputRef) => (
+				<button ref={inputRef} style={{ height: 500, opacity: 0.5, marginTop: -2, '--gap': 2 }} {...props} />
+			));
+			const ref = useRef();
+			render(<Button />, root, widget);
+			export { createPortal as portal, memo } from 'preact/compat';
+		`;
+
+		const { output, stats } = run(source);
+		expectCode(
+			output,
+			`
+				import { render, createPortal } from 'preact';
+				import { memo } from 'preact/compat';
+				import { useRef } from 'preact/hooks';
+				import { createRootFragment } from 'preact-root-fragment';
+
+				const Button = ({ ref: inputRef, ...props }) => (
+					<button ref={inputRef} style={{ height: '500px', opacity: 0.5, marginTop: '-2px', '--gap': 2 }} {...props} />
+				);
+				const ref = useRef(undefined);
+				render(<Button />, createRootFragment(root, widget));
+				export { memo } from 'preact/compat';
+				export { createPortal as portal } from 'preact';
+			`
+		);
+		expect(stats).toEqual([]);
+		expect(run(output).output).toBe(output);
+	});
+
+	it('preserves TypeScript props and migrates removed JSX utility types', () => {
+		const source = `
+			import type { JSX } from 'preact';
+			import { forwardRef as withRef } from 'preact/compat';
+
+			type InputProps = JSX.InputHTMLAttributes<HTMLInputElement> & { label: string };
+			type ButtonHTMLAttributes = { local: true };
+			type ButtonProps = JSX.ButtonHTMLAttributes<HTMLButtonElement>;
+
+			export const Input = withRef<HTMLInputElement, InputProps>((props, inputRef) => (
+				<input ref={inputRef} aria-label={props.label} />
+			));
+		`;
+
+		const { output, stats } = run(source, 'example.tsx');
+		expectCode(
+			output,
+			`
+				import type {
+					RenderableProps,
+					InputHTMLAttributes,
+					ButtonHTMLAttributes as PreactButtonHTMLAttributes
+				} from 'preact';
+
+				type InputProps = InputHTMLAttributes<HTMLInputElement> & { label: string };
+				type ButtonHTMLAttributes = { local: true };
+				type ButtonProps = PreactButtonHTMLAttributes<HTMLButtonElement>;
+
+				export const Input = ({ ref: inputRef, ...props }: RenderableProps<InputProps, HTMLInputElement>) => (
+					<input ref={inputRef} aria-label={props.label} />
+				);
+			`
+		);
+		expect(stats).toEqual([]);
+		expect(run(output, 'example.tsx').output).toBe(output);
+	});
+
+	it('leaves complex and shadowed calls alone', () => {
+		const source = `
+			import { forwardRef, useRef } from 'preact/compat';
+
+			const Named = forwardRef(renderInput);
+			const Complex = forwardRef(({ value, ...props }) => <input value={value} {...props} />);
+			const UsesArguments = forwardRef(function Input(props, ref) {
+				return <input ref={arguments[1]} {...props} />;
+			});
+			const ref = useRef();
+
+			function local(forwardRef, useRef) {
+				return [forwardRef((props, ref) => null), useRef()];
+			}
+		`;
+
+		const { output, stats } = run(source);
+		expectCode(
+			output,
+			`
+				import { forwardRef, useRef } from 'preact/compat';
+
+				const Named = forwardRef(renderInput);
+				const Complex = forwardRef(({ value, ...props }) => <input value={value} {...props} />);
+				const UsesArguments = forwardRef(function Input(props, ref) {
+					return <input ref={arguments[1]} {...props} />;
+				});
+				const ref = useRef(undefined);
+
+				function local(forwardRef, useRef) {
+					return [forwardRef((props, ref) => null), useRef()];
+				}
+			`
+		);
+		expect(stats).toEqual([
+			'manual review: non-inline forwardRef',
+			'manual review: complex forwardRef parameters',
+			'manual review: complex forwardRef parameters'
+		]);
+	});
+
+	it('parses Flow while leaving typed forwardRef callbacks for review', () => {
+		const source = `
+			import { forwardRef, useRef } from 'preact/compat';
+
+			type Props = {| value: string |};
+			const Input = forwardRef((props: Props, ref) => <input ref={ref} value={props.value} />);
+			const ref = useRef();
+		`;
+
+		const { output, stats } = run(source, 'example.jsx');
+		expect(output).toContain(
+			'forwardRef((props: Props, ref) => <input ref={ref} value={props.value} />)'
+		);
+		expect(output).toContain('useRef(undefined)');
+		expect(stats).toEqual(['manual review: complex forwardRef parameters']);
+		expect(run(output, 'example.jsx').output).toBe(output);
+	});
+
+	it('migrates direct distribution paths without removing side-effect imports', () => {
+		const source = `
+			'use client';
+			import 'preact/debug';
+			export * from 'preact/hooks/dist/hooks.module.js';
+			const debug = import('preact/debug/dist/debug.module.js');
+			const compat = require('preact/compat/dist/compat.js');
+			function customLoader(require) {
+				return require('preact/dist/preact.js');
+			}
+		`;
+
+		const { output, stats } = run(source, 'example.js');
+		expectCode(
+			output,
+			`
+				'use client';
+				import 'preact/debug';
+				export * from 'preact/hooks';
+				const debug = import('preact/debug');
+				const compat = require('preact/compat');
+				function customLoader(require) {
+					return require('preact/dist/preact.js');
+				}
+			`
+		);
+		expect(stats).toEqual(['manual review: CommonJS import']);
+		expect(output).not.toContain(';;');
+	});
+
+	it('reports upgrade steps that require manual decisions', () => {
+		const source = `
+			import { Component } from 'preact';
+			import { SuspenseList } from 'preact/compat';
+
+			function App() {}
+			App.defaultProps = { label: 'Default' };
+
+			class Legacy extends Component {
+				get element() {
+					return this.base;
+				}
+			}
+		`;
+
+		const { output, stats } = run(source);
+		expectCode(output, source);
+		expect(stats).toEqual([
+			'manual review: defaultProps',
+			'manual review: Component.base',
+			'manual review: SuspenseList'
+		]);
+	});
+});

--- a/codemods/README.md
+++ b/codemods/README.md
@@ -1,0 +1,68 @@
+# Preact 10 to 11 codemod
+
+This package includes a conservative source codemod for the mechanical parts of
+the [Preact 11 upgrade guide](https://preactjs.com/guide/v11/upgrade-guide/).
+Upgrade `preact` first, then resolve the transform included with the installed
+package:
+
+```sh
+node -p "require.resolve('preact/codemods/10-to-11')"
+```
+
+Pass the printed path to [jscodeshift](https://github.com/facebook/jscodeshift).
+Run it in dry mode first and replace `src` with the files or directories you
+want to migrate:
+
+```sh
+npx jscodeshift@17.4.0 --dry --print \
+  --transform /path/printed/above \
+  --extensions=js,jsx,ts,tsx \
+  src
+```
+
+Remove `--dry --print` to write the changes. The transform:
+
+- moves native `createPortal` imports and re-exports from `preact/compat` to
+  `preact`;
+- removes inline `forwardRef` wrappers and reads `ref` from component props;
+- adds the required `undefined` argument to zero-argument `useRef()` calls;
+- preserves Preact 10's `px` suffix for dimensional numeric literals in inline
+  JSX style objects;
+- replaces three-argument `render(vnode, parent, replaceNode)` calls with
+  `render(vnode, createRootFragment(parent, replaceNode))`;
+- moves Preact types removed from the `JSX` namespace to direct type imports;
+- replaces direct `preact/**/dist/*` module paths with public package entry
+  points.
+
+If the transform adds an import from `preact-root-fragment`, install that
+package in the application as well:
+
+```sh
+npm install preact-root-fragment
+```
+
+The transform only changes bindings imported from Preact's native entry points.
+It intentionally leaves `react`, `react-dom`, namespace imports, and shadowed
+local functions alone. It also leaves non-inline or complex `forwardRef`
+callbacks in place and reports them in jscodeshift's statistics.
+
+## Manual checks
+
+Some upgrade steps need application-specific decisions and are not safe to
+rewrite automatically:
+
+- Preact 11 requires TypeScript 5.1 and newer browser targets, and most bundles
+  are ESM-only. Convert CommonJS or UMD consumers that cannot load ESM.
+- Dynamic numeric style values may need an explicit unit; the transform only
+  changes numeric literals.
+- Replace core `defaultProps` with JavaScript default parameters where
+  appropriate. `preact/compat` continues to support `defaultProps`.
+- Review refs that previously depended on receiving a component instance.
+- Replace `Component.base` access where it is still needed.
+- Remove or redesign `SuspenseList` usage.
+- Tests that expect synchronous `useEffect` cleanup may need to flush effects,
+  or the effect may need to become a `useLayoutEffect` when synchronous cleanup
+  is required.
+
+Review and format the resulting diff, then run the application's typecheck and
+test suite.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "chai": "^6.2.2",
         "cross-env": "^7.0.3",
         "husky": "^9.1.7",
+        "jscodeshift": "^17.4.0",
         "kolorist": "^1.8.0",
         "npm-run-all2": "^7.0.0",
         "oxfmt": "^0.32.0",
@@ -541,6 +542,22 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-flow": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.29.7.tgz",
+      "integrity": "sha512-ajMX6QPcyomotqwpzhkYGxcK2i/us0rs1Qo9QvUpa+Fca0FTmqrzKrctoIYLMxcOhGZldGT/BAVkRGTWBiR8gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-import-assertions": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.29.7.tgz",
@@ -561,6 +578,38 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
       "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -869,6 +918,23 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-flow-strip-types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.29.7.tgz",
+      "integrity": "sha512-wRHeUjUjCZnMHmiO5bRgjFLcoEh7JyTdByOW11ahhwNa4V0bmeGEaIvt51yq0zQp2yWIpqfxXXPyUP6GFJZHOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-syntax-flow": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1378,6 +1444,26 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+      "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-syntax-typescript": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.29.7.tgz",
@@ -1531,6 +1617,24 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/preset-flow": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.29.7.tgz",
+      "integrity": "sha512-KYIRV0BuaN68CDdsqFkAD7MU7yipUqQNuNElwATdxaIdpTjhvtY82QvkBJs7zV3Evxj2jFAAZ1iO8nyy0nhjqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/plugin-transform-flow-strip-types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/preset-modules": {
       "version": "0.1.6-no-external-plugins",
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
@@ -1543,6 +1647,46 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz",
+      "integrity": "sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/plugin-syntax-jsx": "^7.29.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.29.7",
+        "@babel/plugin-transform-typescript": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/register": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.29.7.tgz",
+      "integrity": "sha512-AMGJoWuES861riy6pcB0fphE1YXybtQnBYQMuIyPv6mKLiosfa79BKTnAOyx215c/3RJPJpdQwoHZ3earVH7AA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "find-cache-dir": "^2.0.0",
+        "make-dir": "^2.1.0",
+        "pirates": "^4.0.6",
+        "source-map-support": "^0.5.16"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -2680,19 +2824,6 @@
         }
       }
     },
-    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
@@ -3518,6 +3649,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ast-v8-to-istanbul": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.3.tgz",
@@ -3708,6 +3852,21 @@
         "node": ">= 16"
       }
     },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3725,6 +3884,13 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -3908,6 +4074,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -3930,6 +4110,57 @@
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/flow-estree": {
+      "version": "0.329.0",
+      "resolved": "https://registry.npmjs.org/flow-estree/-/flow-estree-0.329.0.tgz",
+      "integrity": "sha512-Stv2+LumW7n6DUrV+KlqB4HikeyQtLFUpd9iVexISblopKiYFjNYMmTGUcN5at8NKEmkhjAV5UGps3Z8QqK1lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/flow-parser": {
+      "version": "0.329.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.329.0.tgz",
+      "integrity": "sha512-skMH3HUOF3+JSlIKt4F/LITfzMGEPpJ0S+Gu7HcmxOjWeYEO5PUZJi5WpLw+L4MZaNcMEkzUtoN+M2fAbiutWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flow-estree": "0.329.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/foreground-child": {
@@ -3980,6 +4211,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4023,6 +4261,16 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -4047,11 +4295,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -4157,6 +4428,47 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
+    "node_modules/jscodeshift": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-17.4.0.tgz",
+      "integrity": "sha512-i3ESKiiTsGynxzTg5BhsZViD0ai72/6SsI1efDZxG6/5KCoElsmquxtyhXK5lpEgoO7MTNpYkjFEdEL97SkBNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/plugin-transform-class-properties": "^7.24.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+        "@babel/plugin-transform-optional-chaining": "^7.24.7",
+        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/preset-flow": "^7.24.7",
+        "@babel/preset-typescript": "^7.24.7",
+        "@babel/register": "^7.24.6",
+        "flow-parser": "0.*",
+        "graceful-fs": "^4.2.4",
+        "neo-async": "^2.5.0",
+        "picocolors": "^1.0.1",
+        "picomatch": "^4.0.2",
+        "recast": "^0.23.11",
+        "tmp": "^0.2.3",
+        "write-file-atomic": "^5.0.1"
+      },
+      "bin": {
+        "jscodeshift": "bin/jscodeshift.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@babel/preset-env": "^7.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/preset-env": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -4182,11 +4494,35 @@
         "node": ">=6"
       }
     },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/kolorist": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
       "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
       "dev": true
+    },
+    "node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -4241,6 +4577,30 @@
         "source-map-js": "^1.2.0"
       }
     },
+    "node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/memorystream": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -4291,6 +4651,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.51",
@@ -4495,11 +4862,60 @@
         "@oxlint/win32-x64": "1.8.0"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true
+    },
+    "node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -4554,6 +4970,52 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/playwright": {
       "version": "1.54.1",
@@ -4696,6 +5158,23 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/recast": {
+      "version": "0.23.21",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.21.tgz",
+      "integrity": "sha512-mFAyJq9vUbSTARLZUvAEf1z3YxlvAwswbmxMx2mPA/MSm4KmpwvwvhsH/NIrZhyOuwD60Lzyw2qh83uCbgTPYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -4834,6 +5313,19 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/shebang-command": {
@@ -5180,6 +5672,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -5222,18 +5721,6 @@
         }
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tinypool": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
@@ -5263,6 +5750,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -5271,6 +5768,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.1.6",
@@ -5477,18 +5981,6 @@
         }
       }
     },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/vitest": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
@@ -5588,18 +6080,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
-    "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5668,6 +6148,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
       "import": "./compat/scheduler.mjs",
       "require": "./compat/scheduler.js"
     },
+    "./codemods/10-to-11": "./codemods/10-to-11.cjs",
     "./package.json": "./package.json",
     "./compat/package.json": "./compat/package.json",
     "./debug/package.json": "./debug/package.json",
@@ -110,7 +111,7 @@
     "test:ts:compat": "tsc -p compat/test/ts/",
     "lint": "run-s oxlint tsc",
     "tsc": "tsc -p jsconfig-lint.json",
-    "oxlint": "oxlint src test/browser test/node test/shared debug compat hooks test-utils",
+    "oxlint": "oxlint src test/browser test/node test/shared debug compat hooks test-utils codemods",
     "format": "oxfmt . --write",
     "format:check": "oxfmt --check ."
   },
@@ -141,6 +142,8 @@
     "compat/jsx-dev-runtime.js",
     "compat/jsx-dev-runtime.mjs",
     "compat/package.json",
+    "codemods/10-to-11.cjs",
+    "codemods/README.md",
     "debug/dist",
     "debug/src",
     "debug/package.json",
@@ -186,6 +189,7 @@
     "chai": "^6.2.2",
     "cross-env": "^7.0.3",
     "husky": "^9.1.7",
+    "jscodeshift": "^17.4.0",
     "kolorist": "^1.8.0",
     "npm-run-all2": "^7.0.0",
     "oxfmt": "^0.32.0",

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -227,7 +227,10 @@ export default defineConfig({
 			{
 				extends: true,
 				test: {
-					include: ['./test/{shared,node,ts}/**/*.test.js?(x)']
+					include: [
+						'./codemods/**/*.test.js',
+						'./test/{shared,node,ts}/**/*.test.js?(x)'
+					]
 				}
 			},
 			{


### PR DESCRIPTION
## Summary

> [!NOTE]
> Co-authored-by: GPT5.6-sol

- ship a conservative `preact/codemods/10-to-11` jscodeshift transform
- automate mechanical Preact 11 migrations for public entry points, core `createPortal`, function-component refs, required `useRef` initial values, numeric style units, legacy three-argument `render`, and moved JSX utility types
- document usage and flag upgrade-guide changes that still need application-specific review

The transform is scope-aware, preserves aliases and TypeScript generics, reports cases it cannot safely rewrite, and is idempotent across the covered migrations.

Not sure whether we should bundle this or offer it as a separate CLI, opinions?