### PR TITLE
Normalize onDoubleClickCapture to a real dblclick listener

### DIFF
--- a/compat/src/render.js
+++ b/compat/src/render.js
@@ -214,6 +214,8 @@ function handleDomVNode(vnode) {
 			let lowerCased = i.toLowerCase();
 			if (lowerCased == 'ondoubleclick') {
 				i = 'ondblclick';
+			} else if (lowerCased == 'ondoubleclickcapture') {
+				i = 'ondblclickCapture';
 			} else if (
 				lowerCased == 'onchange' &&
 				(type == 'input' || type == 'textarea') &&

--- a/compat/test/browser/events.test.jsx
+++ b/compat/test/browser/events.test.jsx
@@ -63,6 +63,21 @@ describe('preact/compat events', () => {
 		expect(vnode.props).to.haveOwnProperty('ondblclick');
 	});
 
+	it('should normalize ondoubleclickcapture event', () => {
+		const func = vi.fn(() => {});
+		render(<div onDoubleClickCapture={func} />, scratch);
+
+		expect(proto.addEventListener).toHaveBeenCalledOnce();
+		expect(proto.addEventListener).toHaveBeenCalledWith(
+			'dblclick',
+			expect.any(Function),
+			true
+		);
+
+		scratch.firstChild.dispatchEvent(createEvent('dblclick'));
+		expect(func).toHaveBeenCalledOnce();
+	});
+
 	it('should normalize onChange for textarea', () => {
 		let vnode = <textarea onChange={() => null} />;
 		expect(vnode.props).to.haveOwnProperty('oninput');


### PR DESCRIPTION
`onDoubleClick` is normalized to `dblclick` in compat, but the capture variant isn't:

```jsx
<div onDoubleClickCapture={fn} />
```

The check is an exact `=== 'ondoubleclick'`, so `onDoubleClickCapture` slips past it. Core then strips the `Capture` suffix and registers a listener for `doubleclick` with capture — an event the DOM never fires — so `fn` never runs.

I added the capture branch next to the existing one so it maps to `ondblclickCapture`, and core ends up with `addEventListener('dblclick', fn, true)`. Test added alongside the existing `onDoubleClick` one.