### PR TITLE
Clear class component refs on unmount in compat

### DIFF
--- a/compat/test/browser/render.test.jsx
+++ b/compat/test/browser/render.test.jsx
@@ -3,7 +3,8 @@ import React, {
 	render,
 	Component,
 	hydrate,
-	createContext
+	createContext,
+	createRef
 } from 'preact/compat';
 import { setupRerender, act } from 'preact/test-utils';
 import {
@@ -892,5 +893,21 @@ describe('compat render', () => {
 		render(<div style={style} />, scratch);
 
 		expect(style).to.deep.equal({ margin: 10, opacity: 0.5 });
+	});
+
+	it('should null class-component object ref on unmount', () => {
+		const ref = createRef();
+
+		class Foo extends Component {
+			render() {
+				return <div>foo</div>;
+			}
+		}
+
+		render(<Foo ref={ref} />, scratch);
+		expect(ref.current).to.be.instanceof(Foo);
+
+		render(null, scratch);
+		expect(ref.current).to.equal(null);
 	});
 });

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -755,7 +755,10 @@ export function unmount(vnode, parentVNode, skipRemove) {
 	let r;
 	if (options.unmount) options.unmount(vnode);
 
-	if ((r = vnode.ref) && (!r.current || r.current == vnode._dom)) {
+	if (
+		(r = vnode.ref) &&
+		(!r.current || r.current == vnode._dom || r.current == vnode._component)
+	) {
 		applyRef(r, NULL, parentVNode);
 	}
 


### PR DESCRIPTION
An object ref on a class component isn't reset to `null` when the component unmounts (preact/compat):

```jsx
const ref = createRef()
// render <Foo ref={ref} />, then unmount Foo
ref.current // still the old Foo instance, expected null
```

In `unmount()` the ref is only cleared when `r.current` is falsy or equals the vnode's DOM node. For a compat class component the ref points at the component instance (`vnode._component`), so neither case matches and the stale instance is left behind. DOM refs and function refs are already cleared — it's just the instance case slipping through.

I added `r.current == vnode._component` to that guard. Ran the refs suite too to check nothing regressed. Test added.