### PR TITLE
fix: only treat components with error handlers as error boundaries

### DIFF
--- a/src/diff/catch-error.js
+++ b/src/diff/catch-error.js
@@ -19,7 +19,9 @@ export function _catchError(error, vnode, oldVNode, errorInfo) {
 	/** @type {import('../internal').Component} */
 	let component,
 		/** @type {import('../internal').ComponentType} */
-		ctor;
+		ctor,
+		/** @type {number} */
+		handled;
 
 	for (; (vnode = vnode._parent); ) {
 		if (
@@ -32,14 +34,16 @@ export function _catchError(error, vnode, oldVNode, errorInfo) {
 
 				if (ctor && ctor.getDerivedStateFromError) {
 					component.setState(ctor.getDerivedStateFromError(error));
+					handled = component._bits & COMPONENT_DIRTY;
 				}
 
 				if (component.componentDidCatch) {
 					component.componentDidCatch(error, errorInfo || {});
+					handled = component._bits & COMPONENT_DIRTY;
 				}
 
 				// This is an error boundary. Mark it as having bailed out, and whether it was mid-hydration.
-				if (component._bits & COMPONENT_DIRTY) {
+				if (handled) {
 					component._bits |= COMPONENT_PENDING_ERROR;
 					return;
 				}

--- a/test/browser/lifecycles/componentDidCatch.test.jsx
+++ b/test/browser/lifecycles/componentDidCatch.test.jsx
@@ -622,6 +622,44 @@ describe('Lifecycle methods', () => {
 			expect(scratch).to.have.property('textContent', 'Error: Adapted Error!');
 		});
 
+		it('should not treat a dirty ancestor without error handling as a boundary', () => {
+			let parent;
+			class Parent extends Component {
+				render() {
+					parent = this;
+					return <div>{this.props.children}</div>;
+				}
+			}
+			class Sibling extends Component {
+				componentDidMount() {
+					// Leaves Parent dirty (a pending update) when ThrowErr's
+					// componentDidMount throws right after this one.
+					parent.setState({ x: 1 });
+				}
+				render() {
+					return <i>a</i>;
+				}
+			}
+			class ThrowErr extends Component {
+				componentDidMount() {
+					throwExpectedError();
+				}
+				render() {
+					return <i>b</i>;
+				}
+			}
+
+			expect(() =>
+				render(
+					<Parent>
+						<Sibling />
+						<ThrowErr />
+					</Parent>,
+					scratch
+				)
+			).to.throw(expectedError);
+		});
+
 		it('should bubble on repeated errors', () => {
 			class Adapter extends Component {
 				componentDidCatch(error) {


### PR DESCRIPTION
> [!NOTE]
> This PR was authored by an LLM (Claude Fable 5.1) during the v11 release-readiness audit; Jovi reviewed the change and the tests.

## Summary

`_catchError` marks a component as the boundary when it is dirty after `getDerivedStateFromError` / `componentDidCatch` ran. The size-golf commit 0bea5fcf2 dropped the `handled` variable that scoped that check to components which actually have one of those methods, so **any dirty ancestor** now claims the error: it gets `PENDING_ERROR`, `_catchError` returns, and the error is silently discarded.

This is easy to hit: a sibling's `componentDidMount` calls `parent.setState()`, the next sibling's `componentDidMount` throws, and the error vanishes because `Parent` is dirty. v10 propagated it.

This restores the v10 gate: only a component whose error-handling method enqueued state counts as handled.

## Test

`should not treat a dirty ancestor without error handling as a boundary` in `componentDidCatch.test.jsx` fails on `main` (no error thrown) and passes here.

Core brotli: 4428 → 4433 B.
