### PR TITLE
fix: keep the pending error flag until the boundary's retry render

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -360,9 +360,11 @@ export function diff(
 				commitQueue.push(c);
 			}
 
-			// PROCESSING_EXCEPTION is only ever set together with PENDING_ERROR,
-			// so the clear doesn't need a guard.
-			c._bits &= ~(COMPONENT_PROCESSING_EXCEPTION | COMPONENT_PENDING_ERROR);
+			// Only clear when this render was the retry; PENDING_ERROR set by a
+			// descendant during this render must survive until then.
+			if (c._bits & COMPONENT_PROCESSING_EXCEPTION) {
+				c._bits &= ~(COMPONENT_PROCESSING_EXCEPTION | COMPONENT_PENDING_ERROR);
+			}
 		} catch (e) {
 			// We remove any componentDidMount, ...
 			// that have been invalidated by us

--- a/test/browser/lifecycles/componentDidCatch.test.jsx
+++ b/test/browser/lifecycles/componentDidCatch.test.jsx
@@ -664,6 +664,45 @@ describe('Lifecycle methods', () => {
 			expect(scratch).to.have.property('textContent', 'Error: Error!');
 		});
 
+		it('should skip the boundary when the retry render throws again', () => {
+			let catches = 0;
+			class Boundary extends Component {
+				componentDidCatch() {
+					catches++;
+					this.setState({ attempt: catches });
+				}
+				render() {
+					return (
+						<div>
+							<Thrower />
+						</div>
+					);
+				}
+			}
+			function Thrower() {
+				throwExpectedError();
+			}
+
+			render(
+				<Receiver>
+					<Boundary />
+				</Receiver>,
+				scratch
+			);
+			expect(catches).to.equal(1);
+
+			// The retry render throws again: Boundary is now processing that
+			// error and must be skipped so it bubbles up to Receiver instead of
+			// being re-caught (which would schedule retries forever).
+			rerender();
+			expect(catches).to.equal(1);
+			expect(Receiver.prototype.componentDidCatch).toHaveBeenCalledWith(
+				expectedError,
+				expect.anything()
+			);
+			expect(scratch).to.have.property('textContent', 'Error: Error!');
+		});
+
 		it('should bubble on ignored errors', () => {
 			class Adapter extends Component {
 				componentDidCatch() {


### PR DESCRIPTION
> [!NOTE]
> This PR was authored by an LLM (Claude Fable 5.1) during the v11 release-readiness audit; Jovi reviewed the change and the tests.

## Summary

When a descendant throws and a boundary handles it, `_catchError` sets `PENDING_ERROR` on the boundary from inside the boundary's own `diffChildren` call. Since 943fa2626 the end of `diff()` clears `PROCESSING_EXCEPTION | PENDING_ERROR` unconditionally, so that bit is wiped in the same render that set it. On the retry render the boundary is therefore never marked `PROCESSING_EXCEPTION`, catches the same error again, enqueues another retry, and loops: one microtask per iteration, forever. A boundary that retries on error hangs the tab instead of letting the error bubble.

v10 captured `clearProcessingException = c._pendingError` before rendering and only cleared at the end when it was set at the start. This restores that: the bits are cleared only when the render began as the retry.

## Test

`should skip the boundary when the retry render throws again` in `componentDidCatch.test.jsx`: on `main` the `rerender()` call never returns (the test runner hangs); here the second error bubbles to the outer boundary and the inner one catches exactly once.

Core brotli: 4428 → 4426 B.
