### PR TITLE
types: make the Children.map/forEach context argument optional

### DIFF
--- a/compat/src/index.d.ts
+++ b/compat/src/index.d.ts
@@ -412,12 +412,12 @@ declare namespace React {
 		map<T extends _preact.ComponentChild, R>(
 			children: T | T[],
 			fn: (child: T, i: number) => R,
-			context: any
+			context?: any
 		): R[];
 		forEach<T extends _preact.ComponentChild>(
 			children: T | T[],
 			fn: (child: T, i: number) => void,
-			context: any
+			context?: any
 		): void;
 		count: (children: _preact.ComponentChildren) => number;
 		only: (children: _preact.ComponentChildren) => _preact.ComponentChild;

--- a/compat/test/ts/index.tsx
+++ b/compat/test/ts/index.tsx
@@ -46,3 +46,10 @@ React.render(
 	<SimpleComponentWithContextAsProvider />,
 	document.createElement('div')
 );
+
+// Children.map / Children.forEach accept an optional context argument
+const mappedChildren: string[] = React.Children.map([<div />], () => 'child');
+React.Children.forEach([<div />], () => {});
+React.Children.map([<div />], () => 'child', {});
+React.Children.forEach([<div />], () => {}, {});
+mappedChildren.length;


### PR DESCRIPTION
> [!NOTE]
> This PR was authored by an LLM (Claude Fable 5.1) during the v11 release-readiness audit; Jovi reviewed the change and the tests.

## Summary

The optional `thisArg` added to `Children.map` / `Children.forEach` (React parity) is optional at runtime (`fn.bind(context)`), but the declaration was written as `context: any`, making it required. Every existing two-argument `React.Children.map(children, fn)` call in a TypeScript codebase fails with "Expected 3 arguments, but got 2" on the rc.

This makes the parameter optional and adds two-argument calls to the compat type tests.
