### PR TITLE
chore: require preact-render-to-string >=6.7.0 as the optional peer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "url": "https://opencollective.com/preact"
       },
       "peerDependencies": {
-        "preact-render-to-string": ">=5"
+        "preact-render-to-string": ">=6.7.0"
       },
       "peerDependenciesMeta": {
         "preact-render-to-string": {

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "preact-render-to-string": ">=5"
+    "preact-render-to-string": ">=6.7.0"
   },
   "peerDependenciesMeta": {
     "preact-render-to-string": {


### PR DESCRIPTION
> [!NOTE]
> This PR was authored by an LLM (Claude Fable 5.1) during the v11 release-readiness audit; Jovi reviewed the change and the tests.

## Summary

Bumps the optional `preact-render-to-string` peer range from `>=5` to `>=6.7.0`.

Preact 11 is ESM-only, so `preact/compat/server` is now imported through `compat/server.mjs`, which does `import … from 'preact-render-to-string/stream-node'`. In `preact-render-to-string` ≤ 6.6 the `import` condition of that subpath points at a `dist/stream-node.mjs` that is not published, so the import fails with `ERR_MODULE_NOT_FOUND` at startup. 6.7.0 publishes the entry (`dist/stream/node/index.mjs`) and its peer range already allows Preact 11.

The devDependency is left at 6.5.0 for now: 6.7.0's `dist/stream-node.d.ts` imports `WritableStream` from `node:stream`, which no `@types/node` exports, and that fails this repo's `tsc -p jsconfig-lint.json`. That is a one-line upstream fix (import `Writable`); the devDependency can follow once it ships.
