### PR TITLE
chore: drop stale references to the removed min build and JSX.HTMLAttributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@
 [![OpenCollective Sponsors](https://opencollective.com/preact/sponsors/badge.svg)](#sponsors)
 
 [![coveralls](https://img.shields.io/coveralls/preactjs/preact/main.svg)](https://coveralls.io/github/preactjs/preact)
-[![gzip size](https://img.badgesize.io/https://unpkg.com/preact/dist/preact.min.js?compression=gzip&label=gzip)](https://unpkg.com/preact/dist/preact.min.js)
-[![brotli size](https://img.badgesize.io/https://unpkg.com/preact/dist/preact.min.js?compression=brotli&label=brotli)](https://unpkg.com/preact/dist/preact.min.js)
+[![gzip size](https://img.badgesize.io/https://unpkg.com/preact/dist/preact.mjs?compression=gzip&label=gzip)](https://unpkg.com/preact/dist/preact.mjs)
+[![brotli size](https://img.badgesize.io/https://unpkg.com/preact/dist/preact.mjs?compression=brotli&label=brotli)](https://unpkg.com/preact/dist/preact.mjs)
 
 </td>
 </tr>

--- a/demo/people/router.tsx
+++ b/demo/people/router.tsx
@@ -4,7 +4,7 @@ import {
 	createContext,
 	FunctionalComponent,
 	h,
-	JSX
+	HTMLAttributes
 } from 'preact';
 import {
 	useCallback,
@@ -96,7 +96,7 @@ export const Route: FunctionalComponent<RouteProps> = props => {
 	return <RouterContext.Provider children={children} value={innerRouter} />;
 };
 
-export type LinkProps = JSX.HTMLAttributes & {
+export type LinkProps = HTMLAttributes & {
 	active?: boolean | string;
 };
 export const Link: FunctionalComponent<LinkProps> = props => {


### PR DESCRIPTION
> [!NOTE]
> This PR was authored by an LLM (Claude Fable 5.1) during the v11 release-readiness audit; Jovi reviewed the change and the tests.

## Summary

Two leftovers from the v10 → v11 packaging and typing changes:

- The README size badges pointed at `dist/preact.min.js`, which no longer exists; they now point at `dist/preact.mjs`, so they stop 404ing once `latest` moves to 11.
- `demo/people/router.tsx` still used `JSX.HTMLAttributes`, which moved to the `preact` namespace in v11. The demo is outside the lint tsconfig, so this was not caught.
