### PR TITLE
Stop appending "px" to unitless SVG paint and aspect-ratio values

### DIFF
--- a/compat/src/util.js
+++ b/compat/src/util.js
@@ -13,4 +13,4 @@ export function shallowDiffers(a, b) {
 }
 
 export const IS_NON_DIMENSIONAL =
-	/^(-|f[lo].*[^se]$|g.{5,}[^ps]$|z|o[pr]|(W.{5})?[lL]i.*(t|mp)$|an|(bo|s).{4}Im|sca|m.{6}[ds]|ta|c.*[st]$|wido|ini)/;
+	/^(-|f[lo].*[^se]$|g.{5,}[^ps]$|z|o[pr]|(W.{5})?[lL]i.*(t|mp)$|an|(bo|s).{4}Im|sca|m.{6}[ds]|ta|c.*[st]$|wido|ini|asp|fill|st)/;

--- a/compat/test/browser/render.test.jsx
+++ b/compat/test/browser/render.test.jsx
@@ -893,4 +893,28 @@ describe('compat render', () => {
 
 		expect(style).to.deep.equal({ margin: 10, opacity: 0.5 });
 	});
+
+	it('should not append "px" to unitless SVG paint and aspect-ratio values', () => {
+		// None of these accepts a <length>, so appending "px" makes the value
+		// invalid and the declaration is dropped entirely. React lists all of
+		// them in `isUnitlessNumber` for the same reason.
+		const style = {
+			aspectRatio: 2,
+			fillOpacity: 0.5,
+			stopOpacity: 0.5,
+			strokeOpacity: 0.5,
+			strokeMiterlimit: 3,
+			strokeWidth: 2
+		};
+		render(<div style={style} />, scratch);
+
+		const rendered = scratch.firstChild.style;
+		for (const key in style) {
+			expect(rendered[key], `${key} should not be dropped`).to.not.equal('');
+			expect(
+				rendered[key].endsWith('px'),
+				`${key} should not have "px" appended, got "${rendered[key]}"`
+			).to.equal(false);
+		}
+	});
 });


### PR DESCRIPTION
`IS_NON_DIMENSIONAL` misses five properties that reject a `<length>`, so the appended `px` makes the value invalid and the browser drops the declaration outright:

| `style={{ … }}` | today | after |
|---|---|---|
| `aspectRatio: 2` | *(nothing)* | `aspect-ratio: 2 / 1` |
| `fillOpacity: 0.5` | *(nothing)* | `fill-opacity: 0.5` |
| `stopOpacity: 0.5` | *(nothing)* | `stop-opacity: 0.5` |
| `strokeOpacity: 0.5` | *(nothing)* | `stroke-opacity: 0.5` |
| `strokeMiterlimit: 3` | *(nothing)* | `stroke-miterlimit: 3` |

All five sit in React's `isUnitlessNumber`.

Corpus: every CSS property Chromium exposes, camelCase and kebab — 1,261 names. 26 classifications change, **zero regressions**: 10 dropped declarations restored, 6 are `stroke-width`/`-dasharray`/`-dashoffset` going `2px` → `2` (spec-equivalent, matches React), 10 no-ops (`fill`, `stroke`, `-linecap`, `-linejoin`, `stop-color` reject a bare number either way).

Deliberately uncovered: `boxFlex`, `boxFlexGroup`, `boxOrdinalGroup`, `flexPositive`, `flexNegative` — React keeps them for the 2009 flexbox draft; Chromium accepts neither `2` nor `2px` for any.

Two naive alternatives measured and rejected: `f[lo]`→`f[ilo]` sweeps in `filter` and `field-sizing` and still leaves 4 of 5 broken; `asp` alone leaves 4 broken and fails the new test.

Reverting only `util.js` fails the new test and nothing else (46/47). Full suite 1306 passing; Compressed size 3,913 → 3,920 gzipped (+7 B).

🤖 Written with Claude Code (claude-opus-5)
