### PR TITLE
Add selectedcontent JSX type

### DIFF
--- a/src/jsx.d.ts
+++ b/src/jsx.d.ts
@@ -233,6 +233,7 @@ export namespace JSXInternal {
 		search: preact.SearchHTMLAttributes<HTMLElement>;
 		section: preact.HTMLAttributes<HTMLElement>;
 		select: preact.AccessibleSelectHTMLAttributes<HTMLSelectElement>;
+		selectedcontent: preact.HTMLAttributes<HTMLElement>;
 		slot: preact.SlotHTMLAttributes<HTMLSlotElement>;
 		small: preact.HTMLAttributes<HTMLElement>;
 		source: preact.SourceHTMLAttributes<HTMLSourceElement>;

--- a/test/ts/preact.tsx
+++ b/test/ts/preact.tsx
@@ -365,6 +365,11 @@ let elementProps: ComponentProps<'button'> = {
 	type: 'button'
 };
 
+let selectedContentProps: ComponentProps<'selectedcontent'> = {
+	id: 'selected-option'
+};
+const selectedContent = <selectedcontent ref={createRef<HTMLElement>()} />;
+
 // Typing of style property
 const acceptsNumberAsLength = <div style={{ marginTop: 20 }} />;
 const acceptsStringAsLength = <div style={{ marginTop: '20px' }} />;


### PR DESCRIPTION
## Summary
- add the customizable select `<selectedcontent>` element to JSX intrinsic element types
- add a TypeScript coverage case for JSX and ComponentProps usage