### PR TITLE
Remove dead _dom/_children copy from compat Suspense _catchError

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -17,10 +17,6 @@ function initSuspenseHooks() {
 
 			while ((vnode = vnode._parent)) {
 				if ((component = vnode._component) && component._childDidSuspend) {
-					if (newVNode._dom == null) {
-						newVNode._dom = oldVNode._dom;
-						newVNode._children = oldVNode._children || [];
-					}
 					// Don't call oldCatchError if we found a Suspense
 					return component._childDidSuspend(error, newVNode);
 				}


### PR DESCRIPTION
Core already assigns `newVNode._dom` and `newVNode._children` from the old vnode before calling `options._catchError` (`src/diff/index.js`), so the copy in compat's Suspense handler never changes anything. The other `_catchError` call sites (commit callbacks, refs, unmount) pass no `oldVNode` at all, so the block could only ever throw there.

compat.mjs: −49 B brotli.