### PR TITLE
perf: diff single-child render results without a wrapper array

### DIFF
--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -71,7 +71,7 @@ export function diffChildren(
 	/** @type {VNode[]} */
 	let oldChildren = oldParentVNode._children || EMPTY_ARR;
 
-	let newChildrenLength = renderResult.length;
+	let newChildrenLength = isArray(renderResult) ? renderResult.length : 1;
 
 	oldDom = constructNewChildrenArray(
 		newParentVNode,
@@ -184,7 +184,7 @@ function constructNewChildrenArray(
 	for (i = 0; i < newChildrenLength; i++) {
 		// @ts-expect-error We are reusing the childVNode variable to hold both the
 		// pre and post normalized childVNode
-		childVNode = renderResult[i];
+		childVNode = isArray(renderResult) ? renderResult[i] : renderResult;
 
 		if (
 			childVNode == NULL ||

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -334,7 +334,7 @@ export function diff(
 
 			oldDom = diffChildren(
 				parentDom,
-				isArray(renderResult) ? renderResult : [renderResult],
+				renderResult,
 				newVNode,
 				oldVNode,
 				globalContext,
@@ -677,7 +677,7 @@ function diffElementNodes(
 
 			diffChildren(
 				parentDom,
-				isArray(newChildren) ? newChildren : [newChildren],
+				newChildren,
 				newVNode,
 				oldVNode,
 				globalContext,


### PR DESCRIPTION
`diff()` and `diffElementNodes()` wrapped every non-array render result in a fresh `[result]` array before calling `diffChildren()`. Exactly-one-child is by far the most common children diff, so that was a throwaway allocation per component and per element on nearly every update. `diffChildren` now takes the bare value and `constructNewChildrenArray` reads it directly.

Single text children was the prevailing thing according to https://github.com/preactjs/preact/issues/2618