### PR TITLE
perf(hooks): stop scanning once an update is required

### DIFF
--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -258,6 +258,7 @@ export function useReducer(reducer, initialState, init) {
 							shouldUpdate = true;
 						}
 					}
+					return updatedHook && shouldUpdate;
 				});
 
 				if (prevScu) {


### PR DESCRIPTION
Stop scanning hook state once a pending update requires a render, while preserving the chained `shouldComponentUpdate` call and committing all pending state before rendering.
