### PR TITLE
perf: reduce gzip size when using jsx()

### DIFF
--- a/src/create-portal.js
+++ b/src/create-portal.js
@@ -1,4 +1,4 @@
-import { createElement } from './create-element';
+import { createVNode } from './create-element';
 
 /**
  * Portal component. A unique type is used instead of Fragment so that a
@@ -16,5 +16,5 @@ function Portal(props) {
  * @param {import('./internal').PreactElement} container The DOM node to continue rendering in to
  */
 export function createPortal(vnode, container) {
-	return createElement(Portal, { _parentDom: container }, vnode);
+	return createVNode(Portal, { _parentDom: container, children: vnode });
 }

--- a/src/render.js
+++ b/src/render.js
@@ -1,6 +1,6 @@
 import { EMPTY_OBJ, MODE_HYDRATE, NULL } from './constants';
 import { commitRoot, diff } from './diff/index';
-import { createElement, Fragment } from './create-element';
+import { createVNode, Fragment } from './create-element';
 import options from './options';
 import { slice } from './util';
 
@@ -28,7 +28,7 @@ export function render(vnode, parentDom) {
 	// means that we are mounting a new tree for the first time.
 	let oldVNode = isHydrating ? NULL : parentDom._children;
 
-	parentDom._children = createElement(Fragment, NULL, [vnode]);
+	parentDom._children = createVNode(Fragment, { children: [vnode] });
 
 	// List of effects that need to be called after diffing.
 	let commitQueue = [],


### PR DESCRIPTION
Allow `createElement` to be tree-shaken when using `jsx()`, saving 77–79 gzip bytes in apps using `jsx` but no `createElement`. Our internal usage prevented tree-shaking these before.