### PR TITLE
11.0.0-rc.2

### DIFF
--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -13,7 +13,7 @@ export function initDevTools() {
 		globalVar !== undefined &&
 		globalVar.__PREACT_DEVTOOLS__
 	) {
-		globalVar.__PREACT_DEVTOOLS__.attachPreact('11.0.0-rc.1', options, {
+		globalVar.__PREACT_DEVTOOLS__.attachPreact('11.0.0-rc.2', options, {
 			Fragment,
 			Component
 		});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "preact",
-  "version": "11.0.0-rc.1",
+  "version": "11.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "preact",
-      "version": "11.0.0-rc.1",
+      "version": "11.0.0-rc.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.28.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact",
   "amdName": "preact",
-  "version": "11.0.0-rc.1",
+  "version": "11.0.0-rc.2",
   "private": false,
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
> [!NOTE]
> barring no more bugs we should be good to release the stable 11 by end of month
> There are some more open PR's but they are perf and correctness

## Notable

- Preserve hook state when Suspense re-suspends (#5239, thanks @JoviDeCroock)

## Types

- Add `selectedcontent` JSX type (#5234, thanks @JoviDeCroock)
- Make the Children.map/forEach context argument optional (#5230, thanks @JoviDeCroock)

## Fixes

- Keep the pending error flag until the boundary's retry render (#5227, thanks @JoviDeCroock)
- Only treat components with error handlers as error boundaries (#5226, thanks @JoviDeCroock)
- Anchor the MathML token element regex (#5228, thanks @JoviDeCroock)
- Fall back to insertBefore when the moved node was detached externally (#5244, thanks @JoviDeCroock)

## Performance

- Omit dev fields from production jsx vnodes (#5220, thanks @JoviDeCroock)
- Resolve unmount error routing lazily (fixes #5217) (#5218, thanks @JoviDeCroock)
- Reduce gzip size when using jsx() (#5243, thanks @JoviDeCroock)

## Maintenance

- Upgrade Vitest to 5 (#5238, thanks @JoviDeCroock)
- Upgrade Node.js to 22 (#5237, thanks @JoviDeCroock)
- Remove dead _dom/_children copy from compat Suspense _catchError (#5240, thanks @JoviDeCroock)
- Require preact-render-to-string >=6.7.0 as the optional peer (#5231, thanks @JoviDeCroock)
- Drop stale references to the removed min build and JSX.HTMLAttributes (#5232, thanks @JoviDeCroock)


