### PR TITLE
Append when the insertion reference node lives in another container

### DIFF
--- a/compat/test/browser/suspense.test.jsx
+++ b/compat/test/browser/suspense.test.jsx
@@ -999,6 +999,68 @@ describe('suspense', () => {
 		});
 	});
 
+	it('should mount DOM in a parked component without throwing and keep its refs (#5251)', () => {
+		/** @type {(v: boolean) => void} */
+		let setSlot;
+		const ref = vi.fn();
+		const layout = vi.fn();
+
+		function Slot() {
+			const [show, set] = useState(false);
+			setSlot = set;
+			useLayoutEffect(() => {
+				if (show) layout();
+			}, [show]);
+			return show ? <header ref={ref}>bar</header> : null;
+		}
+
+		const [Suspender, suspend] = createSuspender(() => (
+			<div id="page">page</div>
+		));
+
+		render(
+			<Suspense fallback={<div>Suspended...</div>}>
+				<Slot />
+				<Suspender />
+				<footer>foot</footer>
+			</Suspense>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal(
+			'<div id="page">page</div><footer>foot</footer>'
+		);
+
+		// 1. Park the subtree
+		const [resolve] = suspend();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div>Suspended...</div>');
+
+		// 2. Mount new DOM while parked: the insertion reference is a sibling
+		// that was removed from the document, which used to throw NotFoundError
+		setSlot(true);
+		expect(() => rerender()).not.to.throw();
+		expect(ref).toHaveBeenCalledTimes(1);
+		expect(layout).toHaveBeenCalledTimes(1);
+		// The new DOM went into the detached container, not the document
+		expect(scratch.innerHTML).to.equal('<div>Suspended...</div>');
+		expect(document.contains(ref.mock.calls[0][0])).to.equal(false);
+		expect(ref.mock.calls[0][0].parentNode.nodeName).to.equal('DIV');
+
+		// 3. Any further update while parked must not re-run mount work
+		setSlot(true);
+		rerender();
+
+		// 4. Resolve: the new DOM is restored at the right position
+		return resolve(() => <div id="page">page2</div>).then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.equal(
+				'<header>bar</header><div id="page">page2</div><footer>foot</footer>'
+			);
+			expect(ref).toHaveBeenCalledTimes(1);
+			expect(ref.mock.calls[0][0]).to.equal(scratch.firstChild);
+			expect(layout).toHaveBeenCalledTimes(1);
+		});
+	});
 	it('should suspend with custom error boundary', () => {
 		const [Suspender, suspend] = createSuspender(() => (
 			<div>within error boundary</div>

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -400,16 +400,28 @@ function insert(parentVNode, oldDom, parentDom, isMounting) {
 		}
 
 		return oldDom;
-	} else if (parentVNode._dom != oldDom) {
-		if (oldDom && parentVNode.type && !oldDom.parentNode) {
+	} else {
+		if (oldDom && !oldDom.parentNode) {
 			oldDom = getDomSibling(parentVNode);
 		}
 
-		if (HAS_MOVE_BEFORE_SUPPORT && !isMounting && parentVNode._dom.parentNode) {
-			// @ts-expect-error This isn't added to TypeScript lib.d.ts yet
-			parentDom.moveBefore(parentVNode._dom, oldDom);
-		} else {
-			parentDom.insertBefore(parentVNode._dom, oldDom || NULL);
+		// A cursor outside the container (another root's container, or a node a
+		// parked Suspense subtree detached) can't be a reference node.
+		if (oldDom && oldDom.parentNode != parentDom) {
+			oldDom = NULL;
+		}
+
+		if (parentVNode._dom != oldDom) {
+			if (
+				HAS_MOVE_BEFORE_SUPPORT &&
+				!isMounting &&
+				parentVNode._dom.parentNode
+			) {
+				// @ts-expect-error This isn't added to TypeScript lib.d.ts yet
+				parentDom.moveBefore(parentVNode._dom, oldDom);
+			} else {
+				parentDom.insertBefore(parentVNode._dom, oldDom || NULL);
+			}
 		}
 		oldDom = parentVNode._dom;
 	}


### PR DESCRIPTION
Fixes #5251

## Problem

When a component parked by `<Suspense>` re-renders and mounts new DOM, it renders into the detached container that Suspense created. `getDomSibling` still returns the element of a sibling that was removed from the document when the subtree was parked, and `insertBefore` throws `NotFoundError` because that reference node is not a child of the container.

## Fix

In `insert()`, treat a reference node whose `parentNode` is not the target container the same as a missing one and append instead. Inside the detached container the order does not matter: on resolve, `removeOriginal` and the restore diff place every node at its correct position. The new DOM stays out of the document while suspended, only the fallback is shown.

The test covers the reporter's four steps: park, mount DOM while parked (no throw, ref and layout effect run once, nothing in the document), a further update while parked, and resolve with the correct final order.