### PR TITLE
Defer refs and effects until Suspense reveals

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -3,6 +3,8 @@ import {
 	COMPONENT_FORCE,
 	FORCE_PROPS_REVALIDATE,
 	MODE_HYDRATE,
+	MODE_PARKED,
+	REF_PENDING,
 	UNDEFINED
 } from '../../src/constants';
 import { assign } from './util';
@@ -60,7 +62,12 @@ function detachedClone(vnode, detachedParent, parentDom) {
 			hooks._pendingEffects = vnode._component._renderCallbacks = [];
 		}
 
-		vnode = assign({ constructor: UNDEFINED }, vnode);
+		vnode._flags |= MODE_PARKED;
+		const clone = assign({ constructor: UNDEFINED }, vnode);
+		// The clone detaches previously attached refs; the retained tree
+		// attaches them again on reveal. Already pending refs stay pending.
+		if (vnode.ref) vnode._flags |= REF_PENDING;
+		vnode = clone;
 		if (vnode._component != null) {
 			if (vnode._component._parentDom == parentDom) {
 				vnode._component._parentDom = detachedParent;
@@ -81,25 +88,27 @@ function detachedClone(vnode, detachedParent, parentDom) {
 	return vnode;
 }
 
-function removeOriginal(vnode, detachedParent, originalParent) {
+function removeOriginal(vnode, detachedParent, originalParent, stillParked) {
 	if (vnode && originalParent) {
 		if (typeof vnode.type == 'string') {
 			vnode._flags |= FORCE_PROPS_REVALIDATE;
 		}
 
+		vnode._flags &= stillParked | ~MODE_PARKED;
 		vnode._original = null;
 		vnode._children =
 			vnode._children &&
 			vnode._children.map(child =>
-				removeOriginal(child, detachedParent, originalParent)
+				removeOriginal(child, detachedParent, originalParent, stillParked)
 			);
 
 		if (vnode._component) {
+			// Hidden updates may have consumed the force flag set when parking.
+			vnode._component._bits |= COMPONENT_FORCE;
 			if (vnode._component._parentDom == detachedParent) {
 				if (vnode._dom) {
 					originalParent.appendChild(vnode._dom);
 				}
-				vnode._component._bits |= COMPONENT_FORCE;
 				vnode._component._parentDom = originalParent;
 			}
 		}
@@ -164,7 +173,8 @@ function createSuspense() {
 					this._vnode._children[0] = removeOriginal(
 						suspendedVNode,
 						suspendedVNode._component._parentDom,
-						suspendedVNode._component._originalParentDom
+						suspendedVNode._component._originalParentDom,
+						this._vnode._flags & MODE_PARKED
 					);
 				}
 

--- a/compat/test/browser/suspense.test.jsx
+++ b/compat/test/browser/suspense.test.jsx
@@ -1039,12 +1039,10 @@ describe('suspense', () => {
 		// that was removed from the document, which used to throw NotFoundError
 		setSlot(true);
 		expect(() => rerender()).not.to.throw();
-		expect(ref).toHaveBeenCalledTimes(1);
-		expect(layout).toHaveBeenCalledTimes(1);
+		expect(ref).not.toHaveBeenCalled();
+		expect(layout).not.toHaveBeenCalled();
 		// The new DOM went into the detached container, not the document
 		expect(scratch.innerHTML).to.equal('<div>Suspended...</div>');
-		expect(document.contains(ref.mock.calls[0][0])).to.equal(false);
-		expect(ref.mock.calls[0][0].parentNode.nodeName).to.equal('DIV');
 
 		// 3. Any further update while parked must not re-run mount work
 		setSlot(true);
@@ -1947,6 +1945,190 @@ describe('suspense', () => {
 
 		expect(scratch.innerHTML).to.equal(`<div>i: 2<div>Resolved</div></div>`);
 	});
+
+	it('should commit new children when a parked sibling updates twice', async () => {
+		let updateSlot, suspendPage, resolve;
+		let resolved = false;
+		const promise = new Promise(r => {
+			resolve = () => {
+				resolved = true;
+				r();
+				return promise;
+			};
+		});
+		const headerRef = vi.fn(node => {
+			if (node) node.style.color = 'red';
+		});
+		const layoutEffect = vi.fn();
+
+		function Header({ count }) {
+			useLayoutEffect(() => {
+				layoutEffect(scratch.querySelector('header').isConnected);
+			}, []);
+			return <header ref={headerRef}>bar {count}</header>;
+		}
+
+		function Slot() {
+			const [count, setCount] = useState(0);
+			updateSlot = setCount;
+			return count > 0 ? <Header count={count} /> : null;
+		}
+
+		function Page() {
+			const [suspended, setSuspended] = useState(false);
+			suspendPage = () => setSuspended(true);
+			if (suspended && !resolved) throw promise;
+			return <div>page</div>;
+		}
+
+		render(
+			<Suspense fallback={<p>Loading</p>}>
+				<Slot />
+				<Page />
+				<footer>foot</footer>
+			</Suspense>,
+			scratch
+		);
+		suspendPage();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<p>Loading</p>');
+
+		updateSlot(1);
+		rerender();
+		expect(scratch.innerHTML).to.equal('<p>Loading</p>');
+
+		updateSlot(2);
+		rerender();
+		expect(scratch.innerHTML).to.equal('<p>Loading</p>');
+		expect(headerRef).not.toHaveBeenCalled();
+		expect(layoutEffect).not.toHaveBeenCalled();
+
+		await resolve();
+		rerender();
+		expect(scratch.innerHTML).to.equal(
+			'<header style="color: red;">bar 2</header><div>page</div><footer>foot</footer>'
+		);
+		expect(headerRef).toHaveBeenCalledOnce();
+		expect(headerRef.mock.calls[0][0]).to.equal(scratch.firstChild);
+		expect(layoutEffect).toHaveBeenCalledExactlyOnceWith(true);
+	});
+
+	for (const innerFirst of [true, false]) {
+		it(`should defer parked updates until both boundaries reveal (inner first: ${innerFirst})`, async () => {
+			const [InnerPage, suspendInner] = createSuspender(() => <div>inner</div>);
+			const [OuterPage, suspendOuter] = createSuspender(() => <div>outer</div>);
+			let update;
+			const effect = vi.fn();
+			const ref = vi.fn();
+
+			function Header({ count }) {
+				useLayoutEffect(effect, []);
+				return <header ref={ref}>{count}</header>;
+			}
+
+			function Slot() {
+				const [count, setCount] = useState(0);
+				update = setCount;
+				return count ? <Header count={count} /> : null;
+			}
+
+			render(
+				<Suspense fallback={<p>outer loading</p>}>
+					<Suspense fallback={<p>inner loading</p>}>
+						<section>
+							<Slot />
+						</section>
+						<InnerPage />
+					</Suspense>
+					<OuterPage />
+				</Suspense>,
+				scratch
+			);
+			const [resolveInner] = suspendInner();
+			rerender();
+			update(1);
+			rerender();
+			const [resolveOuter] = suspendOuter();
+			rerender();
+			expect(ref).not.toHaveBeenCalled();
+			expect(effect).not.toHaveBeenCalled();
+
+			if (innerFirst) await resolveInner(() => <div>inner done</div>);
+			else await resolveOuter(() => <div>outer done</div>);
+			rerender();
+			update(2);
+			rerender();
+			expect(ref).not.toHaveBeenCalled();
+			expect(effect).not.toHaveBeenCalled();
+
+			if (innerFirst) await resolveOuter(() => <div>outer done</div>);
+			else await resolveInner(() => <div>inner done</div>);
+			rerender();
+			expect(scratch.innerHTML).to.equal(
+				'<section><header>2</header></section><div>inner done</div><div>outer done</div>'
+			);
+			expect(ref).toHaveBeenCalledOnce();
+			expect(effect).toHaveBeenCalledOnce();
+		});
+	}
+
+	for (const removeBeforeReveal of [false, true]) {
+		it(`should defer replaced refs and memoized effects (remove before reveal: ${removeBeforeReveal})`, async () => {
+			const [Page, suspend] = createSuspender(() => <div>page</div>);
+			let update;
+			const firstRef = vi.fn();
+			const secondRef = vi.fn();
+			const layout = vi.fn();
+			const passive = vi.fn();
+			const Header = memo(function Header({ count }) {
+				useLayoutEffect(layout, []);
+				useEffect(passive, []);
+				return (
+					<header ref={count === 1 ? firstRef : secondRef}>{count}</header>
+				);
+			});
+			function Slot() {
+				const [count, setCount] = useState(0);
+				update = setCount;
+				return count ? <Header count={count} /> : null;
+			}
+			render(
+				<Suspense fallback={<p>Loading</p>}>
+					<section>
+						<Slot />
+					</section>
+					<Page />
+				</Suspense>,
+				scratch
+			);
+			const [resolve] = suspend();
+			rerender();
+			await act(() => update(1));
+			await act(() => update(2));
+			if (removeBeforeReveal) await act(() => update(0));
+			expect(firstRef).not.toHaveBeenCalled();
+			expect(secondRef).not.toHaveBeenCalled();
+			expect(layout).not.toHaveBeenCalled();
+			expect(passive).not.toHaveBeenCalled();
+			await act(() => resolve(() => <div>done</div>));
+			expect(firstRef).not.toHaveBeenCalled();
+			if (removeBeforeReveal) {
+				expect(secondRef).not.toHaveBeenCalled();
+				expect(layout).not.toHaveBeenCalled();
+				expect(passive).not.toHaveBeenCalled();
+				expect(scratch.innerHTML).to.equal(
+					'<section></section><div>done</div>'
+				);
+			} else {
+				expect(secondRef).toHaveBeenCalledOnce();
+				expect(layout).toHaveBeenCalledOnce();
+				expect(passive).toHaveBeenCalledOnce();
+				expect(scratch.innerHTML).to.equal(
+					'<section><header>2</header></section><div>done</div>'
+				);
+			}
+		});
+	}
 
 	it('should call componentWillUnmount on a suspended component', () => {
 		const cWUSpy = vi.fn();

--- a/compat/test/browser/suspense.test.jsx
+++ b/compat/test/browser/suspense.test.jsx
@@ -999,6 +999,68 @@ describe('suspense', () => {
 		});
 	});
 
+	it('should mount DOM in a parked component without throwing and keep its refs (#5251)', () => {
+		/** @type {(v: boolean) => void} */
+		let setSlot;
+		const ref = vi.fn();
+		const layout = vi.fn();
+
+		function Slot() {
+			const [show, set] = useState(false);
+			setSlot = set;
+			useLayoutEffect(() => {
+				if (show) layout();
+			}, [show]);
+			return show ? <header ref={ref}>bar</header> : null;
+		}
+
+		const [Suspender, suspend] = createSuspender(() => (
+			<div id="page">page</div>
+		));
+
+		render(
+			<Suspense fallback={<div>Suspended...</div>}>
+				<Slot />
+				<Suspender />
+				<footer>foot</footer>
+			</Suspense>,
+			scratch
+		);
+		expect(scratch.innerHTML).to.equal(
+			'<div id="page">page</div><footer>foot</footer>'
+		);
+
+		// 1. Park the subtree
+		const [resolve] = suspend();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div>Suspended...</div>');
+
+		// 2. Mount new DOM while parked: the insertion reference is a sibling
+		// that was removed from the document, which used to throw NotFoundError
+		setSlot(true);
+		expect(() => rerender()).not.to.throw();
+		expect(ref).toHaveBeenCalledTimes(1);
+		expect(layout).toHaveBeenCalledTimes(1);
+		// The new DOM went into the detached container, not the document
+		expect(scratch.innerHTML).to.equal('<div>Suspended...</div>');
+		expect(document.contains(ref.mock.calls[0][0])).to.equal(false);
+		expect(ref.mock.calls[0][0].parentNode.nodeName).to.equal('DIV');
+
+		// 3. Any further update while parked must not re-run mount work
+		setSlot(true);
+		rerender();
+
+		// 4. Resolve: the new DOM is restored at the right position
+		return resolve(() => <div id="page">page2</div>).then(() => {
+			rerender();
+			expect(scratch.innerHTML).to.equal(
+				'<header>bar</header><div id="page">page2</div><footer>foot</footer>'
+			);
+			expect(ref).toHaveBeenCalledTimes(1);
+			expect(ref.mock.calls[0][0]).to.equal(scratch.firstChild);
+			expect(layout).toHaveBeenCalledTimes(1);
+		});
+	});
 	it('should suspend with custom error boundary', () => {
 		const [Suspender, suspend] = createSuspender(() => (
 			<div>within error boundary</div>

--- a/hooks/src/index.js
+++ b/hooks/src/index.js
@@ -1,4 +1,5 @@
 import { options as _options } from 'preact';
+import { MODE_PARKED } from '../../src/constants';
 
 const ObjectIs = Object.is;
 
@@ -91,13 +92,18 @@ options.diffed = vnode => {
 	if (oldAfterDiff) oldAfterDiff(vnode);
 
 	const c = vnode._component;
-	if (c && c.__hooks) {
-		if (c.__hooks._pendingEffects.length) afterPaint(afterPaintEffects.push(c));
-		// `_pendingArgs` is cleared again by `options._render` before anything
-		// can read it, so committing it here is enough.
-		c.__hooks._list.some(hookItem => {
-			if (hookItem._pendingArgs) hookItem._args = hookItem._pendingArgs;
-		});
+	const hooks = c && c.__hooks;
+	if (hooks) {
+		if (vnode._flags & MODE_PARKED) {
+			hooks._pendingEffects = [];
+		} else {
+			if (hooks._pendingEffects.length) afterPaint(afterPaintEffects.push(c));
+			// `_pendingArgs` is cleared again by `options._render` before anything
+			// can read it, so committing it here is enough.
+			hooks._list.some(hookItem => {
+				if (hookItem._pendingArgs) hookItem._args = hookItem._pendingArgs;
+			});
+		}
 	}
 	previousComponent = currentComponent = null;
 };
@@ -107,9 +113,10 @@ options.diffed = vnode => {
 options._commit = (vnode, commitQueue) => {
 	commitQueue.some(component => {
 		try {
-			component._renderCallbacks.some(invokeCleanup);
+			const parked = component._vnode._flags & MODE_PARKED;
+			if (!parked) component._renderCallbacks.some(invokeCleanup);
 			component._renderCallbacks = component._renderCallbacks.filter(cb =>
-				cb._value ? invokeEffect(cb) : true
+				cb._value ? !parked && invokeEffect(cb) : true
 			);
 		} catch (e) {
 			commitQueue.some(c => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,6 +10,11 @@ export const MATCHED = 1 << 1;
 /** Indicates that this vnode has been unmounted before indicating the loss of event listeners */
 export const FORCE_PROPS_REVALIDATE = 1 << 0;
 
+/** The subtree is hidden by Suspense. */
+export const MODE_PARKED = 1 << 4;
+/** A ref has not been attached while its subtree is hidden. */
+export const REF_PENDING = 1 << 3;
+
 // component._bits
 /** Component is processing an exception */
 export const COMPONENT_PROCESSING_EXCEPTION = 1 << 0;

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -405,6 +405,10 @@ function insert(parentVNode, oldDom, parentDom, isMounting) {
 			oldDom = getDomSibling(parentVNode);
 		}
 
+		if (oldDom && oldDom.parentNode != parentDom) {
+			oldDom = NULL;
+		}
+
 		if (HAS_MOVE_BEFORE_SUPPORT && !isMounting && parentVNode._dom.parentNode) {
 			// @ts-expect-error This isn't added to TypeScript lib.d.ts yet
 			parentDom.moveBefore(parentVNode._dom, oldDom);

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -5,6 +5,8 @@ import {
 	EMPTY_ARR,
 	INSERT_VNODE,
 	MATCHED,
+	MODE_PARKED,
+	REF_PENDING,
 	UNDEFINED,
 	NULL,
 	HAS_MOVE_BEFORE_SUPPORT
@@ -111,8 +113,11 @@ export function diffChildren(
 
 		// Adjust DOM nodes
 		newDom = childVNode._dom;
-		if (childVNode.ref && oldVNode.ref != childVNode.ref) {
-			if (oldVNode.ref) {
+		if (
+			childVNode.ref &&
+			(oldVNode.ref != childVNode.ref || oldVNode._flags & REF_PENDING)
+		) {
+			if (oldVNode.ref && !(oldVNode._flags & REF_PENDING)) {
 				applyRef(oldVNode.ref, NULL, childVNode);
 			}
 			refQueue.push(
@@ -226,6 +231,7 @@ function constructNewChildrenArray(
 		}
 
 		const skewedIndex = i + skew;
+		childVNode._flags |= newParentVNode._flags & MODE_PARKED;
 		childVNode._parent = newParentVNode;
 		childVNode._depth = newParentVNode._depth + 1;
 

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -10,6 +10,8 @@ import {
 	MATHML_TOKEN_ELEMENTS,
 	MATH_NAMESPACE,
 	MODE_HYDRATE,
+	MODE_PARKED,
+	REF_PENDING,
 	MODE_SUSPENDED,
 	NULL,
 	RESET_MODE,
@@ -470,6 +472,7 @@ export function commitRoot(commitQueue, root, refQueue) {
 	if (options._commit) options._commit(root, commitQueue);
 
 	commitQueue.some(c => {
+		if (c._vnode._flags & MODE_PARKED) return;
 		try {
 			// @ts-expect-error Reuse the commitQueue variable here so the type changes
 			commitQueue = c._renderCallbacks;
@@ -728,6 +731,13 @@ function diffElementNodes(
  * @param {VNode} vnode
  */
 export function applyRef(ref, value, vnode) {
+	if (value) {
+		if (vnode._flags & MODE_PARKED) {
+			vnode._flags |= REF_PENDING;
+			return;
+		}
+		vnode._flags &= ~REF_PENDING;
+	}
 	try {
 		if (typeof ref == 'function') {
 			if (typeof ref._unmount == 'function') {
@@ -757,7 +767,11 @@ export function unmount(vnode, parentVNode, skipRemove) {
 	let r;
 	if (options.unmount) options.unmount(vnode);
 
-	if ((r = vnode.ref) && (!r.current || r.current == vnode._dom)) {
+	if (
+		(r = vnode.ref) &&
+		!(vnode._flags & REF_PENDING) &&
+		(!r.current || r.current == vnode._dom)
+	) {
 		applyRef(r, NULL, parentVNode);
 	}
 


### PR DESCRIPTION
Stacked on #5252.

## Problem

Components can keep rendering in a parked Suspense tree, but their refs and effects run against detached DOM.

## Fix

Keep refs and effects pending until reveal. Hidden renders still run so removing a suspender can release the boundary. Force restored components, including memoized children, to pick up the deferred work.

Cost relative to #5252: +46 B brotli on core, +28 B on compat, +17 B on hooks.

Tests cover repeated parked updates, nested resolution order, memoized effects, ref replacement, and removal before reveal. Source and minified suites, lint, and type checks pass.
