### PR TITLE
Fix compressed size comparison with pnpm

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,12 +38,12 @@ jobs:
           package-manager-cache: false
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
       - name: test
         env:
           CI: true
           COVERAGE: true
           FLAKEY: false
-        # The install already runs prepare, including the build.
         run: pnpm run lint && pnpm run test:unit
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
@@ -52,7 +52,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-error: false
       - name: Package
-        # The install already built the package; skip pack lifecycle scripts.
+        # Package the tested build without running pack lifecycle scripts.
         run: |
           pnpm pack --config.ignore-scripts=true
           mv preact-*.tgz preact.tgz

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -19,6 +19,6 @@ jobs:
       - uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # 2.9.1
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
-          # Our `prepare` script already builds the app post-install,
-          # building it again would be redundant
-          build-script: '--if-present noop'
+          # pnpm can skip prepare when dependencies are unchanged between refs.
+          # Rebuild each ref so the base cannot reuse the PR's bundles.
+          build-script: 'build'

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   },
   "types": "src/index.d.ts",
   "scripts": {
-    "prepare": "husky && pnpm run test:install && run-s build",
+    "prepare": "husky && pnpm run test:install",
     "build": "node ./scripts/build.mjs",
     "postbuild": "node ./config/compat-entries.js",
     "dev": "node ./scripts/build.mjs --watch",


### PR DESCRIPTION
Since the pnpm migration, an install with unchanged dependencies can skip `prepare`. The compressed-size action therefore reused the PR's bundles for the base revision and reported no size changes. Run `build` explicitly for both revisions.

Keep Husky and `test:install` in `prepare`, and run builds explicitly in CI.
