### PR TITLE
Mount portal children fresh during hydration

### DIFF
--- a/compat/test/browser/suspense-hydration.test.jsx
+++ b/compat/test/browser/suspense-hydration.test.jsx
@@ -8,7 +8,8 @@ import React, {
 	use,
 	memo,
 	useState,
-	useSyncExternalStore
+	useSyncExternalStore,
+	createPortal
 } from 'preact/compat';
 import { logCall, getLog, clearLog } from '../../../test/_util/logCall';
 import {
@@ -928,7 +929,12 @@ describe('suspense hydration', () => {
 			return <button>Count: {count}</button>;
 		}
 
-		render(<Suspense fallback="Fallback"><App /></Suspense>, scratch);
+		render(
+			<Suspense fallback="Fallback">
+				<App />
+			</Suspense>,
+			scratch
+		);
 		await promise;
 		rerender();
 		rerender();
@@ -1444,5 +1450,37 @@ describe('suspense hydration', () => {
 			expect(scratch.innerHTML).to.equal(originalHtml);
 			clearLog();
 		});
+	});
+
+	it('should mount a portal fresh while a sibling suspends during hydration', async () => {
+		scratch.innerHTML = '<p>a</p><p>lazy</p>';
+		const portalRoot = document.createElement('div');
+		portalRoot.innerHTML = '<em>existing</em>';
+		document.body.appendChild(portalRoot);
+
+		const [Lazy, resolve] = createLazy();
+		function App() {
+			return (
+				<Suspense fallback={<div>fallback</div>}>
+					<p>a</p>
+					{createPortal(<p>b</p>, portalRoot)}
+					<Lazy />
+				</Suspense>
+			);
+		}
+
+		try {
+			hydrate(<App />, scratch);
+			rerender();
+			expect(scratch.innerHTML).to.equal('<p>a</p><p>lazy</p>');
+			expect(portalRoot.innerHTML).to.equal('<em>existing</em><p>b</p>');
+
+			await resolve(() => <p>lazy</p>);
+			rerender();
+			expect(scratch.innerHTML).to.equal('<p>a</p><p>lazy</p>');
+			expect(portalRoot.innerHTML).to.equal('<em>existing</em><p>b</p>');
+		} finally {
+			portalRoot.remove();
+		}
 	});
 });

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -320,6 +320,9 @@ export function diff(
 				// The document follows the container too (e.g. iframes) as
 				// diffElementNodes derives it from its parentDom.
 				namespace = parentDom.namespaceURI;
+				// Portals are never server-rendered: hydration must not claim the
+				// host parent's excess nodes for the container's children.
+				isHydrating = excessDomChildren = NULL;
 
 				// Changing the container remounts the children into the new one
 				if (oldVNode.props && oldVNode.props._parentDom != parentDom) {

--- a/test/browser/portals.test.jsx
+++ b/test/browser/portals.test.jsx
@@ -1,6 +1,7 @@
 import {
 	createElement,
 	render,
+	hydrate,
 	createPortal,
 	Component,
 	Fragment
@@ -782,5 +783,70 @@ describe('createPortal', () => {
 		expect(portalG.constructor.name).to.equal('SVGGElement');
 
 		svgRoot.parentNode.removeChild(svgRoot);
+	});
+
+	describe('hydration', () => {
+		/** @type {HTMLDivElement} */
+		let root;
+
+		beforeEach(() => {
+			root = document.createElement('div');
+			root.innerHTML = '<em>existing</em>';
+			document.body.appendChild(root);
+		});
+
+		afterEach(() => {
+			root.remove();
+		});
+
+		it('should mount a portal fresh without claiming host nodes', () => {
+			scratch.innerHTML = '<div><p>a</p><p>c</p></div>';
+			const div = scratch.firstChild;
+			const a = div.firstChild;
+			const c = div.lastChild;
+
+			function App() {
+				return (
+					<div>
+						<p>a</p>
+						{createPortal(<p>b</p>, root)}
+						<p>c</p>
+					</div>
+				);
+			}
+
+			hydrate(<App />, scratch);
+
+			expect(scratch.innerHTML).to.equal('<div><p>a</p><p>c</p></div>');
+			expect(root.innerHTML).to.equal('<em>existing</em><p>b</p>');
+			expect(scratch.firstChild).to.equal(div);
+			expect(div.firstChild).to.equal(a);
+			expect(div.lastChild).to.equal(c);
+		});
+
+		it('should hydrate host text after a leading portal', () => {
+			scratch.innerHTML = '<div>text<p>c</p></div>';
+
+			function App() {
+				return (
+					<div>
+						{createPortal(<p>b</p>, root)}
+						text
+						<p>c</p>
+					</div>
+				);
+			}
+
+			hydrate(<App />, scratch);
+			expect(scratch.innerHTML).to.equal('<div>text<p>c</p></div>');
+			expect(root.innerHTML).to.equal('<em>existing</em><p>b</p>');
+
+			render(<App />, scratch);
+			expect(root.innerHTML).to.equal('<em>existing</em><p>b</p>');
+
+			render(null, scratch);
+			expect(scratch.innerHTML).to.equal('');
+			expect(root.innerHTML).to.equal('<em>existing</em>');
+		});
 	});
 });


### PR DESCRIPTION
> [!NOTE]
> Co-Authored with Claude

Stacked on #5256.

`hydrate()` threw `NotFoundError` whenever the tree contained a `createPortal`. The portal branch of `diff()` forwarded the host parent's `excessDomChildren` and `isHydrating` into the container diff, so host nodes were claimed for the portal's children and then inserted into the container they don't belong to.

Portals are never server-rendered, so entering one now drops the excess list and the hydrating flag and the container's children mount fresh. v10's compat portal was a separate `render()` root and never saw host excess, so this is a regression from moving portals into core.