### PR TITLE
Re-attach refs when a suspended subtree reveals

### DIFF
--- a/compat/src/suspense.js
+++ b/compat/src/suspense.js
@@ -3,6 +3,7 @@ import {
 	COMPONENT_FORCE,
 	FORCE_PROPS_REVALIDATE,
 	MODE_HYDRATE,
+	REF_DETACHED,
 	UNDEFINED
 } from '../../src/constants';
 import { assign } from './util';
@@ -59,6 +60,10 @@ function detachedClone(vnode, detachedParent, parentDom) {
 			// sharing one empty array here is safe.
 			hooks._pendingEffects = vnode._component._renderCallbacks = [];
 		}
+
+		// Unmounting the clone detaches DOM refs; flag the original so the
+		// reveal attaches them again.
+		if (typeof vnode.type == 'string') vnode._flags |= REF_DETACHED;
 
 		vnode = assign({ constructor: UNDEFINED }, vnode);
 		if (vnode._component != null) {

--- a/compat/test/browser/suspense.test.jsx
+++ b/compat/test/browser/suspense.test.jsx
@@ -12,7 +12,8 @@ import React, {
 	useEffect,
 	useLayoutEffect,
 	memo,
-	createPortal
+	createPortal,
+	createRef
 } from 'preact/compat';
 import { setupScratch, teardown } from '../../../test/_util/helpers';
 import { createLazy, createSuspender } from './suspense-utils';
@@ -2886,6 +2887,31 @@ describe('suspense', () => {
 		// Render count should not have increased
 		expect(renderCount).to.equal(renderCountAfterSuspend);
 		expect(scratch.innerHTML).to.equal('<div>Loading...</div>');
+	});
+
+	it('should detach DOM refs while parked and attach them again on reveal', async () => {
+		const [Suspender, suspend] = createSuspender(() => <p>content</p>);
+		const ref = createRef();
+		render(
+			<Suspense fallback={<div>fallback</div>}>
+				<b ref={ref}>host</b>
+				<Suspender />
+			</Suspense>,
+			scratch
+		);
+		const host = scratch.firstChild;
+		expect(ref.current).to.equal(host);
+
+		const [resolve] = suspend();
+		rerender();
+		expect(scratch.innerHTML).to.equal('<div>fallback</div>');
+		expect(ref.current).to.equal(null);
+
+		await resolve(() => <p>resolved</p>);
+		rerender();
+		expect(scratch.innerHTML).to.equal('<b>host</b><p>resolved</p>');
+		expect(scratch.firstChild).to.equal(host);
+		expect(ref.current).to.equal(host);
 	});
 
 	describe('portals', () => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,8 @@ export const INSERT_VNODE = 1 << 2;
 export const MATCHED = 1 << 1;
 /** Indicates that this vnode has been unmounted before indicating the loss of event listeners */
 export const FORCE_PROPS_REVALIDATE = 1 << 0;
+/** The vnode's ref was detached while its subtree was parked by Suspense */
+export const REF_DETACHED = 1 << 3;
 
 // component._bits
 /** Component is processing an exception */

--- a/src/diff/children.js
+++ b/src/diff/children.js
@@ -5,6 +5,7 @@ import {
 	EMPTY_ARR,
 	INSERT_VNODE,
 	MATCHED,
+	REF_DETACHED,
 	UNDEFINED,
 	NULL,
 	HAS_MOVE_BEFORE_SUPPORT
@@ -111,8 +112,13 @@ export function diffChildren(
 
 		// Adjust DOM nodes
 		newDom = childVNode._dom;
-		if (childVNode.ref && oldVNode.ref != childVNode.ref) {
-			if (oldVNode.ref) {
+		// A ref detached while its subtree was parked by Suspense is attached
+		// again on reveal.
+		if (
+			childVNode.ref &&
+			(oldVNode.ref != childVNode.ref || oldVNode._flags & REF_DETACHED)
+		) {
+			if (oldVNode.ref != childVNode.ref && oldVNode.ref) {
 				applyRef(oldVNode.ref, NULL, childVNode);
 			}
 			refQueue.push(


### PR DESCRIPTION
> [!NOTE]
> Co-Authored with Claude

When a Suspense boundary parks its subtree, the clone unmount detaches DOM refs (`ref(null)` / `ref.current = null`). On reveal the same vnodes come back with the same `ref` identity, so `diffChildren` never re-applied them and `ref.current` stayed `null` for the rest of the element's life.

Reveal marks the old vnodes with a nulled `_original`; `diffChildren` now treats that as a reason to push the ref again. Detach on hide, attach on reveal, matching React.